### PR TITLE
Add drag-and-drop between Studio areas and thumbnail artifact cards

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -423,64 +423,125 @@ col.col-participant-col {
   text-align: center;
 }
 
-/* Queue items */
+/* Artifact cards */
 
-.queue-item {
-  display: flex;
-  align-items: center;
+#artifactsArea {
+  min-width: 0;
+}
+
+#artifactsList {
+  flex-direction: row;
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-height: none;
+  min-height: 100px;
   gap: 0.5rem;
-  padding: 0.35rem 0.5rem;
-  background: var(--color-surface);
+  padding: 0.5rem;
+}
+
+.artifact-card {
+  flex-shrink: 0;
+  width: 140px;
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
-  font-size: 0.78rem;
-  transition: background-color 0.1s;
+  background: var(--color-surface);
+  overflow: hidden;
+  cursor: grab;
+  position: relative;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  user-select: none;
 }
 
-.queue-item:hover {
+.artifact-card:active {
+  cursor: grabbing;
+}
+
+.artifact-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.artifact-card-thumb {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
   background: var(--color-surface-alt);
+  overflow: hidden;
 }
 
-.queue-item-ref {
+.artifact-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.artifact-card-duration {
+  position: absolute;
+  bottom: 3px;
+  right: 3px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 0.62rem;
+  font-family: var(--font-mono);
+  padding: 1px 4px;
+  border-radius: 3px;
+  line-height: 1.3;
+}
+
+.artifact-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.7rem;
+}
+
+.artifact-card-ref {
   font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.75rem;
-  background: var(--color-surface-alt);
-  padding: 0.1rem 0.4rem;
-  border-radius: 4px;
-  white-space: nowrap;
-  flex-shrink: 0;
+  font-size: 0.7rem;
 }
 
-.queue-item-desc {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--color-text-dim);
-}
-
-.queue-item-ts {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  color: var(--color-text-dim);
-  flex-shrink: 0;
-}
-
-.queue-item-remove {
-  background: none;
+.artifact-card-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
   border: none;
-  color: var(--color-text-dim);
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  font-size: 0.7rem;
+  line-height: 18px;
+  text-align: center;
   cursor: pointer;
-  font-size: 0.85rem;
-  padding: 0 0.2rem;
-  line-height: 1;
-  flex-shrink: 0;
-  transition: color 0.15s;
+  opacity: 0;
+  transition: opacity 0.15s;
+  padding: 0;
 }
 
-.queue-item-remove:hover {
+.artifact-card:hover .artifact-card-remove {
+  opacity: 1;
+}
+
+.artifact-card-remove:hover {
+  background: #dc2626;
+}
+
+.artifact-card.artifact-card-error {
+  border-color: #dc2626;
+  background: #fef2f2;
+}
+
+.artifact-card.artifact-card-error .artifact-card-thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: #dc2626;
+  font-size: 1.4rem;
+  font-weight: 700;
 }
 
 /* Reel timeline */
@@ -710,6 +771,16 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
 .btn-small {
   padding: 0.25rem 0.6rem;
   font-size: 0.72rem;
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.btn-icon svg {
+  flex-shrink: 0;
 }
 
 /* Viewer area */

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -38,6 +38,12 @@
         <div class="drop-target-empty">Click or drag cells here to queue for generation</div>
       </div>
       <div class="area-controls">
+        <button id="addToReelBtn" class="btn btn-small btn-icon" disabled>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3.5 8h9M9 4.5L12.5 8 9 11.5"/>
+          </svg>
+          Add to Reel
+        </button>
         <select id="artifactFormat">
           <option value="clip">Clip (.mp4)</option>
           <option value="screen">Screenshot (.png)</option>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -549,11 +549,24 @@
 
   // ---- Drop targets ----
 
+  function removeFromQueue(queue, participant, row) {
+    var idx = findInQueue(queue, participant, row);
+    if (idx >= 0) queue.splice(idx, 1);
+  }
+
   function initDropTargets() {
     setupDropTarget(qs("#artifactsList"), function (info) {
+      if (info.source === "reel") {
+        removeFromQueue(state.reelQueue, info.participant, info.row);
+        renderReelQueue();
+      }
       addToQueue(state.artifactQueue, info, renderArtifactQueue);
     });
     setupDropTarget(qs("#reelList"), function (info) {
+      if (info.source === "artifact") {
+        removeFromQueue(state.artifactQueue, info.participant, info.row);
+        renderArtifactQueue();
+      }
       addToQueue(state.reelQueue, info, renderReelQueue);
     });
   }
@@ -589,11 +602,22 @@
     var list = qs("#reelList");
 
     list.addEventListener("dragstart", function (ev) {
-      var item = ev.target.closest(".reel-card[data-reel-idx]");
-      if (!item) return;
-      _reelDragIdx = parseInt(item.getAttribute("data-reel-idx"), 10);
-      ev.dataTransfer.effectAllowed = "move";
+      var card = ev.target.closest(".reel-card[data-reel-idx]");
+      if (!card) return;
+      _reelDragIdx = parseInt(card.getAttribute("data-reel-idx"), 10);
+      ev.dataTransfer.effectAllowed = "copyMove";
       ev.dataTransfer.setData("text/plain", String(_reelDragIdx));
+      var reelItem = state.reelQueue[_reelDragIdx];
+      if (reelItem) {
+        var data = {
+          participant: reelItem.participant,
+          row: reelItem.row,
+          desc: reelItem.desc,
+          timestamp: reelItem.timestamp,
+          source: "reel",
+        };
+        ev.dataTransfer.setData("application/json", JSON.stringify(data));
+      }
     });
 
     list.addEventListener("dragover", function (ev) {
@@ -626,20 +650,73 @@
 
   function renderArtifactQueue() {
     var list = qs("#artifactsList");
-    qs("#artifactsCount").textContent = "(" + state.artifactQueue.length + ")";
-    qs("#generateBtn").disabled = state.artifactQueue.length === 0;
+    var n = state.artifactQueue.length;
+    qs("#artifactsCount").textContent = "(" + n + ")";
+    qs("#generateBtn").disabled = n === 0;
+    qs("#addToReelBtn").disabled = n === 0;
     list.innerHTML = "";
 
-    if (state.artifactQueue.length === 0) {
+    if (n === 0) {
       list.appendChild(
         el("div", "drop-target-empty", "Click or drag cells here to queue for generation")
       );
       return;
     }
 
-    for (var i = 0; i < state.artifactQueue.length; i++) {
+    for (var i = 0; i < n; i++) {
       var item = state.artifactQueue[i];
-      list.appendChild(makeQueueItem(item, i, "artifact"));
+      var parsed = parseClipTimestamp(item.timestamp);
+
+      var card = el("div", "artifact-card");
+      card.setAttribute("draggable", "true");
+      (function (itm) {
+        card.addEventListener("dragstart", function (ev) {
+          var data = {
+            participant: itm.participant,
+            row: itm.row,
+            desc: itm.desc,
+            timestamp: itm.timestamp,
+            source: "artifact",
+          };
+          ev.dataTransfer.setData("application/json", JSON.stringify(data));
+          ev.dataTransfer.effectAllowed = "copyMove";
+        });
+      })(item);
+
+      var thumb = el("div", "artifact-card-thumb");
+      var img = document.createElement("img");
+      img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + parsed.startSeconds;
+      img.loading = "lazy";
+      img.alt = "";
+      img.draggable = false;
+      (function (cardEl, thumbEl) {
+        img.addEventListener("error", function () {
+          this.remove();
+          thumbEl.appendChild(el("span", "", "\u2715"));
+          cardEl.classList.add("artifact-card-error");
+        });
+      })(card, thumb);
+      thumb.appendChild(img);
+      thumb.appendChild(el("span", "artifact-card-duration", formatDuration(parsed.totalDuration)));
+      card.appendChild(thumb);
+
+      var meta = el("div", "artifact-card-meta");
+      meta.appendChild(el("span", "artifact-card-ref", item.participant + "." + item.row));
+      card.appendChild(meta);
+
+      var removeBtn = el("button", "artifact-card-remove", "\u00D7");
+      removeBtn.title = "Remove";
+      (function (idx) {
+        removeBtn.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          state.artifactQueue.splice(idx, 1);
+          renderArtifactQueue();
+          updateCellClasses();
+        });
+      })(i);
+      card.appendChild(removeBtn);
+
+      list.appendChild(card);
     }
   }
 
@@ -707,38 +784,19 @@
     qs("#reelDuration").textContent = formatDuration(totalDur);
   }
 
-  function makeQueueItem(item, idx, type) {
-    var div = el("div", "queue-item");
-    div.appendChild(
-      el("span", "queue-item-ref", item.participant + "." + item.row)
-    );
-    div.appendChild(el("span", "queue-item-desc", truncate(item.desc, 40)));
-    div.appendChild(el("span", "queue-item-ts", item.timestamp));
-
-    var removeBtn = el("button", "queue-item-remove", "\u00D7");
-    removeBtn.title = "Remove";
-    removeBtn.addEventListener("click", function (ev) {
-      ev.stopPropagation();
-      if (type === "artifact") {
-        state.artifactQueue.splice(idx, 1);
-        renderArtifactQueue();
-      } else {
-        state.reelQueue.splice(idx, 1);
-        renderReelQueue();
-      }
-      updateCellClasses();
-    });
-    div.appendChild(removeBtn);
-
-    return div;
-  }
-
   // ---- Buttons ----
 
   function bindButtons() {
     qs("#clearArtifactsBtn").addEventListener("click", function () {
       state.artifactQueue = [];
       renderArtifactQueue();
+      updateCellClasses();
+    });
+
+    qs("#addToReelBtn").addEventListener("click", function () {
+      for (var i = 0; i < state.artifactQueue.length; i++) {
+        addToQueue(state.reelQueue, state.artifactQueue[i], renderReelQueue);
+      }
       updateCellClasses();
     });
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.36"
+VERSIONNUM: str = "0.9.37"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary

- Add an "Add to Reel" button in the Artifacts area that copies all queued artifacts into the Reel (deduplicating), with an arrow SVG icon and text label
- Enable drag-and-drop between the Artifacts and Reel drop areas — dragging an item from one area to the other moves it (removed from origin, added to destination)
- Replace the Artifacts list-style queue items with thumbnail cards matching the Reel card design, including thumbnail generation and red error state when thumbnails fail to load
- Fix Artifacts area layout to respect the centered panel bounds with horizontal scrolling, preserving space for the Viewer area

## Test plan
- [ ] Verify "Add to Reel" button copies all artifact items to reel without removing them from artifacts
- [ ] Drag artifact card to reel area: card moves from artifacts to reel
- [ ] Drag reel card to artifact area: card moves from reel to artifacts
- [ ] Reel card reordering still works
- [ ] Grid cell drag to either area still works (copy, not move)
- [ ] Artifact cards show thumbnails with duration badges; failed thumbnails show red error state
- [ ] Artifact area scrolls horizontally within bounds, viewer area remains visible