### PR TITLE
Add floating expanded cell on hover for overflowing timestamps in Studio

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -656,6 +656,22 @@ col.col-participant-col {
   cursor: default;
 }
 
+/* Floating expanded cell overlay */
+
+.ts-cell-float {
+  position: fixed;
+  z-index: 10;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.35rem 0.6rem;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 60ms ease;
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: 2px 0 6px rgba(0, 0, 0, 0.15);
+}
+
 /* Empty row separator */
 
 .empty-rows-separator td {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -18,6 +18,7 @@
     settingsData: null,
     dividerOffset: 0,
     activeFunction: "",
+    cellExpandHover: true,
     filtersVisible: false,
     filters: {
       categories: [],
@@ -623,6 +624,9 @@
         if (tcDurInput && data.titlecardDuration) {
           tcDurInput.value = data.titlecardDuration;
         }
+        if (data.cellExpandHover !== undefined) {
+          state.cellExpandHover = data.cellExpandHover;
+        }
         var tcGroup = qs("#titlecardGroup");
         if (tcGroup && qs("#artifactFormat").value === "clip") {
           tcGroup.classList.remove("hidden");
@@ -1200,6 +1204,60 @@
       var info = getCellInfo(td);
       toggleReelCell(info);
     });
+
+    // Floating expanded cell for overflowing timestamp cells
+    var cellFloat = document.createElement("div");
+    cellFloat.className = "ts-cell-float";
+    cellFloat.style.display = "none";
+    document.body.appendChild(cellFloat);
+    var floatCell = null;
+    var floatTitle = "";
+
+    function showFloat(td) {
+      if (!state.cellExpandHover) return;
+      if (td.scrollWidth <= td.clientWidth) return;
+      floatCell = td;
+      floatTitle = td.title || "";
+      td.title = "";
+      var rect = td.getBoundingClientRect();
+      cellFloat.textContent = td.textContent;
+      cellFloat.style.backgroundColor = getComputedStyle(td).backgroundColor;
+      cellFloat.style.top = rect.top + "px";
+      cellFloat.style.left = rect.left + "px";
+      cellFloat.style.height = rect.height + "px";
+      cellFloat.style.lineHeight = rect.height + "px";
+      cellFloat.style.display = "block";
+      cellFloat.offsetWidth; // force reflow
+      cellFloat.style.opacity = "1";
+    }
+
+    function hideFloat() {
+      cellFloat.style.opacity = "0";
+      if (floatCell) {
+        floatCell.title = floatTitle;
+        floatCell = null;
+      }
+      setTimeout(function () {
+        if (!floatCell) cellFloat.style.display = "none";
+      }, 70);
+    }
+
+    grid.addEventListener("mouseover", function (ev) {
+      var td = ev.target.closest(".ts-cell");
+      if (!td || td.classList.contains("empty")) { if (floatCell) hideFloat(); return; }
+      if (td !== floatCell) {
+        if (floatCell) hideFloat();
+        showFloat(td);
+      }
+    });
+
+    grid.addEventListener("mouseleave", function () {
+      if (floatCell) hideFloat();
+    });
+
+    grid.addEventListener("scroll", function () {
+      if (floatCell) hideFloat();
+    }, { passive: true });
   }
 
   // ---- Drag from grid ----
@@ -2656,6 +2714,10 @@
     if (hlDuration) {
       var hl = qs("#highlightsDuration");
       if (hl) hl.value = hlDuration.value;
+    }
+    var cellExpand = findSetting("STUDIO_CELL_EXPAND_HOVER");
+    if (cellExpand) {
+      state.cellExpandHover = !!cellExpand.value;
     }
   }
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.51"
+VERSIONNUM: str = "0.9.52"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [
@@ -87,6 +87,7 @@ INSIGHTS_MANIFEST_FILENAME: str = "insights_manifest.json"
 STASHES_MANIFEST_FILENAME: str = "reel_stashes.json"
 ARTIFACT_STASHES_MANIFEST_FILENAME: str = "artifact_stashes.json"
 STUDIO_SETTINGS_FILENAME: str = "studio_settings.json"
+STUDIO_CELL_EXPAND_HOVER: bool = True
 GOOGLE_API_MAX_RETRIES: int = 3  # Retries for transient Google API errors (5xx)
 
 # Sprite sheet constants (for insights builder hover-to-scrub)
@@ -177,6 +178,7 @@ SETTINGS_DESCRIPTIONS: Dict[str, str] = {
     "TRANSCRIBE_FORMAT": "Transcript output format: md (Markdown), srt, or vtt.",
     "HIGHLIGHTS_REEL_DURATION_SECONDS": "Maximum duration in seconds for the highlights reel time budget.",
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
+    "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
 }
 
 # Studio-exposed settings with UI metadata (group, type, constraints).
@@ -192,4 +194,5 @@ STUDIO_SETTINGS: Dict[str, Dict[str, Any]] = {
     "TITLECARD_DURATION_SECONDS": {"group": "Titlecards", "type": "int", "min": 1, "step": 1},
     "HIGHLIGHTS_REEL_DURATION_SECONDS": {"group": "Generation", "type": "int", "min": 10, "step": 10},
     "MANIFEST_ENABLED": {"group": "Generation", "type": "bool"},
+    "STUDIO_CELL_EXPAND_HOVER": {"group": "Sheet Preview", "type": "bool"},
 }

--- a/server.py
+++ b/server.py
@@ -188,6 +188,7 @@ def api_sheet() -> FlaskResponse:
             "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
             "titlecardsEnabled": config.TITLECARDS_ENABLED,
             "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
+            "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
             "participants": participants,
             "rows": rows,
         }


### PR DESCRIPTION
## Summary

- Hovering a truncated timestamp cell in the Studio Sheet Preview now shows a floating overlay with the full cell content, positioned exactly over the original cell and matching its background color
- The overlay fades in/out in ~60ms for a responsive feel, and hides on scroll or mouse leave
- Added `STUDIO_CELL_EXPAND_HOVER` as a toggle-able setting (enabled by default) in the Studio settings panel under "Sheet Preview"
- The setting is wired end-to-end: `config.py` → `server.py` `/api/sheet` response → `studio.js` state, and syncs when changed via the settings panel