### PR TITLE
Document Studio, Insights Builder, and Manifest features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,10 @@ clipgen is a Python CLI tool that generates clips from timestamps stored in a Go
 | [config.py](config.py) | Global constants and settings (version, headers, limits, commands) |
 | [google_api.py](google_api.py) | Google Sheets auth, worksheet selection by priority, spreadsheet listing/search |
 | [excel_io.py](excel_io.py) | Excel adapter: `ExcelSheetAdapter` mimics gspread Worksheet interface for local .xlsx |
-| [assets/web/](assets/web/) | Static HTML/JS/CSS templates for viewers: timeline (`viewer.html/js/css`), gallery (`gallery.html/js/css`) |
+| [server.py](server.py) | Combined Flask server for Studio + Insights; Studio REST API (sheet data, generate, reel, viewer, manifest, regenerate) |
+| [insights.py](insights.py) | Insights data model: CRUD operations for insight records, insights manifest read/write |
+| [insights_server.py](insights_server.py) | Insights Builder Flask REST API: insight CRUD, artifact browsing, sprite sheet generation, viewer export |
+| [assets/web/](assets/web/) | Static HTML/JS/CSS templates: timeline viewer (`viewer.html/js/css`), gallery (`gallery.html/js/css`), studio (`studio.html/js/css`), insights builder (`insights-builder.html/js/css`), insights viewer (`insights-viewer.html/js/css`) |
 
 ### Architecture overview
 
@@ -55,6 +58,13 @@ flowchart LR
   transcriptLayer --> transcriptFiles["Transcript files (.md / .srt / .vtt)"]
 
   artifacts --> viewer["assets/web (timeline viewer)"]
+
+  cli --> server["server.py (Flask)"]
+  server --> studioUI["Studio (assets/web)"]
+  server --> insightsUI["Insights Builder (assets/web)"]
+  server --> spreadsheetLayer
+  server --> videoLayer
+  insightsUI --> insightsData["insights.py (data model)"]
 ```
 
 1. **Input and selection**: `clipgen.py` reads CLI arguments, selects mode, and chooses a spreadsheet source (Google Sheets via `google_api.py` or local Excel via `excel_io.py`).
@@ -63,6 +73,7 @@ flowchart LR
 4. **Rendering**: `video.py` uses ffmpeg/ffprobe to cut clips, screenshots, GIFs, or reels from `{study}_{participant}.mp4`, honoring limits and other settings in `config.py`.
 5. **Optional transcription**: When `--transcribe` is set, `transcripts.py` uses faster-whisper to transcribe source videos (cached per video), filters segments to each clip's time range, and writes transcript files alongside artifacts.
 6. **Optional viewer**: When requested, `clipgen.py` uses the templates in `assets/web` to build an HTML timeline viewer from the generated artifacts.
+7. **Web interfaces**: When `--studio` or `--insights` is passed, `server.py` starts a combined Flask server. Studio serves an interactive spreadsheet grid backed by the same spreadsheet/video pipeline. Insights Builder reads `clipgen_manifest.json` and provides CRUD for structured research findings, persisted to `insights_manifest.json`.
 
 ## Key data structures
 
@@ -121,12 +132,16 @@ Source video filenames follow `{study}_{participant}.mp4` (e.g. `mystudy_P01.mp4
 | **reellate** | Build a reel from already-generated clips in the working directory |
 | **gallery** | Generate interval screenshots/GIFs from a video and build a gallery HTML viewer (available via interactive `gv`/`gallery` or CLI `--gallery`) |
 | **browse** | Interactive view of spreadsheet rows (no clip generation) |
+| **studio** | Web-based interactive artifact generation and reel building from spreadsheet data (CLI `--studio`; requires spreadsheet) |
+| **insights** | Web-based Insights Builder for authoring structured UX research findings from generated artifacts (CLI `--insights`; no spreadsheet required) |
 
 Reel selectors: `batch`, `keyword`, `chronologic`, `severity`, `highlights`, line numbers, ranges like `13-16`, quoted categories, cells like `P01.11`, participant IDs like `P01`.
 
 CLI mode flags are mutually exclusive for selection (`-b/-l/-r/-C/-c/-p/-k/-S/-M/-R/-T/-H`) and can be combined with output format flags (`--screen` or `--gif`) except reel/chronologic/highlights, which always output a single video reel. `-H/--highlights` generates a highlights reel scored by severity, uniqueness, and keyword annotations within a configurable time budget (default 180s); optionally pass a duration in seconds (e.g. `-H 120`). `-C/--category` accepts one or more category names (comma- or plus-separated, e.g. `"Observations,Onboarding"`), `-k/--keyword` selects only key-annotated clips, `-S/--severity` accepts severity levels (e.g. `"Critical,High"` or `"-4,-3"`), and `-M/--mixed` combines selectors for individual outputs. `--transcribe` can be combined with any mode/format to generate transcript files alongside artifacts; `--transcript-format` overrides the output format (`md`, `srt`, `vtt`).
 
 `--gallery [VIDEO]` generates interval screenshots or GIFs from a video file and builds a gallery HTML viewer. Combine with `--gif` for GIF output and `--interval N` to set the capture interval in seconds (default 10). No spreadsheet is required.
+
+`--studio` launches a Flask-based web interface for interactive artifact generation. Requires a spreadsheet (Google Sheets or Excel); can combine with `-s`, `-i/-o`, `-v`. Cannot combine with mode flags, format flags, `--viewer`, or `--regenerate`. `--insights` launches the Insights Builder for authoring research findings from generated artifacts; no spreadsheet required. Can combine with `-i/-o`, `-v`. Cannot combine with mode flags, format flags, `--viewer`, `--regenerate`, or `--studio`. `--manifest` writes a cumulative artifact manifest (`clipgen_manifest.json`) alongside generated clips; required by `--insights` and `--regenerate`. `--regenerate` re-creates all media artifacts and reels from a saved manifest without a spreadsheet.
 
 Interactive-only modes without dedicated CLI flags:
 
@@ -161,6 +176,13 @@ Interactive-only modes without dedicated CLI flags:
 - `TRANSCRIBE_FORMAT` – Output format: `"md"` (Markdown, default), `"srt"`, or `"vtt"`
 - `TRANSCRIBE_INITIAL_PROMPT` – Context prompt sent to Whisper (default: UX research session description)
 - `TRANSCRIBE_BEAM_SIZE` – Beam search width (`5` default)
+- `MANIFEST_FILENAME` – `"clipgen_manifest.json"` – cumulative artifact manifest file name
+- `MANIFEST_ENABLED` – `False`; set `True` or use `--manifest` CLI flag to write manifest alongside generated artifacts
+- `SERVER_PORT` – `8089` – port for the combined Studio/Insights Flask server
+- `INSIGHTS_MANIFEST_FILENAME` – `"insights_manifest.json"` – insights data manifest file name
+- `SPRITE_SHEET_FRAME_COUNT` – `20` – number of frames extracted per sprite sheet
+- `SPRITE_SHEET_THUMB_WIDTH` – `160` – pixel width of each sprite thumbnail
+- `SPRITE_SHEET_MIN_INTERVAL` – `1` – minimum seconds between sprite frames
 
 ## Spreadsheet layout
 
@@ -197,6 +219,71 @@ Reference spreadsheet layout is described in [README.md](README.md).
 - **Key functions**: `generate_interval_captures()` in [video.py](video.py), `finalize_gallery_data()` and `generate_gallery_viewer()` in [viewer.py](viewer.py).
 - Gallery artifacts are NOT written to the manifest by default.
 
+## Studio Web Interface
+
+- **Opt-in**: CLI flag `--studio`. Requires a spreadsheet (Google Sheets or Excel).
+- **Server**: `start_combined_server()` in [server.py](server.py) starts a Flask app serving both Studio (at `/studio/`) and Insights Builder (at `/insights/`) on `config.SERVER_PORT` (default 8089). Opens the browser automatically.
+- **Assets**: Static template in [assets/web/](assets/web/) (`studio.html`, `studio.js`, `studio.css`). Served directly by Flask (no inlining).
+- **API endpoints** (all under `/studio/`):
+  - `GET /api/sheet` – returns spreadsheet grid data (rows, participants, observations, categories, severity, per-cell timestamp validity)
+  - `POST /api/generate` – generates artifacts for specified cells in a given format (clip/screen/gif)
+  - `POST /api/reel` – builds a reel from specified cells
+  - `POST /api/viewer` – generates a timeline viewer from session artifacts
+  - `POST /api/timeline-viewer` – batch-exports all clips and generates a timeline viewer
+  - `POST /api/manifest` – writes the cumulative artifact manifest to disk
+  - `POST /api/regenerate` – regenerates all media from saved manifest
+  - `GET /api/status` – reports which interfaces are available (studio/insights)
+- **State**: Module-level `_worksheet`, `_sheet_context`, `_generated_artifacts`, `_generated_reels` in [server.py](server.py), initialized by `_init_studio_state()`.
+- **Key function**: `start_combined_server(worksheet, port, default_page)` – registers both Studio and Insights blueprints on one Flask app.
+
+## Insights Builder ([insights.py](insights.py), [insights_server.py](insights_server.py))
+
+- **Opt-in**: CLI flag `--insights`. No spreadsheet required; reads from `clipgen_manifest.json`.
+- **Server**: Served by the same combined Flask server as Studio, at `/insights/`. When `--insights` is used alone (no spreadsheet), only the Insights blueprint is active.
+- **Assets**: Static template in [assets/web/](assets/web/) (`insights-builder.html/js/css` for the builder, `insights-viewer.html/js/css` for the exported viewer). Builder is served by Flask; viewer is generated as a standalone HTML file via `generate_insights_viewer()`.
+- **Data model** ([insights.py](insights.py)):
+  - `load_insights_manifest()` / `save_insights_manifest()` – read/write `insights_manifest.json`
+  - `create_insight()` – returns a new insight dict with all fields initialized
+  - `update_insight()` – merge updates into an existing insight by ID
+  - `delete_insight()` – remove an insight by ID
+- **Insight record**:
+  ```python
+  {
+      "id": "ins_<8hex>",         # Unique ID (uuid4 hex prefix)
+      "title": str,
+      "summary": str,
+      "severity": str,            # Critical/High/Medium/Low/N/A/Positive/Very Positive
+      "status": str,              # "draft" or "final"
+      "createdAt": str,           # ISO 8601 UTC
+      "updatedAt": str,           # ISO 8601 UTC
+      "causes": {"narrative": str, "artifacts": [ids]},
+      "behaviors": {"narrative": str, "artifacts": [ids]},
+      "impacts": {"narrative": str, "artifacts": [ids]},
+      "timelineContext": str,
+  }
+  ```
+- **API endpoints** (all under `/insights/`):
+  - `GET /api/artifacts` – returns artifacts from manifest, enriched with sprite sheet data
+  - `GET/POST /api/insights` – list all or create new insight
+  - `GET/PUT/DELETE /api/insights/<id>` – read, update, or delete a single insight
+  - `POST /api/sprites/generate` – generate missing sprite sheets for clip artifacts
+  - `POST /api/generate-viewer` – export standalone insights viewer HTML
+  - `GET /media/<filename>` – serve artifact media files from output directory
+- **Sprite sheets**: `video.generate_sprite_sheet()` extracts frames at regular intervals and tiles them into a PNG contact sheet for hover-to-scrub previews. Configured by `SPRITE_SHEET_FRAME_COUNT`, `SPRITE_SHEET_THUMB_WIDTH`, `SPRITE_SHEET_MIN_INTERVAL` in [config.py](config.py).
+- **Viewer export**: `finalize_insights_viewer_data()` and `generate_insights_viewer()` in [viewer.py](viewer.py) produce a standalone `insights_viewer.html`. Shows only "final" insights if any exist; otherwise shows all. Only artifacts referenced by visible insights are included.
+- **Manifests**: `clipgen_manifest.json` (artifacts, read-only) and `insights_manifest.json` (insights, read-write) in the output directory.
+
+## Artifact Manifest
+
+- **Opt-in**: CLI flag `--manifest` or `config.MANIFEST_ENABLED = True` via interactive settings.
+- **File**: `clipgen_manifest.json` in the output directory (name from `config.MANIFEST_FILENAME`).
+- **Key functions** in [viewer.py](viewer.py):
+  - `save_manifest(new_artifacts, *, new_reels, study, ...)` – merges new artifacts/reels into existing manifest (deduplicates by `id`; newer entries win) and writes JSON.
+  - `load_manifest_artifacts()` – reads artifact records from manifest, or returns `[]`.
+  - `load_manifest_reels()` – reads reel records from manifest, or returns `[]`.
+- **Regeneration**: `--regenerate` CLI flag invokes `clipgen.regenerate_from_manifest()`, which re-creates media artifacts and reels from manifest entries without a spreadsheet. Skips transcript-type artifacts.
+- **Consumers**: The Insights Builder reads `clipgen_manifest.json` for its media library. Studio can export and regenerate from manifest. The standalone `--viewer` flag (without a mode) also reads from manifest.
+
 ## Transcription ([transcripts.py](transcripts.py))
 
 - **Opt-in**: CLI flag `--transcribe` or `config.TRANSCRIBE_ENABLED = True` via interactive settings.
@@ -213,10 +300,12 @@ Reference spreadsheet layout is described in [README.md](README.md).
 
 ## Version
 
-- The version is stored as `VERSIONNUM` in [config.py](config.py) (currently `'0.9.4'`).
+- The version is stored as `VERSIONNUM` in [config.py](config.py).
 - **When making substantive code changes** (bug fixes or features), increment the **last segment only** (patch) in `config.py`, e.g. `0.9.0` → `0.9.1`. Do not bump for docs-only, comment-only, or refactor-only changes unless they affect user-visible behavior.
 
 ## Testing notes
 
-- There is no test suite in the repo.
+- Run the test suite with `pytest -c tests/pytest.ini` from the project root.
+- Tests cover: CLI argument parsing, CLI mode dispatch, clip pipeline, file/artifact handling, Google/Excel adapters, insights data model, insights API, manifest operations, selectors, spreadsheet generation, studio API, titlecards, transcripts, timestamp utilities, video commands, viewer data, and viewer inlining.
+- Every new CLI mode, flag, or selector should include at least one smoke test in the same PR.
 - With `config.DEBUGGING = True`, icecream is enabled, [video.py](video.py) does not invoke ffmpeg, and [transcripts.py](transcripts.py) returns stub results without loading a Whisper model.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,65 @@ The viewer is a standalone `clips_viewer.html` file written to the same director
 - Filters by category, participant, and artifact type.
 - A detail panel with inline video/image preview.
 
+### Studio
+
+clipgen can launch a web-based Studio interface for interactive artifact generation and reel building from your spreadsheet data.
+
+- **CLI**: Pass `--studio` to launch the Studio. A spreadsheet is required (Google Sheets or Excel):
+
+``` shell
+python clipgen.py --studio
+python clipgen.py --studio -s "My Study"
+```
+
+The Studio opens in your browser at `http://127.0.0.1:8089/studio/` and provides:
+
+- An interactive spreadsheet grid with color-coded timestamp cells.
+- Click cells to queue clips, screenshots, or GIFs for generation; shift-click or right-click cells for reel queue.
+- Format selection: video clip (.mp4), screenshot (.png), or GIF (.gif).
+- Drag-to-reorder reel building from queued cells.
+- Build a timeline viewer or export a manifest from generated artifacts.
+- Regenerate all artifacts from a saved manifest.
+- Dark/light theme toggle.
+
+### Insights Builder
+
+clipgen includes an Insights Builder for authoring structured UX research findings from generated artifacts. No spreadsheet is required — it reads artifacts from a previously saved manifest.
+
+- **CLI**: Pass `--insights` to launch the Insights Builder:
+
+``` shell
+python clipgen.py --insights
+python clipgen.py --insights -i ./output -o ./output
+```
+
+The Insights Builder opens in your browser at `http://127.0.0.1:8089/insights/` and provides:
+
+- A media library sidebar showing all artifacts from `clipgen_manifest.json`, with filters by participant, category, severity, and type.
+- Hover-to-scrub previews via auto-generated sprite sheets.
+- Create, edit, and delete insights with structured sections: causes, behaviors, and impacts — each with narrative text and artifact references.
+- Severity and status (draft/final) per insight.
+- Export to a standalone `insights_viewer.html` file that shows finalized insights with embedded artifact references.
+
+When `--studio` is used, the Insights Builder is also available via the `/insights/` path on the same server, so both interfaces share a single port.
+
+### Manifest
+
+clipgen can write a cumulative artifact manifest (`clipgen_manifest.json`) alongside generated clips. The manifest tracks all artifacts and reels across runs, and is required by the Insights Builder and the `--regenerate` flag.
+
+- **CLI**: Pass `--manifest` alongside any mode flag to enable manifest writing:
+
+``` shell
+python clipgen.py -b --manifest
+python clipgen.py -b --viewer --manifest
+```
+
+To regenerate all media artifacts from a saved manifest (no spreadsheet needed):
+
+``` shell
+python clipgen.py --regenerate
+```
+
 ### About the spreadsheet
 
 clipgen assumes that you are using a spreadsheet with a particular layout. A reference spreadsheet is [available here](https://docs.google.com/spreadsheets/d/1O51wnzRrYyz63tT6qy1HlJyVzdh9RT3t6QL5NohrcPc/edit?usp=sharing) - feel free to make a copy and use it in your studies.


### PR DESCRIPTION
## Summary

- Add user-facing README sections for `--studio`, `--insights`, and `--manifest`/`--regenerate` with CLI examples and feature descriptions
- Add technical CLAUDE.md sections: Studio Web Interface, Insights Builder (data model, API endpoints, insight record structure, sprite sheets), and Artifact Manifest
- Update architecture table and mermaid diagram with `server.py`, `insights.py`, `insights_server.py`
- Add CLI flag documentation for `--studio`, `--insights`, `--manifest`, `--regenerate` and their combinability constraints
- Update config section with 7 new constants, fix stale testing notes, remove hardcoded version string

## Test plan

- [ ] Verify README renders correctly on GitHub (code blocks, bullet lists)
- [ ] Verify CLAUDE.md mermaid diagram renders in GitHub preview
- [ ] Spot-check that documented API endpoints and config values match the code