### PR TITLE
Consolidate Screenspace timelines and add drag-to-scrub

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -262,20 +262,6 @@ body {
   pointer-events: none;
 }
 
-/* Frame controls */
-
-#frameControls {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-#timestampSlider {
-  flex: 1;
-  accent-color: var(--color-accent);
-  height: 4px;
-}
-
 #timestampInput {
   width: 5.5rem;
   font-size: 0.78rem;
@@ -346,6 +332,31 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
+}
+
+#timelineRow {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+#timelineRow #timelineCanvas {
+  flex: 1;
+  min-width: 0;
+}
+
+#timelineSeek {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  flex-shrink: 0;
+}
+
+#timelineStepBtns {
+  display: flex;
+  gap: 0.2rem;
 }
 
 #timelineCanvas {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -33,13 +33,6 @@
         <canvas id="overlayCanvas"></canvas>
         <div id="frameEmpty">Select a participant to view frames</div>
       </div>
-      <div id="frameControls">
-        <input id="timestampSlider" type="range" min="0" max="100" step="0.01" value="0">
-        <input id="timestampInput" type="text" placeholder="0:00" spellcheck="false">
-        <button id="framePrev" class="btn btn-small" title="Step back 1s">&lsaquo;</button>
-        <button id="frameNext" class="btn btn-small" title="Step forward 1s">&rsaquo;</button>
-      </div>
-
       <div id="regionBar">
         <div id="regionChips"></div>
         <button id="saveRegionBtn" class="btn btn-small hidden">Save Region</button>
@@ -49,7 +42,16 @@
     </section>
 
     <section id="timelineSection">
-      <canvas id="timelineCanvas"></canvas>
+      <div id="timelineRow">
+        <canvas id="timelineCanvas"></canvas>
+        <div id="timelineSeek">
+          <input id="timestampInput" type="text" placeholder="0:00" spellcheck="false">
+          <div id="timelineStepBtns">
+            <button id="framePrev" class="btn btn-small" title="Step back 1s">&lsaquo;</button>
+            <button id="frameNext" class="btn btn-small" title="Step forward 1s">&rsaquo;</button>
+          </div>
+        </div>
+      </div>
       <div id="timelineControls">
         <button id="zoomInBtn" class="btn btn-small">+</button>
         <button id="zoomOutBtn" class="btn btn-small">&minus;</button>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -247,8 +247,6 @@
         if (data.info.width && data.info.height) parts.push(data.info.width + "x" + data.info.height);
         if (data.info.fps) parts.push(Math.round(data.info.fps) + "fps");
         qs("#videoInfo").textContent = parts.join(" \u00b7 ");
-        qs("#timestampSlider").max = data.info.duration || 100;
-        qs("#timestampSlider").value = 0;
         renderTimeline();
         loadFrame(0);
       })
@@ -262,7 +260,6 @@
     if (state.frameLoading) return;
     state.frameLoading = true;
     state.currentTimestamp = timestamp;
-    qs("#timestampSlider").value = timestamp;
     qs("#timestampInput").value = formatTimestamp(timestamp);
 
     var img = new Image();
@@ -290,13 +287,7 @@
   }
 
   function initFrameControls() {
-    var slider = qs("#timestampSlider");
     var input = qs("#timestampInput");
-
-    slider.addEventListener("input", function () {
-      var ts = parseFloat(slider.value);
-      if (!isNaN(ts)) loadFrame(ts);
-    });
 
     input.addEventListener("change", function () {
       var ts = parseTimestampInput(input.value);
@@ -585,7 +576,6 @@
       var mouseTs = timelineXToTime(e);
       var oldZoom = state.timelineZoom;
       state.timelineZoom = clamp(oldZoom * zoomFactor, 1, 200);
-      // Keep mouse position stable
       if (mouseTs !== null && state.timelineZoom > 1) {
         var rect = canvas.getBoundingClientRect();
         var frac = (e.clientX - rect.left) / rect.width;
@@ -597,12 +587,25 @@
     }, { passive: false });
 
     var dragStart = null;
+    var scrubbing = false;
     canvas.addEventListener("mousedown", function (e) {
-      if (state.timelineZoom <= 1) return;
-      dragStart = { x: e.clientX, offset: state.timelineOffset };
-      state.timelineDragging = false;
+      if (state.timelineZoom > 1) {
+        // Zoomed in: drag to pan
+        dragStart = { x: e.clientX, offset: state.timelineOffset };
+        state.timelineDragging = false;
+      } else {
+        // Not zoomed: drag to scrub
+        scrubbing = true;
+        var ts = timelineXToTime(e);
+        if (ts !== null) loadFrame(ts);
+      }
     });
     document.addEventListener("mousemove", function (e) {
+      if (scrubbing) {
+        var ts = timelineXToTime(e);
+        if (ts !== null) loadFrame(ts);
+        return;
+      }
       if (!dragStart) return;
       var dx = e.clientX - dragStart.x;
       if (Math.abs(dx) > 3) state.timelineDragging = true;
@@ -615,6 +618,7 @@
       renderTimeline();
     });
     document.addEventListener("mouseup", function () {
+      scrubbing = false;
       if (dragStart) {
         setTimeout(function () { state.timelineDragging = false; }, 50);
         dragStart = null;
@@ -667,7 +671,7 @@
 
   function sizeTimelineCanvas() {
     var canvas = qs("#timelineCanvas");
-    var rect = canvas.parentElement.getBoundingClientRect();
+    var rect = canvas.getBoundingClientRect();
     canvas.width = Math.floor(rect.width);
     canvas.height = 64;
     renderTimeline();


### PR DESCRIPTION
## Summary

- Removes the redundant slider bar (`#frameControls`) from under the video frame, keeping only the full canvas timeline
- Relocates the timestamp input and step-back/forward buttons to sit to the right of the timeline canvas
- Adds drag-to-scrub on the timeline at default zoom so the video preview updates in real-time while dragging; drag-to-pan is preserved when zoomed in
- Fixes `sizeTimelineCanvas()` to measure the canvas directly instead of its parent, accounting for the new flex layout

## Test plan

- [ ] Open Screenspace, select a participant — slider bar should be gone, timestamp input and step buttons visible beside the timeline
- [ ] Click timeline to seek, type in the timestamp input, use step buttons and arrow keys
- [ ] Drag across the timeline at default zoom — frames should scrub live
- [ ] Zoom in and drag — should pan the timeline, not scrub
- [ ] Resize the window — timeline canvas should resize correctly