### PR TITLE
Screenspace: 3-column bottom panel with draggable divider

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -410,14 +410,15 @@ body {
   display: flex;
   gap: 0;
   border-bottom: 1px solid var(--color-border);
+  flex-wrap: wrap;
 }
 
 .wf-tab {
-  padding: 0.4rem 0.9rem;
+  padding: 0.35rem 0.6rem;
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   font-weight: 500;
   color: var(--color-text-dim);
   cursor: pointer;
@@ -436,16 +437,18 @@ body {
 
 #workflowBody {
   display: flex;
-  align-items: flex-start;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.6rem;
   padding: 0.6rem 0;
 }
 
 #workflowParams {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .param-row {
@@ -456,8 +459,8 @@ body {
 }
 
 .param-label {
-  font-size: 0.78rem;
-  min-width: 7rem;
+  font-size: 0.72rem;
+  min-width: 5.5rem;
   color: var(--color-text-dim);
 }
 
@@ -468,7 +471,7 @@ body {
 }
 
 .param-control input[type="range"] {
-  width: 120px;
+  width: 80px;
   accent-color: var(--color-accent);
 }
 
@@ -605,6 +608,44 @@ body {
   opacity: 1;
 }
 
+/* Panel divider */
+
+#panelDivider {
+  max-width: 1120px;
+  width: 100%;
+  margin: 0 auto;
+  height: 12px;
+  background: var(--color-panel-bg);
+  border-left: 1px solid var(--color-panel-border);
+  border-right: 1px solid var(--color-panel-border);
+  cursor: row-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  user-select: none;
+  transition: background-color 0.15s;
+}
+
+#panelDivider:hover,
+#panelDivider.active {
+  background-color: var(--color-surface-alt);
+}
+
+.divider-handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-border);
+  transition: background-color 0.15s, width 0.15s;
+}
+
+#panelDivider:hover .divider-handle,
+#panelDivider.active .divider-handle {
+  background: var(--color-text-dim);
+  width: 48px;
+}
+
 /* Bottom panel */
 
 #bottomPanel {
@@ -618,10 +659,20 @@ body {
   box-shadow: 0 24px 60px var(--color-panel-shadow);
   padding: 0.8rem 1.5rem 1.2rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 1.5rem;
   flex-shrink: 0;
   margin-bottom: 1.5rem;
+  height: 260px;
+  min-height: 120px;
+  overflow: hidden;
+}
+
+#bottomPanel > * {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .panel-header {
@@ -655,7 +706,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
-  max-height: 260px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -770,7 +822,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0;
-  max-height: 260px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -1021,6 +1074,7 @@ html[data-theme="dark"] .region-chip.active {
 @media (max-width: 768px) {
   #ssHeader,
   #ssMain,
+  #panelDivider,
   #bottomPanel {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
@@ -1028,8 +1082,6 @@ html[data-theme="dark"] .region-chip.active {
   }
   #bottomPanel {
     grid-template-columns: 1fr;
-  }
-  #workflowBody {
-    flex-direction: column;
+    height: auto;
   }
 }

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -63,6 +63,11 @@
       </div>
     </section>
 
+  </main>
+
+  <div id="panelDivider"><div class="divider-handle"></div></div>
+
+  <div id="bottomPanel">
     <section id="workflowSection">
       <div id="workflowTabs">
         <button class="wf-tab active" data-type="color">Color</button>
@@ -81,9 +86,6 @@
         </button>
       </div>
     </section>
-  </main>
-
-  <div id="bottomPanel">
     <div id="taskQueuePanel">
       <div class="panel-header">
         <h3>Task Queue <span id="taskCount">(0)</span></h3>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -42,6 +42,7 @@
     selectedTaskResults: null,
     pollTimer: null,
     timelineDragging: false,
+    panelHeight: 260,
   };
 
   // ---- Helpers ----
@@ -1456,6 +1457,61 @@
     });
   }
 
+  // ---- Panel divider ----
+
+  function initPanelDivider() {
+    var handle = qs("#panelDivider");
+    var panel = qs("#bottomPanel");
+    if (!handle || !panel) return;
+    var dragging = false;
+    var startY = 0;
+    var startHeight = 0;
+
+    var MIN_H = 120;
+    var MAX_H = Math.round(window.innerHeight * 0.6);
+
+    function onDown(e) {
+      e.preventDefault();
+      dragging = true;
+      startY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
+      startHeight = state.panelHeight;
+      handle.classList.add("active");
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+    }
+
+    handle.addEventListener("mousedown", onDown);
+    handle.addEventListener("touchstart", onDown, { passive: false });
+
+    var rafPending = false;
+
+    function onMove(e) {
+      if (!dragging || rafPending) return;
+      rafPending = true;
+      var clientY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
+      requestAnimationFrame(function () {
+        var delta = startY - clientY;
+        state.panelHeight = Math.max(MIN_H, Math.min(MAX_H, startHeight + delta));
+        panel.style.height = state.panelHeight + "px";
+        rafPending = false;
+      });
+    }
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("touchmove", onMove, { passive: false });
+
+    function onUp() {
+      if (!dragging) return;
+      dragging = false;
+      handle.classList.remove("active");
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
+
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchend", onUp);
+  }
+
   // ---- Init ----
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -1467,6 +1523,7 @@
     initRunButton();
     initTaskQueue();
     initResultsPanel();
+    initPanelDivider();
     initKeyboard();
     checkNavLinks();
 


### PR DESCRIPTION
## Summary
- Moves workflow controls (tool tabs + params + run button) from the scrollable main area into the bottom panel, creating a 3-column horizontal layout: Workflow | Task Queue | Results
- Bottom panel now has a fixed height (260px) so it doesn't resize when switching between tools with different parameter counts
- Adds a Studio-style draggable divider between the viewer/timeline area and the bottom panel for manual height adjustment (120px–60% viewport, mouse + touch)
- Tightens tab padding, param label widths, and slider widths to fit the narrower columns; internal lists scroll independently

## Test plan
- [ ] Verify 3-column layout renders correctly at default width
- [ ] Switch between all five tool types — panel height should remain stable
- [ ] Drag the divider up and down; confirm min/max constraints
- [ ] Check responsive behavior at narrow widths (single column, auto height)
- [ ] Verify dark mode styling is preserved