### PR TITLE
Add Artifact stashing and cross-zone stash drag-and-drop to Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -884,6 +884,77 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   background: #dc2626;
 }
 
+.stash-card[draggable="true"] {
+  cursor: grab;
+}
+
+.stash-card[draggable="true"]:active {
+  cursor: grabbing;
+}
+
+/* Stashed artifacts */
+
+#stashedArtifactsArea {
+  max-width: 1120px;
+  margin: 0 auto;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-top: none;
+  border-radius: 0;
+  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  padding: 0.8rem 1.5rem 1rem;
+}
+
+#stashedArtifactsArea.hidden {
+  display: none;
+}
+
+#stashedArtifactsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+#stashedArtifactsHeader h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+#stashedArtifactsHeader h3 span {
+  font-weight: 400;
+  color: var(--color-text-dim);
+  font-size: 0.78rem;
+}
+
+#stashedArtifactsList {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.3rem 0;
+}
+
+/* Stash drop zone styling */
+
+#stashedReelsList.drag-over,
+#stashedArtifactsList.drag-over {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: -2px;
+  background-color: var(--color-selected);
+  border-radius: var(--radius);
+}
+
+.stash-drop-reveal #stashedReelsList:empty,
+.stash-drop-reveal #stashedArtifactsList:empty {
+  min-height: 50px;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius);
+}
+
 /* Area controls */
 
 .area-controls {
@@ -1353,6 +1424,7 @@ html[data-theme="dark"] .stash-card-name-input {
   #dropAreas,
   #reelArea,
   #stashedReelsArea,
+  #stashedArtifactsArea,
   #quickActions {
     margin-left: 0.5rem;
     margin-right: 0.5rem;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -75,12 +75,20 @@
         </select>
         <button id="generateBtn" class="btn btn-primary" disabled>Generate</button>
         <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
+        <button id="stashArtifactsBtn" class="btn btn-small" disabled>Stash</button>
         <button id="clearArtifactsBtn" class="btn btn-small">Clear</button>
       </div>
       <div id="artifactsList" class="drop-target">
         <div class="drop-target-empty">Click or drag cells here to queue for generation</div>
       </div>
     </div>
+  </section>
+
+  <section id="stashedArtifactsArea" class="hidden">
+    <div id="stashedArtifactsHeader">
+      <h3>Stashed Artifacts <span id="stashedArtifactsCount">(0)</span></h3>
+    </div>
+    <div id="stashedArtifactsList"></div>
   </section>
 
   <section id="reelArea">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -14,6 +14,7 @@
     generating: false,
     cellResults: {},
     stashes: [],
+    artifactStashes: [],
   };
 
   // ---- Helpers ----
@@ -705,6 +706,11 @@
 
   function initDropTargets() {
     setupDropTarget(qs("#artifactsList"), function (info) {
+      if (info.source === "reel-stash" || info.source === "artifact-stash") {
+        for (var i = 0; i < info.items.length; i++)
+          addToQueue(state.artifactQueue, info.items[i], renderArtifactQueue);
+        return;
+      }
       if (info.source === "reel") {
         removeFromQueue(state.reelQueue, info);
         renderReelQueue();
@@ -712,11 +718,33 @@
       addToQueue(state.artifactQueue, info, renderArtifactQueue);
     });
     setupDropTarget(qs("#reelList"), function (info) {
+      if (info.source === "reel-stash" || info.source === "artifact-stash") {
+        for (var i = 0; i < info.items.length; i++)
+          addToQueue(state.reelQueue, info.items[i], renderReelQueue);
+        return;
+      }
       if (info.source === "artifact") {
         removeFromQueue(state.artifactQueue, info);
         renderArtifactQueue();
       }
       addToQueue(state.reelQueue, info, renderReelQueue);
+    });
+
+    setupDropTarget(qs("#stashedReelsList"), function (info) {
+      if (info.source === "reel-stash" || info.source === "artifact-stash") {
+        createStashViaAPI("api/stashes", info.items, function (stash) {
+          state.stashes.push(stash);
+          renderStashedReels();
+        });
+      }
+    });
+    setupDropTarget(qs("#stashedArtifactsList"), function (info) {
+      if (info.source === "reel-stash" || info.source === "artifact-stash") {
+        createStashViaAPI("api/artifact-stashes", info.items, function (stash) {
+          state.artifactStashes.push(stash);
+          renderStashedArtifacts();
+        });
+      }
     });
   }
 
@@ -736,7 +764,7 @@
       target.classList.remove("drag-over");
       try {
         var info = JSON.parse(ev.dataTransfer.getData("application/json"));
-        if (info && info.participant && info.row) {
+        if (info && (info.participant || info.items)) {
           onDrop(info);
         }
       } catch (_) {}
@@ -808,6 +836,7 @@
     qs("#artifactsCount").textContent = "(" + n + ")";
     qs("#generateBtn").disabled = n === 0;
     qs("#addToReelBtn").disabled = n === 0;
+    qs("#stashArtifactsBtn").disabled = n === 0;
     list.innerHTML = "";
     saveQueues();
 
@@ -999,23 +1028,36 @@
     qs("#stashedReelsCount").textContent = "(" + n + ")";
 
     if (n === 0) {
-      area.classList.add("hidden");
+      if (!area.classList.contains("stash-drop-reveal")) area.classList.add("hidden");
+      list.innerHTML = "";
       return;
     }
     area.classList.remove("hidden");
+    area.classList.remove("stash-drop-reveal");
     list.innerHTML = "";
 
     for (var i = 0; i < n; i++) {
       var stash = state.stashes[i];
       var card = el("div", "stash-card");
       card.setAttribute("data-stash-id", stash.id);
+      card.setAttribute("draggable", "true");
+      (function (stashRef) {
+        card.addEventListener("dragstart", function (ev) {
+          ev.dataTransfer.setData("application/json", JSON.stringify({
+            stashId: stashRef.id,
+            items: stashRef.items,
+            source: "reel-stash",
+          }));
+          ev.dataTransfer.effectAllowed = "copy";
+        });
+      })(stash);
 
       var nameEl = el("span", "stash-card-name", truncate(stash.name, 20));
       nameEl.title = stash.name;
       (function (stashRef, nameNode) {
         nameNode.addEventListener("click", function (ev) {
           ev.stopPropagation();
-          startStashRename(stashRef, nameNode);
+          startStashRename(stashRef, nameNode, "api/stashes");
         });
       })(stash, nameEl);
       card.appendChild(nameEl);
@@ -1030,7 +1072,7 @@
       (function (stashId) {
         removeBtn.addEventListener("click", function (ev) {
           ev.stopPropagation();
-          deleteStash(stashId);
+          deleteStash(stashId, "api/stashes", state.stashes, renderStashedReels);
         });
       })(stash.id);
       card.appendChild(removeBtn);
@@ -1091,8 +1133,8 @@
     updateCellClasses();
   }
 
-  function deleteStash(stashId) {
-    fetch("api/stashes", {
+  function deleteStash(stashId, endpoint, stateArray, renderFn) {
+    fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action: "delete", id: stashId }),
@@ -1100,19 +1142,19 @@
       .then(function (r) { return r.json(); })
       .then(function (data) {
         if (data.ok) {
-          for (var i = 0; i < state.stashes.length; i++) {
-            if (state.stashes[i].id === stashId) {
-              state.stashes.splice(i, 1);
+          for (var i = 0; i < stateArray.length; i++) {
+            if (stateArray[i].id === stashId) {
+              stateArray.splice(i, 1);
               break;
             }
           }
-          renderStashedReels();
+          renderFn();
         }
       })
       .catch(function () {});
   }
 
-  function startStashRename(stash, nameNode) {
+  function startStashRename(stash, nameNode, endpoint) {
     var parent = nameNode.parentNode;
     var input = document.createElement("input");
     input.className = "stash-card-name-input";
@@ -1126,11 +1168,11 @@
       span.title = newName;
       span.addEventListener("click", function (ev) {
         ev.stopPropagation();
-        startStashRename(stash, span);
+        startStashRename(stash, span, endpoint);
       });
       parent.replaceChild(span, input);
 
-      fetch("api/stashes", {
+      fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action: "update", id: stash.id, name: newName }),
@@ -1147,6 +1189,161 @@
     parent.replaceChild(input, nameNode);
     input.focus();
     input.select();
+  }
+
+  function createStashViaAPI(endpoint, items, onSuccess) {
+    var totalDuration = computeReelDuration(items);
+    fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "create", items: items, name: "", totalDuration: totalDuration }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) onSuccess(data.stash);
+      })
+      .catch(function () {});
+  }
+
+  // ---- Stashed artifacts ----
+
+  function loadArtifactStashes() {
+    fetch("api/artifact-stashes")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          state.artifactStashes = data.stashes || [];
+          renderStashedArtifacts();
+        }
+      })
+      .catch(function () {});
+  }
+
+  function renderStashedArtifacts() {
+    var area = qs("#stashedArtifactsArea");
+    var list = qs("#stashedArtifactsList");
+    var n = state.artifactStashes.length;
+    qs("#stashedArtifactsCount").textContent = "(" + n + ")";
+
+    if (n === 0) {
+      if (!area.classList.contains("stash-drop-reveal")) area.classList.add("hidden");
+      list.innerHTML = "";
+      return;
+    }
+    area.classList.remove("hidden");
+    area.classList.remove("stash-drop-reveal");
+    list.innerHTML = "";
+
+    for (var i = 0; i < n; i++) {
+      var stash = state.artifactStashes[i];
+      var card = el("div", "stash-card");
+      card.setAttribute("data-stash-id", stash.id);
+      card.setAttribute("draggable", "true");
+      (function (stashRef) {
+        card.addEventListener("dragstart", function (ev) {
+          ev.dataTransfer.setData("application/json", JSON.stringify({
+            stashId: stashRef.id,
+            items: stashRef.items,
+            source: "artifact-stash",
+          }));
+          ev.dataTransfer.effectAllowed = "copy";
+        });
+      })(stash);
+
+      var nameEl = el("span", "stash-card-name", truncate(stash.name, 20));
+      nameEl.title = stash.name;
+      (function (stashRef, nameNode) {
+        nameNode.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          startStashRename(stashRef, nameNode, "api/artifact-stashes");
+        });
+      })(stash, nameEl);
+      card.appendChild(nameEl);
+
+      var info = el("div", "stash-card-info");
+      info.appendChild(el("span", "", stash.count + " clips"));
+      info.appendChild(el("span", "", formatDuration(stash.totalDuration)));
+      card.appendChild(info);
+
+      var removeBtn = el("button", "stash-card-remove", "\u00D7");
+      removeBtn.title = "Delete stash";
+      (function (stashId) {
+        removeBtn.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          deleteStash(stashId, "api/artifact-stashes", state.artifactStashes, renderStashedArtifacts);
+        });
+      })(stash.id);
+      card.appendChild(removeBtn);
+
+      (function (stashRef) {
+        card.addEventListener("click", function () {
+          recallArtifactStash(stashRef);
+        });
+      })(stash);
+
+      list.appendChild(card);
+    }
+  }
+
+  function stashCurrentArtifacts() {
+    if (state.artifactQueue.length === 0) return;
+
+    var items = state.artifactQueue.slice();
+    var totalDuration = computeReelDuration(items);
+    fetch("api/artifact-stashes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "create", items: items, name: "", totalDuration: totalDuration }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          state.artifactStashes.push(data.stash);
+          for (var i = 0; i < state.artifactQueue.length; i++) {
+            var item = state.artifactQueue[i];
+            delete state.cellResults[cellKey(item.participant, item.row)];
+          }
+          state.artifactQueue = [];
+          renderArtifactQueue();
+          renderStashedArtifacts();
+          updateCellClasses();
+        }
+      })
+      .catch(function () {});
+  }
+
+  function recallArtifactStash(stash) {
+    state.artifactQueue = stash.items.slice();
+    renderArtifactQueue();
+    updateCellClasses();
+  }
+
+  // ---- Stash drag-reveal ----
+
+  function revealEmptyStashAreas() {
+    var artArea = qs("#stashedArtifactsArea");
+    var reelArea = qs("#stashedReelsArea");
+    if (state.artifactStashes.length === 0) {
+      artArea.classList.remove("hidden");
+      artArea.classList.add("stash-drop-reveal");
+    }
+    if (state.stashes.length === 0) {
+      reelArea.classList.remove("hidden");
+      reelArea.classList.add("stash-drop-reveal");
+    }
+  }
+
+  function hideEmptyStashAreas() {
+    var artArea = qs("#stashedArtifactsArea");
+    var reelArea = qs("#stashedReelsArea");
+    if (state.artifactStashes.length === 0) {
+      artArea.classList.add("hidden");
+      artArea.classList.remove("stash-drop-reveal");
+    }
+    if (state.stashes.length === 0) {
+      reelArea.classList.add("hidden");
+      reelArea.classList.remove("stash-drop-reveal");
+    }
   }
 
   // ---- Buttons ----
@@ -1180,6 +1377,7 @@
     });
 
     qs("#stashReelBtn").addEventListener("click", stashCurrentReel);
+    qs("#stashArtifactsBtn").addEventListener("click", stashCurrentArtifacts);
     qs("#generateBtn").addEventListener("click", onGenerate);
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
@@ -1708,7 +1906,16 @@
     bindButtons();
     loadSheetData();
     loadStashes();
+    loadArtifactStashes();
     updateViewerButton();
     checkNavLinks();
+
+    document.addEventListener("dragstart", function (ev) {
+      if (!ev.target.closest(".stash-card")) return;
+      requestAnimationFrame(revealEmptyStashAreas);
+    });
+    document.addEventListener("dragend", function () {
+      hideEmptyStashAreas();
+    });
   });
 })();

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.43"
+VERSIONNUM: str = "0.9.44"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [
@@ -85,6 +85,7 @@ MANIFEST_ENABLED: bool = False
 SERVER_PORT: int = 8089
 INSIGHTS_MANIFEST_FILENAME: str = "insights_manifest.json"
 STASHES_MANIFEST_FILENAME: str = "reel_stashes.json"
+ARTIFACT_STASHES_MANIFEST_FILENAME: str = "artifact_stashes.json"
 GOOGLE_API_MAX_RETRIES: int = 3  # Retries for transient Google API errors (5xx)
 
 # Sprite sheet constants (for insights builder hover-to-scrub)

--- a/server.py
+++ b/server.py
@@ -237,6 +237,36 @@ def _save_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
         return None
 
 
+def _load_artifact_stashes() -> List[Dict[str, Any]]:
+    stash_path = (
+        Path(utils.get_effective_output_dir()) / config.ARTIFACT_STASHES_MANIFEST_FILENAME
+    )
+    if not stash_path.is_file():
+        return []
+    try:
+        data = json.loads(stash_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def _save_artifact_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
+    stash_path = (
+        Path(utils.get_effective_output_dir()) / config.ARTIFACT_STASHES_MANIFEST_FILENAME
+    )
+    try:
+        stash_path.parent.mkdir(parents=True, exist_ok=True)
+        stash_path.write_text(
+            json.dumps(stashes, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return stash_path
+    except OSError:
+        return None
+
+
 def _find_existing_artifacts(
     cell_row: int, cell_col: int, artifact_type: str
 ) -> List[Dict[str, Any]]:
@@ -682,6 +712,67 @@ def api_stashes_post() -> FlaskResponse:
             if s["id"] == stash_id:
                 stashes.pop(i)
                 _save_stashes(stashes)
+                return jsonify({"ok": True})
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    return jsonify({"ok": False, "error": f"Unknown action: {action}"}), 400
+
+
+@studio_bp.route("/api/artifact-stashes", methods=["GET"])
+def api_artifact_stashes_get() -> FlaskResponse:
+    return jsonify({"ok": True, "stashes": _load_artifact_stashes()})
+
+
+@studio_bp.route("/api/artifact-stashes", methods=["POST"])
+def api_artifact_stashes_post() -> FlaskResponse:
+    import uuid
+    from datetime import datetime, timezone
+
+    data = request.get_json(silent=True) or {}
+    action = data.get("action", "create")
+    stashes = _load_artifact_stashes()
+
+    if action == "create":
+        items = data.get("items", [])
+        if not items:
+            return jsonify({"ok": False, "error": "No items to stash"}), 400
+        name = data.get("name", "")
+        total_duration = data.get("totalDuration") or sum(
+            item.get("segDuration", 0) for item in items
+        )
+        stash = {
+            "id": f"astash_{uuid.uuid4().hex[:8]}",
+            "name": name or f"Stash {len(stashes) + 1}",
+            "items": items,
+            "count": len(items),
+            "totalDuration": total_duration,
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+        }
+        stashes.append(stash)
+        _save_artifact_stashes(stashes)
+        return jsonify({"ok": True, "stash": stash})
+
+    if action == "update":
+        stash_id = data.get("id")
+        if not stash_id:
+            return jsonify({"ok": False, "error": "No stash ID"}), 400
+        for s in stashes:
+            if s["id"] == stash_id:
+                name = data.get("name")
+                if name is not None:
+                    s["name"] = name
+                _save_artifact_stashes(stashes)
+                return jsonify({"ok": True, "stash": s})
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    if action == "delete":
+        stash_id = data.get("id")
+        if not stash_id:
+            return jsonify({"ok": False, "error": "No stash ID"}), 400
+        for i, s in enumerate(stashes):
+            if s["id"] == stash_id:
+                stashes.pop(i)
+                _save_artifact_stashes(stashes)
                 return jsonify({"ok": True})
         return jsonify({"ok": False, "error": "Stash not found"}), 404
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -511,3 +511,132 @@ def test_api_stashes_unknown_action_400(client, monkeypatch):
     assert resp.status_code == 400
     data = resp.get_json()
     assert "Unknown action" in data["error"]
+
+
+# ---- Artifact stash API tests ----
+
+
+def test_api_artifact_stashes_get_empty(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    resp = client.get("/studio/api/artifact-stashes")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["stashes"] == []
+
+
+def test_api_artifact_stashes_create(client, monkeypatch):
+    saved = []
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_save_artifact_stashes", lambda s: saved.append(s))
+
+    items = [
+        {"participant": "P01", "row": 5, "segDuration": 30},
+        {"participant": "P02", "row": 7, "segDuration": 45},
+    ]
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "create", "items": items, "name": "My artifacts"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    stash = data["stash"]
+    assert stash["name"] == "My artifacts"
+    assert stash["count"] == 2
+    assert stash["totalDuration"] == 75
+    assert stash["id"].startswith("astash_")
+    assert "createdAt" in stash
+    assert len(saved) == 1
+    assert len(saved[0]) == 1
+
+
+def test_api_artifact_stashes_create_default_name(client, monkeypatch):
+    monkeypatch.setattr(
+        server, "_load_artifact_stashes", lambda: [{"id": "astash_old"}]
+    )
+    monkeypatch.setattr(server, "_save_artifact_stashes", lambda s: None)
+
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "create", "items": [{"segDuration": 10}]},
+    )
+    data = resp.get_json()
+    assert data["stash"]["name"] == "Stash 2"
+
+
+def test_api_artifact_stashes_create_empty_items_400(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "create", "items": []},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "No items" in data["error"]
+
+
+def test_api_artifact_stashes_update_name(client, monkeypatch):
+    existing = [{"id": "astash_abc", "name": "Old name", "items": [], "count": 0}]
+    saved = []
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: list(existing))
+    monkeypatch.setattr(server, "_save_artifact_stashes", lambda s: saved.append(s))
+
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "update", "id": "astash_abc", "name": "New name"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["stash"]["name"] == "New name"
+    assert saved[0][0]["name"] == "New name"
+
+
+def test_api_artifact_stashes_update_404(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "update", "id": "astash_nope", "name": "x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_api_artifact_stashes_delete(client, monkeypatch):
+    existing = [
+        {"id": "astash_aaa", "name": "A"},
+        {"id": "astash_bbb", "name": "B"},
+    ]
+    saved = []
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: list(existing))
+    monkeypatch.setattr(server, "_save_artifact_stashes", lambda s: saved.append(s))
+
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "delete", "id": "astash_aaa"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(saved[0]) == 1
+    assert saved[0][0]["id"] == "astash_bbb"
+
+
+def test_api_artifact_stashes_delete_not_found_404(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "delete", "id": "astash_nope"},
+    )
+    assert resp.status_code == 404
+
+
+def test_api_artifact_stashes_unknown_action_400(client, monkeypatch):
+    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    resp = client.post(
+        "/studio/api/artifact-stashes",
+        json={"action": "bogus"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Unknown action" in data["error"]


### PR DESCRIPTION
## Summary

- Adds artifact stashing (Stash button in artifact controls, Stashed Artifacts section) mirroring the existing reel stash feature, backed by a new `/api/artifact-stashes` endpoint and `artifact_stashes.json` persistence file.
- Makes all stash cards (both reel and artifact) draggable to four drop zones: artifact queue, reel queue, stashed artifacts list, and stashed reels list — enabling cross-type stash conversion and queue population via drag-and-drop.
- Empty stash areas are temporarily revealed as drop targets during stash card drags, then re-hidden if no drop occurs. Uses `requestAnimationFrame` to defer the DOM reveal and avoid cancelling the browser's drag operation.
- Refactors `deleteStash` and `startStashRename` to accept endpoint/state parameters so both stash types share the same logic.

## Test plan
- [x] 9 new API tests for artifact stash CRUD (mirroring existing reel stash tests)
- [ ] Manual: Stash artifacts via button, recall by clicking, rename, delete
- [ ] Manual: Drag reel stash → artifact queue, reel queue, artifact stash area
- [ ] Manual: Drag artifact stash → reel queue, artifact queue, reel stash area
- [ ] Manual: Drag-reveal of empty stash areas works; re-hides on dragend
- [ ] Manual: Border-radius cascade correct in all visibility combinations