### PR TITLE
Add filter bar to Studio Sheet Preview

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -215,8 +215,196 @@ body {
 #sheetPreview h3 {
   font-size: 0.9rem;
   font-weight: 600;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0;
   padding-top: 0.5rem;
+}
+
+.sheet-preview-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#filterToggle svg {
+  transition: color 0.15s;
+}
+
+/* Filter bar */
+
+#filterBar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+}
+
+.filter-group-label {
+  color: var(--color-text-dim);
+  font-weight: 500;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.filter-range-sep {
+  color: var(--color-text-dim);
+  font-size: 0.72rem;
+}
+
+.filter-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+  color: var(--color-text);
+  cursor: pointer;
+  min-width: 0;
+  max-width: 9rem;
+}
+
+.filter-select:hover {
+  border-color: var(--color-accent);
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.filter-select:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.filter-number {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.2rem 0.3rem;
+  font-size: 0.75rem;
+  color: var(--color-text);
+  width: 3.5rem;
+  font-family: var(--font-mono);
+}
+
+.filter-number:hover {
+  border-color: var(--color-accent);
+}
+
+.filter-number:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.filter-number:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Category dropdown */
+
+.filter-cat-wrap {
+  position: relative;
+}
+
+.filter-cat-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.filter-cat-btn:hover {
+  border-color: var(--color-accent);
+}
+
+.filter-cat-btn .chevron {
+  font-size: 0.6rem;
+  color: var(--color-text-dim);
+  transition: transform 0.15s;
+}
+
+.filter-cat-btn.open .chevron {
+  transform: rotate(180deg);
+}
+
+.filter-cat-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  padding: 0.3rem 0;
+  min-width: 10rem;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.filter-cat-panel label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.filter-cat-panel label:hover {
+  background: var(--color-cell-hover);
+}
+
+.filter-cat-panel input[type="checkbox"] {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.filter-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+  border-radius: 2px;
+  transition: color 0.15s;
+}
+
+.filter-clear:hover {
+  color: var(--color-text);
+}
+
+.filter-clear svg {
+  width: 12px;
+  height: 12px;
 }
 
 #sheetGrid {
@@ -1595,6 +1783,16 @@ html[data-theme="dark"] .reel-card-fail {
 }
 
 html[data-theme="dark"] .stash-card-name-input {
+  background: var(--color-surface-alt);
+}
+
+html[data-theme="dark"] .filter-cat-panel {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+html[data-theme="dark"] .filter-select,
+html[data-theme="dark"] .filter-number,
+html[data-theme="dark"] .filter-cat-btn {
   background: var(--color-surface-alt);
 }
 

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -61,7 +61,16 @@
   </header>
 
   <section id="sheetPreview">
-    <h3>Sheet Preview</h3>
+    <div class="sheet-preview-header">
+      <h3>Sheet Preview</h3>
+      <button id="filterToggle" class="btn btn-small btn-icon" title="Filter rows">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M14 2C14 1.44772 13.5523 1 13 1H3C2.44772 1 2 1.44772 2 2V4.17157C2 4.70201 2.21071 5.21071 2.58579 5.58579L5.41421 8.41421C5.78929 8.78929 6 9.29799 6 9.82843V14.191C6 14.5627 6.39116 14.8044 6.72361 14.6382L8.89443 13.5528C9.572 13.214 10 12.5215 10 11.7639V9.82843C10 9.29799 10.2107 8.78929 10.5858 8.41421L13.4142 5.58579C13.7893 5.21071 14 4.70201 14 4.17157V2Z"/>
+        </svg>
+        Filter
+      </button>
+    </div>
+    <div id="filterBar" class="hidden"></div>
     <div id="sheetGrid">
       <div id="sheetLoading" style="padding: 2rem; text-align: center; color: var(--color-text-dim);">
         Loading sheet data...

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -18,7 +18,25 @@
     settingsData: null,
     dividerOffset: 0,
     activeFunction: "",
+    filtersVisible: false,
+    filters: {
+      categories: [],
+      sevMin: "",
+      sevMax: "",
+      fnMin: null,
+      fnMax: null,
+    },
   };
+
+  var SEVERITY_ORDER = [
+    { label: "Critical", rank: -4 },
+    { label: "High", rank: -3 },
+    { label: "Medium", rank: -2 },
+    { label: "Low", rank: -1 },
+    { label: "N/A", rank: 0 },
+    { label: "Positive", rank: 1 },
+    { label: "Very Positive", rank: 2 },
+  ];
 
   var ROW_FUNCTIONS = {
     Count: function (row, participants) {
@@ -207,6 +225,306 @@
     return m2 + ":" + (s2 < 10 ? "0" : "") + s2;
   }
 
+  // ---- Filtering ----
+
+  function severityRank(label) {
+    if (!label) return null;
+    var k = label.trim().toLowerCase();
+    for (var i = 0; i < SEVERITY_ORDER.length; i++) {
+      if (SEVERITY_ORDER[i].label.toLowerCase() === k) return SEVERITY_ORDER[i].rank;
+    }
+    return null;
+  }
+
+  function hasActiveFilters() {
+    var f = state.filters;
+    return (
+      f.categories.length > 0 ||
+      f.sevMin !== "" ||
+      f.sevMax !== "" ||
+      f.fnMin !== null ||
+      f.fnMax !== null
+    );
+  }
+
+  function getFilteredRows(rows) {
+    var f = state.filters;
+    if (!hasActiveFilters()) return rows;
+
+    var sevMinRank = f.sevMin ? severityRank(f.sevMin) : null;
+    var sevMaxRank = f.sevMax ? severityRank(f.sevMax) : null;
+    var fnActive = state.activeFunction && ROW_FUNCTIONS[state.activeFunction];
+    var participants = state.sheetData ? state.sheetData.participants : [];
+
+    return rows.filter(function (row) {
+      if (f.categories.length > 0) {
+        if (!row.category || f.categories.indexOf(row.category) < 0) return false;
+      }
+      if (sevMinRank !== null || sevMaxRank !== null) {
+        var r = severityRank(row.severity);
+        if (r === null) return false;
+        if (sevMinRank !== null && r < sevMinRank) return false;
+        if (sevMaxRank !== null && r > sevMaxRank) return false;
+      }
+      if (f.fnMin !== null || f.fnMax !== null) {
+        if (!fnActive) return false;
+        var val = fnActive(row, participants);
+        if (f.fnMin !== null && val < f.fnMin) return false;
+        if (f.fnMax !== null && val > f.fnMax) return false;
+      }
+      return true;
+    });
+  }
+
+  function clearAllFilters() {
+    state.filters.categories = [];
+    state.filters.sevMin = "";
+    state.filters.sevMax = "";
+    state.filters.fnMin = null;
+    state.filters.fnMax = null;
+  }
+
+  function renderFilterBar() {
+    var bar = qs("#filterBar");
+    if (!bar || !state.sheetData) return;
+    bar.innerHTML = "";
+
+    var d = state.sheetData;
+
+    // --- Category filter ---
+    var uniqueCats = [];
+    for (var i = 0; i < d.rows.length; i++) {
+      var cat = d.rows[i].category;
+      if (cat && uniqueCats.indexOf(cat) < 0) uniqueCats.push(cat);
+    }
+    uniqueCats.sort();
+
+    if (uniqueCats.length > 0) {
+      var catGroup = el("div", "filter-group");
+      catGroup.appendChild(el("span", "filter-group-label", "Category"));
+
+      var catWrap = el("div", "filter-cat-wrap");
+      var catBtn = el("button", "filter-cat-btn");
+      catBtn.type = "button";
+      catBtn.innerHTML = 'All <span class="chevron">\u25BE</span>';
+      var catPanel = el("div", "filter-cat-panel hidden");
+
+      for (var ci = 0; ci < uniqueCats.length; ci++) {
+        var lbl = document.createElement("label");
+        var cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.value = uniqueCats[ci];
+        cb.setAttribute("data-filter-cat", uniqueCats[ci]);
+        lbl.appendChild(cb);
+        lbl.appendChild(document.createTextNode(uniqueCats[ci]));
+        catPanel.appendChild(lbl);
+      }
+
+      catBtn.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        catBtn.classList.toggle("open");
+        catPanel.classList.toggle("hidden");
+      });
+
+      catPanel.addEventListener("change", function () {
+        var checked = catPanel.querySelectorAll("input:checked");
+        state.filters.categories = [];
+        for (var j = 0; j < checked.length; j++) {
+          state.filters.categories.push(checked[j].value);
+        }
+        var count = state.filters.categories.length;
+        catBtn.innerHTML =
+          (count === 0 ? "All" : count + " selected") +
+          ' <span class="chevron">\u25BE</span>';
+        renderGrid();
+        computeGridMaxHeight();
+      });
+
+      catWrap.appendChild(catBtn);
+      catWrap.appendChild(catPanel);
+      catGroup.appendChild(catWrap);
+
+      var catClear = document.createElement("button");
+      catClear.className = "filter-clear";
+      catClear.type = "button";
+      catClear.title = "Clear category filter";
+      catClear.innerHTML =
+        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z"/></svg>';
+      catClear.addEventListener("click", function () {
+        state.filters.categories = [];
+        var cbs = catPanel.querySelectorAll("input[type=checkbox]");
+        for (var j = 0; j < cbs.length; j++) cbs[j].checked = false;
+        catBtn.innerHTML = 'All <span class="chevron">\u25BE</span>';
+        renderGrid();
+        computeGridMaxHeight();
+      });
+      catGroup.appendChild(catClear);
+
+      bar.appendChild(catGroup);
+    }
+
+    // --- Severity filter ---
+    var showSeverity = hasSeverityData(d.rows);
+    if (showSeverity) {
+      var sevGroup = el("div", "filter-group");
+      sevGroup.appendChild(el("span", "filter-group-label", "Severity"));
+
+      var sevMin = document.createElement("select");
+      sevMin.className = "filter-select";
+      sevMin.id = "filterSevMin";
+      var sevMinDefault = document.createElement("option");
+      sevMinDefault.value = "";
+      sevMinDefault.textContent = "Any";
+      sevMin.appendChild(sevMinDefault);
+      for (var si = 0; si < SEVERITY_ORDER.length; si++) {
+        var opt = document.createElement("option");
+        opt.value = SEVERITY_ORDER[si].label;
+        opt.textContent = SEVERITY_ORDER[si].label;
+        sevMin.appendChild(opt);
+      }
+
+      var sevMax = document.createElement("select");
+      sevMax.className = "filter-select";
+      sevMax.id = "filterSevMax";
+      var sevMaxDefault = document.createElement("option");
+      sevMaxDefault.value = "";
+      sevMaxDefault.textContent = "Any";
+      sevMax.appendChild(sevMaxDefault);
+      for (var sj = 0; sj < SEVERITY_ORDER.length; sj++) {
+        var opt2 = document.createElement("option");
+        opt2.value = SEVERITY_ORDER[sj].label;
+        opt2.textContent = SEVERITY_ORDER[sj].label;
+        sevMax.appendChild(opt2);
+      }
+
+      function onSevChange() {
+        state.filters.sevMin = sevMin.value;
+        state.filters.sevMax = sevMax.value;
+        renderGrid();
+        computeGridMaxHeight();
+      }
+      sevMin.addEventListener("change", onSevChange);
+      sevMax.addEventListener("change", onSevChange);
+
+      sevGroup.appendChild(sevMin);
+      sevGroup.appendChild(el("span", "filter-range-sep", "to"));
+      sevGroup.appendChild(sevMax);
+
+      var sevClear = document.createElement("button");
+      sevClear.className = "filter-clear";
+      sevClear.type = "button";
+      sevClear.title = "Clear severity filter";
+      sevClear.innerHTML =
+        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z"/></svg>';
+      sevClear.addEventListener("click", function () {
+        state.filters.sevMin = "";
+        state.filters.sevMax = "";
+        sevMin.value = "";
+        sevMax.value = "";
+        renderGrid();
+        computeGridMaxHeight();
+      });
+      sevGroup.appendChild(sevClear);
+
+      bar.appendChild(sevGroup);
+    }
+
+    // --- Function filter ---
+    var fnGroup = el("div", "filter-group");
+    fnGroup.appendChild(el("span", "filter-group-label", "Function"));
+
+    var fnMin = document.createElement("input");
+    fnMin.type = "number";
+    fnMin.className = "filter-number";
+    fnMin.id = "filterFnMin";
+    fnMin.placeholder = "Min";
+    fnMin.disabled = !state.activeFunction;
+
+    var fnMax = document.createElement("input");
+    fnMax.type = "number";
+    fnMax.className = "filter-number";
+    fnMax.id = "filterFnMax";
+    fnMax.placeholder = "Max";
+    fnMax.disabled = !state.activeFunction;
+
+    function onFnChange() {
+      var minVal = fnMin.value.trim();
+      var maxVal = fnMax.value.trim();
+      state.filters.fnMin = minVal !== "" ? parseFloat(minVal) : null;
+      state.filters.fnMax = maxVal !== "" ? parseFloat(maxVal) : null;
+      renderGrid();
+      computeGridMaxHeight();
+    }
+    fnMin.addEventListener("input", onFnChange);
+    fnMax.addEventListener("input", onFnChange);
+
+    fnGroup.appendChild(fnMin);
+    fnGroup.appendChild(el("span", "filter-range-sep", "to"));
+    fnGroup.appendChild(fnMax);
+
+    var fnClear = document.createElement("button");
+    fnClear.className = "filter-clear";
+    fnClear.type = "button";
+    fnClear.title = "Clear function filter";
+    fnClear.innerHTML =
+      '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z"/></svg>';
+    fnClear.addEventListener("click", function () {
+      state.filters.fnMin = null;
+      state.filters.fnMax = null;
+      fnMin.value = "";
+      fnMax.value = "";
+      renderGrid();
+      computeGridMaxHeight();
+    });
+    fnGroup.appendChild(fnClear);
+
+    bar.appendChild(fnGroup);
+
+    // Close category dropdown on outside click
+    document.addEventListener("click", function (ev) {
+      var wrap = qs(".filter-cat-wrap");
+      if (wrap && !wrap.contains(ev.target)) {
+        var btn = wrap.querySelector(".filter-cat-btn");
+        var panel = wrap.querySelector(".filter-cat-panel");
+        if (btn) btn.classList.remove("open");
+        if (panel) panel.classList.add("hidden");
+      }
+    });
+  }
+
+  function initFilterToggle() {
+    var btn = qs("#filterToggle");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      state.filtersVisible = !state.filtersVisible;
+      var bar = qs("#filterBar");
+      if (state.filtersVisible) {
+        bar.classList.remove("hidden");
+      } else {
+        bar.classList.add("hidden");
+        if (hasActiveFilters()) {
+          clearAllFilters();
+          renderGrid();
+        }
+      }
+      computeGridMaxHeight();
+    });
+  }
+
+  function syncFilterFnDisabled() {
+    var fnMin = qs("#filterFnMin");
+    var fnMax = qs("#filterFnMax");
+    var enabled = !!state.activeFunction;
+    if (fnMin) fnMin.disabled = !enabled;
+    if (fnMax) fnMax.disabled = !enabled;
+    if (!enabled && (state.filters.fnMin !== null || state.filters.fnMax !== null)) {
+      state.filters.fnMin = null;
+      state.filters.fnMax = null;
+      if (fnMin) fnMin.value = "";
+      if (fnMax) fnMax.value = "";
+    }
+  }
+
   // ---- Theme ----
 
   function initThemeToggle() {
@@ -299,6 +617,7 @@
         }
         state.sheetData = data;
         renderHeader();
+        renderFilterBar();
         renderGrid();
         computeGridMaxHeight();
         populateGalleryParticipants(data.participants || []);
@@ -476,12 +795,14 @@
     fnSelect.addEventListener("change", function () {
       state.activeFunction = this.value;
       fnClear.style.display = this.value ? "" : "none";
+      syncFilterFnDisabled();
       updateFunctionColumn();
     });
     fnClear.addEventListener("click", function () {
       state.activeFunction = "";
       fnSelect.value = "";
       this.style.display = "none";
+      syncFilterFnDisabled();
       updateFunctionColumn();
     });
     fnWrap.appendChild(fnSelect);
@@ -505,13 +826,14 @@
     table.appendChild(thead);
 
     // Group consecutive empty rows into separators
+    var filteredRows = getFilteredRows(d.rows);
     var tbody = el("tbody");
     var i = 0;
-    while (i < d.rows.length) {
-      var row = d.rows[i];
+    while (i < filteredRows.length) {
+      var row = filteredRows[i];
       if (isRowEmpty(row, d.participants)) {
         var emptyStart = i;
-        while (i < d.rows.length && isRowEmpty(d.rows[i], d.participants)) {
+        while (i < filteredRows.length && isRowEmpty(filteredRows[i], d.participants)) {
           i++;
         }
         var emptyCount = i - emptyStart;
@@ -547,18 +869,24 @@
     var grid = qs("#sheetGrid");
     if (!header || !preview || !divider || !bottom || !grid) return;
 
-    var previewH3 = preview.querySelector("h3");
+    var previewHeader = preview.querySelector(".sheet-preview-header");
+    var filterBar = qs("#filterBar");
     var previewStyle = getComputedStyle(preview);
     var previewPadTop = parseFloat(previewStyle.paddingTop) || 0;
     var previewPadBot = parseFloat(previewStyle.paddingBottom) || 0;
-    var h3Height = previewH3 ? previewH3.offsetHeight : 0;
-    var h3Style = previewH3 ? getComputedStyle(previewH3) : null;
-    var h3Margin = h3Style
-      ? (parseFloat(h3Style.marginTop) || 0) + (parseFloat(h3Style.marginBottom) || 0)
+    var phHeight = previewHeader ? previewHeader.offsetHeight : 0;
+    var phStyle = previewHeader ? getComputedStyle(previewHeader) : null;
+    var phMargin = phStyle
+      ? (parseFloat(phStyle.marginTop) || 0) + (parseFloat(phStyle.marginBottom) || 0)
+      : 0;
+    var fbHeight = filterBar && !filterBar.classList.contains("hidden") ? filterBar.offsetHeight : 0;
+    var fbStyle = filterBar && !filterBar.classList.contains("hidden") ? getComputedStyle(filterBar) : null;
+    var fbMargin = fbStyle
+      ? (parseFloat(fbStyle.marginTop) || 0) + (parseFloat(fbStyle.marginBottom) || 0)
       : 0;
 
     var headerRect = header.getBoundingClientRect();
-    var sheetChrome = previewPadTop + h3Height + h3Margin + previewPadBot;
+    var sheetChrome = previewPadTop + phHeight + phMargin + fbHeight + fbMargin + previewPadBot;
     var available = window.innerHeight - headerRect.top - headerRect.height
       - sheetChrome - divider.offsetHeight - bottom.offsetHeight;
 
@@ -2395,6 +2723,7 @@
 
   document.addEventListener("DOMContentLoaded", function () {
     initThemeToggle();
+    initFilterToggle();
     initDropTargets();
     bindReelReorder();
     bindButtons();

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.49"
+VERSIONNUM: str = "0.9.50"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary
- Adds a toggleable filter bar next to the "Sheet Preview" title, revealed by a funnel icon button
- **Category filter**: custom checkbox dropdown for multi-selecting specific categories
- **Severity filter**: min/max dropdown pair for filtering by severity range (Critical through Very Positive)
- **Function filter**: min/max number inputs for filtering by computed function values (enabled only when a row function is active)
- Each filter group has its own clear button; all filters are AND-combined; hiding the bar clears all filters
- Integrates with empty-row grouping so separators update correctly when rows are filtered out
- Dark mode support via existing CSS variable overrides

## Test plan
- [x] All 202 existing tests pass (`uv run pytest`)
- [ ] Verify filter button appears next to "Sheet Preview" with funnel icon
- [ ] Toggle filter bar open/closed; confirm grid height recalculates
- [ ] Filter by category: select categories, confirm non-matching rows hidden
- [ ] Filter by severity range: set min/max, confirm range filtering works
- [ ] Filter by function value: activate a function, set min/max, confirm filtering
- [ ] Clear individual filters via x buttons; confirm rows reappear
- [ ] Hide filter bar; confirm all filters reset
- [ ] Verify dark mode styling for filter controls