### PR TITLE
Add discard button to Insights Builder

### DIFF
--- a/assets/web/insights-builder.html
+++ b/assets/web/insights-builder.html
@@ -13,6 +13,7 @@
       <div id="headerActions">
         <a id="studioLink" href="/studio/" class="nav-link hidden">Studio</a>
         <span id="unsavedIndicator" class="hidden">Unsaved changes</span>
+        <button id="discardBtn" class="btn" disabled>Discard</button>
         <button id="saveAllBtn" class="btn btn-primary" disabled>Save</button>
         <button id="generateViewerBtn" class="btn">Generate Viewer</button>
         <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -726,6 +726,7 @@
     var hasDirty = Object.keys(state.dirtyIds).length > 0;
     qs("#unsavedIndicator").classList.toggle("hidden", !hasDirty);
     qs("#saveAllBtn").disabled = !hasDirty;
+    qs("#discardBtn").disabled = !hasDirty;
   }
 
   function saveAll() {
@@ -776,6 +777,21 @@
         delete state.dirtyIds[insightId];
         updateDirtyUI();
         showToast("Insight saved.");
+      });
+  }
+
+  function discardAll() {
+    if (!confirm("Discard all unsaved changes?")) return;
+    fetch("api/insights")
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (data) {
+        state.insights = data.insights || [];
+        state.dirtyIds = {};
+        updateDirtyUI();
+        renderInsightCards();
+        showToast("Changes discarded.");
       });
   }
 
@@ -1236,6 +1252,7 @@
 
     // Header buttons
     qs("#saveAllBtn").addEventListener("click", saveAll);
+    qs("#discardBtn").addEventListener("click", discardAll);
     qs("#newInsightBtn").addEventListener("click", createNewInsight);
 
     // Popover bucket buttons

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.30"
+VERSIONNUM: str = "0.9.31"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary
- Adds a "Discard" button to the Insights Builder header that reverts all unsaved changes to the last saved state
- The button sits next to Save, stays disabled when there are no unsaved changes, and shows a confirmation dialog before discarding
- Discard works by re-fetching the saved insights from the server, replacing local state, and clearing dirty tracking

## Test plan
- [ ] Open the Insights Builder and edit an insight — verify Discard button enables alongside Save
- [ ] Click Discard, confirm — verify insight reverts to saved state and both buttons disable
- [ ] Click Discard, cancel — verify nothing changes