### PR TITLE
Add interactive Screenspace launch

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -83,6 +83,8 @@ MODE_ALIASES = {
     "insights": "insights",
     "st": "studio",
     "studio": "studio",
+    "ss": "screenspace",
+    "screenspace": "screenspace",
     "se": "settings",
     "settings": "settings",
 }
@@ -1701,6 +1703,13 @@ def _dispatch_interactive_mode(
 
         server.start_combined_server(worksheet=worksheet, default_page="studio")
         return None
+    if mode == "screenspace":
+        import server
+
+        server.start_combined_server(
+            worksheet=worksheet, default_page="screenspace", screenspace=True
+        )
+        return None
     if mode == "timeline-viewer":
         clips_list = spreadsheet.generate_list(worksheet, "batch", skip_prompts=True)
         outputs_generated, artifacts = process_clips(clips_list, output_format="clip")
@@ -1783,7 +1792,7 @@ def run_interactive_mode(worksheet: Any) -> None:
             input_mode = utils.read_user_input(
                 "\nEnter mode or input directly:\n"
                 "  Tools: (s)creen, (g)if, (re)el, (rl) reel-late, (rg) regenerate, (se)ttings \n"
-                "  Front: (st) studio, (in) insights, (br)owse \n"
+                "  Front: (st) studio, (in) insights, (ss) screenspace, (br)owse \n"
                 "  Packs: (v)iewer, (tv) timeline-viewer, (gv) gallery \n"
                 "  Modes: (b)atch, (r)ange, (c)ategory, (l)ine, (ce)ll, (p)articipant, (k)eyword, (sv) severity \n"
                 '  Or enter mixed selectors directly: e.g. 5, P01.11, 13-16, "Observations"\n>> '

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.54"
+VERSIONNUM: str = "0.9.55"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary
- Adds Screenspace to the interactive mode selection prompt under the "Front:" line, launchable via `screenspace` or the `ss` shortcut
- Dispatches to `start_combined_server()` with `screenspace=True`, matching the existing `--screenspace` CLI flag behavior
- Bumps version to 0.9.55

## Test plan
- [x] All 256 existing tests pass
- [ ] Run interactively, confirm `ss` / `screenspace` appears in the prompt and launches the Screenspace server