### PR TITLE
Add tests for web asset features

### DIFF
--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,0 +1,128 @@
+import json
+import time
+
+import config
+import insights
+import utils
+
+
+def _redirect_output(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+
+
+def test_create_insight_returns_well_formed_dict():
+    ins = insights.create_insight(title="Login bug", severity="High", status="draft")
+
+    assert ins["id"].startswith("ins_")
+    assert len(ins["id"]) == 12
+    assert ins["title"] == "Login bug"
+    assert ins["severity"] == "High"
+    assert ins["status"] == "draft"
+    assert ins["summary"] == ""
+    assert ins["timelineContext"] == ""
+    assert ins["createdAt"] == ins["updatedAt"]
+
+    for bucket in ("causes", "behaviors", "impacts"):
+        assert isinstance(ins[bucket]["narrative"], str)
+        assert isinstance(ins[bucket]["artifacts"], list)
+        assert ins[bucket]["artifacts"] == []
+
+
+def test_create_insight_defaults():
+    ins = insights.create_insight()
+    assert ins["title"] == "Untitled insight"
+    assert ins["severity"] == ""
+    assert ins["status"] == "draft"
+
+
+def test_update_insight_merges_fields():
+    ins = insights.create_insight(title="Old")
+    original_created = ins["createdAt"]
+    original_id = ins["id"]
+    time.sleep(0.01)
+
+    result = insights.update_insight([ins], original_id, {"title": "New", "severity": "Critical"})
+
+    assert result is ins
+    assert ins["title"] == "New"
+    assert ins["severity"] == "Critical"
+    assert ins["id"] == original_id
+    assert ins["createdAt"] == original_created
+    assert ins["updatedAt"] >= original_created
+
+
+def test_update_insight_protects_id_and_createdAt():
+    ins = insights.create_insight(title="Safe")
+    original_id = ins["id"]
+    original_created = ins["createdAt"]
+
+    insights.update_insight([ins], original_id, {"id": "hacked", "createdAt": "hacked"})
+
+    assert ins["id"] == original_id
+    assert ins["createdAt"] == original_created
+
+
+def test_update_insight_returns_none_for_missing_id():
+    ins = insights.create_insight()
+    result = insights.update_insight([ins], "ins_nonexistent", {"title": "X"})
+    assert result is None
+
+
+def test_delete_insight_removes_and_returns_true():
+    a = insights.create_insight(title="A")
+    b = insights.create_insight(title="B")
+    lst = [a, b]
+
+    assert insights.delete_insight(lst, a["id"]) is True
+    assert len(lst) == 1
+    assert lst[0]["id"] == b["id"]
+
+
+def test_delete_insight_returns_false_for_missing_id():
+    ins = insights.create_insight()
+    lst = [ins]
+    assert insights.delete_insight(lst, "ins_nonexistent") is False
+    assert len(lst) == 1
+
+
+def test_save_and_load_roundtrip(tmp_path, monkeypatch):
+    _redirect_output(tmp_path, monkeypatch)
+
+    ins_list = [
+        insights.create_insight(title="First", severity="High"),
+        insights.create_insight(title="Second", severity="Low"),
+    ]
+    path = insights.save_insights_manifest({"study": "demo"}, ins_list)
+    assert path is not None
+    assert path.is_file()
+
+    loaded = insights.load_insights_manifest()
+    assert len(loaded["insights"]) == 2
+    assert loaded["meta"]["study"] == "demo"
+    assert "generatedAt" in loaded["meta"]
+    assert "version" in loaded["meta"]
+    titles = {i["title"] for i in loaded["insights"]}
+    assert titles == {"First", "Second"}
+
+
+def test_load_handles_missing_and_malformed(tmp_path, monkeypatch):
+    _redirect_output(tmp_path, monkeypatch)
+    manifest_path = tmp_path / config.INSIGHTS_MANIFEST_FILENAME
+
+    # Missing file
+    result = insights.load_insights_manifest()
+    assert result == {"meta": {}, "insights": []}
+
+    # Malformed JSON
+    manifest_path.write_text("not json at all")
+    result = insights.load_insights_manifest()
+    assert result == {"meta": {}, "insights": []}
+
+    # Legacy insight missing 'summary' field
+    legacy = {
+        "meta": {},
+        "insights": [{"id": "ins_old", "title": "Old", "severity": "Low"}],
+    }
+    manifest_path.write_text(json.dumps(legacy))
+    result = insights.load_insights_manifest()
+    assert result["insights"][0]["summary"] == ""

--- a/tests/test_insights_api.py
+++ b/tests/test_insights_api.py
@@ -1,0 +1,101 @@
+import pytest
+
+Flask = pytest.importorskip("flask").Flask
+import insights
+import insights_server
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(insights_server.insights_bp, url_prefix="/insights")
+
+    # Set module state directly — no disk reads or sprite generation
+    insights_server._insights_data = {"meta": {}, "insights": []}
+    insights_server._artifacts = []
+    insights_server._output_dir = str(tmp_path)
+
+    # No-op manifest save to avoid disk I/O (roundtrip covered in test_insights.py)
+    monkeypatch.setattr(insights, "save_insights_manifest", lambda meta, ins: None)
+
+    with app.test_client() as c:
+        yield c
+
+
+def test_list_insights_empty(client):
+    resp = client.get("/insights/api/insights")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["insights"] == []
+
+
+def test_create_insight_via_api(client):
+    resp = client.post(
+        "/insights/api/insights",
+        json={"title": "Navigation bug", "severity": "High"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    ins = data["insight"]
+    assert ins["id"].startswith("ins_")
+    assert ins["title"] == "Navigation bug"
+    assert ins["severity"] == "High"
+    assert ins["status"] == "draft"
+
+    # Verify it appears in the list
+    list_resp = client.get("/insights/api/insights")
+    assert len(list_resp.get_json()["insights"]) == 1
+
+
+def test_get_single_insight(client):
+    create_resp = client.post("/insights/api/insights", json={"title": "A"})
+    insight_id = create_resp.get_json()["insight"]["id"]
+
+    resp = client.get(f"/insights/api/insights/{insight_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["insight"]["id"] == insight_id
+
+
+def test_get_nonexistent_returns_404(client):
+    resp = client.get("/insights/api/insights/ins_nonexistent")
+    assert resp.status_code == 404
+    assert resp.get_json()["ok"] is False
+
+
+def test_update_insight_via_api(client):
+    create_resp = client.post("/insights/api/insights", json={"title": "Original"})
+    insight_id = create_resp.get_json()["insight"]["id"]
+
+    resp = client.put(
+        f"/insights/api/insights/{insight_id}",
+        json={"title": "Updated", "severity": "Critical"},
+    )
+    assert resp.status_code == 200
+    updated = resp.get_json()["insight"]
+    assert updated["title"] == "Updated"
+    assert updated["severity"] == "Critical"
+    assert "updatedAt" in updated
+
+
+def test_update_nonexistent_returns_404(client):
+    resp = client.put("/insights/api/insights/ins_missing", json={"title": "X"})
+    assert resp.status_code == 404
+
+
+def test_delete_insight_via_api(client):
+    create_resp = client.post("/insights/api/insights", json={"title": "Doomed"})
+    insight_id = create_resp.get_json()["insight"]["id"]
+
+    resp = client.delete(f"/insights/api/insights/{insight_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+    list_resp = client.get("/insights/api/insights")
+    assert list_resp.get_json()["insights"] == []
+
+
+def test_delete_nonexistent_returns_404(client):
+    resp = client.delete("/insights/api/insights/ins_missing")
+    assert resp.status_code == 404

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1,0 +1,58 @@
+import pytest
+
+Flask = pytest.importorskip("flask").Flask
+import server
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(server.studio_bp, url_prefix="/studio")
+
+    # Default: no worksheet/context loaded (error state)
+    monkeypatch.setattr(server, "_worksheet", None)
+    monkeypatch.setattr(server, "_sheet_context", None)
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_generated_reels", [])
+
+    with app.test_client() as c:
+        yield c
+
+
+def test_api_sheet_500_when_no_context(client):
+    resp = client.get("/studio/api/sheet")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert "No sheet loaded" in data["error"]
+
+
+def test_api_generate_500_when_no_worksheet(client):
+    resp = client.post("/studio/api/generate", json={"cells": ["P01.3"]})
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["ok"] is False
+
+
+def test_api_generate_400_when_no_cells(client, monkeypatch):
+    monkeypatch.setattr(server, "_worksheet", object())
+    resp = client.post("/studio/api/generate", json={"cells": []})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "No cells" in data["error"]
+
+
+def test_api_generate_400_for_invalid_format(client, monkeypatch):
+    monkeypatch.setattr(server, "_worksheet", object())
+    resp = client.post("/studio/api/generate", json={"cells": ["P01.3"], "format": "pdf"})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Invalid format" in data["error"]
+
+
+def test_api_viewer_400_when_no_artifacts(client):
+    resp = client.post("/studio/api/viewer")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert "No artifacts" in data["error"]

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -1,0 +1,152 @@
+import viewer
+
+
+def _make_artifact(artifact_id, *, start=10.0, end=20.0, study="study", participant="P01"):
+    return {
+        "id": artifact_id,
+        "type": "clip",
+        "file": f"{artifact_id}.mp4",
+        "start": start,
+        "end": end,
+        "thumbnail": "",
+        "study": study,
+        "participant": participant,
+        "category": "cat",
+        "severity": "",
+        "description": "desc",
+        "cellRow": 4,
+        "cellCol": 2,
+        "cellA1": "B4",
+        "annotations": [],
+        "sourceVideo": f"{study}_{participant}.mp4",
+    }
+
+
+# ---- finalize_timeline_data ----
+
+
+def test_finalize_timeline_data_duration_and_structure():
+    arts = [_make_artifact("a1", end=20.0), _make_artifact("a2", end=50.0)]
+    data = viewer.finalize_timeline_data(
+        arts, study="s", participant="P01", worksheet_title="Sheet1", is_excel=True, mode="batch"
+    )
+
+    assert set(data.keys()) == {"meta", "artifacts", "timeline"}
+    assert data["timeline"]["duration"] == 50.0 * 1.05
+    assert data["timeline"]["startOffset"] == 0.0
+    assert data["meta"]["study"] == "s"
+    assert data["meta"]["participant"] == "P01"
+    assert data["meta"]["sourceFileType"] == "excel"
+    assert data["meta"]["sourceSpreadsheet"] == "Sheet1"
+    assert data["meta"]["mode"] == "batch"
+    assert "reels" not in data
+
+
+def test_finalize_timeline_data_empty_artifacts():
+    data = viewer.finalize_timeline_data([])
+    assert data["timeline"]["duration"] == 0.0
+    assert data["artifacts"] == []
+
+
+def test_finalize_timeline_data_includes_reels():
+    reels = [{"id": "reel_1", "file": "r.mp4"}]
+    data = viewer.finalize_timeline_data([], reels=reels)
+    assert data["reels"] == reels
+
+
+# ---- finalize_gallery_data ----
+
+
+def test_finalize_gallery_data_structure():
+    gallery_artifacts = [{"file": "frame_10.png", "timestamp": 10.0}]
+    data = viewer.finalize_gallery_data(
+        gallery_artifacts, source_video="vid.mp4", video_duration=120, output_format="screen", interval=5
+    )
+
+    assert data["meta"]["mode"] == "gallery"
+    assert data["meta"]["sourceVideo"] == "vid.mp4"
+    assert data["meta"]["videoDuration"] == 120
+    assert data["meta"]["interval"] == 5
+    assert data["meta"]["format"] == "screen"
+    assert data["artifacts"] == gallery_artifacts
+
+
+# ---- finalize_insights_viewer_data ----
+
+
+def _make_insight(insight_id, status="draft", referenced_artifact_ids=None):
+    return {
+        "id": insight_id,
+        "title": f"Insight {insight_id}",
+        "status": status,
+        "causes": {"narrative": "", "artifacts": referenced_artifact_ids or []},
+        "behaviors": {"narrative": "", "artifacts": []},
+        "impacts": {"narrative": "", "artifacts": []},
+    }
+
+
+def test_finalize_insights_viewer_filters_to_final():
+    ins_list = [
+        _make_insight("i1", status="final", referenced_artifact_ids=["a1"]),
+        _make_insight("i2", status="draft", referenced_artifact_ids=["a2"]),
+        _make_insight("i3", status="final", referenced_artifact_ids=["a3"]),
+    ]
+    all_artifacts = [_make_artifact("a1"), _make_artifact("a2"), _make_artifact("a3")]
+
+    data = viewer.finalize_insights_viewer_data(ins_list, all_artifacts, study="s")
+
+    assert len(data["insights"]) == 2
+    ids = {i["id"] for i in data["insights"]}
+    assert ids == {"i1", "i3"}
+
+    art_ids = {a["id"] for a in data["artifacts"]}
+    assert art_ids == {"a1", "a3"}
+
+
+def test_finalize_insights_viewer_shows_all_when_no_finals():
+    ins_list = [
+        _make_insight("i1", status="draft", referenced_artifact_ids=["a1"]),
+        _make_insight("i2", status="draft", referenced_artifact_ids=["a2"]),
+    ]
+    all_artifacts = [_make_artifact("a1"), _make_artifact("a2")]
+
+    data = viewer.finalize_insights_viewer_data(ins_list, all_artifacts, study="s")
+
+    assert len(data["insights"]) == 2
+    art_ids = {a["id"] for a in data["artifacts"]}
+    assert art_ids == {"a1", "a2"}
+
+
+# ---- HTML generation (gallery + insights viewer) ----
+
+
+def test_generate_gallery_viewer_inlines_css_and_js(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    data = {"meta": {}, "artifacts": []}
+    out_path = viewer.generate_gallery_viewer(data, output_basename="gallery.html")
+    assert out_path is not None
+    assert out_path.is_file()
+
+    html = out_path.read_text(encoding="utf-8")
+    assert '<link rel="stylesheet" href="gallery.css">' not in html
+    assert '<script src="gallery.js" defer></script>' not in html
+    assert "<style>" in html
+    assert "<script defer>" in html
+    assert "window.CLIPGEN_DATA" in html
+
+
+def test_generate_insights_viewer_inlines_css_and_js(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    data = {"meta": {}, "insights": [], "artifacts": []}
+    out_path = viewer.generate_insights_viewer(data, output_basename="insights.html")
+    assert out_path is not None
+    assert out_path.is_file()
+
+    html = out_path.read_text(encoding="utf-8")
+    assert '<link rel="stylesheet" href="insights-viewer.css">' not in html
+    assert '<script src="insights-viewer.js" defer></script>' not in html
+    assert "<style>" in html
+    assert "<script defer>" in html
+    assert "window.CLIPGEN_DATA" in html


### PR DESCRIPTION
Adds a pytest test suite covering the web asset layer: insights CRUD operations, insights and studio Flask API endpoints, and viewer data finalization/HTML generation. Tests validate create/update/delete logic, save/load roundtrips, API error handling (400/404/500), timeline/gallery/insights data structures, and CSS/JS inlining in generated HTML viewers.