### PR TITLE
Add Screenspace Numbers tool for numeric OCR comparisons

### DIFF
--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -76,6 +76,7 @@
         <button class="wf-tab" data-type="change">Change</button>
         <button class="wf-tab" data-type="similarity">Similarity</button>
         <button class="wf-tab" data-type="text">Text</button>
+        <button class="wf-tab" data-type="numbers">Numbers</button>
         <button class="wf-tab" data-type="timelapse">Timelapse</button>
       </div>
       <div id="workflowBody">

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -12,6 +12,7 @@
     change: "#f97316",
     similarity: "#0ea5e9",
     text: "#10b981",
+    numbers: "#eab308",
     timelapse: "#ec4899",
   };
 
@@ -941,6 +942,53 @@
       langControl.appendChild(langSel);
       langRow.appendChild(langControl);
       container.appendChild(langRow);
+    } else if (type === "numbers") {
+      // Operator selector
+      var opRow = el("div", "param-row");
+      opRow.appendChild(el("span", "param-label", "Operator"));
+      var opControl = el("div", "param-control");
+      var opSel = document.createElement("select");
+      opSel.id = "paramNumOperator";
+      [["gt", "Greater than (>)"], ["lt", "Less than (<)"], ["eq", "Equal to (=)"],
+       ["gte", "Greater or equal (\u2265)"], ["lte", "Less or equal (\u2264)"], ["range", "In range"]].forEach(function (pair) {
+        var opt = el("option", null, pair[1]);
+        opt.value = pair[0];
+        opSel.appendChild(opt);
+      });
+      opSel.addEventListener("change", function () {
+        var rangeRow = qs("#paramNumRangeRow");
+        var targetRow = qs("#paramNumTargetRow");
+        if (opSel.value === "range") {
+          if (rangeRow) rangeRow.style.display = "";
+          if (targetRow) targetRow.style.display = "none";
+        } else {
+          if (rangeRow) rangeRow.style.display = "none";
+          if (targetRow) targetRow.style.display = "";
+        }
+      });
+      opControl.appendChild(opSel);
+      opRow.appendChild(opControl);
+      container.appendChild(opRow);
+      // Target value (for non-range operators)
+      var targetRow = el("div", "param-row");
+      targetRow.id = "paramNumTargetRow";
+      targetRow.appendChild(el("span", "param-label", "Target value"));
+      var targetCtrl = el("div", "param-control");
+      targetCtrl.appendChild(numberInput("paramNumTarget", -999999, 999999, 100, 1));
+      targetRow.appendChild(targetCtrl);
+      container.appendChild(targetRow);
+      // Range min/max (hidden by default)
+      var numRangeRow = el("div", "param-row");
+      numRangeRow.id = "paramNumRangeRow";
+      numRangeRow.style.display = "none";
+      numRangeRow.appendChild(el("span", "param-label", "Range"));
+      var rangeCtrl = el("div", "param-control");
+      rangeCtrl.appendChild(numberInput("paramNumMin", -999999, 999999, 0, 1));
+      rangeCtrl.appendChild(el("span", "param-value", "\u2013"));
+      rangeCtrl.appendChild(numberInput("paramNumMax", -999999, 999999, 100, 1));
+      numRangeRow.appendChild(rangeCtrl);
+      container.appendChild(numRangeRow);
+      addParamRow(container, "Interval (s)", numberInput("paramNumInterval", 0.5, 60, 2.0, 0.5));
     } else if (type === "timelapse") {
       addParamRow(container, "Speed", numberInput("paramTlSpeed", 2, 100, 10, 1));
       var fmtRow = el("div", "param-row");
@@ -1154,6 +1202,28 @@
       params.interval = parseFloat((qs("#paramTextInterval") || {}).value) || 2.0;
       var lang = (qs("#paramTextLang") || {}).value || "en";
       params.languages = [lang];
+    } else if (type === "numbers") {
+      var op = (qs("#paramNumOperator") || {}).value || "gt";
+      params.operator = op;
+      if (op === "range") {
+        params.range_min = parseFloat((qs("#paramNumMin") || {}).value);
+        params.range_max = parseFloat((qs("#paramNumMax") || {}).value);
+        if (isNaN(params.range_min) || isNaN(params.range_max)) {
+          showToast("Enter valid min and max values");
+          return null;
+        }
+        if (params.range_min > params.range_max) {
+          showToast("Min must be less than or equal to max");
+          return null;
+        }
+      } else {
+        params.target_value = parseFloat((qs("#paramNumTarget") || {}).value);
+        if (isNaN(params.target_value)) {
+          showToast("Enter a valid target number");
+          return null;
+        }
+      }
+      params.interval = parseFloat((qs("#paramNumInterval") || {}).value) || 2.0;
     } else if (type === "timelapse") {
       params.speedup_factor = parseFloat((qs("#paramTlSpeed") || {}).value) || 10;
       params.output_format = (qs("#paramTlFormat") || {}).value || "mp4";
@@ -1397,6 +1467,10 @@
         row.appendChild(el("span", "result-timestamp", formatTimestamp(r.timestamp)));
         row.appendChild(el("span", "result-detail", r.text_found || ""));
         row.appendChild(el("span", "result-score", (r.confidence * 100).toFixed(0) + "%"));
+      } else if (task.type === "numbers") {
+        row.dataset.timestamp = r.timestamp;
+        row.appendChild(el("span", "result-timestamp", formatTimestamp(r.timestamp)));
+        row.appendChild(el("span", "result-detail", String(r.number_found)));
       }
 
       container.appendChild(row);

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.57"
+VERSIONNUM: str = "0.9.58"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/screenspace.py
+++ b/screenspace.py
@@ -11,6 +11,7 @@ import copy
 import difflib
 import json
 import queue
+import re
 import threading
 import uuid
 from datetime import datetime, timezone
@@ -480,6 +481,106 @@ def scan_text(
     return results
 
 
+_NUMBERS_RE = re.compile(r"-?\d+(?:\.\d+)?")
+_VALID_OPERATORS = ("eq", "gt", "lt", "gte", "lte", "range")
+
+
+def scan_numbers(
+    video_path: str,
+    region: Dict[str, int],
+    operator: str,
+    target_value: float = 0,
+    interval_seconds: float = 2.0,
+    *,
+    range_min: Optional[float] = None,
+    range_max: Optional[float] = None,
+    languages: Optional[List[str]] = None,
+    start_seconds: float = 0.0,
+    end_seconds: Optional[float] = None,
+    on_progress: Optional[Callable[[float], None]] = None,
+    cancel_flag: Optional[Callable[[], bool]] = None,
+) -> List[Dict[str, Any]]:
+    """Scan for numeric values in a region and apply a comparison.
+
+    Uses EasyOCR to detect text, parses numbers from it, and returns
+    timestamps where the detected number satisfies the comparison.
+    """
+    if operator not in _VALID_OPERATORS:
+        raise ValueError(
+            f"Unknown operator '{operator}'. Must be one of: {', '.join(_VALID_OPERATORS)}"
+        )
+
+    try:
+        import easyocr  # type: ignore[import-untyped]
+    except ImportError:
+        raise ImportError(
+            "EasyOCR is required for numbers scan. Install with: uv add easyocr"
+        ) from None
+
+    if languages is None:
+        languages = ["en"]
+
+    reader = easyocr.Reader(languages, verbose=False)
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        return []
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    duration = total_frames / fps if fps > 0 else 0.0
+    cap.release()
+
+    if end_seconds is None or end_seconds > duration:
+        end_seconds = duration
+    total_range = end_seconds - start_seconds
+
+    results: List[Dict[str, Any]] = []
+
+    def _check(value: float) -> bool:
+        if operator == "eq":
+            return value == target_value
+        elif operator == "gt":
+            return value > target_value
+        elif operator == "lt":
+            return value < target_value
+        elif operator == "gte":
+            return value >= target_value
+        elif operator == "lte":
+            return value <= target_value
+        elif operator == "range":
+            return (range_min is not None and range_max is not None
+                    and range_min <= value <= range_max)
+        return False
+
+    def _cb(ts: float, pixels: np.ndarray) -> Optional[bool]:
+        if cancel_flag and cancel_flag():
+            return False
+        ocr_results = reader.readtext(pixels, detail=1)
+        for _, text, _conf in ocr_results:
+            cleaned = text.replace(",", "")
+            for match in _NUMBERS_RE.findall(cleaned):
+                num = float(match)
+                if _check(num):
+                    results.append({"timestamp": ts, "number_found": num})
+                    return None
+        if on_progress and total_range > 0:
+            on_progress((ts - start_seconds) / total_range)
+        return None
+
+    scan_video_frames(
+        video_path,
+        region,
+        interval_seconds,
+        _cb,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+    )
+
+    if on_progress:
+        on_progress(1.0)
+    return results
+
+
 def generate_timelapse(
     video_path: str,
     region: Dict[str, int],
@@ -770,6 +871,21 @@ class ScreenspaceWorker:
                 search_string=params.get("search_string", ""),
                 interval_seconds=params.get("interval", 2.0),
                 fuzzy_threshold=params.get("fuzzy_threshold", 0),
+                languages=params.get("languages"),
+                start_seconds=params.get("start_seconds", 0.0),
+                end_seconds=params.get("end_seconds"),
+                on_progress=on_progress,
+                cancel_flag=cancel_flag,
+            )
+        elif task_type == "numbers":
+            return scan_numbers(
+                video_path,
+                region,
+                operator=params.get("operator", "gt"),
+                target_value=params.get("target_value", 0),
+                interval_seconds=params.get("interval", 2.0),
+                range_min=params.get("range_min"),
+                range_max=params.get("range_max"),
                 languages=params.get("languages"),
                 start_seconds=params.get("start_seconds", 0.0),
                 end_seconds=params.get("end_seconds"),

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -219,7 +219,7 @@ def api_tasks_create() -> FlaskResponse:
         return jsonify({"ok": False, "error": "JSON body required"}), 400
 
     task_type = data.get("type", "").strip()
-    valid_types = ("color", "change", "similarity", "text", "timelapse")
+    valid_types = ("color", "change", "similarity", "text", "numbers", "timelapse")
     if task_type not in valid_types:
         return jsonify(
             {"ok": False, "error": f"type must be one of: {', '.join(valid_types)}"}

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -324,3 +324,55 @@ class TestScreenspaceWorker:
     def test_get_task_returns_none_for_unknown(self):
         worker = screenspace.ScreenspaceWorker()
         assert worker.get_task("ss_unknown") is None
+
+
+class TestScanNumbers:
+    def test_unknown_operator_raises(self):
+        with pytest.raises(ValueError, match="Unknown.*operator"):
+            screenspace.scan_numbers(
+                "/nonexistent.mp4",
+                {"x": 0, "y": 0, "w": 10, "h": 10},
+                operator="invalid",
+                target_value=100,
+            )
+
+    def test_valid_operators_accepted(self):
+        for op in ("eq", "gt", "lt", "gte", "lte", "range"):
+            # Should not raise ValueError -- returns [] because video doesn't exist
+            result = screenspace.scan_numbers(
+                "/nonexistent.mp4",
+                {"x": 0, "y": 0, "w": 10, "h": 10},
+                operator=op,
+                target_value=100,
+                range_min=0,
+                range_max=200,
+            )
+            assert result == []
+
+    def test_dispatch_routes_numbers(self):
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "numbers",
+            "P01",
+            "s_P01.mp4",
+            "/nonexistent.mp4",
+            "r",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            parameters={"operator": "gt", "target_value": 50},
+        )
+        # Should not raise -- dispatches to scan_numbers, returns [] for bad video
+        result = worker._dispatch(task, lambda p: None, lambda: False)
+        assert result == []
+
+    def test_dispatch_unknown_type_raises(self):
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "bogus",
+            "P01",
+            "s.mp4",
+            "/v.mp4",
+            "r",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+        )
+        with pytest.raises(ValueError, match="Unknown task type"):
+            worker._dispatch(task, lambda p: None, lambda: False)

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -174,6 +174,23 @@ def test_create_task_no_video(client):
     assert "video" in resp.get_json()["error"].lower()
 
 
+def test_create_task_numbers_type_accepted(client):
+    """'numbers' passes type validation (fails at video check, not type check)."""
+    screenspace_server._manifest["regions"]["r"] = {
+        "x": 0,
+        "y": 0,
+        "w": 10,
+        "h": 10,
+    }
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={"type": "numbers", "participant": "P01", "region": "r"},
+    )
+    data = resp.get_json()
+    assert resp.status_code == 400
+    assert "video" in data["error"].lower()
+
+
 def test_get_task_not_found(client):
     resp = client.get("/screenspace/api/tasks/ss_nonexist")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Adds a new **Numbers** workflow to Screenspace that uses EasyOCR to detect numerals in a screen region and applies mathematical comparisons (equal, greater than, less than, greater/equal, less/equal, and range)
- Backend: `scan_numbers()` in `screenspace.py` extracts numbers from OCR text via regex, checks them against the user-configured condition, and returns matching timestamps
- Frontend: new Numbers tab with operator dropdown, target value / range min-max inputs, and interval control; results display timestamp + detected number
- Useful for tracking scores, health bars, timers, currency, or any on-screen numeric value in video game footage

## Test plan

- [x] All 268 tests pass (`uv run pytest -c tests/pytest.ini`)
- [ ] Launch Screenspace, verify Numbers tab renders with operator/target/range/interval controls
- [ ] Run a Numbers task with `gt` operator against a video with visible numbers
- [ ] Switch to `range` operator and verify target row hides, range min/max row appears
- [ ] Confirm results show timestamps and detected numbers, and clicking a result seeks the video