### PR TITLE
Studio highlights populates reel queue instead of building file

### DIFF
--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -90,7 +90,7 @@
           <label class="quick-action-label">Duration (s)
             <input id="highlightsDuration" type="number" min="10" step="10" value="180" class="quick-action-input">
           </label>
-          <button id="buildHighlightsBtn" class="btn btn-primary">Build Highlights</button>
+          <button id="buildHighlightsBtn" class="btn btn-primary">Find Highlights</button>
         </div>
       </div>
     </div>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1251,25 +1251,34 @@
     var duration = parseInt(qs("#highlightsDuration").value, 10);
     if (!duration || duration < 1) duration = 180;
 
-    showOverlay("Building highlights reel (" + duration + "s budget)...");
+    showOverlay("Finding best clips (" + duration + "s budget)...");
 
-    fetch("api/reel", {
+    fetch("api/highlights-preview", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        cells: ["highlights", "batch"],
-        highlights_duration: duration,
-      }),
+      body: JSON.stringify({ highlights_duration: duration }),
     })
       .then(function (r) {
         return r.json();
       })
       .then(function (data) {
         state.generating = false;
-        if (data.ok) {
-          showResult("Highlights reel built successfully", null);
+        if (data.ok && data.clips && data.clips.length > 0) {
+          state.reelQueue = [];
+          for (var i = 0; i < data.clips.length; i++) {
+            state.reelQueue.push(data.clips[i]);
+          }
+          renderReelQueue();
+          updateCellClasses();
+          showResult(
+            "Added " + data.clips.length + " clip(s) to reel queue",
+            null
+          );
         } else {
-          showResult(null, data.error || "Highlights reel build failed");
+          showResult(
+            null,
+            data.error || "No clips found for highlights selection"
+          );
         }
       })
       .catch(function (err) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.39"
+VERSIONNUM: str = "0.9.40"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -260,6 +260,50 @@ def api_generate() -> FlaskResponse:
     return Response(stream(), mimetype="application/x-ndjson", headers={"X-Accel-Buffering": "no"})
 
 
+@studio_bp.route("/api/highlights-preview", methods=["POST"])
+def api_highlights_preview() -> FlaskResponse:
+    if _worksheet is None:
+        return jsonify({"ok": False, "error": "No worksheet loaded"}), 500
+
+    data = request.get_json(silent=True) or {}
+    highlights_duration = data.get("highlights_duration")
+
+    original_duration = config.HIGHLIGHTS_REEL_DURATION_SECONDS
+    if highlights_duration is not None:
+        try:
+            val = int(highlights_duration)
+            if val > 0:
+                config.HIGHLIGHTS_REEL_DURATION_SECONDS = val
+        except (ValueError, TypeError):
+            pass
+
+    try:
+        clips = spreadsheet.generate_list(
+            _worksheet, "reel", reel_input="highlights, batch", skip_prompts=True
+        )
+    finally:
+        config.HIGHLIGHTS_REEL_DURATION_SECONDS = original_duration
+
+    if not clips:
+        return jsonify(
+            {"ok": False, "error": "No clips found for highlights selection"}
+        ), 400
+
+    result = []
+    for clip in clips:
+        cell = clip.get("cell")
+        result.append(
+            {
+                "participant": clip.get("participant", ""),
+                "row": cell.row if cell else 0,
+                "desc": clip.get("desc", ""),
+                "timestamp": str(cell.value) if cell else "",
+            }
+        )
+
+    return jsonify({"ok": True, "clips": result})
+
+
 @studio_bp.route("/api/reel", methods=["POST"])
 def api_reel() -> FlaskResponse:
     if _worksheet is None:


### PR DESCRIPTION
## Summary
- The "Find Highlights" button (formerly "Build Highlights") now scores and selects the best clips but populates the Reel queue instead of immediately building a video file
- Adds a new `POST /api/highlights-preview` endpoint that returns scored clip metadata without invoking ffmpeg
- Users can review, reorder, and remove clips in the reel queue before building the reel

## Test plan
- [ ] Run `uv run pytest -c tests/pytest.ini` — all 164 tests pass
- [ ] Launch Studio, click "Find Highlights", verify clips appear in Reel area
- [ ] Verify reel cards can be reordered and "Build Reel" still works