### PR TITLE
Detect and fix video format mismatches in reel concatenation

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.37"
+VERSIONNUM: str = "0.9.38"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1,6 +1,14 @@
+import json
 import subprocess
 
 import video
+
+_MATCHING_PROPS = {
+    "width": 1920,
+    "height": 1080,
+    "video_codec": "h264",
+    "audio_codec": "aac",
+}
 
 
 def test_build_ffmpeg_cut_command_includes_expected_flags():
@@ -33,6 +41,9 @@ def test_build_ffmpeg_cut_command_includes_expected_flags():
 def test_concatenate_clips_reencode_fallback(monkeypatch):
     monkeypatch.setattr(video.Path, "is_file", lambda self: True)
     monkeypatch.setattr(video, "verify_output_file", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        video, "probe_video_properties", lambda _path: dict(_MATCHING_PROPS)
+    )
 
     captured_commands = []
     results = [
@@ -54,6 +65,246 @@ def test_concatenate_clips_reencode_fallback(monkeypatch):
     assert "-c" in captured_commands[0] and "copy" in captured_commands[0]
     assert "-c:v" in captured_commands[1] and "libx264" in captured_commands[1]
     assert "-c:a" in captured_commands[1] and "aac" in captured_commands[1]
+
+
+# -- probe_video_properties tests --
+
+
+def test_probe_video_properties_parses_output(monkeypatch):
+    fake_json = json.dumps(
+        {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                },
+                {"codec_type": "audio", "codec_name": "aac"},
+            ]
+        }
+    )
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(
+        video.subprocess, "check_output", lambda _cmd, **_kw: fake_json
+    )
+
+    result = video.probe_video_properties("clip.mp4")
+    assert result == {
+        "width": 1920,
+        "height": 1080,
+        "video_codec": "h264",
+        "audio_codec": "aac",
+    }
+
+
+def test_probe_video_properties_no_audio(monkeypatch):
+    fake_json = json.dumps(
+        {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "hevc",
+                    "width": 1280,
+                    "height": 720,
+                },
+            ]
+        }
+    )
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(
+        video.subprocess, "check_output", lambda _cmd, **_kw: fake_json
+    )
+
+    result = video.probe_video_properties("clip.mp4")
+    assert result is not None
+    assert result["audio_codec"] is None
+    assert result["video_codec"] == "hevc"
+    assert result["width"] == 1280
+
+
+def test_probe_video_properties_failure(monkeypatch):
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+
+    def raise_cpe(_cmd, **_kw):
+        raise subprocess.CalledProcessError(returncode=1, cmd="ffprobe")
+
+    monkeypatch.setattr(video.subprocess, "check_output", raise_cpe)
+    assert video.probe_video_properties("clip.mp4") is None
+
+
+def test_probe_video_properties_file_not_found(monkeypatch):
+    monkeypatch.setattr(video.Path, "is_file", lambda self: False)
+    assert video.probe_video_properties("missing.mp4") is None
+
+
+# -- concatenate mismatch detection tests --
+
+
+def test_concatenate_clips_matching_uses_demuxer(monkeypatch):
+    """Identical properties → concat demuxer path (fast, stream copy)."""
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        video, "probe_video_properties", lambda _p: dict(_MATCHING_PROPS)
+    )
+
+    captured = []
+
+    def fake_run(command, **_kw):
+        captured.append(command)
+        return subprocess.CompletedProcess(args=command, returncode=0, stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.concatenate_clips(["a.mp4", "b.mp4"], "reel.mp4")
+    assert ok is True
+    assert len(captured) == 1
+    assert "-f" in captured[0] and "concat" in captured[0]
+    assert "-c" in captured[0] and "copy" in captured[0]
+    assert "-filter_complex" not in captured[0]
+
+
+def test_concatenate_clips_resolution_mismatch_uses_filter_complex(monkeypatch):
+    """Different resolutions → filter_complex path with scale+pad."""
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+
+    props_by_path = {
+        "a.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": "aac"},
+        "b.mp4": {"width": 1280, "height": 720, "video_codec": "h264", "audio_codec": "aac"},
+    }
+    monkeypatch.setattr(
+        video, "probe_video_properties", lambda p: props_by_path.get(p)
+    )
+
+    captured = []
+
+    def fake_run(command, **_kw):
+        captured.append(command)
+        return subprocess.CompletedProcess(args=command, returncode=0, stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.concatenate_clips(["a.mp4", "b.mp4"], "reel.mp4")
+    assert ok is True
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert "-filter_complex" in cmd
+    fc_idx = cmd.index("-filter_complex")
+    fc_str = cmd[fc_idx + 1]
+    assert "scale=1920:1080" in fc_str
+    assert "pad=1920:1080" in fc_str
+    assert "concat=n=2:v=1:a=1" in fc_str
+    assert "-f" not in cmd  # no concat demuxer
+
+
+def test_concatenate_clips_warns_on_mismatch(monkeypatch):
+    """Mismatch detection prints warnings."""
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+
+    props_by_path = {
+        "a.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": "aac"},
+        "b.mp4": {"width": 1280, "height": 720, "video_codec": "hevc", "audio_codec": "aac"},
+    }
+    monkeypatch.setattr(
+        video, "probe_video_properties", lambda p: props_by_path.get(p)
+    )
+    monkeypatch.setattr(
+        video, "run_ffmpeg_process",
+        lambda cmd, **_kw: subprocess.CompletedProcess(args=cmd, returncode=0, stderr=""),
+    )
+
+    warnings = []
+    original_warning = video.utils.warning_print
+
+    def capture_warning(msg, details=None):
+        warnings.append(msg)
+        original_warning(msg, details)
+
+    monkeypatch.setattr(video.utils, "warning_print", capture_warning)
+
+    video.concatenate_clips(["a.mp4", "b.mp4"], "reel.mp4")
+    warning_text = " ".join(warnings)
+    assert "Resolution mismatch" in warning_text
+    assert "1920x1080" in warning_text
+    assert "1280x720" in warning_text
+    assert "Video codec mismatch" in warning_text
+
+
+def test_concatenate_clips_mixed_audio_presence(monkeypatch):
+    """One clip with audio, one without → anullsrc for the silent clip."""
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(video, "get_file_duration", lambda _p: 10)
+
+    props_by_path = {
+        "a.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": "aac"},
+        "b.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": None},
+    }
+    monkeypatch.setattr(
+        video, "probe_video_properties", lambda p: props_by_path.get(p)
+    )
+
+    captured = []
+
+    def fake_run(command, **_kw):
+        captured.append(command)
+        return subprocess.CompletedProcess(args=command, returncode=0, stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.concatenate_clips(["a.mp4", "b.mp4"], "reel.mp4")
+    assert ok is True
+    cmd = captured[0]
+    assert "-filter_complex" in cmd
+    fc_str = cmd[cmd.index("-filter_complex") + 1]
+    assert "anullsrc" in fc_str
+    assert "concat=n=2:v=1:a=1" in fc_str
+
+
+def test_concatenate_clips_all_no_audio(monkeypatch):
+    """All clips lack audio → concat with a=0, no audio mapping."""
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+
+    no_audio_props = {
+        "width": 1280,
+        "height": 720,
+        "video_codec": "h264",
+        "audio_codec": None,
+    }
+    monkeypatch.setattr(
+        video, "probe_video_properties", lambda _p: dict(no_audio_props)
+    )
+
+    # Same resolution, but audio mismatch is about presence—need at least one
+    # mismatch to trigger filter_complex. Use resolution mismatch instead.
+    call_count = [0]
+    def props_alternating(_p):
+        call_count[0] += 1
+        if call_count[0] % 2 == 1:
+            return {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": None}
+        return {"width": 1280, "height": 720, "video_codec": "h264", "audio_codec": None}
+
+    monkeypatch.setattr(video, "probe_video_properties", props_alternating)
+
+    captured = []
+
+    def fake_run(command, **_kw):
+        captured.append(command)
+        return subprocess.CompletedProcess(args=command, returncode=0, stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.concatenate_clips(["a.mp4", "b.mp4"], "reel.mp4")
+    assert ok is True
+    cmd = captured[0]
+    fc_str = cmd[cmd.index("-filter_complex") + 1]
+    assert "concat=n=2:v=1:a=0" in fc_str
+    assert "[outa]" not in fc_str
+    assert '"-map", "[outa]"' not in str(cmd)
 
 
 def test_get_duration_valid_and_invalid_values(monkeypatch):

--- a/titlecards.py
+++ b/titlecards.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import Optional
@@ -12,34 +11,10 @@ from utils import ClipRecord
 
 def _get_video_resolution(filepath: str) -> Optional[str]:
     """Return 'WIDTHxHEIGHT' resolution string for the first video stream."""
-    if not Path(filepath).is_file():
+    props = video.probe_video_properties(filepath)
+    if props is None:
         return None
-
-    probe_command = [
-        "ffprobe",
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=width,height",
-        "-of",
-        "csv=s=x:p=0",
-        filepath,
-    ]
-    utils.debug_print(f"ffprobe resolution command: {' '.join(probe_command)}")
-    try:
-        output = subprocess.check_output(probe_command, encoding="utf-8").strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as error:
-        utils.warning_print(
-            f"Could not probe video resolution for '{filepath}'.",
-            [str(error)],
-        )
-        return None
-
-    if not output or "x" not in output:
-        return None
-    return output
+    return f"{props['width']}x{props['height']}"
 
 
 def _build_drawtext_filter(text: str) -> str:

--- a/video.py
+++ b/video.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 """Video processing operations for clipgen."""
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from icecream import ic
 
@@ -594,6 +596,68 @@ def get_file_duration(filepath: str) -> Optional[int]:
         return None
 
 
+def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
+    """Probe video file for stream properties (resolution, codecs).
+
+    Returns:
+        Dict with 'width' (int), 'height' (int), 'video_codec' (str),
+        'audio_codec' (str or None if no audio stream), or None if probe fails.
+    """
+    if config.DEBUGGING:
+        return {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": "aac",
+        }
+
+    if not Path(filepath).is_file():
+        return None
+
+    probe_command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "stream=width,height,codec_name,codec_type",
+        "-of",
+        "json",
+        filepath,
+    ]
+    try:
+        raw = subprocess.check_output(probe_command, encoding="utf-8")
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+    streams = data.get("streams", [])
+    width = height = 0
+    video_codec: Optional[str] = None
+    audio_codec: Optional[str] = None
+    for stream in streams:
+        codec_type = stream.get("codec_type", "")
+        if codec_type == "video" and video_codec is None:
+            width = int(stream.get("width", 0))
+            height = int(stream.get("height", 0))
+            video_codec = stream.get("codec_name")
+        elif codec_type == "audio" and audio_codec is None:
+            audio_codec = stream.get("codec_name")
+
+    if not video_codec or width <= 0 or height <= 0:
+        return None
+
+    return {
+        "width": width,
+        "height": height,
+        "video_codec": video_codec,
+        "audio_codec": audio_codec,
+    }
+
+
 def get_duration(start_time: str, end_time: Optional[str]) -> Optional[int]:
     """Calculate the duration between two timestamps.
 
@@ -844,13 +908,118 @@ def compress_to_size(filepath: str, target_size_mb: float) -> bool:
                 )
 
 
+def _detect_clip_mismatches(
+    clip_paths: List[str],
+) -> Tuple[List[Optional[Dict[str, Any]]], bool, bool]:
+    """Probe clips and detect property mismatches.
+
+    Returns:
+        (properties_list, has_resolution_mismatch, has_audio_presence_mismatch)
+        properties_list parallels clip_paths (None entries for failed probes).
+    """
+    props_list: List[Optional[Dict[str, Any]]] = [
+        probe_video_properties(p) for p in clip_paths
+    ]
+    probed = [p for p in props_list if p is not None]
+    if len(probed) < 2:
+        return (props_list, False, False)
+
+    resolutions = Counter((p["width"], p["height"]) for p in probed)
+    video_codecs = Counter(p["video_codec"] for p in probed)
+    has_audio = [p["audio_codec"] is not None for p in probed]
+
+    has_resolution_mismatch = len(resolutions) > 1
+    has_audio_presence_mismatch = len(set(has_audio)) > 1
+
+    if has_resolution_mismatch:
+        detail = ", ".join(
+            f"{w}x{h} ({n} clip{'s' if n > 1 else ''})"
+            for (w, h), n in resolutions.most_common()
+        )
+        utils.warning_print(f"Resolution mismatch across reel clips: {detail}.")
+
+    if len(video_codecs) > 1:
+        detail = ", ".join(
+            f"{c} ({n} clip{'s' if n > 1 else ''})"
+            for c, n in video_codecs.most_common()
+        )
+        utils.warning_print(f"Video codec mismatch across reel clips: {detail}.")
+
+    if has_audio_presence_mismatch:
+        utils.warning_print(
+            "Audio stream mismatch: some clips have no audio track."
+        )
+
+    return (props_list, has_resolution_mismatch, has_audio_presence_mismatch)
+
+
+def _pick_target_resolution(
+    props_list: List[Optional[Dict[str, Any]]],
+) -> Tuple[int, int]:
+    """Choose target resolution from probed properties (most common, ties broken by largest)."""
+    resolutions = Counter(
+        (p["width"], p["height"]) for p in props_list if p is not None
+    )
+    max_count = max(resolutions.values())
+    candidates = [res for res, cnt in resolutions.items() if cnt == max_count]
+    w, h = max(candidates, key=lambda r: r[0] * r[1])
+    # libx264 requires even dimensions
+    return (w if w % 2 == 0 else w + 1, h if h % 2 == 0 else h + 1)
+
+
+def _build_filter_complex_concat(
+    clip_paths: List[str],
+    props_list: List[Optional[Dict[str, Any]]],
+    target_w: int,
+    target_h: int,
+) -> Tuple[str, bool]:
+    """Build a filter_complex string that scales/pads all inputs to target resolution.
+
+    Returns:
+        (filter_complex_string, has_any_audio)
+    """
+    filter_parts: List[str] = []
+    has_any_audio = any(
+        p is not None and p.get("audio_codec") is not None for p in props_list
+    )
+
+    for i, props in enumerate(props_list):
+        filter_parts.append(
+            f"[{i}:v]scale={target_w}:{target_h}"
+            f":force_original_aspect_ratio=decrease,"
+            f"pad={target_w}:{target_h}:(ow-iw)/2:(oh-ih)/2,"
+            f"setsar=1[v{i}]"
+        )
+        if has_any_audio:
+            if props is not None and props.get("audio_codec") is not None:
+                filter_parts.append(f"[{i}:a]aresample=44100[a{i}]")
+            else:
+                dur = get_file_duration(clip_paths[i]) or 1
+                filter_parts.append(
+                    f"anullsrc=r=44100:cl=stereo[sil{i}];"
+                    f"[sil{i}]atrim=duration={dur}[a{i}]"
+                )
+
+    n = len(props_list)
+    if has_any_audio:
+        concat_inputs = "".join(f"[v{i}][a{i}]" for i in range(n))
+        filter_parts.append(f"{concat_inputs}concat=n={n}:v=1:a=1[outv][outa]")
+    else:
+        concat_inputs = "".join(f"[v{i}]" for i in range(n))
+        filter_parts.append(f"{concat_inputs}concat=n={n}:v=1:a=0[outv]")
+
+    return (";".join(filter_parts), has_any_audio)
+
+
 def concatenate_clips(
     clip_paths: List[str], output_file: str, reencode_on_fail: bool = True
 ) -> bool:
-    """Concatenate multiple video clips into a single file using ffmpeg concat demuxer.
+    """Concatenate multiple video clips into a single file.
 
-    Writes a temporary file list for ffmpeg, runs concat demuxer with stream copy,
-    and optionally falls back to re-encoding if stream copy fails (e.g. codec mismatch).
+    Probes all clips for property mismatches. When resolutions or audio presence
+    differ, uses ffmpeg filter_complex to scale/pad inputs to a common resolution.
+    Otherwise uses the fast concat demuxer with stream copy, falling back to
+    re-encoding if stream copy fails.
 
     Args:
         clip_paths: List of paths to clip files (order preserved)
@@ -872,6 +1041,79 @@ def concatenate_clips(
             )
             return False
 
+    utils.standard_print(
+        f"Concatenating {len(clip_paths)} clips into {output_file}."
+    )
+    if config.DEBUGGING:
+        utils.debug_print("Debugging enabled, not calling ffmpeg for concat.")
+        return False
+
+    props_list, res_mismatch, audio_mismatch = _detect_clip_mismatches(clip_paths)
+
+    if res_mismatch or audio_mismatch:
+        utils.warning_print(
+            "Re-encoding all clips to produce a compatible reel (this may take longer)."
+        )
+        return _concatenate_filter_complex(
+            clip_paths, props_list, output_file
+        )
+
+    return _concatenate_demuxer(clip_paths, output_file, reencode_on_fail)
+
+
+def _concatenate_filter_complex(
+    clip_paths: List[str],
+    props_list: List[Optional[Dict[str, Any]]],
+    output_file: str,
+) -> bool:
+    """Concatenate clips using filter_complex (handles resolution/audio mismatches)."""
+    target_w, target_h = _pick_target_resolution(props_list)
+    filter_str, has_audio = _build_filter_complex_concat(
+        clip_paths, props_list, target_w, target_h
+    )
+
+    ffmpeg_command = ["ffmpeg", "-y", "-loglevel", config.FFMPEG_LOGLEVEL]
+    for path in clip_paths:
+        ffmpeg_command.extend(["-i", str(Path(path).resolve())])
+    ffmpeg_command.extend(["-filter_complex", filter_str])
+    ffmpeg_command.extend(["-map", "[outv]"])
+    if has_audio:
+        ffmpeg_command.extend(["-map", "[outa]"])
+    ffmpeg_command.extend(["-c:v", "libx264", "-c:a", "aac", output_file])
+
+    utils.debug_print(f"ffmpeg filter_complex concat: {' '.join(ffmpeg_command)}")
+    try:
+        result = run_ffmpeg_process(
+            ffmpeg_command,
+            input_file=clip_paths[0],
+            output_file=output_file,
+            os_error_message="Filter-complex concatenation failed.",
+        )
+        if result is None or result.returncode != 0:
+            error_details = [
+                f"Output: '{output_file}'",
+                f"Clips: {len(clip_paths)} files",
+                f"Target resolution: {target_w}x{target_h}",
+            ]
+            if result is not None:
+                error_details = _add_ffmpeg_stderr(error_details, result)
+            utils.error_print("ffmpeg filter_complex concat failed.", error_details)
+            return False
+
+        if not verify_output_file(output_file, "Concat"):
+            return False
+
+        utils.standard_print(f"+ Generated reel '{output_file}' successfully.")
+        return True
+    except OSError as e:
+        utils.error_print(f"Concatenation failed: {e}")
+        return False
+
+
+def _concatenate_demuxer(
+    clip_paths: List[str], output_file: str, reencode_on_fail: bool
+) -> bool:
+    """Concatenate clips using concat demuxer (fast path for matching properties)."""
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".txt", delete=False, encoding="utf-8"
     ) as file_handle:
@@ -897,13 +1139,7 @@ def concatenate_clips(
             "copy",
             output_file,
         ]
-        utils.standard_print(
-            f"Concatenating {len(clip_paths)} clips into {output_file}."
-        )
         utils.debug_print(f"ffmpeg concat command: {' '.join(ffmpeg_command)}")
-        if config.DEBUGGING:
-            utils.debug_print("Debugging enabled, not calling ffmpeg for concat.")
-            return False
 
         ffmpeg_result = run_ffmpeg_process(
             ffmpeg_command,
@@ -1091,29 +1327,10 @@ def generate_sprite_sheet(
     rows = ceil(actual_frames / cols)
 
     # Get source video dimensions for aspect-ratio-correct frame height
-    probe_cmd = [
-        "ffprobe",
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=width,height",
-        "-of",
-        "csv=s=x:p=0",
-        input_file,
-    ]
     frame_height = round(thumb_width * 9 / 16)  # fallback to 16:9
-    if not config.DEBUGGING:
-        try:
-            probe_out = subprocess.check_output(probe_cmd, encoding="utf-8").strip()
-            if "x" in probe_out:
-                src_w, src_h = probe_out.split("x")[:2]
-                src_w, src_h = int(src_w), int(src_h)
-                if src_w > 0:
-                    frame_height = round(thumb_width * src_h / src_w)
-        except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
-            pass
+    props = probe_video_properties(input_file)
+    if props and props["width"] > 0:
+        frame_height = round(thumb_width * props["height"] / props["width"])
 
     if config.DEBUGGING:
         ic(input_file, output_file, actual_frames, cols, rows, interval)


### PR DESCRIPTION
## Summary

- Adds `probe_video_properties()` to `video.py` — probes resolution, video codec, and audio codec via a single ffprobe call (replaces 3 duplicated inline probes in video.py, titlecards.py)
- Before concatenating reel clips, detects mismatches in resolution, codec, and audio presence, and prints specific warnings (e.g. "Resolution mismatch across reel clips: 1920x1080 (3 clips), 1280x720 (1 clip)")
- When resolution or audio-presence mismatches are found, uses ffmpeg `filter_complex` with scale+pad+setsar to normalize all clips to the most common resolution, generating silent audio tracks for clips that lack them — the only approach that produces playable output from mixed sources
- Preserves the fast concat-demuxer stream-copy path when all clips match

## Test plan
- [x] 161/161 tests pass (`uv run pytest -c tests/pytest.ini`)
- [x] 8 new tests covering probe parsing, failure paths, demuxer vs filter_complex routing, warning output, mixed audio presence, and all-silent clips
- [x] Ruff clean
- [ ] Manual: build a reel from clips with different resolutions, verify warning is printed and output plays correctly