### PR TITLE
Screenspace task queue: drag-and-drop, dismiss, and edit

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -817,19 +817,70 @@ body {
   color: var(--color-text-dim);
 }
 
-.task-card-cancel {
+/* Drag-and-drop */
+.task-card.dragging {
+  opacity: 0.4;
+}
+
+.task-card.drag-over {
+  border-top: 2px solid var(--color-accent);
+}
+
+/* Drag handle */
+.task-card-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  cursor: grab;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  padding: 0.1rem 0;
+  opacity: 0.5;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.task-card-drag-handle:hover {
+  opacity: 1;
+  color: var(--color-text);
+}
+
+.task-card-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* Edit button */
+.task-card-edit {
   background: none;
   border: none;
   color: var(--color-text-dim);
   cursor: pointer;
-  font-size: 0.72rem;
   padding: 0.1rem 0.3rem;
   border-radius: 3px;
   transition: background 0.15s, color 0.15s;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
 }
 
-.task-card-cancel:hover {
+.task-card-edit:hover {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-accent);
+}
+
+/* Dismiss button */
+.task-card-dismiss {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.task-card-dismiss:hover {
   background: rgba(220, 38, 38, 0.1);
   color: #dc2626;
 }

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1163,26 +1163,100 @@
 
   // ---- Task queue ----
 
+  function svgEditIcon() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "14");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    // pencil-square.svg from assets/icons
+    var p1 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p1.setAttribute("d", "M13.4875 2.51256C12.804 1.82915 11.696 1.82915 11.0126 2.51256L6.75098 6.77417C6.49563 7.02951 6.29308 7.33265 6.15488 7.66628L5.30712 9.71282C5.19103 9.99307 5.25519 10.3157 5.46968 10.5302C5.68417 10.7447 6.00676 10.8088 6.28702 10.6928L8.33382 9.84501C8.66748 9.70681 8.97066 9.50423 9.22604 9.24886L13.4875 4.98744C14.1709 4.30402 14.1709 3.19598 13.4875 2.51256Z");
+    svg.appendChild(p1);
+    var p2 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p2.setAttribute("d", "M4.75 3.5C4.05964 3.5 3.5 4.05964 3.5 4.75V11.25C3.5 11.9404 4.05964 12.5 4.75 12.5H11.25C11.9404 12.5 12.5 11.9404 12.5 11.25V9C12.5 8.58579 12.8358 8.25 13.25 8.25C13.6642 8.25 14 8.58579 14 9V11.25C14 12.7688 12.7688 14 11.25 14H4.75C3.23122 14 2 12.7688 2 11.25V4.75C2 3.23122 3.23122 2 4.75 2H7C7.41421 2 7.75 2.33579 7.75 2.75C7.75 3.16421 7.41421 3.5 7 3.5H4.75Z");
+    svg.appendChild(p2);
+    return svg;
+  }
+
+  function svgDragHandle() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "10");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    // bars-2.svg from assets/icons
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("fill-rule", "evenodd");
+    path.setAttribute("clip-rule", "evenodd");
+    path.setAttribute("d", "M2 4.75C2 4.33579 2.33579 4 2.75 4H13.25C13.6642 4 14 4.33579 14 4.75C14 5.16421 13.6642 5.5 13.25 5.5H2.75C2.33579 5.5 2 5.16421 2 4.75ZM2 11.25C2 10.8358 2.33579 10.5 2.75 10.5H13.25C13.6642 10.5 14 10.8358 14 11.25C14 11.6642 13.6642 12 13.25 12H2.75C2.33579 12 2 11.6642 2 11.25Z");
+    svg.appendChild(path);
+    return svg;
+  }
+
+  function svgDismissIcon() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "14");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    // x-mark.svg from assets/icons
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M5.28033 4.21967C4.98744 3.92678 4.51256 3.92678 4.21967 4.21967C3.92678 4.51256 3.92678 4.98744 4.21967 5.28033L6.93934 8L4.21967 10.7197C3.92678 11.0126 3.92678 11.4874 4.21967 11.7803C4.51256 12.0732 4.98744 12.0732 5.28033 11.7803L8 9.06066L10.7197 11.7803C11.0126 12.0732 11.4874 12.0732 11.7803 11.7803C12.0732 11.4874 12.0732 11.0126 11.7803 10.7197L9.06066 8L11.7803 5.28033C12.0732 4.98744 12.0732 4.51256 11.7803 4.21967C11.4874 3.92678 11.0126 3.92678 10.7197 4.21967L8 6.93934L5.28033 4.21967Z");
+    svg.appendChild(path);
+    return svg;
+  }
+
+  function sortTasks() {
+    // completed/failed at top (oldest first), then running, then queued (by priority), cancelled last
+    var statusOrder = { completed: 0, failed: 1, running: 2, queued: 3, cancelled: 4 };
+    state.tasks.sort(function (a, b) {
+      var sa = statusOrder[a.status] !== undefined ? statusOrder[a.status] : 5;
+      var sb = statusOrder[b.status] !== undefined ? statusOrder[b.status] : 5;
+      if (sa !== sb) return sa - sb;
+      if (a.status === "queued" && b.status === "queued") {
+        return (a.priority || 100) - (b.priority || 100);
+      }
+      return (a.created_at || "").localeCompare(b.created_at || "");
+    });
+  }
+
   function initTaskQueue() {
+    var taskListEl = qs("#taskList");
+
     // Click handler delegated on taskList
-    qs("#taskList").addEventListener("click", function (e) {
+    taskListEl.addEventListener("click", function (e) {
       var card = e.target.closest(".task-card");
       if (!card) return;
       var taskId = card.dataset.taskId;
-      // Cancel button
-      if (e.target.closest(".task-card-cancel")) {
-        apiDelete("api/tasks/" + taskId)
+
+      // Dismiss button
+      if (e.target.closest(".task-card-dismiss")) {
+        apiDelete("api/tasks/" + taskId + "?dismiss=true")
           .then(function (data) {
             if (data.ok) {
-              var task = findTask(taskId);
-              if (task) task.status = "cancelled";
+              state.tasks = state.tasks.filter(function (t) { return t.id !== taskId; });
+              if (state.selectedTaskId === taskId) {
+                state.selectedTaskId = null;
+                state.selectedTaskResults = null;
+                renderResults();
+              }
               renderTaskList();
-              showToast("Task cancelled");
+              renderTimeline();
+              showToast("Task dismissed");
             }
           })
-          .catch(function () { showToast("Failed to cancel task"); });
+          .catch(function () { showToast("Failed to dismiss task"); });
         return;
       }
+
+      // Edit button
+      if (e.target.closest(".task-card-edit")) {
+        var task = findTask(taskId);
+        if (task) restoreTaskToWorkflow(task);
+        return;
+      }
+
       // Select completed task to view results
       var task = findTask(taskId);
       if (task && task.status === "completed") {
@@ -1191,6 +1265,241 @@
         renderTaskList();
       }
     });
+
+    // Drag-and-drop: only initiate drag from the handle
+    taskListEl.addEventListener("dragstart", function (e) {
+      var card = e.target.closest(".task-card");
+      if (!card) { e.preventDefault(); return; }
+      var task = findTask(card.dataset.taskId);
+      if (!task) { e.preventDefault(); return; }
+      var allowed = task.status === "queued" || task.status === "completed" || task.status === "failed";
+      if (!allowed) { e.preventDefault(); return; }
+      card.classList.add("dragging");
+      e.dataTransfer.setData("text/plain", card.dataset.taskId);
+      e.dataTransfer.setData("application/x-task-status", task.status);
+      e.dataTransfer.effectAllowed = "move";
+    });
+
+    taskListEl.addEventListener("dragend", function (e) {
+      var card = e.target.closest(".task-card");
+      if (card) {
+        card.classList.remove("dragging");
+        card.removeAttribute("draggable");
+      }
+      clearDragIndicators(taskListEl);
+    });
+
+    taskListEl.addEventListener("dragover", function (e) {
+      if (e.dataTransfer.types.indexOf("text/plain") < 0) return;
+
+      var cards = taskListEl.querySelectorAll(".task-card:not(.dragging)");
+      var insertIdx = getDropIndex(taskListEl, e.clientY);
+
+      // Determine boundary between finished (completed/failed) and queued zones
+      var finishedCount = 0;
+      var queuedStart = cards.length;
+      for (var i = 0; i < cards.length; i++) {
+        var t = findTask(cards[i].dataset.taskId);
+        if (t && (t.status === "completed" || t.status === "failed")) finishedCount++;
+        else { queuedStart = i; break; }
+      }
+
+      var dragStatus = e.dataTransfer.types.indexOf("application/x-task-status") >= 0
+        ? "unknown" : "unknown";
+      // Infer dragged status from position constraint:
+      // We stored it in dataTransfer but can't read it during dragover (security).
+      // Instead, find the dragging card to determine its status.
+      var draggingCard = taskListEl.querySelector(".task-card.dragging");
+      var draggingTask = draggingCard ? findTask(draggingCard.dataset.taskId) : null;
+      var isQueuedDrag = draggingTask && draggingTask.status === "queued";
+      var isFinishedDrag = draggingTask && (draggingTask.status === "completed" || draggingTask.status === "failed");
+
+      // Queued tasks can't go above finished tasks
+      if (isQueuedDrag && insertIdx < finishedCount) return;
+      // Finished tasks can't go below into queued zone
+      if (isFinishedDrag && insertIdx > finishedCount) return;
+
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      clearDragIndicators(taskListEl);
+      if (insertIdx < cards.length) {
+        cards[insertIdx].classList.add("drag-over");
+      }
+    });
+
+    taskListEl.addEventListener("dragleave", function (e) {
+      var card = e.target.closest(".task-card");
+      if (card) card.classList.remove("drag-over");
+    });
+
+    taskListEl.addEventListener("drop", function (e) {
+      e.preventDefault();
+      clearDragIndicators(taskListEl);
+      var draggedId = e.dataTransfer.getData("text/plain");
+      if (!draggedId) return;
+
+      var draggedTask = findTask(draggedId);
+      if (!draggedTask) return;
+      var isQueued = draggedTask.status === "queued";
+
+      if (isQueued) {
+        // Reorder among queued tasks
+        var queuedIds = [];
+        state.tasks.forEach(function (t) {
+          if (t.status === "queued") queuedIds.push(t.id);
+        });
+        var fromIdx = queuedIds.indexOf(draggedId);
+        if (fromIdx < 0) return;
+        queuedIds.splice(fromIdx, 1);
+        var toIdx = getDropIndexAmongStatus(taskListEl, e.clientY, "queued");
+        queuedIds.splice(toIdx, 0, draggedId);
+
+        apiPut("api/tasks/reorder", { task_ids: queuedIds }).catch(function () {
+          showToast("Failed to reorder tasks");
+        });
+        for (var i = 0; i < queuedIds.length; i++) {
+          var t = findTask(queuedIds[i]);
+          if (t) t.priority = i + 1;
+        }
+      } else {
+        // Reorder finished tasks visually via created_at swapping
+        var finishedTasks = [];
+        state.tasks.forEach(function (t) {
+          if (t.status === "completed" || t.status === "failed") finishedTasks.push(t);
+        });
+        var fromIdx2 = -1;
+        for (var j = 0; j < finishedTasks.length; j++) {
+          if (finishedTasks[j].id === draggedId) { fromIdx2 = j; break; }
+        }
+        if (fromIdx2 < 0) return;
+        finishedTasks.splice(fromIdx2, 1);
+        var toIdx2 = getDropIndexAmongStatus(taskListEl, e.clientY, "finished");
+        finishedTasks.splice(toIdx2, 0, draggedTask);
+        // Reassign created_at to maintain the visual order across polls
+        var timestamps = finishedTasks.map(function (t) { return t.created_at; });
+        timestamps.sort();
+        for (var k = 0; k < finishedTasks.length; k++) {
+          finishedTasks[k].created_at = timestamps[k];
+        }
+      }
+
+      sortTasks();
+      renderTaskList();
+    });
+  }
+
+  function getDropIndex(container, clientY) {
+    var cards = container.querySelectorAll(".task-card:not(.dragging)");
+    for (var i = 0; i < cards.length; i++) {
+      var rect = cards[i].getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return i;
+    }
+    return cards.length;
+  }
+
+  function getDropIndexAmongStatus(container, clientY, group) {
+    var cards = container.querySelectorAll(".task-card:not(.dragging)");
+    var idx = 0;
+    for (var i = 0; i < cards.length; i++) {
+      var t = findTask(cards[i].dataset.taskId);
+      if (!t) continue;
+      var match = group === "queued"
+        ? t.status === "queued"
+        : (t.status === "completed" || t.status === "failed");
+      if (!match) continue;
+      var rect = cards[i].getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return idx;
+      idx++;
+    }
+    return idx;
+  }
+
+  function clearDragIndicators(container) {
+    var cards = container.querySelectorAll(".task-card.drag-over");
+    for (var i = 0; i < cards.length; i++) cards[i].classList.remove("drag-over");
+  }
+
+  function setInputValue(selector, value) {
+    var inp = qs(selector);
+    if (inp) inp.value = value;
+  }
+
+  function syncValueDisplays() {
+    var inputs = qsa(".param-control input[type='range']");
+    for (var i = 0; i < inputs.length; i++) {
+      var valSpan = inputs[i].parentNode.querySelector(".param-value");
+      if (valSpan) valSpan.textContent = inputs[i].value;
+    }
+  }
+
+  function restoreTaskToWorkflow(task) {
+    // Switch workflow tab
+    state.activeWorkflow = task.type;
+    qsa(".wf-tab").forEach(function (t) { t.classList.remove("active"); });
+    var targetTab = qs('.wf-tab[data-type="' + task.type + '"]');
+    if (targetTab) targetTab.classList.add("active");
+
+    // Select participant
+    if (task.participant) {
+      state.selectedParticipant = task.participant;
+      var sel = qs("#participantSelect");
+      if (sel) sel.value = task.participant;
+    }
+
+    // Select region
+    if (task.region && state.regions[task.region]) {
+      state.activeRegion = task.region;
+      state.pendingRegion = null;
+      renderRegionChips();
+      renderOverlay();
+      updateRegionButtons();
+    }
+
+    // For similarity, restore reference timestamp before rendering params
+    if (task.type === "similarity") {
+      var params = task.parameters || {};
+      if (params.reference_timestamp !== undefined) {
+        state.referenceTimestamp = params.reference_timestamp;
+      } else {
+        showToast("Reference frame must be recaptured");
+      }
+    }
+
+    // Rebuild param controls then set values
+    renderWorkflowParams();
+
+    var params = task.parameters || {};
+    if (task.type === "color") {
+      setInputValue("#paramColorH", params.target_color ? params.target_color.h : 90);
+      setInputValue("#paramColorS", params.target_color ? params.target_color.s : 200);
+      setInputValue("#paramColorV", params.target_color ? params.target_color.v : 200);
+      setInputValue("#paramColorTolH", params.tolerance ? params.tolerance.h : 15);
+      setInputValue("#paramColorTolS", params.tolerance ? params.tolerance.s : 40);
+      setInputValue("#paramColorTolV", params.tolerance ? params.tolerance.v : 40);
+      setInputValue("#paramColorInterval", params.interval || 1.0);
+      updateColorPreview();
+    } else if (task.type === "change") {
+      setInputValue("#paramChangeThresh", params.threshold || 0.03);
+      setInputValue("#paramChangeNoise", params.noise_threshold || 30);
+      setInputValue("#paramChangeInterval", params.interval || 1.0);
+    } else if (task.type === "similarity") {
+      setInputValue("#paramSimThresh", params.threshold || 0.90);
+      setInputValue("#paramSimInterval", params.interval || 1.0);
+    } else if (task.type === "text") {
+      setInputValue("#paramTextSearch", params.search_string || "");
+      setInputValue("#paramTextFuzzy", params.fuzzy_threshold || 0.80);
+      setInputValue("#paramTextInterval", params.interval || 2.0);
+      if (params.languages && params.languages[0]) {
+        setInputValue("#paramTextLang", params.languages[0]);
+      }
+    } else if (task.type === "timelapse") {
+      setInputValue("#paramTlSpeed", params.speedup_factor || 10);
+      setInputValue("#paramTlFormat", params.output_format || "mp4");
+    }
+
+    syncValueDisplays();
+    updateRunButton();
+    showToast("Restored " + task.type + " task parameters");
   }
 
   function findTask(id) {
@@ -1201,6 +1510,7 @@
   }
 
   function renderTaskList() {
+    sortTasks();
     var container = qs("#taskList");
     var count = qs("#taskCount");
     count.textContent = "(" + state.tasks.length + ")";
@@ -1213,6 +1523,16 @@
       var card = el("div", "task-card task-card-" + task.status);
       card.dataset.taskId = task.id;
       if (task.id === state.selectedTaskId) card.classList.add("selected");
+
+      // Drag handle for reorderable tasks (completed, failed, queued)
+      var isDraggable = task.status === "queued" || task.status === "completed" || task.status === "failed";
+      if (isDraggable) {
+        var handle = el("span", "task-card-drag-handle");
+        handle.appendChild(svgDragHandle());
+        handle.addEventListener("mousedown", function () { card.setAttribute("draggable", "true"); });
+        handle.addEventListener("mouseup", function () { card.removeAttribute("draggable"); });
+        card.appendChild(handle);
+      }
 
       // Type badge
       var badge = el("span", "task-card-type");
@@ -1248,12 +1568,17 @@
       }
       card.appendChild(el("span", "task-card-status", statusText));
 
-      // Cancel button
-      if (task.status === "queued" || task.status === "running") {
-        var cancelBtn = el("button", "task-card-cancel", "\u2715");
-        cancelBtn.title = "Cancel";
-        card.appendChild(cancelBtn);
-      }
+      // Edit button
+      var editBtn = el("button", "task-card-edit");
+      editBtn.title = "Edit";
+      editBtn.appendChild(svgEditIcon());
+      card.appendChild(editBtn);
+
+      // Dismiss button
+      var dismissBtn = el("button", "task-card-dismiss");
+      dismissBtn.title = "Dismiss";
+      dismissBtn.appendChild(svgDismissIcon());
+      card.appendChild(dismissBtn);
 
       container.appendChild(card);
     });

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.57"
+VERSIONNUM: str = "0.9.58"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/screenspace.py
+++ b/screenspace.py
@@ -656,6 +656,17 @@ class ScreenspaceWorker:
                     task["priority"] = i + 1
         return True
 
+    def remove_task(self, task_id: str) -> bool:
+        """Cancel (if active) and fully remove a task."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return False
+            if task["status"] == TASK_STATUS_RUNNING:
+                task["_cancelled"] = True
+            self._tasks.pop(task_id, None)
+            return True
+
     def _run(self) -> None:
         """Worker loop."""
         while self._running:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -273,7 +273,6 @@ def api_tasks_create() -> FlaskResponse:
             ), 400
         ref_region = screenspace.extract_region(frame, region_coords)
         parameters["reference_frame"] = ref_region
-        parameters.pop("reference_timestamp", None)
 
     task = screenspace.create_task(
         task_type=task_type,
@@ -293,9 +292,17 @@ def api_tasks_create() -> FlaskResponse:
 
 @screenspace_bp.route("/api/tasks/<task_id>", methods=["DELETE"])
 def api_tasks_cancel(task_id: str) -> FlaskResponse:
-    """Cancel a queued or running task."""
+    """Cancel or dismiss a task.  ?dismiss=true fully removes the task."""
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+    if request.args.get("dismiss") == "true":
+        if not _worker.remove_task(task_id):
+            return jsonify({"ok": False, "error": "Task not found"}), 404
+        _manifest["tasks"] = [
+            t for t in _manifest.get("tasks", []) if t["id"] != task_id
+        ]
+        _persist_manifest()
+        return jsonify({"ok": True})
     if _worker.cancel(task_id):
         return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Task not found or already finished"}), 400

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -324,3 +324,28 @@ class TestScreenspaceWorker:
     def test_get_task_returns_none_for_unknown(self):
         worker = screenspace.ScreenspaceWorker()
         assert worker.get_task("ss_unknown") is None
+
+    def test_remove_queued_task(self):
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+        )
+        worker.enqueue(task)
+        assert worker.remove_task(task["id"]) is True
+        assert worker.get_task(task["id"]) is None
+
+    def test_remove_nonexistent(self):
+        worker = screenspace.ScreenspaceWorker()
+        assert worker.remove_task("ss_nonexist") is False
+
+    def test_remove_running_task_sets_cancelled(self):
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+        )
+        worker.enqueue(task)
+        # Simulate running status
+        with worker._lock:
+            worker._tasks[task["id"]]["status"] = screenspace.TASK_STATUS_RUNNING
+        assert worker.remove_task(task["id"]) is True
+        assert worker.get_task(task["id"]) is None

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -184,6 +184,43 @@ def test_cancel_task_not_found(client):
     assert resp.status_code == 400
 
 
+def test_dismiss_queued_task(client):
+    worker = screenspace_server._worker
+    task = screenspace.create_task(
+        "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
+    screenspace_server._manifest["tasks"].append(task)
+    resp = client.delete(f"/screenspace/api/tasks/{task['id']}?dismiss=true")
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+    # Task removed from worker
+    assert worker.get_task(task["id"]) is None
+    # Task removed from manifest
+    assert all(t["id"] != task["id"] for t in screenspace_server._manifest["tasks"])
+
+
+def test_dismiss_completed_task(client):
+    worker = screenspace_server._worker
+    task = screenspace.create_task(
+        "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
+    # Simulate completed status
+    with worker._lock:
+        worker._tasks[task["id"]]["status"] = "completed"
+    screenspace_server._manifest["tasks"].append(task)
+    resp = client.delete(f"/screenspace/api/tasks/{task['id']}?dismiss=true")
+    assert resp.status_code == 200
+    assert worker.get_task(task["id"]) is None
+    assert all(t["id"] != task["id"] for t in screenspace_server._manifest["tasks"])
+
+
+def test_dismiss_nonexistent_task(client):
+    resp = client.delete("/screenspace/api/tasks/ss_nonexist?dismiss=true")
+    assert resp.status_code == 404
+
+
 def test_task_results_not_found(client):
     resp = client.get("/screenspace/api/tasks/ss_nonexist/results")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Add drag-and-drop reordering to Screenspace task queue items via a dedicated drag handle. Completed/failed tasks sort to the top and can be reordered among themselves; queued tasks remain at the bottom with execution order updated via the backend reorder API.
- Add a Dismiss button (x-mark icon) on all task statuses that fully removes the task from the worker, manifest, and timeline.
- Add an Edit button (pencil-square icon) that restores a task's workflow type, participant, region, and all parameters into the tool section for re-submission.
- Backend: new `ScreenspaceWorker.remove_task()` method, extended DELETE endpoint with `?dismiss=true`, preserved `reference_timestamp` in similarity task parameters for edit support.
- Icons sourced from `assets/icons/` (pencil-square, x-mark, bars-2). Version bumped to 0.9.58.

## Test plan

- [x] `uv run pytest -c tests/pytest.ini` — all 263 tests pass
- [ ] Launch Screenspace, create multiple tasks, verify drag handle reorders queued tasks and completed tasks independently
- [ ] Verify dismiss removes tasks from queue, manifest, and timeline across all statuses
- [ ] Verify edit restores correct workflow tab, participant, region, and parameter values