### PR TITLE
Fix floating cell visual bugs in Studio Sheet Preview

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -661,9 +661,11 @@ col.col-participant-col {
 .ts-cell-float {
   position: fixed;
   z-index: 10;
+  box-sizing: border-box;
   font-family: var(--font-mono);
   font-size: 0.72rem;
   padding: 0.35rem 0.6rem;
+  text-align: center;
   white-space: nowrap;
   pointer-events: none;
   opacity: 0;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -980,7 +980,6 @@
 
       if (cellData.hasText) {
         td.textContent = cellData.value;
-        td.title = cellData.value;
         if (cellData.valid) {
           td.classList.add("valid-ts");
         } else {
@@ -1211,21 +1210,17 @@
     cellFloat.style.display = "none";
     document.body.appendChild(cellFloat);
     var floatCell = null;
-    var floatTitle = "";
 
     function showFloat(td) {
       if (!state.cellExpandHover) return;
       if (td.scrollWidth <= td.clientWidth) return;
       floatCell = td;
-      floatTitle = td.title || "";
-      td.title = "";
       var rect = td.getBoundingClientRect();
       cellFloat.textContent = td.textContent;
       cellFloat.style.backgroundColor = getComputedStyle(td).backgroundColor;
-      cellFloat.style.top = rect.top + "px";
+      cellFloat.style.top = (rect.top + 1) + "px";
       cellFloat.style.left = rect.left + "px";
-      cellFloat.style.height = rect.height + "px";
-      cellFloat.style.lineHeight = rect.height + "px";
+      cellFloat.style.height = (rect.height - 1) + "px";
       cellFloat.style.display = "block";
       cellFloat.offsetWidth; // force reflow
       cellFloat.style.opacity = "1";
@@ -1233,10 +1228,7 @@
 
     function hideFloat() {
       cellFloat.style.opacity = "0";
-      if (floatCell) {
-        floatCell.title = floatTitle;
-        floatCell = null;
-      }
+      floatCell = null;
       setTimeout(function () {
         if (!floatCell) cellFloat.style.display = "none";
       }, 70);


### PR DESCRIPTION
## Summary

Fixes three visual bugs in the floating expanded cell overlay introduced in #40:
- **Vertical alignment**: Removed `lineHeight` override that pushed text down; added `box-sizing: border-box` and `text-align: center` to match cell styling
- **1px offset**: Shifted float down 1px and reduced height by 1px to align with collapsed table borders, eliminating the gap beneath and overlap above
- **Double tooltip**: Removed native `title` attribute from timestamp cells entirely, since the float handles overflow and non-truncated cells don't need a tooltip