### PR TITLE
Pin Studio artifact and reel areas to bottom of viewport

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -53,14 +53,19 @@ body {
   background-size: 40px 40px;
   color: var(--color-text);
   line-height: 1.5;
-  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 /* Header */
 
 #studioHeader {
+  flex-shrink: 0;
   padding: 1.2rem 1.5rem 0.8rem;
   max-width: 1120px;
+  width: 100%;
   margin: 1.5rem auto 0;
   background: var(--color-panel-bg);
   border-radius: 18px 18px 0 0;
@@ -189,7 +194,12 @@ body {
 /* Sheet preview */
 
 #sheetPreview {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   max-width: 1120px;
+  width: 100%;
   margin: 0 auto;
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
@@ -205,8 +215,9 @@ body {
 }
 
 #sheetGrid {
+  flex: 1;
+  min-height: 0;
   overflow: auto;
-  max-height: 50vh;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
 }
@@ -362,6 +373,13 @@ col.col-participant-col {
   border-bottom: 1px solid var(--color-border);
   background: transparent;
   opacity: 0.6;
+}
+
+/* Bottom panel (sticky to viewport bottom) */
+
+#bottomPanel {
+  flex-shrink: 0;
+  width: 100%;
 }
 
 /* Drop areas */
@@ -1124,6 +1142,7 @@ html[data-theme="dark"] .reel-card-fail {
 @media (max-width: 768px) {
   #studioHeader,
   #sheetPreview,
+  #bottomPanel,
   #dropAreas,
   #reelArea,
   #quickActions {
@@ -1134,9 +1153,5 @@ html[data-theme="dark"] .reel-card-fail {
 
   #dropAreas {
     grid-template-columns: 1fr;
-  }
-
-  #sheetGrid {
-    max-height: 40vh;
   }
 }

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -31,6 +31,7 @@
     </div>
   </section>
 
+  <div id="bottomPanel">
   <section id="dropAreas">
     <div id="artifactsArea" class="drop-area">
       <h3><svg id="artifactsSpinner" class="title-spinner" width="14" height="14" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>Artifacts <span id="artifactsCount">(0)</span></h3>
@@ -95,6 +96,7 @@
       </div>
     </div>
   </section>
+  </div>
 
   <div id="statusOverlay" class="hidden">
     <div class="status-card">


### PR DESCRIPTION
## Summary
- Converts the Studio page body into a full-viewport flex column so the artifact, reel, and quick actions sections stay pinned to the bottom of the viewport
- The sheet preview now fills remaining space and scrolls internally, replacing the old `max-height: 50vh` constraint
- Makes it easy to see where artifacts land when clicking cells in the spreadsheet grid

## Test plan
- [ ] Launch Studio and confirm the spreadsheet grid scrolls independently while artifact/reel areas remain visible at the bottom
- [ ] Click cells in the grid and verify cards appear in the pinned artifact area without needing to scroll down
- [ ] Test at narrow viewport widths (≤768px) to confirm responsive layout still works
- [ ] Verify dark mode is unaffected