### PR TITLE
Add resizable divider between Sheet Preview and bottom panel in Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -200,8 +200,7 @@ body {
 /* Sheet preview */
 
 #sheetPreview {
-  flex: 1;
-  min-height: 0;
+  flex: 0 1 auto;
   display: flex;
   flex-direction: column;
   max-width: 1120px;
@@ -221,8 +220,6 @@ body {
 }
 
 #sheetGrid {
-  flex: 1;
-  min-height: 0;
   overflow: auto;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
@@ -233,6 +230,44 @@ body {
   border-collapse: collapse;
   font-size: 0.82rem;
   table-layout: fixed;
+}
+
+/* Panel divider (resizable handle between sheet preview and bottom panel) */
+
+#panelDivider {
+  max-width: 1120px;
+  width: 100%;
+  margin: 0 auto;
+  height: 12px;
+  background: var(--color-panel-bg);
+  border-left: 1px solid var(--color-panel-border);
+  border-right: 1px solid var(--color-panel-border);
+  cursor: row-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  user-select: none;
+  transition: background-color 0.15s;
+}
+
+#panelDivider:hover,
+#panelDivider.active {
+  background-color: var(--color-surface-alt);
+}
+
+.divider-handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-border);
+  transition: background-color 0.15s, width 0.15s;
+}
+
+#panelDivider:hover .divider-handle,
+#panelDivider.active .divider-handle {
+  background: var(--color-text-dim);
+  width: 48px;
 }
 
 #sheetGrid thead th {
@@ -1685,6 +1720,7 @@ html[data-theme="dark"] .settings-panel {
 @media (max-width: 768px) {
   #studioHeader,
   #sheetPreview,
+  #panelDivider,
   #bottomPanel,
   #dropAreas,
   #reelArea,

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -69,6 +69,8 @@
     </div>
   </section>
 
+  <div id="panelDivider"><div class="divider-handle"></div></div>
+
   <div id="bottomPanel">
   <section id="dropAreas">
     <div id="artifactsArea" class="drop-area">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -16,6 +16,7 @@
     stashes: [],
     artifactStashes: [],
     settingsData: null,
+    dividerOffset: 0,
   };
 
   // ---- Helpers ----
@@ -279,6 +280,7 @@
         state.sheetData = data;
         renderHeader();
         renderGrid();
+        computeGridMaxHeight();
         populateGalleryParticipants(data.participants || []);
         var durInput = qs("#highlightsDuration");
         if (durInput && data.highlightsDuration) {
@@ -470,6 +472,90 @@
 
     bindGridEvents();
     bindDragFromGrid();
+  }
+
+  // ---- Panel divider (resizable split between sheet preview and bottom panel) ----
+
+  function computeGridMaxHeight() {
+    var header = qs("#studioHeader");
+    var preview = qs("#sheetPreview");
+    var divider = qs("#panelDivider");
+    var bottom = qs("#bottomPanel");
+    var grid = qs("#sheetGrid");
+    if (!header || !preview || !divider || !bottom || !grid) return;
+
+    var previewH3 = preview.querySelector("h3");
+    var previewStyle = getComputedStyle(preview);
+    var previewPadTop = parseFloat(previewStyle.paddingTop) || 0;
+    var previewPadBot = parseFloat(previewStyle.paddingBottom) || 0;
+    var h3Height = previewH3 ? previewH3.offsetHeight : 0;
+    var h3Style = previewH3 ? getComputedStyle(previewH3) : null;
+    var h3Margin = h3Style
+      ? (parseFloat(h3Style.marginTop) || 0) + (parseFloat(h3Style.marginBottom) || 0)
+      : 0;
+
+    var headerRect = header.getBoundingClientRect();
+    var sheetChrome = previewPadTop + h3Height + h3Margin + previewPadBot;
+    var available = window.innerHeight - headerRect.top - headerRect.height
+      - sheetChrome - divider.offsetHeight - bottom.offsetHeight;
+
+    var MIN_GRID = 100;
+    var maxAllowed = Math.max(0, available - MIN_GRID);
+    state.dividerOffset = Math.min(state.dividerOffset, maxAllowed);
+
+    grid.style.maxHeight = Math.max(MIN_GRID, available - state.dividerOffset) + "px";
+  }
+
+  function initPanelDivider() {
+    var handle = qs("#panelDivider");
+    if (!handle) return;
+    var dragging = false;
+    var startY = 0;
+    var startOffset = 0;
+
+    function onDown(e) {
+      e.preventDefault();
+      dragging = true;
+      startY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
+      startOffset = state.dividerOffset;
+      handle.classList.add("active");
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+    }
+
+    handle.addEventListener("mousedown", onDown);
+    handle.addEventListener("touchstart", onDown, { passive: false });
+
+    var rafPending = false;
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("touchmove", onMove, { passive: false });
+
+    function onMove(e) {
+      if (!dragging || rafPending) return;
+      rafPending = true;
+      var clientY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
+      requestAnimationFrame(function () {
+        var delta = startY - clientY;
+        var grid = qs("#sheetGrid");
+        var table = grid ? grid.querySelector("table") : null;
+        var tableH = table ? table.offsetHeight : 0;
+        var maxOff = Math.max(0, tableH - 100);
+        state.dividerOffset = Math.max(0, Math.min(maxOff, startOffset + delta));
+        computeGridMaxHeight();
+        rafPending = false;
+      });
+    }
+
+    function onUp() {
+      if (!dragging) return;
+      dragging = false;
+      handle.classList.remove("active");
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
+
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchend", onUp);
   }
 
   function renderDataRow(row, participants, showSeverity) {
@@ -1103,6 +1189,7 @@
 
       list.appendChild(card);
     }
+    computeGridMaxHeight();
   }
 
   function computeReelDuration(items) {
@@ -1301,6 +1388,7 @@
 
       list.appendChild(card);
     }
+    computeGridMaxHeight();
   }
 
   function stashCurrentArtifacts() {
@@ -1349,6 +1437,7 @@
       reelArea.classList.remove("hidden");
       reelArea.classList.add("stash-drop-reveal");
     }
+    computeGridMaxHeight();
   }
 
   function hideEmptyStashAreas() {
@@ -1362,6 +1451,7 @@
       reelArea.classList.add("hidden");
       reelArea.classList.remove("stash-drop-reveal");
     }
+    computeGridMaxHeight();
   }
 
   // ---- Buttons ----
@@ -2203,11 +2293,13 @@
     initDropTargets();
     bindReelReorder();
     bindButtons();
+    initPanelDivider();
     loadSheetData();
     loadStashes();
     loadArtifactStashes();
     updateViewerButton();
     checkNavLinks();
+    window.addEventListener("resize", computeGridMaxHeight);
 
     document.addEventListener("dragstart", function (ev) {
       if (!ev.target.closest(".stash-card")) return;

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.47"
+VERSIONNUM: str = "0.9.48"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary

- The bottom panel (Artifacts/Reel work areas) now hugs the sheet's last row by default, instead of being pinned to the viewport bottom when the spreadsheet is short or the window is tall.
- Adds a draggable divider with a visible pill-shaped handle between the Sheet Preview and bottom panel. Dragging up shrinks the sheet preview (content scrolls); dragging down returns to the default position.
- The layout recomputes on window resize and when stash areas toggle visibility.

## Test plan

- [ ] Launch Studio with a short spreadsheet (~5 rows) — bottom panel should sit right below the last row, not at the viewport bottom
- [ ] Drag the divider handle upward — sheet preview shrinks, bottom panel moves up, sheet content scrolls
- [ ] Drag back down to default — sheet preview expands back to content height
- [ ] Test with a long spreadsheet (>30 rows) — sheet grid should scroll as before
- [ ] Resize the browser window — layout recomputes correctly
- [ ] Toggle stash areas — layout adjusts without gaps