### PR TITLE
Add thumbnail timeline to Studio reel builder

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -370,7 +370,7 @@ col.col-participant-col {
   box-shadow: 0 24px 60px var(--color-panel-shadow);
   padding: 1rem 1.5rem 1.5rem;
   display: grid;
-  grid-template-columns: 1fr 1fr 0.6fr;
+  grid-template-columns: 1fr 0.6fr;
   gap: 1rem;
 }
 
@@ -483,27 +483,175 @@ col.col-participant-col {
   color: #dc2626;
 }
 
-/* Reel drag handle */
+/* Reel timeline */
 
-.reel-handle {
-  cursor: grab;
+#reelArea {
+  max-width: 1120px;
+  margin: 0 auto;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-top: none;
+  border-radius: 0;
+  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+#reelArea h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+#reelArea h3 span {
+  font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
+}
+
+#reelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+#reelList {
+  flex-direction: row;
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-height: none;
+  min-height: 100px;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+#reelDuration {
+  font-weight: 400;
+  font-size: 0.78rem;
+  color: var(--color-text-dim);
+}
+
+.reel-card {
   flex-shrink: 0;
+  width: 140px;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  overflow: hidden;
+  cursor: grab;
+  position: relative;
+  transition: box-shadow 0.15s, border-color 0.15s;
   user-select: none;
 }
 
-.reel-handle:active {
+.reel-card:active {
   cursor: grabbing;
 }
 
-.reel-order {
+.reel-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.reel-card-thumb {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: var(--color-surface-alt);
+  overflow: hidden;
+}
+
+.reel-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.reel-card-duration {
+  position: absolute;
+  bottom: 3px;
+  right: 3px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 0.62rem;
   font-family: var(--font-mono);
+  padding: 1px 4px;
+  border-radius: 3px;
+  line-height: 1.3;
+}
+
+.reel-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.35rem;
   font-size: 0.7rem;
+}
+
+.reel-card-order {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
   color: var(--color-text-dim);
-  min-width: 1.2rem;
+  min-width: 1rem;
   text-align: center;
-  flex-shrink: 0;
+}
+
+.reel-card-ref {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 0.7rem;
+}
+
+.reel-card-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  font-size: 0.7rem;
+  line-height: 18px;
+  text-align: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+  padding: 0;
+}
+
+.reel-card:hover .reel-card-remove {
+  opacity: 1;
+}
+
+.reel-card-remove:hover {
+  background: #dc2626;
+}
+
+.reel-card.reel-card-error {
+  border-color: #dc2626;
+  background: #fef2f2;
+}
+
+.reel-card.reel-card-error .reel-card-thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #dc2626;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+html[data-theme="dark"] .reel-card.reel-card-error {
+  background: #451a1a;
+}
+
+html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
+  color: #f87171;
 }
 
 /* Area controls */
@@ -773,6 +921,7 @@ html[data-theme="dark"] .status-card {
   #studioHeader,
   #sheetPreview,
   #dropAreas,
+  #reelArea,
   #quickActions {
     margin-left: 0.5rem;
     margin-right: 0.5rem;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -48,17 +48,6 @@
       </div>
     </div>
 
-    <div id="reelArea" class="drop-area">
-      <h3>Reel <span id="reelCount">(0)</span></h3>
-      <div id="reelList" class="drop-target">
-        <div class="drop-target-empty">Shift+click or drag cells here to build a reel</div>
-      </div>
-      <div class="area-controls">
-        <button id="buildReelBtn" class="btn btn-primary" disabled>Build Reel</button>
-        <button id="clearReelBtn" class="btn btn-small">Clear</button>
-      </div>
-    </div>
-
     <div id="viewerArea" class="drop-area">
       <h3>Viewers</h3>
       <p>Build Viewer requires generated artifacts. Timeline Viewer runs a full batch export.</p>
@@ -67,6 +56,19 @@
         <button id="buildTimelineViewerBtn" class="btn btn-primary">Timeline Viewer</button>
       </div>
       <span id="viewerArtifactCount" style="font-size: 0.75rem; color: var(--color-text-dim);"></span>
+    </div>
+  </section>
+
+  <section id="reelArea">
+    <div id="reelHeader">
+      <h3>Reel <span id="reelCount">(0)</span> <span id="reelDuration"></span></h3>
+      <div class="area-controls">
+        <button id="buildReelBtn" class="btn btn-primary" disabled>Build Reel</button>
+        <button id="clearReelBtn" class="btn btn-small">Clear</button>
+      </div>
+    </div>
+    <div id="reelList" class="drop-target">
+      <div class="drop-target-empty">Shift+click or drag cells here to build a reel</div>
     </div>
   </section>
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -61,6 +61,73 @@
     return -1;
   }
 
+  function parseTimestampToSeconds(ts) {
+    var parts = ts.split(":");
+    if (parts.length === 3)
+      return (
+        parseInt(parts[0], 10) * 3600 +
+        parseInt(parts[1], 10) * 60 +
+        parseInt(parts[2], 10)
+      );
+    if (parts.length === 2)
+      return parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
+    return NaN;
+  }
+
+  function parseClipTimestamp(raw) {
+    var DEFAULT_DUR = 60;
+    var cleaned = raw
+      .toLowerCase()
+      .replace(/!key/g, "")
+      .replace(/[+;,]/g, " ");
+    var tokens = cleaned.split(/\s+/).filter(function (t) {
+      return t && t !== "x";
+    });
+    var firstStart = NaN;
+    var totalDur = 0;
+    for (var i = 0; i < tokens.length; i++) {
+      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
+      var dashIdx = -1;
+      for (var d = 1; d < tok.length; d++) {
+        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") {
+          dashIdx = d;
+          break;
+        }
+      }
+      if (dashIdx > 0) {
+        var s = parseTimestampToSeconds(tok.substring(0, dashIdx));
+        var e = parseTimestampToSeconds(tok.substring(dashIdx + 1));
+        if (!isNaN(s) && !isNaN(e)) {
+          if (isNaN(firstStart)) firstStart = s;
+          totalDur += Math.max(0, e - s);
+        }
+      } else if (tok.indexOf(":") > 0) {
+        var sec = parseTimestampToSeconds(tok);
+        if (!isNaN(sec)) {
+          if (isNaN(firstStart)) firstStart = sec;
+          totalDur += DEFAULT_DUR;
+        }
+      }
+    }
+    return {
+      startSeconds: isNaN(firstStart) ? 0 : Math.floor(firstStart),
+      totalDuration: totalDur || DEFAULT_DUR,
+    };
+  }
+
+  function formatDuration(secs) {
+    secs = Math.round(secs);
+    if (secs >= 3600) {
+      var h = Math.floor(secs / 3600);
+      var m = Math.floor((secs % 3600) / 60);
+      var s = secs % 60;
+      return h + ":" + (m < 10 ? "0" : "") + m + ":" + (s < 10 ? "0" : "") + s;
+    }
+    var m2 = Math.floor(secs / 60);
+    var s2 = secs % 60;
+    return m2 + ":" + (s2 < 10 ? "0" : "") + s2;
+  }
+
   // ---- Theme ----
 
   function initThemeToggle() {
@@ -522,7 +589,7 @@
     var list = qs("#reelList");
 
     list.addEventListener("dragstart", function (ev) {
-      var item = ev.target.closest(".queue-item[data-reel-idx]");
+      var item = ev.target.closest(".reel-card[data-reel-idx]");
       if (!item) return;
       _reelDragIdx = parseInt(item.getAttribute("data-reel-idx"), 10);
       ev.dataTransfer.effectAllowed = "move";
@@ -530,7 +597,7 @@
     });
 
     list.addEventListener("dragover", function (ev) {
-      var item = ev.target.closest(".queue-item[data-reel-idx]");
+      var item = ev.target.closest(".reel-card[data-reel-idx]");
       if (item && _reelDragIdx !== null) {
         ev.preventDefault();
         ev.dataTransfer.dropEffect = "move";
@@ -538,7 +605,7 @@
     });
 
     list.addEventListener("drop", function (ev) {
-      var item = ev.target.closest(".queue-item[data-reel-idx]");
+      var item = ev.target.closest(".reel-card[data-reel-idx]");
       if (!item || _reelDragIdx === null) return;
       ev.preventDefault();
       var toIdx = parseInt(item.getAttribute("data-reel-idx"), 10);
@@ -578,29 +645,66 @@
 
   function renderReelQueue() {
     var list = qs("#reelList");
-    qs("#reelCount").textContent = "(" + state.reelQueue.length + ")";
-    qs("#buildReelBtn").disabled = state.reelQueue.length === 0;
+    var n = state.reelQueue.length;
+    qs("#reelCount").textContent = "(" + n + ")";
+    qs("#buildReelBtn").disabled = n === 0;
     list.innerHTML = "";
 
-    if (state.reelQueue.length === 0) {
+    if (n === 0) {
       list.appendChild(
         el("div", "drop-target-empty", "Shift+click or drag cells here to build a reel")
       );
+      qs("#reelDuration").textContent = "";
       return;
     }
 
-    for (var i = 0; i < state.reelQueue.length; i++) {
+    var totalDur = 0;
+    for (var i = 0; i < n; i++) {
       var item = state.reelQueue[i];
-      var row = makeQueueItem(item, i, "reel");
-      row.setAttribute("data-reel-idx", i);
-      row.setAttribute("draggable", "true");
+      var parsed = parseClipTimestamp(item.timestamp);
+      totalDur += parsed.totalDuration;
 
-      var handle = el("span", "reel-handle", "\u2261");
-      var order = el("span", "reel-order", String(i + 1));
-      row.insertBefore(order, row.firstChild);
-      row.insertBefore(handle, row.firstChild);
-      list.appendChild(row);
+      var card = el("div", "reel-card");
+      card.setAttribute("data-reel-idx", i);
+      card.setAttribute("draggable", "true");
+
+      var thumb = el("div", "reel-card-thumb");
+      var img = document.createElement("img");
+      img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + parsed.startSeconds;
+      img.loading = "lazy";
+      img.alt = "";
+      img.draggable = false;
+      (function (cardEl, thumbEl) {
+        img.addEventListener("error", function () {
+          this.remove();
+          thumbEl.appendChild(el("span", "", "\u2715"));
+          cardEl.classList.add("reel-card-error");
+        });
+      })(card, thumb);
+      thumb.appendChild(img);
+      thumb.appendChild(el("span", "reel-card-duration", formatDuration(parsed.totalDuration)));
+      card.appendChild(thumb);
+
+      var meta = el("div", "reel-card-meta");
+      meta.appendChild(el("span", "reel-card-order", String(i + 1)));
+      meta.appendChild(el("span", "reel-card-ref", item.participant + "." + item.row));
+      card.appendChild(meta);
+
+      var removeBtn = el("button", "reel-card-remove", "\u00D7");
+      removeBtn.title = "Remove";
+      (function (idx) {
+        removeBtn.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          state.reelQueue.splice(idx, 1);
+          renderReelQueue();
+          updateCellClasses();
+        });
+      })(i);
+      card.appendChild(removeBtn);
+
+      list.appendChild(card);
     }
+    qs("#reelDuration").textContent = formatDuration(totalDur);
   }
 
   function makeQueueItem(item, idx, type) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.35"
+VERSIONNUM: str = "0.9.36"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [
@@ -89,6 +89,7 @@ INSIGHTS_MANIFEST_FILENAME: str = "insights_manifest.json"
 SPRITE_SHEET_FRAME_COUNT: int = 20
 SPRITE_SHEET_THUMB_WIDTH: int = 160
 SPRITE_SHEET_MIN_INTERVAL: int = 1
+STUDIO_THUMBNAIL_WIDTH: int = 200
 
 # Highlights reel constants
 HIGHLIGHTS_REEL_DURATION_SECONDS: int = 180  # 3-minute budget for highlights reel

--- a/server.py
+++ b/server.py
@@ -23,8 +23,10 @@ from flask import (
 
 import clipgen
 import config
+import files
 import spreadsheet
 import utils
+import video
 import viewer
 
 FlaskResponse = Union[Response, Tuple[Response, int]]
@@ -35,6 +37,7 @@ _worksheet: Any = None
 _sheet_context: Optional[spreadsheet.SheetContext] = None
 _generated_artifacts: List[Dict[str, Any]] = []
 _generated_reels: List[Dict[str, Any]] = []
+_thumbnail_cache: Dict[tuple, bytes] = {}
 
 _assets_dir = Path(__file__).resolve().parent / "assets" / "web"
 
@@ -56,7 +59,66 @@ def serve_static(filename: str) -> FlaskResponse:
     return send_from_directory(_assets_dir, filename)
 
 
+# ---- Helpers ----
+
+
+def _resolve_source_video(participant: str) -> Optional[Path]:
+    """Return the resolved path to a participant's source video, or None."""
+    if _sheet_context is None:
+        return None
+    ctx = _sheet_context
+    participants = spreadsheet.get_participant_list(
+        ctx.header_row, ctx.id_cell, ctx.num_participants
+    )
+    if participant not in participants:
+        return None
+    p_idx = participants.index(participant)
+    col_idx = ctx.id_cell.col + p_idx
+
+    override = None
+    if ctx.filename_row_idx is not None:
+        row_data = ctx.sheet_data[ctx.filename_row_idx]
+        if col_idx < len(row_data) and row_data[col_idx].strip():
+            override = row_data[col_idx].strip()
+
+    filename = files.get_source_video_filename(ctx.study_name, participant, override)
+    return utils.resolve_input_path(filename)
+
+
 # ---- API endpoints ----
+
+
+@studio_bp.route("/api/thumbnail/<participant>/<int:start_seconds>")
+def api_thumbnail(participant: str, start_seconds: int) -> FlaskResponse:
+    if _sheet_context is None:
+        return jsonify({"ok": False, "error": "No sheet loaded"}), 500
+
+    start_seconds = max(0, start_seconds)
+    video_path = _resolve_source_video(participant)
+    if video_path is None or not video_path.is_file():
+        return jsonify({"ok": False, "error": "Source video not found"}), 404
+
+    cache_key = (str(video_path), start_seconds)
+    cached = _thumbnail_cache.get(cache_key)
+    if cached is not None:
+        return Response(
+            cached,
+            mimetype="image/jpeg",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+    jpeg_bytes = video.extract_thumbnail_bytes(
+        str(video_path), start_seconds, width=config.STUDIO_THUMBNAIL_WIDTH
+    )
+    if jpeg_bytes is None:
+        return jsonify({"ok": False, "error": "Thumbnail extraction failed"}), 404
+
+    _thumbnail_cache[cache_key] = jpeg_bytes
+    return Response(
+        jpeg_bytes,
+        mimetype="image/jpeg",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 @studio_bp.route("/api/sheet")
@@ -369,12 +431,13 @@ def api_regenerate() -> FlaskResponse:
 
 def _init_studio_state(worksheet: Any) -> None:
     """Initialize module-level state for Studio routes."""
-    global _worksheet, _sheet_context, _generated_artifacts, _generated_reels
+    global _worksheet, _sheet_context, _generated_artifacts, _generated_reels, _thumbnail_cache
 
     _worksheet = worksheet
     _sheet_context = spreadsheet.build_sheet_context(worksheet)
     _generated_artifacts = []
     _generated_reels = []
+    _thumbnail_cache = {}
 
     if _sheet_context is None:
         utils.error_print("Could not load spreadsheet data for Studio.")

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -101,6 +101,77 @@ def test_api_reel_highlights_duration_restored_on_error(client, monkeypatch):
     assert config.HIGHLIGHTS_REEL_DURATION_SECONDS == original
 
 
+def test_api_thumbnail_500_when_no_context(client):
+    resp = client.get("/studio/api/thumbnail/P01/0")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert "No sheet loaded" in data["error"]
+
+
+def test_api_thumbnail_returns_jpeg(client, monkeypatch, tmp_path):
+    import types
+
+    import video
+
+    fake_jpeg = b"\xff\xd8\xff\xe0fake-jpeg-data"
+    dummy_video = tmp_path / "study_P01.mp4"
+    dummy_video.write_bytes(b"not a real video")
+
+    ctx = types.SimpleNamespace(
+        header_row=["ID", "P01"],
+        id_cell=types.SimpleNamespace(col=1),
+        num_participants=1,
+        study_name="study",
+        filename_row_idx=None,
+        sheet_data=[],
+    )
+    monkeypatch.setattr(server, "_sheet_context", ctx)
+    monkeypatch.setattr(server, "_thumbnail_cache", {})
+    monkeypatch.setattr("utils.resolve_input_path", lambda name: dummy_video)
+    monkeypatch.setattr(video, "extract_thumbnail_bytes", lambda *a, **kw: fake_jpeg)
+
+    resp = client.get("/studio/api/thumbnail/P01/10")
+    assert resp.status_code == 200
+    assert resp.content_type == "image/jpeg"
+    assert resp.data == fake_jpeg
+
+
+def test_api_thumbnail_caches(client, monkeypatch, tmp_path):
+    import types
+
+    import video
+
+    call_count = [0]
+    fake_jpeg = b"\xff\xd8\xff\xe0cached"
+    dummy_video = tmp_path / "study_P01.mp4"
+    dummy_video.write_bytes(b"x")
+
+    ctx = types.SimpleNamespace(
+        header_row=["ID", "P01"],
+        id_cell=types.SimpleNamespace(col=1),
+        num_participants=1,
+        study_name="study",
+        filename_row_idx=None,
+        sheet_data=[],
+    )
+    monkeypatch.setattr(server, "_sheet_context", ctx)
+    monkeypatch.setattr(server, "_thumbnail_cache", {})
+    monkeypatch.setattr("utils.resolve_input_path", lambda name: dummy_video)
+
+    def counting_extract(*a, **kw):
+        call_count[0] += 1
+        return fake_jpeg
+
+    monkeypatch.setattr(video, "extract_thumbnail_bytes", counting_extract)
+
+    resp1 = client.get("/studio/api/thumbnail/P01/5")
+    resp2 = client.get("/studio/api/thumbnail/P01/5")
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert call_count[0] == 1
+
+
 def test_api_viewer_400_when_no_artifacts(client):
     resp = client.post("/studio/api/viewer")
     assert resp.status_code == 400

--- a/video.py
+++ b/video.py
@@ -372,6 +372,57 @@ def extract_screenshot(input_file: str, output_file: str, timestamp: str) -> boo
     return True
 
 
+def extract_thumbnail_bytes(
+    input_file: str,
+    start_seconds: int,
+    *,
+    width: int = 200,
+) -> Optional[bytes]:
+    """Extract a small JPEG thumbnail frame from a video at *start_seconds*.
+
+    Uses fast input seeking (``-ss`` before ``-i``) so performance is
+    independent of file size.  Returns raw JPEG bytes on success or
+    ``None`` on any failure.
+    """
+    if config.DEBUGGING:
+        ic(input_file, start_seconds, width)
+        return None
+
+    if not Path(input_file).is_file():
+        return None
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-loglevel",
+        config.FFMPEG_LOGLEVEL,
+        "-ss",
+        str(max(0, start_seconds)),
+        "-i",
+        input_file,
+        "-vframes",
+        "1",
+        "-vf",
+        f"scale={width}:-1",
+        "-f",
+        "image2pipe",
+        "-vcodec",
+        "mjpeg",
+        "-q:v",
+        "5",
+        "pipe:1",
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=15)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout
+
+
 def extract_gif(
     input_file: str, output_file: str, timestamp: str, duration_seconds: int
 ) -> bool:


### PR DESCRIPTION
## Summary

- Replaces the flat text list in the Studio reel builder with a horizontal filmstrip timeline showing thumbnail previews extracted from source video files
- Adds `video.extract_thumbnail_bytes()` using fast ffmpeg input seeking (`-ss` before `-i`) for O(1) performance on large files, with server-side in-memory caching
- Moves the reel area to a full-width section below the artifacts/viewers panel for proper horizontal space
- Handles failed thumbnails gracefully with red-tinted error cards instead of broken image references
- Adds 3 new tests for the thumbnail endpoint (context check, JPEG response, caching behavior)

## Test plan

- [ ] Run `uv run pytest -c tests/pytest.ini` — all 152 tests pass
- [ ] Launch Studio with `uv run clipgen.py --studio -s <spreadsheet>` and source videos present
- [ ] Shift+click cells into reel — thumbnails load in horizontal filmstrip
- [ ] Drag to reorder cards, remove via hover X button, clear all
- [ ] Add cells with bad timestamps — verify red error cards with X shown (no broken images)
- [ ] Build Reel still works as before