### PR TITLE
Add Regenerate from Manifest button to Studio

### DIFF
--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -61,11 +61,12 @@
 
     <div id="viewerArea" class="drop-area">
       <h3>Viewers</h3>
-      <p>Build Viewer requires generated artifacts. Timeline Viewer runs a full batch export.</p>
+      <p>Build Viewer requires generated artifacts. Timeline Viewer runs a full batch export. Regenerate re-creates media from a saved manifest.</p>
       <div class="area-controls">
         <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
         <button id="buildTimelineViewerBtn" class="btn btn-primary">Timeline Viewer</button>
         <button id="exportManifestBtn" class="btn btn-primary" disabled>Export Manifest</button>
+        <button id="regenerateBtn" class="btn btn-primary">Regenerate from Manifest</button>
       </div>
       <span id="viewerArtifactCount" style="font-size: 0.75rem; color: var(--color-text-dim);"></span>
     </div>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -645,6 +645,7 @@
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
     qs("#buildTimelineViewerBtn").addEventListener("click", onBuildTimelineViewer);
     qs("#exportManifestBtn").addEventListener("click", onExportManifest);
+    qs("#regenerateBtn").addEventListener("click", onRegenerate);
 
     qs("#statusDismiss").addEventListener("click", hideOverlay);
   }
@@ -804,6 +805,37 @@
           showResult("Manifest exported: " + (data.file || ""), null);
         } else {
           showResult(null, data.error || "Manifest export failed");
+        }
+      })
+      .catch(function (err) {
+        state.generating = false;
+        showResult(null, "Request failed: " + err);
+      });
+  }
+
+  function onRegenerate() {
+    if (state.generating) return;
+    state.generating = true;
+
+    showOverlay("Regenerating artifacts from manifest...");
+
+    fetch("api/regenerate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (data) {
+        state.generating = false;
+        if (data.ok) {
+          showResult(
+            "Regenerated " + data.regenerated + " of " + data.total + " item(s)",
+            null
+          );
+        } else {
+          showResult(null, data.error || "Regeneration failed");
         }
       })
       .catch(function (err) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.30"
+VERSIONNUM: str = "0.9.31"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -298,6 +298,30 @@ def api_manifest() -> FlaskResponse:
         return jsonify({"ok": False, "error": str(e)}), 500
 
 
+@studio_bp.route("/api/regenerate", methods=["POST"])
+def api_regenerate() -> FlaskResponse:
+    try:
+        artifacts = viewer.load_manifest_artifacts()
+        reels = viewer.load_manifest_reels()
+        if not artifacts and not reels:
+            return jsonify(
+                {
+                    "ok": False,
+                    "error": "No manifest found on disk. Export a manifest first.",
+                }
+            ), 400
+
+        media_count = sum(1 for a in artifacts if a.get("type") != "transcript")
+        reel_count = len(reels)
+        total = media_count + reel_count
+
+        regenerated = clipgen.regenerate_from_manifest(artifacts, reels=reels)
+        return jsonify({"ok": True, "regenerated": regenerated, "total": total})
+
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)}), 500
+
+
 # ---- State initialization ----
 
 


### PR DESCRIPTION
## Summary
- Adds a "Regenerate from Manifest" button to the Studio Viewers section that re-creates all media artifacts (clips, screenshots, GIFs, reels) from an existing `clipgen_manifest.json` on disk
- New `POST /studio/api/regenerate` endpoint loads the manifest via `viewer.load_manifest_artifacts()` / `load_manifest_reels()` and calls the existing `clipgen.regenerate_from_manifest()`
- Button is always enabled since it reads from disk rather than depending on session state
- Bumps version to 0.9.31

## Test plan
- [ ] Start server with `uv run clipgen.py --server`, generate artifacts, export manifest
- [ ] Delete generated media files, click "Regenerate from Manifest" — files should be recreated
- [ ] Click "Regenerate from Manifest" with no manifest on disk — should show descriptive error