### PR TITLE
Add Stashed Reels archive to Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -581,6 +581,11 @@ col.col-participant-col {
   padding: 1rem 1.5rem 1.5rem;
 }
 
+#reelArea:has(+ #stashedReelsArea:not(.hidden)) {
+  border-radius: 0;
+  margin-bottom: 0;
+}
+
 #reelArea h3 {
   font-size: 0.9rem;
   font-weight: 600;
@@ -737,6 +742,138 @@ html[data-theme="dark"] .reel-card.reel-card-error {
 
 html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   color: #f87171;
+}
+
+/* Stashed reels */
+
+#stashedReelsArea {
+  max-width: 1120px;
+  margin: 0 auto 1.5rem;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-top: none;
+  border-radius: 0 0 18px 18px;
+  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  padding: 0.8rem 1.5rem 1rem;
+}
+
+#stashedReelsArea.hidden {
+  display: none;
+}
+
+#stashedReelsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+#stashedReelsHeader h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+#stashedReelsHeader h3 span {
+  font-weight: 400;
+  color: var(--color-text-dim);
+  font-size: 0.78rem;
+}
+
+#stashedReelsList {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.3rem 0;
+}
+
+.stash-card {
+  flex-shrink: 0;
+  width: 160px;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  padding: 0.5rem 0.6rem;
+  cursor: pointer;
+  position: relative;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.stash-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.stash-card-name {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: text;
+  padding: 1px 2px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+
+.stash-card-name:hover {
+  border-color: var(--color-border);
+}
+
+.stash-card-name-input {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  width: 100%;
+  padding: 1px 2px;
+  border: 1px solid var(--color-accent);
+  border-radius: 3px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  outline: none;
+  font-family: inherit;
+}
+
+.stash-card-info {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--color-text-dim);
+  margin-top: 0.25rem;
+  font-family: var(--font-mono);
+}
+
+.stash-card-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  font-size: 0.7rem;
+  line-height: 18px;
+  text-align: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+  padding: 0;
+}
+
+.stash-card:hover .stash-card-remove {
+  opacity: 1;
+}
+
+.stash-card-remove:hover {
+  background: #dc2626;
 }
 
 /* Area controls */
@@ -1074,6 +1211,9 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
     border-color: #f87171;
     background: #451a1a;
   }
+  .stash-card-name-input {
+    background: var(--color-surface-alt);
+  }
 }
 
 html[data-theme="dark"] {
@@ -1131,6 +1271,10 @@ html[data-theme="dark"] .reel-card-fail {
   background: #451a1a;
 }
 
+html[data-theme="dark"] .stash-card-name-input {
+  background: var(--color-surface-alt);
+}
+
 /* ---- Responsive ---- */
 
 @media (max-width: 768px) {
@@ -1139,6 +1283,7 @@ html[data-theme="dark"] .reel-card-fail {
   #bottomPanel,
   #dropAreas,
   #reelArea,
+  #stashedReelsArea,
   #quickActions {
     margin-left: 0.5rem;
     margin-right: 0.5rem;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -86,6 +86,7 @@
             </label>
           </div>
         </div>
+        <button id="stashReelBtn" class="btn btn-small" disabled>Stash</button>
         <button id="buildReelBtn" class="btn btn-primary" disabled>Build Reel</button>
         <button id="clearReelBtn" class="btn btn-small">Clear</button>
       </div>
@@ -93,6 +94,13 @@
     <div id="reelList" class="drop-target">
       <div class="drop-target-empty">Shift+click or drag cells here to build a reel</div>
     </div>
+  </section>
+
+  <section id="stashedReelsArea" class="hidden">
+    <div id="stashedReelsHeader">
+      <h3>Stashed Reels <span id="stashedReelsCount">(0)</span></h3>
+    </div>
+    <div id="stashedReelsList"></div>
   </section>
   </div>
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -13,6 +13,7 @@
     generatedArtifacts: [],
     generating: false,
     cellResults: {},
+    stashes: [],
   };
 
   // ---- Helpers ----
@@ -898,6 +899,7 @@
     var n = state.reelQueue.length;
     qs("#reelCount").textContent = "(" + n + ")";
     qs("#buildReelBtn").disabled = n === 0;
+    qs("#stashReelBtn").disabled = n === 0;
     list.innerHTML = "";
     saveQueues();
 
@@ -973,6 +975,177 @@
     applyCardStates(list);
   }
 
+  // ---- Stashed reels ----
+
+  function loadStashes() {
+    fetch("api/stashes")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          state.stashes = data.stashes || [];
+          renderStashedReels();
+        }
+      })
+      .catch(function () {});
+  }
+
+  function renderStashedReels() {
+    var area = qs("#stashedReelsArea");
+    var list = qs("#stashedReelsList");
+    var n = state.stashes.length;
+    qs("#stashedReelsCount").textContent = "(" + n + ")";
+
+    if (n === 0) {
+      area.classList.add("hidden");
+      return;
+    }
+    area.classList.remove("hidden");
+    list.innerHTML = "";
+
+    for (var i = 0; i < n; i++) {
+      var stash = state.stashes[i];
+      var card = el("div", "stash-card");
+      card.setAttribute("data-stash-id", stash.id);
+
+      var nameEl = el("span", "stash-card-name", truncate(stash.name, 20));
+      nameEl.title = stash.name;
+      (function (stashRef, nameNode) {
+        nameNode.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          startStashRename(stashRef, nameNode);
+        });
+      })(stash, nameEl);
+      card.appendChild(nameEl);
+
+      var info = el("div", "stash-card-info");
+      info.appendChild(el("span", "", stash.count + " clips"));
+      info.appendChild(el("span", "", formatDuration(stash.totalDuration)));
+      card.appendChild(info);
+
+      var removeBtn = el("button", "stash-card-remove", "\u00D7");
+      removeBtn.title = "Delete stash";
+      (function (stashId) {
+        removeBtn.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          deleteStash(stashId);
+        });
+      })(stash.id);
+      card.appendChild(removeBtn);
+
+      (function (stashRef) {
+        card.addEventListener("click", function () {
+          recallStash(stashRef);
+        });
+      })(stash);
+
+      list.appendChild(card);
+    }
+  }
+
+  function computeReelDuration(items) {
+    var total = 0;
+    for (var i = 0; i < items.length; i++) {
+      var dur = items[i].segDuration;
+      if (dur === undefined || dur === null) {
+        var segs = parseClipTimestamps(items[i].timestamp);
+        dur = segs.length > 0 ? segs[0].duration : 0;
+      }
+      total += dur || 0;
+    }
+    return total;
+  }
+
+  function stashCurrentReel() {
+    if (state.reelQueue.length === 0) return;
+
+    var items = state.reelQueue.slice();
+    var totalDuration = computeReelDuration(items);
+    fetch("api/stashes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "create", items: items, name: "", totalDuration: totalDuration }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          state.stashes.push(data.stash);
+          for (var i = 0; i < state.reelQueue.length; i++) {
+            var item = state.reelQueue[i];
+            delete state.cellResults[cellKey(item.participant, item.row)];
+          }
+          state.reelQueue = [];
+          renderReelQueue();
+          renderStashedReels();
+          updateCellClasses();
+        }
+      })
+      .catch(function () {});
+  }
+
+  function recallStash(stash) {
+    state.reelQueue = stash.items.slice();
+    renderReelQueue();
+    updateCellClasses();
+  }
+
+  function deleteStash(stashId) {
+    fetch("api/stashes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "delete", id: stashId }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          for (var i = 0; i < state.stashes.length; i++) {
+            if (state.stashes[i].id === stashId) {
+              state.stashes.splice(i, 1);
+              break;
+            }
+          }
+          renderStashedReels();
+        }
+      })
+      .catch(function () {});
+  }
+
+  function startStashRename(stash, nameNode) {
+    var parent = nameNode.parentNode;
+    var input = document.createElement("input");
+    input.className = "stash-card-name-input";
+    input.type = "text";
+    input.value = stash.name;
+
+    function commit() {
+      var newName = input.value.trim() || stash.name;
+      stash.name = newName;
+      var span = el("span", "stash-card-name", truncate(newName, 20));
+      span.title = newName;
+      span.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        startStashRename(stash, span);
+      });
+      parent.replaceChild(span, input);
+
+      fetch("api/stashes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "update", id: stash.id, name: newName }),
+      }).catch(function () {});
+    }
+
+    input.addEventListener("blur", commit);
+    input.addEventListener("keydown", function (ev) {
+      if (ev.key === "Enter") { ev.preventDefault(); input.blur(); }
+      if (ev.key === "Escape") { input.value = stash.name; input.blur(); }
+    });
+    input.addEventListener("click", function (ev) { ev.stopPropagation(); });
+
+    parent.replaceChild(input, nameNode);
+    input.focus();
+    input.select();
+  }
+
   // ---- Buttons ----
 
   function bindButtons() {
@@ -1003,6 +1176,7 @@
       updateCellClasses();
     });
 
+    qs("#stashReelBtn").addEventListener("click", stashCurrentReel);
     qs("#generateBtn").addEventListener("click", onGenerate);
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
@@ -1453,6 +1627,7 @@
     bindReelReorder();
     bindButtons();
     loadSheetData();
+    loadStashes();
     updateViewerButton();
     checkNavLinks();
   });

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.41"
+VERSIONNUM: str = "0.9.42"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [
@@ -84,6 +84,7 @@ MANIFEST_FILENAME: str = "clipgen_manifest.json"
 MANIFEST_ENABLED: bool = False
 SERVER_PORT: int = 8089
 INSIGHTS_MANIFEST_FILENAME: str = "insights_manifest.json"
+STASHES_MANIFEST_FILENAME: str = "reel_stashes.json"
 
 # Sprite sheet constants (for insights builder hover-to-scrub)
 SPRITE_SHEET_FRAME_COUNT: int = 20

--- a/server.py
+++ b/server.py
@@ -211,6 +211,32 @@ def _save_manifest_quiet() -> None:
         pass
 
 
+def _load_stashes() -> List[Dict[str, Any]]:
+    stash_path = Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
+    if not stash_path.is_file():
+        return []
+    try:
+        data = json.loads(stash_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def _save_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
+    stash_path = Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
+    try:
+        stash_path.parent.mkdir(parents=True, exist_ok=True)
+        stash_path.write_text(
+            json.dumps(stashes, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return stash_path
+    except OSError:
+        return None
+
+
 def _find_existing_artifacts(
     cell_row: int, cell_col: int, artifact_type: str
 ) -> List[Dict[str, Any]]:
@@ -545,6 +571,67 @@ def api_regenerate() -> FlaskResponse:
 
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
+
+
+@studio_bp.route("/api/stashes", methods=["GET"])
+def api_stashes_get() -> FlaskResponse:
+    return jsonify({"ok": True, "stashes": _load_stashes()})
+
+
+@studio_bp.route("/api/stashes", methods=["POST"])
+def api_stashes_post() -> FlaskResponse:
+    import uuid
+    from datetime import datetime, timezone
+
+    data = request.get_json(silent=True) or {}
+    action = data.get("action", "create")
+    stashes = _load_stashes()
+
+    if action == "create":
+        items = data.get("items", [])
+        if not items:
+            return jsonify({"ok": False, "error": "No items to stash"}), 400
+        name = data.get("name", "")
+        total_duration = data.get("totalDuration") or sum(
+            item.get("segDuration", 0) for item in items
+        )
+        stash = {
+            "id": f"stash_{uuid.uuid4().hex[:8]}",
+            "name": name or f"Stash {len(stashes) + 1}",
+            "items": items,
+            "count": len(items),
+            "totalDuration": total_duration,
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+        }
+        stashes.append(stash)
+        _save_stashes(stashes)
+        return jsonify({"ok": True, "stash": stash})
+
+    if action == "update":
+        stash_id = data.get("id")
+        if not stash_id:
+            return jsonify({"ok": False, "error": "No stash ID"}), 400
+        for s in stashes:
+            if s["id"] == stash_id:
+                name = data.get("name")
+                if name is not None:
+                    s["name"] = name
+                _save_stashes(stashes)
+                return jsonify({"ok": True, "stash": s})
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    if action == "delete":
+        stash_id = data.get("id")
+        if not stash_id:
+            return jsonify({"ok": False, "error": "No stash ID"}), 400
+        for i, s in enumerate(stashes):
+            if s["id"] == stash_id:
+                stashes.pop(i)
+                _save_stashes(stashes)
+                return jsonify({"ok": True})
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    return jsonify({"ok": False, "error": f"Unknown action: {action}"}), 400
 
 
 # ---- State initialization ----

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -348,3 +348,130 @@ def test_api_viewer_400_when_no_artifacts(client):
     data = resp.get_json()
     assert data["ok"] is False
     assert "No artifacts" in data["error"]
+
+
+# ---- Stash API tests ----
+
+
+def test_api_stashes_get_empty(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    resp = client.get("/studio/api/stashes")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["stashes"] == []
+
+
+def test_api_stashes_create(client, monkeypatch):
+    saved = []
+    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_save_stashes", lambda s: saved.append(s))
+
+    items = [
+        {"participant": "P01", "row": 5, "segDuration": 30},
+        {"participant": "P02", "row": 7, "segDuration": 45},
+    ]
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "create", "items": items, "name": "My reel"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    stash = data["stash"]
+    assert stash["name"] == "My reel"
+    assert stash["count"] == 2
+    assert stash["totalDuration"] == 75
+    assert stash["id"].startswith("stash_")
+    assert "createdAt" in stash
+    assert len(saved) == 1
+    assert len(saved[0]) == 1
+
+
+def test_api_stashes_create_default_name(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_stashes", lambda: [{"id": "stash_old"}])
+    monkeypatch.setattr(server, "_save_stashes", lambda s: None)
+
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "create", "items": [{"segDuration": 10}]},
+    )
+    data = resp.get_json()
+    assert data["stash"]["name"] == "Stash 2"
+
+
+def test_api_stashes_create_empty_items_400(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "create", "items": []},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "No items" in data["error"]
+
+
+def test_api_stashes_update_name(client, monkeypatch):
+    existing = [{"id": "stash_abc", "name": "Old name", "items": [], "count": 0}]
+    saved = []
+    monkeypatch.setattr(server, "_load_stashes", lambda: list(existing))
+    monkeypatch.setattr(server, "_save_stashes", lambda s: saved.append(s))
+
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "update", "id": "stash_abc", "name": "New name"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["stash"]["name"] == "New name"
+    assert saved[0][0]["name"] == "New name"
+
+
+def test_api_stashes_update_404(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "update", "id": "stash_nope", "name": "x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_api_stashes_delete(client, monkeypatch):
+    existing = [
+        {"id": "stash_aaa", "name": "A"},
+        {"id": "stash_bbb", "name": "B"},
+    ]
+    saved = []
+    monkeypatch.setattr(server, "_load_stashes", lambda: list(existing))
+    monkeypatch.setattr(server, "_save_stashes", lambda s: saved.append(s))
+
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "delete", "id": "stash_aaa"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(saved[0]) == 1
+    assert saved[0][0]["id"] == "stash_bbb"
+
+
+def test_api_stashes_delete_not_found_404(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "delete", "id": "stash_nope"},
+    )
+    assert resp.status_code == 404
+
+
+def test_api_stashes_unknown_action_400(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/stashes",
+        json={"action": "bogus"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Unknown action" in data["error"]


### PR DESCRIPTION
## Summary

- Adds a "Stashed Reels" area beneath the Reel timeline where users can save, name, recall, and delete reel queues
- Stash cards display an editable name, clip count, and total duration; clicking a card recalls its contents into the reel queue
- Stashes persist across sessions via a `reel_stashes.json` manifest with `GET/POST /api/stashes` endpoints (create/update/delete actions)
- Duration is computed client-side with timestamp parsing fallback to handle entries that lack precomputed `segDuration`

## Test plan

- [x] All 176 tests pass including 10 new stash API tests
- [ ] Launch Studio, add cells to reel, click Stash — verify card appears, reel clears
- [ ] Edit stash name inline, reload page, confirm name persists
- [ ] Click stash card to recall, verify reel queue populates
- [ ] Delete stash via × button