### PR TITLE
Add per-card generation progress feedback to Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -864,6 +864,99 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   font-family: var(--font-mono);
 }
 
+/* Title spinner */
+
+.title-spinner {
+  display: none;
+  flex-shrink: 0;
+}
+
+.title-spinner.active {
+  display: inline-block;
+}
+
+/* Card generation states */
+
+.artifact-card-queued,
+.reel-card-queued {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.card-gen-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.45);
+  z-index: 1;
+}
+
+.card-gen-overlay svg circle {
+  fill: var(--color-accent);
+}
+
+@keyframes pulse-dot {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-4px); }
+}
+
+.card-gen-overlay svg circle:nth-child(1) { animation: pulse-dot 0.9s ease-in-out infinite; }
+.card-gen-overlay svg circle:nth-child(2) { animation: pulse-dot 0.9s ease-in-out 0.15s infinite; }
+.card-gen-overlay svg circle:nth-child(3) { animation: pulse-dot 0.9s ease-in-out 0.3s infinite; }
+
+.artifact-card-success,
+.reel-card-success {
+  border-color: #16a34a;
+  background: #f0fdf4;
+}
+
+.artifact-card-fail,
+.reel-card-fail {
+  border-color: #dc2626;
+  background: #fef2f2;
+}
+
+.card-gen-badge {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.card-gen-badge-ok {
+  background: #16a34a;
+}
+
+.card-gen-badge-fail {
+  background: #dc2626;
+}
+
+.card-gen-badge svg {
+  display: block;
+}
+
+.artifact-card-queued .artifact-card-remove,
+.artifact-card-success .artifact-card-remove,
+.artifact-card-fail .artifact-card-remove,
+.reel-card-queued .reel-card-remove,
+.reel-card-success .reel-card-remove,
+.reel-card-fail .reel-card-remove {
+  display: none;
+}
+
+.studio-generating .drop-target,
+.studio-generating .ts-cell {
+  pointer-events: none;
+}
+
 /* Status overlay */
 
 #statusOverlay {
@@ -960,6 +1053,19 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   #sheetGrid .col-row-num-clickable.header-highlight {
     background-color: rgba(56, 189, 248, 0.18);
   }
+  .card-gen-overlay {
+    background: rgba(0, 0, 0, 0.45);
+  }
+  .artifact-card-success,
+  .reel-card-success {
+    border-color: #4ade80;
+    background: #052e16;
+  }
+  .artifact-card-fail,
+  .reel-card-fail {
+    border-color: #f87171;
+    background: #451a1a;
+  }
 }
 
 html[data-theme="dark"] {
@@ -999,6 +1105,22 @@ html[data-theme="dark"] #sheetGrid .col-row-num-clickable.header-highlight {
 
 html[data-theme="dark"] .status-card {
   background: var(--color-surface-alt);
+}
+
+html[data-theme="dark"] .card-gen-overlay {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+html[data-theme="dark"] .artifact-card-success,
+html[data-theme="dark"] .reel-card-success {
+  border-color: #4ade80;
+  background: #052e16;
+}
+
+html[data-theme="dark"] .artifact-card-fail,
+html[data-theme="dark"] .reel-card-fail {
+  border-color: #f87171;
+  background: #451a1a;
 }
 
 /* ---- Responsive ---- */

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -33,7 +33,7 @@
 
   <section id="dropAreas">
     <div id="artifactsArea" class="drop-area">
-      <h3>Artifacts <span id="artifactsCount">(0)</span></h3>
+      <h3><svg id="artifactsSpinner" class="title-spinner" width="14" height="14" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>Artifacts <span id="artifactsCount">(0)</span></h3>
       <div id="artifactsList" class="drop-target">
         <div class="drop-target-empty">Click or drag cells here to queue for generation</div>
       </div>
@@ -67,7 +67,7 @@
 
   <section id="reelArea">
     <div id="reelHeader">
-      <h3>Reel <span id="reelCount">(0)</span> <span id="reelDuration"></span></h3>
+      <h3><svg id="reelSpinner" class="title-spinner" width="14" height="14" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>Reel <span id="reelCount">(0)</span> <span id="reelDuration"></span></h3>
       <div class="area-controls">
         <button id="buildReelBtn" class="btn btn-primary" disabled>Build Reel</button>
         <button id="clearReelBtn" class="btn btn-small">Clear</button>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -845,79 +845,232 @@
     qs("#statusDismiss").addEventListener("click", hideOverlay);
   }
 
+  // ---- Generation progress helpers ----
+
+  function setTitleSpinner(id, active) {
+    var s = qs("#" + id);
+    if (s) s.classList.toggle("active", active);
+  }
+
+  function findCard(listEl, participant, row) {
+    return listEl.querySelector(
+      '[data-participant="' + participant + '"][data-row="' + row + '"]'
+    );
+  }
+
+  function createPulserOverlay() {
+    var overlay = el("div", "card-gen-overlay");
+    overlay.innerHTML =
+      '<svg width="26" height="10" viewBox="0 0 26 10">' +
+      '<circle cx="5" cy="7" r="3"/>' +
+      '<circle cx="13" cy="7" r="3"/>' +
+      '<circle cx="21" cy="7" r="3"/>' +
+      '</svg>';
+    return overlay;
+  }
+
+  function createResultBadge(success) {
+    var badge = el("div", "card-gen-badge " + (success ? "card-gen-badge-ok" : "card-gen-badge-fail"));
+    badge.innerHTML = success
+      ? '<svg width="12" height="12" viewBox="0 0 12 12"><path d="M2.5 6.5l2.5 2.5 4.5-5" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+      : '<svg width="12" height="12" viewBox="0 0 12 12"><path d="M3 3l6 6M9 3l-6 6" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/></svg>';
+    return badge;
+  }
+
+  function setCardQueued(card) {
+    card.classList.add(
+      card.classList.contains("reel-card") ? "reel-card-queued" : "artifact-card-queued"
+    );
+    var thumb = card.querySelector(".artifact-card-thumb, .reel-card-thumb");
+    if (thumb) thumb.appendChild(createPulserOverlay());
+  }
+
+  function setCardResult(card, success) {
+    var isReel = card.classList.contains("reel-card");
+    card.classList.remove(isReel ? "reel-card-queued" : "artifact-card-queued");
+    card.classList.add(
+      isReel
+        ? (success ? "reel-card-success" : "reel-card-fail")
+        : (success ? "artifact-card-success" : "artifact-card-fail")
+    );
+    var overlay = card.querySelector(".card-gen-overlay");
+    if (overlay) overlay.remove();
+    var thumb = card.querySelector(".artifact-card-thumb, .reel-card-thumb");
+    if (thumb) thumb.appendChild(createResultBadge(success));
+  }
+
+  function clearCardStates(listEl) {
+    var cards = listEl.querySelectorAll(
+      ".artifact-card-queued, .artifact-card-success, .artifact-card-fail," +
+      ".reel-card-queued, .reel-card-success, .reel-card-fail"
+    );
+    for (var i = 0; i < cards.length; i++) {
+      cards[i].classList.remove(
+        "artifact-card-queued", "artifact-card-success", "artifact-card-fail",
+        "reel-card-queued", "reel-card-success", "reel-card-fail"
+      );
+      var overlay = cards[i].querySelector(".card-gen-overlay");
+      if (overlay) overlay.remove();
+      var badge = cards[i].querySelector(".card-gen-badge");
+      if (badge) badge.remove();
+    }
+  }
+
+  function setGeneratingLock(locked) {
+    var ids = [
+      "#generateBtn", "#buildReelBtn", "#clearArtifactsBtn",
+      "#clearReelBtn", "#addToReelBtn", "#buildHighlightsBtn",
+      "#buildViewerBtn", "#buildTimelineViewerBtn", "#regenerateBtn"
+    ];
+    for (var i = 0; i < ids.length; i++) {
+      var b = qs(ids[i]);
+      if (b) b.disabled = locked;
+    }
+    document.body.classList.toggle("studio-generating", locked);
+  }
+
   // ---- API calls ----
 
   function onGenerate() {
     if (state.generating || state.artifactQueue.length === 0) return;
     state.generating = true;
+    setGeneratingLock(true);
+    setTitleSpinner("artifactsSpinner", true);
 
-    var cells = state.artifactQueue.map(function (item) {
+    var format = qs("#artifactFormat").value;
+    var list = qs("#artifactsList");
+    var items = state.artifactQueue.slice();
+    var cells = items.map(function (item) {
       return item.participant + "." + item.row;
     });
-    var format = qs("#artifactFormat").value;
 
-    showOverlay("Generating " + cells.length + " " + format + "(s)...");
+    for (var i = 0; i < items.length; i++) {
+      var c = findCard(list, items[i].participant, items[i].row);
+      if (c) setCardQueued(c);
+    }
+
+    var totalSuccess = 0;
+    var totalFail = 0;
+    var allArtifacts = [];
+
+    function finishGenerate() {
+      setTitleSpinner("artifactsSpinner", false);
+      state.generating = false;
+      setGeneratingLock(false);
+      if (allArtifacts.length > 0) {
+        state.generatedArtifacts = state.generatedArtifacts.concat(allArtifacts);
+        updateViewerButton();
+      }
+      var msg = "Generated " + totalSuccess + " artifact(s)";
+      if (totalFail > 0) msg += ", " + totalFail + " failed";
+      showResult(
+        totalSuccess > 0 ? msg : null,
+        totalSuccess === 0 && totalFail > 0 ? "All generations failed" : null
+      );
+      qs("#statusOverlay").classList.remove("hidden");
+    }
+
+    function handleLine(line) {
+      var data = JSON.parse(line);
+      var dot = data.cell.lastIndexOf(".");
+      var participant = data.cell.substring(0, dot);
+      var row = data.cell.substring(dot + 1);
+      var card = findCard(list, participant, row);
+      if (data.ok) {
+        if (card) setCardResult(card, true);
+        totalSuccess += (data.generated || 1);
+        if (data.artifacts) allArtifacts = allArtifacts.concat(data.artifacts);
+      } else {
+        if (card) setCardResult(card, false);
+        totalFail++;
+      }
+    }
 
     fetch("api/generate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cells: cells, format: format }),
     })
-      .then(function (r) {
-        return r.json();
-      })
-      .then(function (data) {
-        state.generating = false;
-        if (data.ok) {
-          if (data.artifacts) {
-            state.generatedArtifacts = state.generatedArtifacts.concat(
-              data.artifacts
-            );
-          }
-          updateViewerButton();
-          showResult(
-            "Generated " + (data.generated || 0) + " artifact(s)",
-            null
-          );
-        } else {
-          showResult(null, data.error || "Generation failed");
+      .then(function (response) {
+        var reader = response.body.getReader();
+        var decoder = new TextDecoder();
+        var buffer = "";
+
+        function read() {
+          return reader.read().then(function (result) {
+            if (result.done) {
+              if (buffer.trim()) handleLine(buffer.trim());
+              finishGenerate();
+              return;
+            }
+            buffer += decoder.decode(result.value, { stream: true });
+            var lines = buffer.split("\n");
+            buffer = lines.pop();
+            for (var i = 0; i < lines.length; i++) {
+              if (lines[i].trim()) handleLine(lines[i].trim());
+            }
+            return read();
+          });
         }
+
+        return read();
       })
       .catch(function (err) {
-        state.generating = false;
-        showResult(null, "Request failed: " + err);
+        finishGenerate();
       });
   }
 
   function onBuildReel() {
     if (state.generating || state.reelQueue.length === 0) return;
     state.generating = true;
+    setGeneratingLock(true);
+    setTitleSpinner("reelSpinner", true);
 
     var cells = state.reelQueue.map(function (item) {
       return item.participant + "." + item.row;
     });
 
-    showOverlay("Building reel from " + cells.length + " clips...");
+    var list = qs("#reelList");
+    var reelCards = list.querySelectorAll(".reel-card");
+    for (var i = 0; i < reelCards.length; i++) {
+      setCardQueued(reelCards[i]);
+    }
 
     fetch("api/reel", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cells: cells }),
     })
-      .then(function (r) {
-        return r.json();
-      })
+      .then(function (r) { return r.json(); })
       .then(function (data) {
         state.generating = false;
+        setTitleSpinner("reelSpinner", false);
+        setGeneratingLock(false);
+
+        var cards = list.querySelectorAll(".reel-card");
+        for (var j = 0; j < cards.length; j++) {
+          setCardResult(cards[j], !!data.ok);
+        }
+
         if (data.ok) {
           showResult("Reel built successfully", null);
         } else {
           showResult(null, data.error || "Reel build failed");
         }
+        qs("#statusOverlay").classList.remove("hidden");
       })
       .catch(function (err) {
         state.generating = false;
+        setTitleSpinner("reelSpinner", false);
+        setGeneratingLock(false);
+
+        var cards = list.querySelectorAll(".reel-card");
+        for (var j = 0; j < cards.length; j++) {
+          setCardResult(cards[j], false);
+        }
+
         showResult(null, "Request failed: " + err);
+        qs("#statusOverlay").classList.remove("hidden");
       });
   }
 
@@ -1079,6 +1232,8 @@
 
   function hideOverlay() {
     qs("#statusOverlay").classList.add("hidden");
+    clearCardStates(qs("#artifactsList"));
+    clearCardStates(qs("#reelList"));
   }
 
   // ---- Init ----

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.37"
+VERSIONNUM: str = "0.9.38"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -6,6 +6,7 @@ start_combined_server(), and exposes REST endpoints for sheet data
 access, artifact generation, reel building, and viewer creation.
 """
 
+import json
 import sys
 import webbrowser
 from pathlib import Path
@@ -228,26 +229,35 @@ def api_generate() -> FlaskResponse:
         cell_input = ", ".join(cell_strings)
         cell_specs = spreadsheet.parse_cell_specifications(cell_input)
         if not cell_specs:
-            return jsonify(
-                {"ok": False, "error": "Could not parse cell specifications"}
-            ), 400
+            return jsonify({"ok": False, "error": "Could not parse cell specifications"}), 400
 
         clips = spreadsheet.generate_list(
             _worksheet, "cell", cell_specs=cell_specs, skip_prompts=True
         )
-        if not clips:
-            return jsonify(
-                {"ok": False, "error": "No clips found for the specified cells"}
-            ), 400
-
-        generated, artifacts = clipgen.process_clips(clips, output_format=output_format)
-        _generated_artifacts.extend(artifacts)
-        _save_manifest_quiet()
-
-        return jsonify({"ok": True, "generated": generated, "artifacts": artifacts})
-
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
+
+    def stream() -> Any:
+        clip_cells: set[str] = set()
+        for clip in clips:
+            cell_str = clip["participant"] + "." + str(clip["cell"].row)
+            clip_cells.add(cell_str)
+            try:
+                generated, artifacts = clipgen.process_clips(
+                    [clip], output_format=output_format
+                )
+                _generated_artifacts.extend(artifacts)
+                yield json.dumps(
+                    {"cell": cell_str, "ok": generated > 0, "generated": generated, "artifacts": artifacts}
+                ) + "\n"
+            except Exception as e:
+                yield json.dumps({"cell": cell_str, "ok": False, "error": str(e)}) + "\n"
+        for cs in cell_strings:
+            if cs not in clip_cells:
+                yield json.dumps({"cell": cs, "ok": False, "error": "No clip found"}) + "\n"
+        _save_manifest_quiet()
+
+    return Response(stream(), mimetype="application/x-ndjson", headers={"X-Accel-Buffering": "no"})
 
 
 @studio_bp.route("/api/reel", methods=["POST"])


### PR DESCRIPTION
## Summary

- Replaces the blocking full-screen overlay during artifact generation with inline, per-card progress indicators
- Cards show a pulsing three-dot SVG overlay while queued and flip to a green checkmark or red x as each completes
- SVG spinners appear next to the "Artifacts" and "Reel" area titles during processing
- Server streams NDJSON (one line per cell) so cards update in real time from a single HTTP connection, with spreadsheet data read once upfront
- Correctly detects failed generations (e.g. missing source video) by checking `generated > 0` rather than the blanket `ok: true` the server previously returned

## Test plan
- [ ] Queue 3+ cells, click Generate — title spinner appears, cards dim with pulsing dots, each card turns green/red as it completes, summary popup appears at end
- [ ] Queue cells in reel, click Build Reel — same flow but all cards transition together
- [ ] Dismiss popup — cards return to normal state
- [ ] During generation: buttons disabled, cards not draggable, grid cells not clickable
- [ ] Test with a cell that will fail (e.g. missing source video) — that card turns red, others green
- [ ] Verify dark mode styling for all new states