### PR TITLE
Fix ndarray serialization in screenspace manifest persistence

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.55"
+VERSIONNUM: str = "0.9.56"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/screenspace.py
+++ b/screenspace.py
@@ -838,9 +838,14 @@ def save_screenspace_manifest(
     manifest_path = (
         Path(utils.get_effective_output_dir()) / config.SCREENSPACE_MANIFEST_FILENAME
     )
-    clean_tasks = [
-        {k: v for k, v in task.items() if not k.startswith("_")} for task in tasks
-    ]
+    clean_tasks = []
+    for task in tasks:
+        ct = {k: v for k, v in task.items() if not k.startswith("_")}
+        if "parameters" in ct:
+            ct["parameters"] = {
+                k: v for k, v in ct["parameters"].items() if k != "reference_frame"
+            }
+        clean_tasks.append(ct)
     try:
         manifest_path.write_text(
             json.dumps(


### PR DESCRIPTION
## Summary
- Fixes a `TypeError: Object of type ndarray is not JSON serializable` crash when a screenspace similarity task completes and the manifest is persisted
- The numpy `reference_frame` array (used internally for image comparison) was being included in serialized task parameters — now stripped before writing to JSON
- Bumps version to 0.9.56