### PR TITLE
Polish Studio button layout, add disabled tooltips, fix ghost artifact

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -964,6 +964,21 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   flex-wrap: wrap;
 }
 
+.area-controls .btn {
+  height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+#generateBtn {
+  margin-left: auto;
+}
+
+#addToReelBtn {
+  align-self: flex-end;
+  margin-top: 0.35rem;
+}
+
 .area-controls select {
   padding: 0.35rem 0.5rem;
   border: 1px solid var(--color-border);
@@ -1045,6 +1060,11 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
   color: #fff;
 }
 
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .btn-primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -1063,6 +1083,39 @@ html[data-theme="dark"] .reel-card.reel-card-error .reel-card-thumb {
 
 .btn-icon svg {
   flex-shrink: 0;
+}
+
+/* Disabled button tooltips */
+
+.btn[data-tooltip] {
+  position: relative;
+}
+
+.btn[data-tooltip]:disabled::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.3rem 0.6rem;
+  background: var(--color-text);
+  color: var(--color-bg);
+  font-size: 0.7rem;
+  font-weight: 400;
+  white-space: nowrap;
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 20;
+}
+
+.btn[data-tooltip]:disabled:hover::after {
+  opacity: 1;
+}
+
+.studio-generating .btn[data-tooltip]:disabled::after {
+  display: none;
 }
 
 /* Highlights button group (inside reel header) */

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -74,12 +74,6 @@
     <div id="artifactsArea" class="drop-area">
       <h3><svg id="artifactsSpinner" class="title-spinner" width="14" height="14" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>Artifacts <span id="artifactsCount">(0)</span> <span id="viewerArtifactCount" style="font-weight: 400; font-size: 0.8rem; color: var(--color-text-dim);"></span></h3>
       <div class="area-controls">
-        <button id="addToReelBtn" class="btn btn-small btn-icon" disabled>
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M2.53 3.95633C1.86395 3.54005 1 4.0189 1 4.80433V11.1958C1 11.9813 1.86395 12.4601 2.53 12.0438L7.6432 8.84808C7.80276 8.74836 7.92169 8.61486 8 8.46479V11.1958C8 11.9813 8.86395 12.4601 9.53 12.0438L14.6432 8.84808C15.2699 8.45642 15.2699 7.54376 14.6432 7.15209L9.53 3.95633C8.86395 3.54005 8 4.0189 8 4.80433V7.53538C7.92169 7.38531 7.80276 7.25181 7.6432 7.15209L2.53 3.95633Z"/>
-          </svg>
-          Add to Reel
-        </button>
         <select id="artifactFormat">
           <option value="clip">Clip (.mp4)</option>
           <option value="screen">Screenshot (.png)</option>
@@ -92,9 +86,9 @@
                  class="titlecard-duration-input" title="Duration (seconds)">
           <span class="titlecard-label-unit">s</span>
         </label>
-        <button id="generateBtn" class="btn btn-primary" disabled>Generate</button>
-        <button id="buildViewerBtn" class="btn btn-primary" disabled>Build Viewer</button>
-        <button id="stashArtifactsBtn" class="btn btn-small btn-icon" disabled>
+        <button id="generateBtn" class="btn btn-primary" disabled data-tooltip="Add cells to the work area first">Generate</button>
+        <button id="buildViewerBtn" class="btn btn-primary" disabled data-tooltip="Generate artifacts first">Build Viewer</button>
+        <button id="stashArtifactsBtn" class="btn btn-small btn-icon" disabled data-tooltip="Add cells to the work area first">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M3 2C2.44772 2 2 2.44772 2 3V4C2 4.55228 2.44772 5 3 5H13C13.5523 5 14 4.55228 14 4V3C14 2.44772 13.5523 2 13 2H3Z"/>
             <path fill-rule="evenodd" clip-rule="evenodd" d="M3 6H13V12C13 13.1046 12.1046 14 11 14H5C3.89543 14 3 13.1046 3 12V6ZM6 8.75C6 8.33579 6.33579 8 6.75 8H9.25C9.66421 8 10 8.33579 10 8.75C10 9.16421 9.66421 9.5 9.25 9.5H6.75C6.33579 9.5 6 9.16421 6 8.75Z"/>
@@ -111,6 +105,12 @@
       <div id="artifactsList" class="drop-target">
         <div class="drop-target-empty">Click or drag cells here to queue for generation</div>
       </div>
+      <button id="addToReelBtn" class="btn btn-small btn-icon" disabled data-tooltip="Add cells to the work area first">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M8 2a.75.75 0 0 1 .75.75v8.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V2.75A.75.75 0 0 1 8 2Z"/>
+        </svg>
+        Add to Reel
+      </button>
     </div>
   </section>
 
@@ -141,18 +141,18 @@
             </label>
           </div>
         </div>
-        <button id="stashReelBtn" class="btn btn-small btn-icon" disabled>
+        <button id="buildReelBtn" class="btn btn-primary btn-icon" disabled data-tooltip="Add clips to the reel first">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M3 3.73241C3 2.54878 4.30673 1.83146 5.30531 2.46692L12.0114 6.73441C12.9376 7.32384 12.9376 8.67597 12.0114 9.2654L5.30532 13.5329C4.30673 14.1684 3 13.451 3 12.2674V3.73241Z"/>
+          </svg>
+          Build Reel
+        </button>
+        <button id="stashReelBtn" class="btn btn-small btn-icon" disabled data-tooltip="Add clips to the reel first">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M3 2C2.44772 2 2 2.44772 2 3V4C2 4.55228 2.44772 5 3 5H13C13.5523 5 14 4.55228 14 4V3C14 2.44772 13.5523 2 13 2H3Z"/>
             <path fill-rule="evenodd" clip-rule="evenodd" d="M3 6H13V12C13 13.1046 12.1046 14 11 14H5C3.89543 14 3 13.1046 3 12V6ZM6 8.75C6 8.33579 6.33579 8 6.75 8H9.25C9.66421 8 10 8.33579 10 8.75C10 9.16421 9.66421 9.5 9.25 9.5H6.75C6.33579 9.5 6 9.16421 6 8.75Z"/>
           </svg>
           Stash
-        </button>
-        <button id="buildReelBtn" class="btn btn-primary btn-icon" disabled>
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M3 3.73241C3 2.54878 4.30673 1.83146 5.30531 2.46692L12.0114 6.73441C12.9376 7.32384 12.9376 8.67597 12.0114 9.2654L5.30532 13.5329C4.30673 14.1684 3 13.451 3 12.2674V3.73241Z"/>
-          </svg>
-          Build Reel
         </button>
         <button id="clearReelBtn" class="btn btn-small btn-icon">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -351,7 +351,7 @@
         }
 
         state.generatedArtifacts = state.generatedArtifacts.concat(
-          artifacts.filter(function (a) { return a.type !== "transcript"; })
+          artifacts.filter(function (a) { return a.type !== "transcript" && a.file; })
         );
         renderArtifactQueue();
         updateCellClasses();
@@ -848,8 +848,11 @@
     var n = state.artifactQueue.length;
     qs("#artifactsCount").textContent = "(" + n + ")";
     qs("#generateBtn").disabled = n === 0;
+    if (n === 0) qs("#generateBtn").setAttribute("data-tooltip", "Add cells to the work area first");
     qs("#addToReelBtn").disabled = n === 0;
+    if (n === 0) qs("#addToReelBtn").setAttribute("data-tooltip", "Add cells to the work area first");
     qs("#stashArtifactsBtn").disabled = n === 0;
+    if (n === 0) qs("#stashArtifactsBtn").setAttribute("data-tooltip", "Add cells to the work area first");
     list.innerHTML = "";
     saveQueues();
 
@@ -943,7 +946,9 @@
     var n = state.reelQueue.length;
     qs("#reelCount").textContent = "(" + n + ")";
     qs("#buildReelBtn").disabled = n === 0;
+    if (n === 0) qs("#buildReelBtn").setAttribute("data-tooltip", "Add clips to the reel first");
     qs("#stashReelBtn").disabled = n === 0;
+    if (n === 0) qs("#stashReelBtn").setAttribute("data-tooltip", "Add clips to the reel first");
     list.innerHTML = "";
     saveQueues();
 
@@ -1555,8 +1560,8 @@
       setGeneratingLock(false);
       if (allArtifacts.length > 0) {
         state.generatedArtifacts = state.generatedArtifacts.concat(allArtifacts);
-        updateViewerButton();
       }
+      updateViewerButton();
       var msg = "Generated " + totalSuccess + " artifact(s)";
       if (totalFail > 0) msg += ", " + totalFail + " failed";
       showResult(
@@ -1897,6 +1902,7 @@
   function updateViewerButton() {
     var n = state.generatedArtifacts.length;
     qs("#buildViewerBtn").disabled = n === 0;
+    if (n === 0) qs("#buildViewerBtn").setAttribute("data-tooltip", "Generate artifacts first");
     var count = qs("#viewerArtifactCount");
     count.textContent = n > 0 ? n + " artifact(s) ready" : "";
   }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.46"
+VERSIONNUM: str = "0.9.47"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary
- Normalize button heights across area controls so all buttons match
- Move Add to Reel button below the artifact drop area (right-aligned) and replace its icon with a downward arrow
- Left-align settings (format, titlecards) and right-align action buttons (Generate, Build Viewer, Stash, Clear) in the Artifacts area
- Reorder reel buttons so Stash appears directly left of Clear, matching the Artifacts area layout
- Add floating CSS tooltips on disabled buttons explaining why they are unavailable (suppressed during generation)
- Fix ghost artifact bug: filter out manifest entries without a `file` field so empty artifacts don't enable Build Viewer
- Ensure `updateViewerButton()` always runs after generation lock release

## Test plan
- [x] Launch Studio and verify all area-controls buttons are the same height
- [x] Verify Add to Reel has a downward arrow icon and sits below the artifacts list, right-aligned
- [x] Verify format/titlecards are left-aligned, action buttons are right-aligned
- [x] Verify reel area order: Highlights, Build Reel, Stash, Clear
- [x] Hover disabled buttons and confirm tooltips appear with correct messages
- [x] Confirm Build Viewer is disabled on launch with no prior generated artifacts
- [x] Run `uv run pytest -c tests/pytest.ini` (202 tests pass)