### PR TITLE
Persist Studio card states and restore queues across navigation

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -944,11 +944,7 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
 }
 
 .artifact-card-queued .artifact-card-remove,
-.artifact-card-success .artifact-card-remove,
-.artifact-card-fail .artifact-card-remove,
-.reel-card-queued .reel-card-remove,
-.reel-card-success .reel-card-remove,
-.reel-card-fail .reel-card-remove {
+.reel-card-queued .reel-card-remove {
   display: none;
 }
 

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -93,15 +93,6 @@
           <button id="buildHighlightsBtn" class="btn btn-primary">Build Highlights</button>
         </div>
       </div>
-      <div class="quick-action-card">
-        <div class="quick-action-info">
-          <strong>Regenerate from Manifest</strong>
-          <span>Re-create all media artifacts and reels from a saved manifest file.</span>
-        </div>
-        <div class="area-controls">
-          <button id="regenerateBtn" class="btn btn-primary">Regenerate</button>
-        </div>
-      </div>
     </div>
   </section>
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -4,6 +4,7 @@
   "use strict";
 
   var THEME_STORAGE_KEY = "clipgen-studio-theme";
+  var QUEUE_STORAGE_KEY = "clipgen-studio-queues";
 
   var state = {
     sheetData: null,
@@ -11,6 +12,7 @@
     reelQueue: [],
     generatedArtifacts: [],
     generating: false,
+    cellResults: {},
   };
 
   // ---- Helpers ----
@@ -197,6 +199,27 @@
     btn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
   }
 
+  // ---- Queue persistence (sessionStorage) ----
+
+  function saveQueues() {
+    try {
+      sessionStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify({
+        artifactQueue: state.artifactQueue,
+        reelQueue: state.reelQueue,
+      }));
+    } catch (e) { /* ignore quota errors */ }
+  }
+
+  function restoreQueues() {
+    try {
+      var raw = sessionStorage.getItem(QUEUE_STORAGE_KEY);
+      if (!raw) return;
+      var saved = JSON.parse(raw);
+      if (saved.artifactQueue) state.artifactQueue = saved.artifactQueue;
+      if (saved.reelQueue) state.reelQueue = saved.reelQueue;
+    } catch (e) { /* ignore parse errors */ }
+  }
+
   // ---- Data loading ----
 
   function loadSheetData() {
@@ -217,10 +240,66 @@
         if (durInput && data.highlightsDuration) {
           durInput.value = data.highlightsDuration;
         }
+        restoreQueues();
+        if (state.artifactQueue.length > 0 || state.reelQueue.length > 0) {
+          renderArtifactQueue();
+          renderReelQueue();
+          updateCellClasses();
+        }
+        loadManifestState();
       })
       .catch(function (err) {
         qs("#sheetLoading").textContent = "Failed to load sheet: " + err;
       });
+  }
+
+  function loadManifestState() {
+    fetch("api/manifest")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.ok || !state.sheetData) return;
+        var artifacts = data.artifacts || [];
+        if (artifacts.length === 0) return;
+
+        var seen = {};
+        for (var i = 0; i < artifacts.length; i++) {
+          var a = artifacts[i];
+          if (!a.participant || !a.cellRow || a.type === "transcript") continue;
+          var key = cellKey(a.participant, a.cellRow);
+          if (seen[key]) continue;
+          seen[key] = true;
+
+          var matchedRow = null;
+          for (var j = 0; j < state.sheetData.rows.length; j++) {
+            if (state.sheetData.rows[j].rowNum === a.cellRow) {
+              matchedRow = state.sheetData.rows[j];
+              break;
+            }
+          }
+          if (!matchedRow) continue;
+
+          var cellData = matchedRow.cells[a.participant];
+          if (!cellData || !cellData.valid) continue;
+
+          state.cellResults[key] = "success";
+          if (findInQueue(state.artifactQueue, a.participant, a.cellRow) >= 0) continue;
+
+          state.artifactQueue.push({
+            participant: a.participant,
+            row: a.cellRow,
+            desc: matchedRow.observation || "",
+            timestamp: cellData.value || "",
+          });
+        }
+
+        state.generatedArtifacts = state.generatedArtifacts.concat(
+          artifacts.filter(function (a) { return a.type !== "transcript"; })
+        );
+        renderArtifactQueue();
+        updateCellClasses();
+        updateViewerButton();
+      })
+      .catch(function () {});
   }
 
   // ---- Header rendering ----
@@ -669,6 +748,7 @@
     qs("#generateBtn").disabled = n === 0;
     qs("#addToReelBtn").disabled = n === 0;
     list.innerHTML = "";
+    saveQueues();
 
     if (n === 0) {
       list.appendChild(
@@ -725,7 +805,8 @@
       (function (idx) {
         removeBtn.addEventListener("click", function (ev) {
           ev.stopPropagation();
-          state.artifactQueue.splice(idx, 1);
+          var removed = state.artifactQueue.splice(idx, 1)[0];
+          delete state.cellResults[cellKey(removed.participant, removed.row)];
           renderArtifactQueue();
           updateCellClasses();
         });
@@ -739,6 +820,7 @@
 
       list.appendChild(card);
     }
+    applyCardStates(list);
   }
 
   function renderReelQueue() {
@@ -748,6 +830,7 @@
     qs("#reelCount").textContent = "(" + n + ")";
     qs("#buildReelBtn").disabled = n === 0;
     list.innerHTML = "";
+    saveQueues();
 
     if (n === 0) {
       list.appendChild(
@@ -796,7 +879,8 @@
       (function (idx) {
         removeBtn.addEventListener("click", function (ev) {
           ev.stopPropagation();
-          state.reelQueue.splice(idx, 1);
+          var removed = state.reelQueue.splice(idx, 1)[0];
+          delete state.cellResults[cellKey(removed.participant, removed.row)];
           renderReelQueue();
           updateCellClasses();
         });
@@ -811,12 +895,17 @@
       list.appendChild(card);
     }
     qs("#reelDuration").textContent = formatDuration(totalDur);
+    applyCardStates(list);
   }
 
   // ---- Buttons ----
 
   function bindButtons() {
     qs("#clearArtifactsBtn").addEventListener("click", function () {
+      for (var i = 0; i < state.artifactQueue.length; i++) {
+        var item = state.artifactQueue[i];
+        delete state.cellResults[cellKey(item.participant, item.row)];
+      }
       state.artifactQueue = [];
       renderArtifactQueue();
       updateCellClasses();
@@ -830,6 +919,10 @@
     });
 
     qs("#clearReelBtn").addEventListener("click", function () {
+      for (var i = 0; i < state.reelQueue.length; i++) {
+        var item = state.reelQueue[i];
+        delete state.cellResults[cellKey(item.participant, item.row)];
+      }
       state.reelQueue = [];
       renderReelQueue();
       updateCellClasses();
@@ -839,7 +932,6 @@
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
     qs("#buildTimelineViewerBtn").addEventListener("click", onBuildTimelineViewer);
-    qs("#regenerateBtn").addEventListener("click", onRegenerate);
     qs("#buildHighlightsBtn").addEventListener("click", onBuildHighlights);
 
     qs("#statusDismiss").addEventListener("click", hideOverlay);
@@ -883,6 +975,9 @@
     );
     var thumb = card.querySelector(".artifact-card-thumb, .reel-card-thumb");
     if (thumb) thumb.appendChild(createPulserOverlay());
+    var p = card.getAttribute("data-participant");
+    var r = card.getAttribute("data-row");
+    if (p && r) delete state.cellResults[cellKey(p, parseInt(r, 10))];
   }
 
   function setCardResult(card, success) {
@@ -897,6 +992,22 @@
     if (overlay) overlay.remove();
     var thumb = card.querySelector(".artifact-card-thumb, .reel-card-thumb");
     if (thumb) thumb.appendChild(createResultBadge(success));
+    var p = card.getAttribute("data-participant");
+    var r = card.getAttribute("data-row");
+    if (p && r) state.cellResults[cellKey(p, parseInt(r, 10))] = success ? "success" : "fail";
+  }
+
+  function applyCardStates(listEl) {
+    var cards = listEl.querySelectorAll(".artifact-card, .reel-card");
+    for (var i = 0; i < cards.length; i++) {
+      var card = cards[i];
+      var p = card.getAttribute("data-participant");
+      var r = card.getAttribute("data-row");
+      var result = state.cellResults[cellKey(p, parseInt(r, 10))];
+      if (result === "success" || result === "fail") {
+        setCardResult(card, result === "success");
+      }
+    }
   }
 
   function clearCardStates(listEl) {
@@ -920,7 +1031,7 @@
     var ids = [
       "#generateBtn", "#buildReelBtn", "#clearArtifactsBtn",
       "#clearReelBtn", "#addToReelBtn", "#buildHighlightsBtn",
-      "#buildViewerBtn", "#buildTimelineViewerBtn", "#regenerateBtn"
+      "#buildViewerBtn", "#buildTimelineViewerBtn"
     ];
     for (var i = 0; i < ids.length; i++) {
       var b = qs(ids[i]);
@@ -1133,37 +1244,6 @@
       });
   }
 
-  function onRegenerate() {
-    if (state.generating) return;
-    state.generating = true;
-
-    showOverlay("Regenerating artifacts from manifest...");
-
-    fetch("api/regenerate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    })
-      .then(function (r) {
-        return r.json();
-      })
-      .then(function (data) {
-        state.generating = false;
-        if (data.ok) {
-          showResult(
-            "Regenerated " + data.regenerated + " of " + data.total + " item(s)",
-            null
-          );
-        } else {
-          showResult(null, data.error || "Regeneration failed");
-        }
-      })
-      .catch(function (err) {
-        state.generating = false;
-        showResult(null, "Request failed: " + err);
-      });
-  }
-
   function onBuildHighlights() {
     if (state.generating) return;
     state.generating = true;
@@ -1232,8 +1312,6 @@
 
   function hideOverlay() {
     qs("#statusOverlay").classList.add("hidden");
-    clearCardStates(qs("#artifactsList"));
-    clearCardStates(qs("#reelList"));
   }
 
   // ---- Init ----

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.38"
+VERSIONNUM: str = "0.9.39"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -377,8 +377,13 @@ def api_timeline_viewer() -> FlaskResponse:
         return jsonify({"ok": False, "error": str(e)}), 500
 
 
-@studio_bp.route("/api/manifest", methods=["POST"])
+@studio_bp.route("/api/manifest", methods=["GET", "POST"])
 def api_manifest() -> FlaskResponse:
+    if request.method == "GET":
+        artifacts = viewer.load_manifest_artifacts()
+        reels = viewer.load_manifest_reels()
+        return jsonify({"ok": True, "artifacts": artifacts, "reels": reels})
+
     artifacts = _generated_artifacts
     reels = _generated_reels
     if not artifacts and not reels:

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -172,6 +172,44 @@ def test_api_thumbnail_caches(client, monkeypatch, tmp_path):
     assert call_count[0] == 1
 
 
+def test_api_manifest_get_returns_artifacts(client, monkeypatch):
+    import viewer
+
+    fake_artifacts = [{"id": "a5c2s0", "type": "clip", "participant": "P01", "cellRow": 5}]
+    monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: fake_artifacts)
+    monkeypatch.setattr(viewer, "load_manifest_reels", lambda: [])
+    resp = client.get("/studio/api/manifest")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(data["artifacts"]) == 1
+    assert data["artifacts"][0]["id"] == "a5c2s0"
+    assert data["reels"] == []
+
+
+def test_api_manifest_get_empty(client, monkeypatch):
+    import viewer
+
+    monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: [])
+    monkeypatch.setattr(viewer, "load_manifest_reels", lambda: [])
+    resp = client.get("/studio/api/manifest")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["artifacts"] == []
+    assert data["reels"] == []
+
+
+def test_api_manifest_post_still_works(client, monkeypatch):
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_generated_reels", [])
+    resp = client.post("/studio/api/manifest")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert "No artifacts" in data["error"]
+
+
 def test_api_viewer_400_when_no_artifacts(client):
     resp = client.post("/studio/api/viewer")
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Track generation results (success/fail) in JS state so card badges and colors persist after dismissing the status overlay, only resetting when the same cells are re-generated
- Save artifact and reel queues to sessionStorage so all cards (generated or not) survive navigation between Studio and Insights Builder
- On page load, restore queues from sessionStorage and layer success badges from the manifest via a new `GET /api/manifest` endpoint
- Remove the "Regenerate from Manifest" quick action, now redundant with automatic state restoration

## Test plan
- [ ] Verify `uv run pytest -c tests/pytest.ini` passes (3 new tests for GET manifest endpoint)
- [ ] Generate artifacts in Studio → dismiss overlay → confirm badges persist
- [ ] Queue cards without generating → switch to Insights → switch back → confirm cards are still there
- [ ] Generate artifacts → switch to Insights → switch back → confirm cards restored with success badges
- [ ] Clear cards or remove individual cards → confirm badges and state are cleaned up