### PR TITLE
Fix ndarray serialization crash in screenspace similarity task

### DIFF
--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -329,7 +329,12 @@ def api_tasks_results(task_id: str) -> FlaskResponse:
 
 def _clean_task(task: Dict[str, Any]) -> Dict[str, Any]:
     """Remove internal fields from a task dict for API responses."""
-    return {k: v for k, v in task.items() if not k.startswith("_")}
+    cleaned = {k: v for k, v in task.items() if not k.startswith("_")}
+    if "parameters" in cleaned:
+        cleaned["parameters"] = {
+            k: v for k, v in cleaned["parameters"].items() if k != "reference_frame"
+        }
+    return cleaned
 
 
 # ---- State initialization ----


### PR DESCRIPTION
## Summary
- Fixes a crash when creating a similarity analysis task with "capture current frame" source in Screenspace
- The numpy `reference_frame` ndarray was being included in the API response, causing `TypeError: Object of type ndarray is not JSON serializable`
- `_clean_task()` now strips `reference_frame` from task parameters before serialization, while keeping it available internally for the worker thread