### PR TITLE
Capture vertical scroll as horizontal in Studio card queues

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1293,6 +1293,24 @@
     });
   }
 
+  // ---- Wheel-to-horizontal scroll for card queues ----
+
+  function initWheelScroll() {
+    ["#artifactsList", "#reelList"].forEach(function (sel) {
+      var el = qs(sel);
+      el.addEventListener(
+        "wheel",
+        function (e) {
+          if (el.scrollWidth > el.clientWidth) {
+            e.preventDefault();
+            el.scrollLeft += e.deltaY;
+          }
+        },
+        { passive: false },
+      );
+    });
+  }
+
   // ---- Reel reordering ----
 
   var _reelDragIdx = null;
@@ -2714,6 +2732,7 @@
     initThemeToggle();
     initFilterToggle();
     initDropTargets();
+    initWheelScroll();
     bindReelReorder();
     bindButtons();
     initPanelDivider();


### PR DESCRIPTION
The Artifact and Reel card queues in Studio are horizontal-scrolling containers, but users had to shift+scroll or use a trackpad sideways gesture to navigate them. This adds a `wheel` event listener to both `#artifactsList` and `#reelList` that translates vertical scroll (`deltaY`) into horizontal scroll (`scrollLeft`), only when the container has overflow.