### PR TITLE
Add Rich table support for browse mode display

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,8 @@ MAX_FILESIZE_MB = 0  # Maximum output file size in MB (0 = disabled)
 
 # Browse Mode Constants
 BROWSE_LINES_TO_DISPLAY = 5  # Number of rows to show at once when browsing
+BROWSE_DESCRIPTION_MAX_WIDTH = 40  # Max width for description column in table
+BROWSE_TIMESTAMP_MAX_WIDTH = 15    # Max width for each timestamp column
 
 # Spreadsheet Selection Commands
 COMMAND_LIST_ALL = 'all'

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -1199,7 +1199,12 @@ def browse_spreadsheet(sheet: Any) -> None:
     
     def display_rows(start_row, num_rows):
         """Display num_rows starting from start_row (0-indexed into sheet_data)."""
-        utils.info_print('-' * 60)
+        # Column indices (convert gspread 1-based to 0-based)
+        category_col = category_cell.col - 1
+        desc_col = observation_cell.col - 1
+
+        # Build structured rows_data list
+        rows_data = []
         for i in range(num_rows):
             row_idx = start_row + i
             if row_idx > last_data_row:
@@ -1207,41 +1212,37 @@ def browse_spreadsheet(sheet: Any) -> None:
 
             row_data = sheet_data[row_idx]
             row_num = row_idx + 1  # Convert to 1-based for user-facing row number
-            
-            # Get category (gspread col is 1-based -> 0-based for sheet_data)
-            category_col = category_cell.col - 1
-            category = row_data[category_col] if category_col < len(row_data) else ''
 
-            # Get description (observation)
-            desc_col = observation_cell.col - 1
+            # Get category and description
+            category = row_data[category_col] if category_col < len(row_data) else ''
             description = row_data[desc_col] if desc_col < len(row_data) else ''
-            
-            utils.info_print(f'Row {row_num}')
-            utils.info_print(f'  Category: {category if category else "(empty)"}')
-            utils.info_print(f'  Description: {description if description else "(empty)"}')
-            
+
             # Get participant timestamps
-            has_timestamps = False
-            participant_data = []
+            timestamps = {}
             for j, participant_id in enumerate(participant_headers):
                 col_idx = id_cell.col + j  # id_cell.col is 1-based; col_idx matches sheet_data columns
                 if col_idx < len(row_data):
                     timestamp_value = row_data[col_idx]
                     if timestamp_value and timestamp_value.strip():
                         # Replace newlines with commas for display
-                        timestamp_display = timestamp_value.replace('\n', ', ').replace('\r', '')
-                        participant_data.append(f'    {participant_id}: {timestamp_display}')
-                        has_timestamps = True
-            
-            if has_timestamps:
-                utils.info_print('  Participants:')
-                for p_data in participant_data:
-                    utils.info_print(p_data)
-            else:
-                utils.info_print('  Participants: (no timestamps)')
-            
-            utils.info_print('  ---')
-        
+                        timestamps[participant_id] = timestamp_value.replace('\n', ', ').replace('\r', '')
+
+            rows_data.append({
+                'row_num': row_num,
+                'category': category or '(empty)',
+                'description': description or '(empty)',
+                'timestamps': timestamps
+            })
+
+        # Display using Rich Table or plain text fallback
+        if utils._use_rich():
+            table = utils.create_browse_table(rows_data, participant_headers)
+            if table:
+                utils.console.print(table)
+        else:
+            output = utils.format_browse_rows_plain(rows_data, participant_headers)
+            print(output)
+
         # Show position info (convert 0-based start_row to 1-based for display)
         displayed_end = min(start_row + num_rows, last_data_row + 1)
         utils.info_print(f'\nShowing rows {start_row + 1}-{displayed_end} of {last_data_row + 1}')

--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,7 @@ import config
 try:
     from rich.console import Console
     from rich.panel import Panel
+    from rich.table import Table
     from rich.text import Text
     from rich.theme import Theme
     RICH_AVAILABLE = True
@@ -209,6 +210,95 @@ def info_print(message: str) -> None:
         console.print(message, style="info")
     else:
         print(message)
+
+
+def create_browse_table(
+    rows_data: List[dict],
+    participant_headers: List[str]
+) -> Optional['Table']:
+    """Create a Rich Table for browse mode display.
+
+    Args:
+        rows_data: List of dicts with keys: row_num, category, description, timestamps (dict)
+        participant_headers: List of participant IDs for column headers
+
+    Returns:
+        Rich Table object if Rich is available, None otherwise
+    """
+    if not _use_rich():
+        return None
+
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        border_style="dim",
+        row_styles=["", "dim"],
+        expand=False,
+    )
+
+    # Add fixed columns
+    table.add_column("Row", justify="right", style="bold", width=4)
+    table.add_column("Category", style="yellow", max_width=15, overflow="ellipsis")
+    table.add_column("Description", max_width=config.BROWSE_DESCRIPTION_MAX_WIDTH, overflow="ellipsis")
+
+    # Add participant columns
+    for p_id in participant_headers:
+        table.add_column(p_id, max_width=config.BROWSE_TIMESTAMP_MAX_WIDTH, overflow="fold")
+
+    # Add data rows
+    for row in rows_data:
+        row_values = [
+            str(row['row_num']),
+            row['category'],
+            row['description'],
+        ]
+        # Add timestamp values for each participant
+        for p_id in participant_headers:
+            ts = row['timestamps'].get(p_id, '-')
+            row_values.append(ts if ts else '-')
+
+        table.add_row(*row_values)
+
+    return table
+
+
+def format_browse_rows_plain(
+    rows_data: List[dict],
+    participant_headers: List[str]
+) -> str:
+    """Format browse rows as plain text (fallback when Rich unavailable).
+
+    Args:
+        rows_data: List of dicts with keys: row_num, category, description, timestamps (dict)
+        participant_headers: List of participant IDs
+
+    Returns:
+        Formatted plain text string
+    """
+    lines = ['-' * 60]
+
+    for row in rows_data:
+        lines.append(f"Row {row['row_num']}")
+        lines.append(f"  Category: {row['category']}")
+        lines.append(f"  Description: {row['description']}")
+
+        # Get participant timestamps
+        participant_data = []
+        for p_id in participant_headers:
+            ts = row['timestamps'].get(p_id)
+            if ts:
+                participant_data.append(f"    {p_id}: {ts}")
+
+        if participant_data:
+            lines.append('  Participants:')
+            lines.extend(participant_data)
+        else:
+            lines.append('  Participants: (no timestamps)')
+
+        lines.append('  ---')
+
+    return '\n'.join(lines)
+
 
 def normalize_study_name(raw_name: str) -> str:
     """Convert study name to a filesystem-safe format.


### PR DESCRIPTION
Displays spreadsheet rows in an interactive table format with columns for Row, Category, Description, and each participant. Includes graceful fallback to plain text when Rich is unavailable. Adds configuration constants for table column widths.