### PR TITLE
Move Find Highlights into Reel header with two-phase interaction

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -572,7 +572,7 @@ col.col-participant-col {
 
 #reelArea {
   max-width: 1120px;
-  margin: 0 auto;
+  margin: 0 auto 1.5rem;
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
@@ -835,17 +835,25 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
 }
 
 .highlights-drawer {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
   max-height: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-height 0.25s ease, opacity 0.2s ease, margin 0.25s ease;
+  transition: max-height 0.25s ease, opacity 0.2s ease, margin-top 0.25s ease;
   margin-top: 0;
+  background: var(--color-panel-bg);
+  border-radius: calc(var(--radius) - 2px);
+  pointer-events: none;
 }
 
 .highlights-drawer.open {
   max-height: 3rem;
   opacity: 1;
-  margin-top: 0.4rem;
+  margin-top: 0.35rem;
+  pointer-events: auto;
 }
 
 .highlights-drawer-label {

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -576,7 +576,7 @@ col.col-participant-col {
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0;
+  border-radius: 0 0 18px 18px;
   box-shadow: 0 24px 60px var(--color-panel-shadow);
   padding: 1rem 1.5rem 1.5rem;
 }
@@ -815,63 +815,49 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   margin-bottom: 0.5rem;
 }
 
-/* Quick Actions */
+/* Highlights button group (inside reel header) */
 
-#quickActions {
-  max-width: 1120px;
-  margin: 0 auto;
-  background: var(--color-panel-bg);
-  border: 1px solid var(--color-panel-border);
-  border-top: none;
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 1rem 1.5rem 1.5rem;
-}
-
-#quickActions h3 {
-  font-size: 0.9rem;
-  font-weight: 600;
-  margin-bottom: 0.6rem;
-}
-
-.quick-actions-grid {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.quick-action-card {
-  flex: 1;
-  min-width: 240px;
+.highlights-group {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  background: var(--color-surface);
+  align-items: flex-start;
 }
 
-.quick-action-info strong {
-  font-size: 0.82rem;
-  display: block;
-  margin-bottom: 0.15rem;
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
-.quick-action-info span {
-  font-size: 0.78rem;
-  color: var(--color-text-dim);
+.sparkles-icon {
+  flex-shrink: 0;
 }
 
-.quick-action-label {
+.highlights-drawer {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.2s ease, margin 0.25s ease;
+  margin-top: 0;
+}
+
+.highlights-drawer.open {
+  max-height: 3rem;
+  opacity: 1;
+  margin-top: 0.4rem;
+}
+
+.highlights-drawer-label {
   font-size: 0.75rem;
   color: var(--color-text-dim);
   display: flex;
   align-items: center;
   gap: 0.35rem;
+  white-space: nowrap;
 }
 
-.quick-action-input {
+.highlights-drawer-input {
   width: 5rem;
   padding: 0.3rem 0.4rem;
   border: 1px solid var(--color-border);

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -70,30 +70,28 @@
     <div id="reelHeader">
       <h3><svg id="reelSpinner" class="title-spinner" width="14" height="14" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>Reel <span id="reelCount">(0)</span> <span id="reelDuration"></span></h3>
       <div class="area-controls">
+        <div class="highlights-group">
+          <button id="buildHighlightsBtn" class="btn btn-primary btn-icon"
+                  title="Auto-select the best clips scored by severity, uniqueness, and keyword annotations.">
+            <svg class="sparkles-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8 1l1.1 3.4L12.5 5.5l-3.4 1.1L8 10l-1.1-3.4L3.5 5.5l3.4-1.1z"/>
+              <path d="M12.5 10l.6 1.7 1.7.6-1.7.6-.6 1.7-.6-1.7-1.7-.6 1.7-.6z"/>
+              <path d="M3 11l.4 1.1 1.1.4-1.1.4L3 14l-.4-1.1L1.5 12.5l1.1-.4z"/>
+            </svg>
+            Find Highlights
+          </button>
+          <div id="highlightsDurationDrawer" class="highlights-drawer">
+            <label class="highlights-drawer-label">Duration (s)
+              <input id="highlightsDuration" type="number" min="10" step="10" value="180" class="highlights-drawer-input">
+            </label>
+          </div>
+        </div>
         <button id="buildReelBtn" class="btn btn-primary" disabled>Build Reel</button>
         <button id="clearReelBtn" class="btn btn-small">Clear</button>
       </div>
     </div>
     <div id="reelList" class="drop-target">
       <div class="drop-target-empty">Shift+click or drag cells here to build a reel</div>
-    </div>
-  </section>
-
-  <section id="quickActions">
-    <h3>Quick Actions</h3>
-    <div class="quick-actions-grid">
-      <div class="quick-action-card">
-        <div class="quick-action-info">
-          <strong>Build Highlights Reel</strong>
-          <span>Auto-select the best clips scored by severity, uniqueness, and keyword annotations.</span>
-        </div>
-        <div class="area-controls">
-          <label class="quick-action-label">Duration (s)
-            <input id="highlightsDuration" type="number" min="10" step="10" value="180" class="quick-action-input">
-          </label>
-          <button id="buildHighlightsBtn" class="btn btn-primary">Find Highlights</button>
-        </div>
-      </div>
     </div>
   </section>
   </div>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1334,9 +1334,22 @@
     var btn = qs("#buildHighlightsBtn");
     var isOpen = drawer.classList.contains("open");
 
+    var sparklesHTML =
+      '<svg class="sparkles-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M8 1l1.1 3.4L12.5 5.5l-3.4 1.1L8 10l-1.1-3.4L3.5 5.5l3.4-1.1z"/>' +
+      '<path d="M12.5 10l.6 1.7 1.7.6-1.7.6-.6 1.7-.6-1.7-1.7-.6 1.7-.6z"/>' +
+      '<path d="M3 11l.4 1.1 1.1.4-1.1.4L3 14l-.4-1.1L1.5 12.5l1.1-.4z"/>' +
+      "</svg>";
+    var checkHTML =
+      '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M3 8.5l3.5 3.5 6.5-8"/>' +
+      "</svg>";
+
     if (!isOpen) {
       drawer.classList.add("open");
-      btn.textContent = "Confirm";
+      var w = btn.offsetWidth;
+      btn.style.minWidth = w + "px";
+      btn.innerHTML = checkHTML + "Confirm";
       return;
     }
 
@@ -1344,13 +1357,8 @@
     if (!duration || duration < 1) duration = 180;
 
     drawer.classList.remove("open");
-    btn.innerHTML =
-      '<svg class="sparkles-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">' +
-      '<path d="M8 1l1.1 3.4L12.5 5.5l-3.4 1.1L8 10l-1.1-3.4L3.5 5.5l3.4-1.1z"/>' +
-      '<path d="M12.5 10l.6 1.7 1.7.6-1.7.6-.6 1.7-.6-1.7-1.7-.6 1.7-.6z"/>' +
-      '<path d="M3 11l.4 1.1 1.1.4-1.1.4L3 14l-.4-1.1L1.5 12.5l1.1-.4z"/>' +
-      "</svg>" +
-      "Find Highlights";
+    btn.style.minWidth = "";
+    btn.innerHTML = sparklesHTML + "Find Highlights";
 
     state.generating = true;
     showOverlay("Finding best clips (" + duration + "s budget)...");

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1246,11 +1246,30 @@
 
   function onBuildHighlights() {
     if (state.generating) return;
-    state.generating = true;
+
+    var drawer = qs("#highlightsDurationDrawer");
+    var btn = qs("#buildHighlightsBtn");
+    var isOpen = drawer.classList.contains("open");
+
+    if (!isOpen) {
+      drawer.classList.add("open");
+      btn.textContent = "Confirm";
+      return;
+    }
 
     var duration = parseInt(qs("#highlightsDuration").value, 10);
     if (!duration || duration < 1) duration = 180;
 
+    drawer.classList.remove("open");
+    btn.innerHTML =
+      '<svg class="sparkles-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M8 1l1.1 3.4L12.5 5.5l-3.4 1.1L8 10l-1.1-3.4L3.5 5.5l3.4-1.1z"/>' +
+      '<path d="M12.5 10l.6 1.7 1.7.6-1.7.6-.6 1.7-.6-1.7-1.7-.6 1.7-.6z"/>' +
+      '<path d="M3 11l.4 1.1 1.1.4-1.1.4L3 14l-.4-1.1L1.5 12.5l1.1-.4z"/>' +
+      "</svg>" +
+      "Find Highlights";
+
+    state.generating = true;
     showOverlay("Finding best clips (" + duration + "s budget)...");
 
     fetch("api/highlights-preview", {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.40"
+VERSIONNUM: str = "0.9.41"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary
- Moves the "Find Highlights" button from the Quick Actions section into the Reel area header, to the left of "Build Reel", with a sparkles SVG icon and tooltip.
- Adds a two-phase interaction: first click reveals a floating duration input and changes the button to "Confirm" (with checkmark icon, stable width); second click fires the highlights query and resets.
- Removes the now-empty Quick Actions section, transferring its bottom border-radius and adding matching bottom margin to the Reel area for balanced page spacing.

## Test plan
- [x] `uv run pytest` passes (167 tests)
- [ ] Visual check: sparkles button in reel header, tooltip on hover, drawer slides out floating over content, button stays same size as "Confirm", second click populates reel queue and resets
- [ ] Verify balanced top/bottom spacing around the panel column