### PR TITLE
Add Titlecard setting toggles to Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -974,6 +974,48 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   cursor: pointer;
 }
 
+/* Titlecard toggle group */
+
+.titlecard-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.titlecard-group input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--color-accent);
+}
+
+.titlecard-label-text {
+  user-select: none;
+}
+
+.titlecard-duration-input {
+  width: 3rem;
+  padding: 0.25rem 0.35rem;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.75rem;
+}
+
+.titlecard-label-unit {
+  font-size: 0.72rem;
+  color: var(--color-text-dim);
+}
+
+.titlecard-group:has(input[type="checkbox"]:not(:checked)) .titlecard-duration-input {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 .btn {
   padding: 0.4rem 0.9rem;
   border: 1px solid var(--color-border);

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -73,6 +73,13 @@
           <option value="screen">Screenshot (.png)</option>
           <option value="gif">GIF (.gif)</option>
         </select>
+        <label id="titlecardGroup" class="titlecard-group">
+          <input id="titlecardEnabled" type="checkbox">
+          <span class="titlecard-label-text">Titlecards</span>
+          <input id="titlecardDuration" type="number" min="1" step="1" value="2"
+                 class="titlecard-duration-input" title="Duration (seconds)">
+          <span class="titlecard-label-unit">s</span>
+        </label>
         <button id="generateBtn" class="btn btn-primary" disabled>Generate</button>
         <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
         <button id="stashArtifactsBtn" class="btn btn-small" disabled>Stash</button>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -283,6 +283,18 @@
         if (durInput && data.highlightsDuration) {
           durInput.value = data.highlightsDuration;
         }
+        var tcCheckbox = qs("#titlecardEnabled");
+        var tcDurInput = qs("#titlecardDuration");
+        if (tcCheckbox && data.titlecardsEnabled !== undefined) {
+          tcCheckbox.checked = data.titlecardsEnabled;
+        }
+        if (tcDurInput && data.titlecardDuration) {
+          tcDurInput.value = data.titlecardDuration;
+        }
+        var tcGroup = qs("#titlecardGroup");
+        if (tcGroup && qs("#artifactFormat").value === "clip") {
+          tcGroup.classList.remove("hidden");
+        }
         restoreQueues();
         if (state.artifactQueue.length > 0 || state.reelQueue.length > 0) {
           renderArtifactQueue();
@@ -1385,6 +1397,14 @@
     qs("#buildHighlightsBtn").addEventListener("click", onBuildHighlights);
     qs("#galleryBtn").addEventListener("click", onGallery);
 
+    qs("#artifactFormat").addEventListener("change", function () {
+      var tcGroup = qs("#titlecardGroup");
+      if (tcGroup) {
+        if (this.value === "clip") tcGroup.classList.remove("hidden");
+        else tcGroup.classList.add("hidden");
+      }
+    });
+
     qs("#statusDismiss").addEventListener("click", hideOverlay);
   }
 
@@ -1553,10 +1573,18 @@
       }
     }
 
+    var genBody = { cells: cells, format: format };
+    if (format === "clip") {
+      var tcCb = qs("#titlecardEnabled");
+      var tcDur = qs("#titlecardDuration");
+      if (tcCb) genBody.titlecards_enabled = tcCb.checked;
+      if (tcDur) genBody.titlecard_duration = parseInt(tcDur.value, 10) || 2;
+    }
+
     fetch("api/generate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ cells: cells, format: format }),
+      body: JSON.stringify(genBody),
     })
       .then(function (response) {
         var reader = response.body.getReader();
@@ -1606,10 +1634,16 @@
       setCardQueued(reelCards[i]);
     }
 
+    var reelBody = { cells: cells };
+    var tcCb = qs("#titlecardEnabled");
+    var tcDur = qs("#titlecardDuration");
+    if (tcCb) reelBody.titlecards_enabled = tcCb.checked;
+    if (tcDur) reelBody.titlecard_duration = parseInt(tcDur.value, 10) || 2;
+
     fetch("api/reel", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ cells: cells }),
+      body: JSON.stringify(reelBody),
     })
       .then(function (r) { return r.json(); })
       .then(function (data) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.44"
+VERSIONNUM: str = "0.9.45"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/server.py
+++ b/server.py
@@ -181,6 +181,8 @@ def api_sheet() -> FlaskResponse:
             "study": ctx.study_name,
             "version": config.VERSIONNUM,
             "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
+            "titlecardsEnabled": config.TITLECARDS_ENABLED,
+            "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
             "participants": participants,
             "rows": rows,
         }
@@ -291,6 +293,8 @@ def api_generate() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     cell_strings = data.get("cells", [])
     output_format = data.get("format", "clip")
+    tc_enabled = data.get("titlecards_enabled")
+    tc_duration = data.get("titlecard_duration")
 
     if not cell_strings:
         return jsonify({"ok": False, "error": "No cells specified"}), 400
@@ -311,40 +315,55 @@ def api_generate() -> FlaskResponse:
         return jsonify({"ok": False, "error": str(e)}), 500
 
     def stream() -> Any:
-        clip_cells: set[str] = set()
-        for clip in clips:
-            cell_str = clip["participant"] + "." + str(clip["cell"].row)
-            clip_cells.add(cell_str)
-
-            existing = _find_existing_artifacts(
-                clip["cell"].row, clip["cell"].col, output_format
-            )
-            if existing:
-                yield json.dumps(
-                    {
-                        "cell": cell_str,
-                        "ok": True,
-                        "generated": len(existing),
-                        "artifacts": existing,
-                        "skipped": True,
-                    }
-                ) + "\n"
-                continue
-
+        original_tc_enabled = config.TITLECARDS_ENABLED
+        original_tc_duration = config.TITLECARD_DURATION_SECONDS
+        if tc_enabled is not None:
+            config.TITLECARDS_ENABLED = bool(tc_enabled)
+        if tc_duration is not None:
             try:
-                generated, artifacts = clipgen.process_clips(
-                    [clip], output_format=output_format
+                val = int(tc_duration)
+                if val > 0:
+                    config.TITLECARD_DURATION_SECONDS = val
+            except (ValueError, TypeError):
+                pass
+        try:
+            clip_cells: set[str] = set()
+            for clip in clips:
+                cell_str = clip["participant"] + "." + str(clip["cell"].row)
+                clip_cells.add(cell_str)
+
+                existing = _find_existing_artifacts(
+                    clip["cell"].row, clip["cell"].col, output_format
                 )
-                _generated_artifacts.extend(artifacts)
-                yield json.dumps(
-                    {"cell": cell_str, "ok": generated > 0, "generated": generated, "artifacts": artifacts}
-                ) + "\n"
-            except Exception as e:
-                yield json.dumps({"cell": cell_str, "ok": False, "error": str(e)}) + "\n"
-        for cs in cell_strings:
-            if cs not in clip_cells:
-                yield json.dumps({"cell": cs, "ok": False, "error": "No clip found"}) + "\n"
-        _save_manifest_quiet()
+                if existing:
+                    yield json.dumps(
+                        {
+                            "cell": cell_str,
+                            "ok": True,
+                            "generated": len(existing),
+                            "artifacts": existing,
+                            "skipped": True,
+                        }
+                    ) + "\n"
+                    continue
+
+                try:
+                    generated, artifacts = clipgen.process_clips(
+                        [clip], output_format=output_format
+                    )
+                    _generated_artifacts.extend(artifacts)
+                    yield json.dumps(
+                        {"cell": cell_str, "ok": generated > 0, "generated": generated, "artifacts": artifacts}
+                    ) + "\n"
+                except Exception as e:
+                    yield json.dumps({"cell": cell_str, "ok": False, "error": str(e)}) + "\n"
+            for cs in cell_strings:
+                if cs not in clip_cells:
+                    yield json.dumps({"cell": cs, "ok": False, "error": "No clip found"}) + "\n"
+            _save_manifest_quiet()
+        finally:
+            config.TITLECARDS_ENABLED = original_tc_enabled
+            config.TITLECARD_DURATION_SECONDS = original_tc_duration
 
     return Response(stream(), mimetype="application/x-ndjson", headers={"X-Accel-Buffering": "no"})
 
@@ -401,6 +420,8 @@ def api_reel() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     cell_strings = data.get("cells", [])
     highlights_duration = data.get("highlights_duration")
+    tc_enabled = data.get("titlecards_enabled")
+    tc_duration = data.get("titlecard_duration")
 
     if not cell_strings:
         return jsonify({"ok": False, "error": "No cells specified"}), 400
@@ -409,11 +430,22 @@ def api_reel() -> FlaskResponse:
         reel_input = ", ".join(cell_strings)
 
         original_duration = config.HIGHLIGHTS_REEL_DURATION_SECONDS
+        original_tc_enabled = config.TITLECARDS_ENABLED
+        original_tc_duration = config.TITLECARD_DURATION_SECONDS
         if highlights_duration is not None:
             try:
                 val = int(highlights_duration)
                 if val > 0:
                     config.HIGHLIGHTS_REEL_DURATION_SECONDS = val
+            except (ValueError, TypeError):
+                pass
+        if tc_enabled is not None:
+            config.TITLECARDS_ENABLED = bool(tc_enabled)
+        if tc_duration is not None:
+            try:
+                val = int(tc_duration)
+                if val > 0:
+                    config.TITLECARD_DURATION_SECONDS = val
             except (ValueError, TypeError):
                 pass
 
@@ -465,6 +497,9 @@ def api_reel() -> FlaskResponse:
 
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
+    finally:
+        config.TITLECARDS_ENABLED = original_tc_enabled
+        config.TITLECARD_DURATION_SECONDS = original_tc_duration
 
 
 @studio_bp.route("/api/viewer", methods=["POST"])

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -640,3 +640,173 @@ def test_api_artifact_stashes_unknown_action_400(client, monkeypatch):
     assert resp.status_code == 400
     data = resp.get_json()
     assert "Unknown action" in data["error"]
+
+
+# ---- Titlecard settings tests ----
+
+
+def test_api_sheet_returns_titlecard_defaults(client, monkeypatch):
+    """api/sheet includes titlecardsEnabled and titlecardDuration from config."""
+    import types
+
+    import config
+
+    ctx = types.SimpleNamespace(
+        header_row=["ID", "P01"],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=1,
+        study_name="study",
+        observation_cell=types.SimpleNamespace(col=3),
+        category_cell=types.SimpleNamespace(col=4),
+        severity_cell=None,
+        baseline_row_idx=None,
+        filename_row_idx=None,
+        first_data_row_idx=2,
+        sheet_data=[["study"], ["ID", "P01", "Observation", "Category"]],
+    )
+    monkeypatch.setattr(server, "_sheet_context", ctx)
+
+    resp = client.get("/studio/api/sheet")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["titlecardsEnabled"] == config.TITLECARDS_ENABLED
+    assert data["titlecardDuration"] == config.TITLECARD_DURATION_SECONDS
+
+
+def test_api_generate_titlecard_override(client, monkeypatch):
+    """titlecards_enabled and titlecard_duration temporarily override config during generate."""
+    import types
+
+    import config
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    original_enabled = config.TITLECARDS_ENABLED
+    original_duration = config.TITLECARD_DURATION_SECONDS
+    captured = {}
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00")
+
+    def fake_generate_list(ws, mode, *, cell_specs, skip_prompts):
+        return [{"participant": "P01", "cell": cell}]
+
+    def fake_process_clips(clips, *, output_format):
+        captured["enabled"] = config.TITLECARDS_ENABLED
+        captured["duration"] = config.TITLECARD_DURATION_SECONDS
+        return (1, [{"id": "a1", "type": "clip"}])
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
+    monkeypatch.setattr("clipgen.process_clips", fake_process_clips)
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+
+    resp = client.post(
+        "/studio/api/generate",
+        json={
+            "cells": ["P01.5"],
+            "format": "clip",
+            "titlecards_enabled": True,
+            "titlecard_duration": 5,
+        },
+    )
+    lines = [json.loads(ln) for ln in resp.data.decode().strip().split("\n")]
+    assert resp.status_code == 200
+    assert captured["enabled"] is True
+    assert captured["duration"] == 5
+    assert config.TITLECARDS_ENABLED == original_enabled
+    assert config.TITLECARD_DURATION_SECONDS == original_duration
+
+
+def test_api_generate_titlecard_restored_on_error(client, monkeypatch):
+    """Titlecard config is restored even when process_clips raises."""
+    import types
+
+    import config
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    original_enabled = config.TITLECARDS_ENABLED
+    original_duration = config.TITLECARD_DURATION_SECONDS
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00")
+
+    def fake_generate_list(ws, mode, *, cell_specs, skip_prompts):
+        return [{"participant": "P01", "cell": cell}]
+
+    def fake_process_clips(clips, *, output_format):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
+    monkeypatch.setattr("clipgen.process_clips", fake_process_clips)
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+
+    resp = client.post(
+        "/studio/api/generate",
+        json={
+            "cells": ["P01.5"],
+            "format": "clip",
+            "titlecards_enabled": True,
+            "titlecard_duration": 10,
+        },
+    )
+    _ = resp.data  # consume streaming response to trigger finally
+    assert resp.status_code == 200  # streaming response still 200
+    assert config.TITLECARDS_ENABLED == original_enabled
+    assert config.TITLECARD_DURATION_SECONDS == original_duration
+
+
+def test_api_reel_titlecard_override(client, monkeypatch):
+    """titlecards_enabled and titlecard_duration temporarily override config during reel build."""
+    import config
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    original_enabled = config.TITLECARDS_ENABLED
+    original_duration = config.TITLECARD_DURATION_SECONDS
+    captured = {}
+
+    def fake_generate_list(ws, mode, *, reel_input, skip_prompts):
+        captured["enabled"] = config.TITLECARDS_ENABLED
+        captured["duration"] = config.TITLECARD_DURATION_SECONDS
+        return []
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+
+    resp = client.post(
+        "/studio/api/reel",
+        json={
+            "cells": ["P01.5"],
+            "titlecards_enabled": True,
+            "titlecard_duration": 4,
+        },
+    )
+    assert resp.status_code == 400  # no clips → 400
+    assert captured["enabled"] is True
+    assert captured["duration"] == 4
+    assert config.TITLECARDS_ENABLED == original_enabled
+    assert config.TITLECARD_DURATION_SECONDS == original_duration
+
+
+def test_api_reel_titlecard_restored_on_error(client, monkeypatch):
+    """Titlecard config is restored even when generate_list raises."""
+    import config
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    original_enabled = config.TITLECARDS_ENABLED
+    original_duration = config.TITLECARD_DURATION_SECONDS
+
+    def raise_generate_list(ws, mode, *, reel_input, skip_prompts):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("spreadsheet.generate_list", raise_generate_list)
+
+    resp = client.post(
+        "/studio/api/reel",
+        json={
+            "cells": ["P01.5"],
+            "titlecards_enabled": True,
+            "titlecard_duration": 7,
+        },
+    )
+    assert resp.status_code == 500
+    assert config.TITLECARDS_ENABLED == original_enabled
+    assert config.TITLECARD_DURATION_SECONDS == original_duration


### PR DESCRIPTION
## Summary
- Adds a titlecard checkbox and duration input next to the artifact format dropdown in Studio
- Controls load application defaults from config on page load and are hidden for non-clip formats
- Generate and Reel API endpoints accept and temporarily apply titlecard settings per-request
- `/api/sheet` now returns `titlecardsEnabled` and `titlecardDuration` defaults

## Test plan
- [x] 5 new tests in `test_studio_api.py` covering defaults, config override, and restore on error
- [ ] Launch Studio and verify titlecard controls appear only when format is "Clip (.mp4)"
- [ ] Verify checkbox and duration initialize from config defaults
- [ ] Generate clips with titlecards enabled and confirm titlecards are prepended