### PR TITLE
Skip regeneration of existing artifacts and reels in Studio

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -847,6 +847,14 @@ def process_clips(
     return (outputs_generated, all_artifacts)
 
 
+def compute_reel_id(components: List[Dict[str, Any]]) -> str:
+    """Compute a deterministic reel ID from its component metadata."""
+    parts = sorted(
+        f"{c['cellRow']}:{c['cellCol']}:{c['start']}:{c['end']}" for c in components
+    )
+    return "reel_" + hashlib.sha256("|".join(parts).encode()).hexdigest()[:8]
+
+
 def process_reel(
     clips_list: List[ClipRecord],
     output_file: Optional[str] = None,
@@ -944,10 +952,7 @@ def process_reel(
     if not ok:
         return (0, [])
 
-    parts = sorted(
-        f"{c['cellRow']}:{c['cellCol']}:{c['start']}:{c['end']}" for c in components
-    )
-    reel_id = "reel_" + hashlib.sha256("|".join(parts).encode()).hexdigest()[:8]
+    reel_id = compute_reel_id(components)
     reel_record = {
         "id": reel_id,
         "file": Path(output_file).name,

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.39"
+VERSIONNUM: str = "0.9.40"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -6,6 +6,7 @@ start_combined_server(), and exposes REST endpoints for sheet data
 access, artifact generation, reel building, and viewer creation.
 """
 
+import hashlib
 import json
 import sys
 import webbrowser
@@ -210,6 +211,22 @@ def _save_manifest_quiet() -> None:
         pass
 
 
+def _find_existing_artifacts(
+    cell_row: int, cell_col: int, artifact_type: str
+) -> List[Dict[str, Any]]:
+    """Return cached artifact records for a cell+type whose files still exist on disk."""
+    matches = [
+        a
+        for a in _generated_artifacts
+        if a.get("cellRow") == cell_row
+        and a.get("cellCol") == cell_col
+        and a.get("type") == artifact_type
+    ]
+    return [
+        a for a in matches if Path(utils.resolve_output_path(a["file"])).is_file()
+    ]
+
+
 @studio_bp.route("/api/generate", methods=["POST"])
 def api_generate() -> FlaskResponse:
     if _worksheet is None:
@@ -242,6 +259,22 @@ def api_generate() -> FlaskResponse:
         for clip in clips:
             cell_str = clip["participant"] + "." + str(clip["cell"].row)
             clip_cells.add(cell_str)
+
+            existing = _find_existing_artifacts(
+                clip["cell"].row, clip["cell"].col, output_format
+            )
+            if existing:
+                yield json.dumps(
+                    {
+                        "cell": cell_str,
+                        "ok": True,
+                        "generated": len(existing),
+                        "artifacts": existing,
+                        "skipped": True,
+                    }
+                ) + "\n"
+                continue
+
             try:
                 generated, artifacts = clipgen.process_clips(
                     [clip], output_format=output_format
@@ -295,6 +328,35 @@ def api_reel() -> FlaskResponse:
             return jsonify(
                 {"ok": False, "error": "No clips found for the specified cells"}
             ), 400
+
+        # Check if an identical reel already exists
+        components: List[Dict[str, Any]] = []
+        for clip in clips:
+            files.prepare_clip(clip)
+            cell = clip.get("cell")
+            for start_str, end_str in clip.get("times", []):
+                components.append(
+                    {
+                        "cellRow": getattr(cell, "row", None),
+                        "cellCol": getattr(cell, "col", None),
+                        "start": utils.timestamp_to_seconds(start_str),
+                        "end": utils.timestamp_to_seconds(end_str),
+                    }
+                )
+        if components:
+            expected_id = clipgen.compute_reel_id(components)
+            for reel in _generated_reels:
+                if reel.get("id") == expected_id and Path(
+                    utils.resolve_output_path(reel["file"])
+                ).is_file():
+                    return jsonify(
+                        {
+                            "ok": True,
+                            "generated": 1,
+                            "reels": [reel],
+                            "skipped": True,
+                        }
+                    )
 
         generated, reel_records = clipgen.process_reel(clips)
         _generated_reels.extend(reel_records)
@@ -450,8 +512,8 @@ def _init_studio_state(worksheet: Any) -> None:
 
     _worksheet = worksheet
     _sheet_context = spreadsheet.build_sheet_context(worksheet)
-    _generated_artifacts = []
-    _generated_reels = []
+    _generated_artifacts = viewer.load_manifest_artifacts()
+    _generated_reels = viewer.load_manifest_reels()
     _thumbnail_cache = {}
 
     if _sheet_context is None:

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 Flask = pytest.importorskip("flask").Flask
@@ -208,6 +210,136 @@ def test_api_manifest_post_still_works(client, monkeypatch):
     data = resp.get_json()
     assert data["ok"] is False
     assert "No artifacts" in data["error"]
+
+
+def test_api_generate_skips_existing_artifacts(client, monkeypatch, tmp_path):
+    """Already-generated artifacts are returned without re-running process_clips."""
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+
+    # Create the artifact file on disk
+    (tmp_path / "clip.mp4").write_bytes(b"video")
+
+    existing = [
+        {"id": "a5c2s0", "type": "clip", "file": "clip.mp4", "cellRow": 5, "cellCol": 2}
+    ]
+    monkeypatch.setattr(server, "_generated_artifacts", list(existing))
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00")
+
+    def fake_generate_list(ws, mode, *, cell_specs, skip_prompts):
+        return [{"participant": "P01", "cell": cell}]
+
+    def fake_parse_cell_specs(text):
+        return [("P01", 5)]
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", fake_parse_cell_specs)
+
+    process_called = []
+    monkeypatch.setattr(
+        "clipgen.process_clips",
+        lambda *a, **kw: process_called.append(1) or (1, []),
+    )
+
+    resp = client.post("/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"})
+    assert resp.status_code == 200
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert lines[0]["ok"] is True
+    assert lines[0]["skipped"] is True
+    assert lines[0]["artifacts"] == existing
+    assert process_called == []
+
+
+def test_api_generate_regenerates_when_file_missing(client, monkeypatch, tmp_path):
+    """If artifact file is missing from disk, regeneration proceeds normally."""
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+
+    # Artifact record exists but file does NOT
+    stale = [
+        {"id": "a5c2s0", "type": "clip", "file": "gone.mp4", "cellRow": 5, "cellCol": 2}
+    ]
+    monkeypatch.setattr(server, "_generated_artifacts", list(stale))
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00")
+
+    def fake_generate_list(ws, mode, *, cell_specs, skip_prompts):
+        return [{"participant": "P01", "cell": cell}]
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
+
+    new_artifact = {"id": "a5c2s0", "type": "clip", "file": "new.mp4", "cellRow": 5, "cellCol": 2}
+    monkeypatch.setattr(
+        "clipgen.process_clips",
+        lambda *a, **kw: (1, [new_artifact]),
+    )
+
+    resp = client.post("/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"})
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert lines[0]["ok"] is True
+    assert "skipped" not in lines[0]
+    assert lines[0]["artifacts"] == [new_artifact]
+
+
+def test_api_reel_skips_existing_reel(client, monkeypatch, tmp_path):
+    """An identical reel is returned without re-running process_reel."""
+    import types
+
+    import clipgen as clipgen_mod
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+
+    # Create the reel file on disk
+    (tmp_path / "study_reel.mp4").write_bytes(b"reel")
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00-1:30")
+
+    # Compute expected reel ID using the same function the server will use
+    components = [{"cellRow": 5, "cellCol": 2, "start": 60.0, "end": 90.0}]
+    expected_id = clipgen_mod.compute_reel_id(components)
+
+    existing_reel = {
+        "id": expected_id,
+        "file": "study_reel.mp4",
+        "study": "study",
+        "components": components,
+    }
+    monkeypatch.setattr(server, "_generated_reels", [existing_reel])
+
+    def fake_generate_list(ws, mode, *, reel_input, skip_prompts):
+        return [
+            {
+                "participant": "P01",
+                "cell": cell,
+                "desc": "test",
+                "category": "cat",
+                "study": "study",
+                "severity": "",
+            }
+        ]
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+
+    process_called = []
+    monkeypatch.setattr(
+        "clipgen.process_reel",
+        lambda *a, **kw: process_called.append(1) or (1, []),
+    )
+
+    resp = client.post("/studio/api/reel", json={"cells": ["P01.5"]})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["skipped"] is True
+    assert data["reels"] == [existing_reel]
+    assert process_called == []
 
 
 def test_api_viewer_400_when_no_artifacts(client):


### PR DESCRIPTION
## Summary

- Studio `/api/generate` now checks whether artifacts for a cell+format already exist on disk before invoking ffmpeg, returning cached records instead of creating duplicate files
- Studio `/api/reel` pre-computes the deterministic reel ID from clip timestamps and skips generation when a matching reel file is found
- On startup, `_generated_artifacts` and `_generated_reels` are seeded from the manifest so previously generated files are recognized across server restarts
- Extracted `compute_reel_id()` in clipgen.py for shared use by both `process_reel()` and the server skip check

## Test plan

- [x] New test: artifact skip when matching files exist on disk (`process_clips` not called)
- [x] New test: artifact regeneration proceeds when referenced file is missing from disk
- [x] New test: reel skip when matching reel ID and file exist (`process_reel` not called)
- [x] Full suite: 167 tests pass