### PR TITLE
Auto-save manifest on Generate and Build Reel in Studio

### DIFF
--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -65,8 +65,7 @@
       <div class="area-controls">
         <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
         <button id="buildTimelineViewerBtn" class="btn btn-primary">Timeline Viewer</button>
-        <button id="exportManifestBtn" class="btn btn-primary" disabled>Export Manifest</button>
-        <button id="regenerateBtn" class="btn btn-primary">Regenerate from Manifest</button>
+<button id="regenerateBtn" class="btn btn-primary">Regenerate from Manifest</button>
       </div>
       <span id="viewerArtifactCount" style="font-size: 0.75rem; color: var(--color-text-dim);"></span>
     </div>

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -65,7 +65,7 @@
       <div class="area-controls">
         <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
         <button id="buildTimelineViewerBtn" class="btn btn-primary">Timeline Viewer</button>
-<button id="regenerateBtn" class="btn btn-primary">Regenerate from Manifest</button>
+        <button id="regenerateBtn" class="btn btn-primary">Regenerate from Manifest</button>
       </div>
       <span id="viewerArtifactCount" style="font-size: 0.75rem; color: var(--color-text-dim);"></span>
     </div>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -644,7 +644,7 @@
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
     qs("#buildTimelineViewerBtn").addEventListener("click", onBuildTimelineViewer);
-qs("#regenerateBtn").addEventListener("click", onRegenerate);
+    qs("#regenerateBtn").addEventListener("click", onRegenerate);
 
     qs("#statusDismiss").addEventListener("click", hideOverlay);
   }

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -644,8 +644,7 @@
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
     qs("#buildTimelineViewerBtn").addEventListener("click", onBuildTimelineViewer);
-    qs("#exportManifestBtn").addEventListener("click", onExportManifest);
-    qs("#regenerateBtn").addEventListener("click", onRegenerate);
+qs("#regenerateBtn").addEventListener("click", onRegenerate);
 
     qs("#statusDismiss").addEventListener("click", hideOverlay);
   }
@@ -785,34 +784,6 @@
       });
   }
 
-  function onExportManifest() {
-    if (state.generating || state.generatedArtifacts.length === 0) return;
-    state.generating = true;
-
-    showOverlay("Exporting manifest...");
-
-    fetch("api/manifest", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    })
-      .then(function (r) {
-        return r.json();
-      })
-      .then(function (data) {
-        state.generating = false;
-        if (data.ok) {
-          showResult("Manifest exported: " + (data.file || ""), null);
-        } else {
-          showResult(null, data.error || "Manifest export failed");
-        }
-      })
-      .catch(function (err) {
-        state.generating = false;
-        showResult(null, "Request failed: " + err);
-      });
-  }
-
   function onRegenerate() {
     if (state.generating) return;
     state.generating = true;
@@ -847,7 +818,6 @@
   function updateViewerButton() {
     var n = state.generatedArtifacts.length;
     qs("#buildViewerBtn").disabled = n === 0;
-    qs("#exportManifestBtn").disabled = n === 0;
     var count = qs("#viewerArtifactCount");
     count.textContent = n > 0 ? n + " artifact(s) ready" : "";
   }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.34"
+VERSIONNUM: str = "0.9.35"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -122,6 +122,30 @@ def api_sheet() -> FlaskResponse:
     )
 
 
+def _save_manifest_quiet() -> None:
+    """Save manifest after generate/reel; swallow errors so the caller still succeeds."""
+    try:
+        artifacts = _generated_artifacts
+        reels = _generated_reels
+        if not artifacts and not reels:
+            return
+        study = ""
+        if artifacts:
+            study = artifacts[0].get("study", "")
+        elif reels:
+            study = reels[0].get("study", "")
+        viewer.save_manifest(
+            artifacts,
+            new_reels=reels or None,
+            study=study,
+            worksheet_title=getattr(_worksheet, "title", ""),
+            is_excel=clipgen._is_excel_worksheet(_worksheet) if _worksheet else False,
+            mode="studio",
+        )
+    except Exception:
+        pass
+
+
 @studio_bp.route("/api/generate", methods=["POST"])
 def api_generate() -> FlaskResponse:
     if _worksheet is None:
@@ -155,6 +179,7 @@ def api_generate() -> FlaskResponse:
 
         generated, artifacts = clipgen.process_clips(clips, output_format=output_format)
         _generated_artifacts.extend(artifacts)
+        _save_manifest_quiet()
 
         return jsonify({"ok": True, "generated": generated, "artifacts": artifacts})
 
@@ -185,6 +210,7 @@ def api_reel() -> FlaskResponse:
 
         generated, reel_records = clipgen.process_reel(clips)
         _generated_reels.extend(reel_records)
+        _save_manifest_quiet()
         return jsonify({"ok": True, "generated": generated, "reels": reel_records})
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Manifest is now saved automatically after each successful Generate or Build Reel action in Studio, removing the need for a manual export step.
- The Export Manifest button has been removed from the Studio UI.
- A `_save_manifest_quiet()` helper in `server.py` handles the save silently so generate/reel responses are never disrupted by manifest errors.