### PR TITLE
Add Quick Actions panel to Studio with Highlights Reel builder

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -366,7 +366,7 @@ col.col-participant-col {
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0 0 18px 18px;
+  border-radius: 0;
   box-shadow: 0 24px 60px var(--color-panel-shadow);
   padding: 1rem 1.5rem 1.5rem;
   display: grid;
@@ -572,6 +572,73 @@ col.col-participant-col {
   margin-bottom: 0.5rem;
 }
 
+/* Quick Actions */
+
+#quickActions {
+  max-width: 1120px;
+  margin: 0 auto;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-top: none;
+  border-radius: 0 0 18px 18px;
+  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+#quickActions h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+
+.quick-actions-grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.quick-action-card {
+  flex: 1;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+}
+
+.quick-action-info strong {
+  font-size: 0.82rem;
+  display: block;
+  margin-bottom: 0.15rem;
+}
+
+.quick-action-info span {
+  font-size: 0.78rem;
+  color: var(--color-text-dim);
+}
+
+.quick-action-label {
+  font-size: 0.75rem;
+  color: var(--color-text-dim);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.quick-action-input {
+  width: 5rem;
+  padding: 0.3rem 0.4rem;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.78rem;
+  font-family: var(--font-mono);
+}
+
 /* Status overlay */
 
 #statusOverlay {
@@ -705,7 +772,8 @@ html[data-theme="dark"] .status-card {
 @media (max-width: 768px) {
   #studioHeader,
   #sheetPreview,
-  #dropAreas {
+  #dropAreas,
+  #quickActions {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
     max-width: 100%;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -61,14 +61,40 @@
 
     <div id="viewerArea" class="drop-area">
       <h3>Viewers</h3>
-      <p>Build Viewer requires generated artifacts. Timeline Viewer runs a full batch export. Regenerate re-creates media from a saved manifest.</p>
+      <p>Build Viewer requires generated artifacts. Timeline Viewer runs a full batch export.</p>
       <div class="area-controls">
         <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
         <button id="buildTimelineViewerBtn" class="btn btn-primary">Timeline Viewer</button>
         <button id="exportManifestBtn" class="btn btn-primary" disabled>Export Manifest</button>
-        <button id="regenerateBtn" class="btn btn-primary">Regenerate from Manifest</button>
       </div>
       <span id="viewerArtifactCount" style="font-size: 0.75rem; color: var(--color-text-dim);"></span>
+    </div>
+  </section>
+
+  <section id="quickActions">
+    <h3>Quick Actions</h3>
+    <div class="quick-actions-grid">
+      <div class="quick-action-card">
+        <div class="quick-action-info">
+          <strong>Build Highlights Reel</strong>
+          <span>Auto-select the best clips scored by severity, uniqueness, and keyword annotations.</span>
+        </div>
+        <div class="area-controls">
+          <label class="quick-action-label">Duration (s)
+            <input id="highlightsDuration" type="number" min="10" step="10" value="180" class="quick-action-input">
+          </label>
+          <button id="buildHighlightsBtn" class="btn btn-primary">Build Highlights</button>
+        </div>
+      </div>
+      <div class="quick-action-card">
+        <div class="quick-action-info">
+          <strong>Regenerate from Manifest</strong>
+          <span>Re-create all media artifacts and reels from a saved manifest file.</span>
+        </div>
+        <div class="area-controls">
+          <button id="regenerateBtn" class="btn btn-primary">Regenerate</button>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -133,6 +133,10 @@
         state.sheetData = data;
         renderHeader();
         renderGrid();
+        var durInput = qs("#highlightsDuration");
+        if (durInput && data.highlightsDuration) {
+          durInput.value = data.highlightsDuration;
+        }
       })
       .catch(function (err) {
         qs("#sheetLoading").textContent = "Failed to load sheet: " + err;
@@ -646,6 +650,7 @@
     qs("#buildTimelineViewerBtn").addEventListener("click", onBuildTimelineViewer);
     qs("#exportManifestBtn").addEventListener("click", onExportManifest);
     qs("#regenerateBtn").addEventListener("click", onRegenerate);
+    qs("#buildHighlightsBtn").addEventListener("click", onBuildHighlights);
 
     qs("#statusDismiss").addEventListener("click", hideOverlay);
   }
@@ -836,6 +841,40 @@
           );
         } else {
           showResult(null, data.error || "Regeneration failed");
+        }
+      })
+      .catch(function (err) {
+        state.generating = false;
+        showResult(null, "Request failed: " + err);
+      });
+  }
+
+  function onBuildHighlights() {
+    if (state.generating) return;
+    state.generating = true;
+
+    var duration = parseInt(qs("#highlightsDuration").value, 10);
+    if (!duration || duration < 1) duration = 180;
+
+    showOverlay("Building highlights reel (" + duration + "s budget)...");
+
+    fetch("api/reel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        cells: ["highlights", "batch"],
+        highlights_duration: duration,
+      }),
+    })
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (data) {
+        state.generating = false;
+        if (data.ok) {
+          showResult("Highlights reel built successfully", null);
+        } else {
+          showResult(null, data.error || "Highlights reel build failed");
         }
       })
       .catch(function (err) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.34"
+VERSIONNUM: str = "0.9.35"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -116,6 +116,7 @@ def api_sheet() -> FlaskResponse:
             "ok": True,
             "study": ctx.study_name,
             "version": config.VERSIONNUM,
+            "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
             "participants": participants,
             "rows": rows,
         }
@@ -169,15 +170,30 @@ def api_reel() -> FlaskResponse:
 
     data = request.get_json(silent=True) or {}
     cell_strings = data.get("cells", [])
+    highlights_duration = data.get("highlights_duration")
 
     if not cell_strings:
         return jsonify({"ok": False, "error": "No cells specified"}), 400
 
     try:
         reel_input = ", ".join(cell_strings)
-        clips = spreadsheet.generate_list(
-            _worksheet, "reel", reel_input=reel_input, skip_prompts=True
-        )
+
+        original_duration = config.HIGHLIGHTS_REEL_DURATION_SECONDS
+        if highlights_duration is not None:
+            try:
+                val = int(highlights_duration)
+                if val > 0:
+                    config.HIGHLIGHTS_REEL_DURATION_SECONDS = val
+            except (ValueError, TypeError):
+                pass
+
+        try:
+            clips = spreadsheet.generate_list(
+                _worksheet, "reel", reel_input=reel_input, skip_prompts=True
+            )
+        finally:
+            config.HIGHLIGHTS_REEL_DURATION_SECONDS = original_duration
+
         if not clips:
             return jsonify(
                 {"ok": False, "error": "No clips found for the specified cells"}

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -50,6 +50,57 @@ def test_api_generate_400_for_invalid_format(client, monkeypatch):
     assert "Invalid format" in data["error"]
 
 
+def test_api_reel_400_when_no_cells(client, monkeypatch):
+    monkeypatch.setattr(server, "_worksheet", object())
+    resp = client.post("/studio/api/reel", json={"cells": []})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "No cells" in data["error"]
+
+
+def test_api_reel_highlights_duration_override(client, monkeypatch):
+    """highlights_duration temporarily overrides config and is restored after."""
+    import config
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    original = config.HIGHLIGHTS_REEL_DURATION_SECONDS
+    captured = {}
+
+    def fake_generate_list(ws, mode, *, reel_input, skip_prompts):
+        captured["duration"] = config.HIGHLIGHTS_REEL_DURATION_SECONDS
+        return []
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+
+    resp = client.post(
+        "/studio/api/reel",
+        json={"cells": ["highlights", "batch"], "highlights_duration": 120},
+    )
+    assert resp.status_code == 400  # no clips → 400
+    assert captured["duration"] == 120
+    assert config.HIGHLIGHTS_REEL_DURATION_SECONDS == original
+
+
+def test_api_reel_highlights_duration_restored_on_error(client, monkeypatch):
+    """Config is restored even if generate_list raises."""
+    import config
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    original = config.HIGHLIGHTS_REEL_DURATION_SECONDS
+
+    def raise_generate_list(ws, mode, *, reel_input, skip_prompts):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("spreadsheet.generate_list", raise_generate_list)
+
+    resp = client.post(
+        "/studio/api/reel",
+        json={"cells": ["highlights"], "highlights_duration": 999},
+    )
+    assert resp.status_code == 500
+    assert config.HIGHLIGHTS_REEL_DURATION_SECONDS == original
+
+
 def test_api_viewer_400_when_no_artifacts(client):
     resp = client.post("/studio/api/viewer")
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- Adds a new **Quick Actions** section below the Studio grid for self-contained operations that don't require cell selection
- First action: **Build Highlights Reel** with a configurable duration input (prefilled from `config.HIGHLIGHTS_REEL_DURATION_SECONDS`)
- Moves **Regenerate from Manifest** from the Viewers area into Quick Actions with its own description card
- Extends `/api/reel` to accept an optional `highlights_duration` parameter, temporarily overriding the config value (restored via `try/finally`)
- Adds tests verifying the duration override is applied during generation and always restored, even on errors

## Test plan
- [x] All 149 existing tests pass
- [ ] Launch Studio and verify Quick Actions panel renders below the grid
- [ ] Verify duration input is prefilled with 180 (or custom config value)
- [ ] Click Build Highlights and confirm it triggers a highlights reel build
- [ ] Confirm Regenerate button works from its new location
- [ ] Verify responsive layout stacks cards on narrow viewports