### PR TITLE
Add grid header highlighting on card hover in Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -281,7 +281,7 @@ body {
 .col-participant {
   cursor: pointer;
   user-select: none;
-  transition: color 0.15s;
+  transition: color 0.15s, background-color 0.15s;
 }
 
 .col-row-num-header:hover,
@@ -292,10 +292,16 @@ body {
 .col-row-num-clickable {
   cursor: pointer;
   user-select: none;
-  transition: color 0.15s;
+  transition: color 0.15s, background-color 0.15s;
 }
 
 .col-row-num-clickable:hover {
+  color: var(--color-accent);
+}
+
+#sheetGrid .col-participant.header-highlight,
+#sheetGrid .col-row-num-clickable.header-highlight {
+  background-color: rgba(29, 79, 114, 0.15);
   color: var(--color-accent);
 }
 
@@ -950,6 +956,10 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
     --sev-very-positive: #4ade80;
     --sev-unknown: #94a3b8;
   }
+  #sheetGrid .col-participant.header-highlight,
+  #sheetGrid .col-row-num-clickable.header-highlight {
+    background-color: rgba(56, 189, 248, 0.18);
+  }
 }
 
 html[data-theme="dark"] {
@@ -980,6 +990,11 @@ html[data-theme="dark"] {
   --sev-positive: #86efac;
   --sev-very-positive: #4ade80;
   --sev-unknown: #94a3b8;
+}
+
+html[data-theme="dark"] #sheetGrid .col-participant.header-highlight,
+html[data-theme="dark"] #sheetGrid .col-row-num-clickable.header-highlight {
+  background-color: rgba(56, 189, 248, 0.18);
 }
 
 html[data-theme="dark"] .status-card {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -61,6 +61,19 @@
     return -1;
   }
 
+  function clearGridHighlights() {
+    var els = qsa(".header-highlight");
+    for (var i = 0; i < els.length; i++) els[i].classList.remove("header-highlight");
+  }
+
+  function highlightGridHeaders(participant, row) {
+    clearGridHighlights();
+    var th = qs('#sheetGrid thead th[data-participant="' + participant + '"]');
+    if (th) th.classList.add("header-highlight");
+    var td = qs('#sheetGrid tbody td[data-select-row="' + row + '"]');
+    if (td) td.classList.add("header-highlight");
+  }
+
   function parseTimestampToSeconds(ts) {
     var parts = ts.split(":");
     if (parts.length === 3)
@@ -649,6 +662,7 @@
   // ---- Queue rendering ----
 
   function renderArtifactQueue() {
+    clearGridHighlights();
     var list = qs("#artifactsList");
     var n = state.artifactQueue.length;
     qs("#artifactsCount").textContent = "(" + n + ")";
@@ -668,6 +682,8 @@
       var parsed = parseClipTimestamp(item.timestamp);
 
       var card = el("div", "artifact-card");
+      card.setAttribute("data-participant", item.participant);
+      card.setAttribute("data-row", item.row);
       card.setAttribute("draggable", "true");
       (function (itm) {
         card.addEventListener("dragstart", function (ev) {
@@ -716,11 +732,17 @@
       })(i);
       card.appendChild(removeBtn);
 
+      (function (p, r) {
+        card.addEventListener("mouseenter", function () { highlightGridHeaders(p, r); });
+        card.addEventListener("mouseleave", clearGridHighlights);
+      })(item.participant, item.row);
+
       list.appendChild(card);
     }
   }
 
   function renderReelQueue() {
+    clearGridHighlights();
     var list = qs("#reelList");
     var n = state.reelQueue.length;
     qs("#reelCount").textContent = "(" + n + ")";
@@ -743,6 +765,8 @@
 
       var card = el("div", "reel-card");
       card.setAttribute("data-reel-idx", i);
+      card.setAttribute("data-participant", item.participant);
+      card.setAttribute("data-row", item.row);
       card.setAttribute("draggable", "true");
 
       var thumb = el("div", "reel-card-thumb");
@@ -778,6 +802,11 @@
         });
       })(i);
       card.appendChild(removeBtn);
+
+      (function (p, r) {
+        card.addEventListener("mouseenter", function () { highlightGridHeaders(p, r); });
+        card.addEventListener("mouseleave", clearGridHighlights);
+      })(item.participant, item.row);
 
       list.appendChild(card);
     }


### PR DESCRIPTION
## Summary
- Hovering an artifact or reel card in Studio now highlights the corresponding participant column header and row-number cell in the sheet grid with a background color change
- Uses `data-participant` and `data-select-row` attributes already present in the grid DOM, with added `data-participant`/`data-row` on cards
- Supports both light and dark mode with tuned opacity values for visibility

## Test plan
- [x] Launch Studio, add cells to the artifact queue, hover cards and verify column + row headers highlight
- [x] Repeat for reel cards
- [x] Verify highlights clear on mouse leave and on card removal
- [x] Test in dark mode