### PR TITLE
Fix Studio card hover jitter and use SVG remove icon

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -474,6 +474,7 @@ col.col-participant-col {
   position: relative;
   transition: box-shadow 0.15s, border-color 0.15s;
   user-select: none;
+  will-change: transform;
 }
 
 .artifact-card:active {
@@ -537,9 +538,9 @@ col.col-participant-col {
   border-radius: 50%;
   width: 18px;
   height: 18px;
-  font-size: 0.7rem;
-  line-height: 18px;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.15s;
@@ -629,6 +630,7 @@ col.col-participant-col {
   position: relative;
   transition: box-shadow 0.15s, border-color 0.15s;
   user-select: none;
+  will-change: transform;
 }
 
 .reel-card:active {
@@ -700,9 +702,9 @@ col.col-participant-col {
   border-radius: 50%;
   width: 18px;
   height: 18px;
-  font-size: 0.7rem;
-  line-height: 18px;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.15s;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -869,7 +869,8 @@
       meta.appendChild(el("span", "artifact-card-ref", refText));
       card.appendChild(meta);
 
-      var removeBtn = el("button", "artifact-card-remove", "\u00D7");
+      var removeBtn = el("button", "artifact-card-remove");
+      removeBtn.innerHTML = '<svg width="10" height="10" viewBox="0 0 10 10"><path d="M2.5 2.5l5 5M7.5 2.5l-5 5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>';
       removeBtn.title = "Remove";
       (function (idx) {
         removeBtn.addEventListener("click", function (ev) {
@@ -949,7 +950,8 @@
       meta.appendChild(el("span", "reel-card-ref", refText));
       card.appendChild(meta);
 
-      var removeBtn = el("button", "reel-card-remove", "\u00D7");
+      var removeBtn = el("button", "reel-card-remove");
+      removeBtn.innerHTML = '<svg width="10" height="10" viewBox="0 0 10 10"><path d="M2.5 2.5l5 5M7.5 2.5l-5 5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>';
       removeBtn.title = "Remove";
       (function (idx) {
         removeBtn.addEventListener("click", function (ev) {


### PR DESCRIPTION
Hovering over artifact/reel cards caused badges to jitter and cards to the right to shift due to CSS transition-triggered compositing layer promotion. Adding `will-change: transform` to both card classes pre-promotes them to GPU layers, eliminating the subpixel rounding shifts. Also replaces the Unicode × remove button with an inline SVG icon matching the existing result badge style.