### PR TITLE
Normalize Screenspace region resolution for cross-video reuse

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -107,6 +107,17 @@
     return idx >= 0 ? regionColorForIndex(idx) : REGION_COLORS[0];
   }
 
+  function regionToPixels(r) {
+    if (!r.source_width) return r;
+    var canvas = qs("#overlayCanvas");
+    return {
+      x: Math.round(r.x * canvas.width),
+      y: Math.round(r.y * canvas.height),
+      w: Math.round(r.w * canvas.width),
+      h: Math.round(r.h * canvas.height),
+    };
+  }
+
   function taskTypeColor(type) {
     return TASK_COLORS[type] || "#888";
   }
@@ -411,12 +422,15 @@
       if (!name) return;
       var desc = qs("#regionDescInput").value.trim();
       var r = state.pendingRegion;
-      var body = { name: name, x: r.x, y: r.y, w: r.w, h: r.h };
+      var canvas = qs("#overlayCanvas");
+      var body = { name: name, x: r.x, y: r.y, w: r.w, h: r.h, canvas_width: canvas.width, canvas_height: canvas.height };
       if (desc) body.description = desc;
       apiPost("api/regions", body)
         .then(function (data) {
           if (data.ok) {
-            state.regions[name] = { x: r.x, y: r.y, w: r.w, h: r.h, description: desc };
+            var saved = data.region;
+            if (desc) saved.description = desc;
+            state.regions[name] = saved;
             state.pendingRegion = null;
             state.activeRegion = name;
             renderRegionChips();
@@ -493,15 +507,20 @@
     var ctx = canvas.getContext("2d");
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
+    // Scale factor: canvas pixels per display pixel, so chrome looks
+    // the same physical size regardless of the underlying video resolution.
+    var displayW = canvas.getBoundingClientRect().width || canvas.width;
+    var s = canvas.width / displayW;
+
     // Draw saved regions
     var names = Object.keys(state.regions);
     names.forEach(function (name, i) {
-      var r = state.regions[name];
+      var r = regionToPixels(state.regions[name]);
       var color = regionColorForIndex(i);
       var isActive = (name === state.activeRegion);
       ctx.strokeStyle = color;
-      ctx.lineWidth = isActive ? 3 : 1.5;
-      ctx.setLineDash(isActive ? [] : [8, 4]);
+      ctx.lineWidth = (isActive ? 2 : 1) * s;
+      ctx.setLineDash(isActive ? [] : [6 * s, 3 * s]);
       ctx.strokeRect(r.x, r.y, r.w, r.h);
       if (isActive) {
         ctx.fillStyle = hexToRgba(color, 0.12);
@@ -509,29 +528,32 @@
       }
       ctx.setLineDash([]);
       // Label
-      ctx.font = "bold 13px -apple-system, BlinkMacSystemFont, sans-serif";
-      var labelW = ctx.measureText(name).width + 8;
+      var fontSize = Math.round(12 * s);
+      var labelH = Math.round(16 * s);
+      var pad = Math.round(4 * s);
+      ctx.font = "bold " + fontSize + "px -apple-system, BlinkMacSystemFont, sans-serif";
+      var labelW = ctx.measureText(name).width + pad * 2;
       ctx.fillStyle = hexToRgba(color, 0.85);
-      ctx.fillRect(r.x, r.y - 18, labelW, 18);
+      ctx.fillRect(r.x, r.y - labelH, labelW, labelH);
       ctx.fillStyle = "#fff";
-      ctx.fillText(name, r.x + 4, r.y - 5);
+      ctx.fillText(name, r.x + pad, r.y - Math.round(4 * s));
     });
 
     // Drawing in progress
     if (state.drawingRegion) {
       var d = state.drawingRegion;
       ctx.strokeStyle = "#ffffff";
-      ctx.lineWidth = 2;
-      ctx.setLineDash([4, 4]);
+      ctx.lineWidth = 1.5 * s;
+      ctx.setLineDash([4 * s, 3 * s]);
       ctx.strokeRect(d.startX, d.startY, d.endX - d.startX, d.endY - d.startY);
       ctx.setLineDash([]);
       // Dimensions
       var w = Math.abs(d.endX - d.startX);
       var h = Math.abs(d.endY - d.startY);
       if (w > 20 && h > 20) {
-        ctx.font = "12px " + getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim();
+        ctx.font = Math.round(11 * s) + "px " + getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim();
         ctx.fillStyle = "rgba(255,255,255,0.9)";
-        ctx.fillText(w + "\u00d7" + h, Math.min(d.startX, d.endX) + 4, Math.max(d.startY, d.endY) + 16);
+        ctx.fillText(w + "\u00d7" + h, Math.min(d.startX, d.endX) + Math.round(4 * s), Math.max(d.startY, d.endY) + Math.round(14 * s));
       }
     }
 
@@ -539,14 +561,14 @@
     if (state.pendingRegion) {
       var p = state.pendingRegion;
       ctx.strokeStyle = "#ffffff";
-      ctx.lineWidth = 2;
+      ctx.lineWidth = 1.5 * s;
       ctx.setLineDash([]);
       ctx.strokeRect(p.x, p.y, p.w, p.h);
       ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
       ctx.fillRect(p.x, p.y, p.w, p.h);
-      ctx.font = "12px " + getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim();
+      ctx.font = Math.round(11 * s) + "px " + getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim();
       ctx.fillStyle = "rgba(255,255,255,0.9)";
-      ctx.fillText(p.w + "\u00d7" + p.h + " px", p.x + 4, p.y + p.h + 16);
+      ctx.fillText(p.w + "\u00d7" + p.h + " px", p.x + Math.round(4 * s), p.y + p.h + Math.round(14 * s));
     }
   }
 
@@ -1078,7 +1100,7 @@
       showToast("Select a saved region first");
       return;
     }
-    var r = state.regions[state.activeRegion];
+    var r = regionToPixels(state.regions[state.activeRegion]);
     var canvas = qs("#frameCanvas");
     var ctx = canvas.getContext("2d");
     var imgData = ctx.getImageData(r.x, r.y, r.w, r.h);

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.58"
+VERSIONNUM: str = "0.9.59"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -131,6 +131,45 @@ def api_video_info(participant: str) -> FlaskResponse:
     return jsonify({"ok": True, "info": info})
 
 
+# ---- Region coordinate normalization ----
+
+
+def _normalize_region(
+    x: float,
+    y: float,
+    w: float,
+    h: float,
+    frame_w: int,
+    frame_h: int,
+) -> Dict[str, Any]:
+    """Convert pixel coordinates to normalized 0-1 fractions."""
+    return {
+        "x": x / frame_w,
+        "y": y / frame_h,
+        "w": w / frame_w,
+        "h": h / frame_h,
+        "source_width": frame_w,
+        "source_height": frame_h,
+    }
+
+
+def _denormalize_region(
+    region: Dict[str, Any], target_w: int, target_h: int
+) -> Dict[str, int]:
+    """Convert normalized region to pixel coordinates for a target resolution.
+
+    Legacy regions (without ``source_width``) pass through unchanged.
+    """
+    if "source_width" not in region:
+        return {"x": region["x"], "y": region["y"], "w": region["w"], "h": region["h"]}
+    return {
+        "x": int(round(region["x"] * target_w)),
+        "y": int(round(region["y"] * target_h)),
+        "w": int(round(region["w"] * target_w)),
+        "h": int(round(region["h"] * target_h)),
+    }
+
+
 # ---- Regions CRUD ----
 
 
@@ -156,12 +195,24 @@ def api_regions_create() -> FlaskResponse:
         if val is None or not isinstance(val, (int, float)):
             return jsonify({"ok": False, "error": f"'{field}' must be a number"}), 400
 
-    region = {
-        "x": int(data["x"]),
-        "y": int(data["y"]),
-        "w": int(data["w"]),
-        "h": int(data["h"]),
-    }
+    canvas_w = data.get("canvas_width")
+    canvas_h = data.get("canvas_height")
+    if (
+        isinstance(canvas_w, (int, float))
+        and isinstance(canvas_h, (int, float))
+        and canvas_w > 0
+        and canvas_h > 0
+    ):
+        region: Dict[str, Any] = _normalize_region(
+            data["x"], data["y"], data["w"], data["h"], int(canvas_w), int(canvas_h)
+        )
+    else:
+        region = {
+            "x": int(data["x"]),
+            "y": int(data["y"]),
+            "w": int(data["w"]),
+            "h": int(data["h"]),
+        }
     if "description" in data:
         region["description"] = str(data["description"])
 
@@ -249,7 +300,14 @@ def api_tasks_create() -> FlaskResponse:
             source_video = Path(p["video_path"]).name
             break
 
-    region_coords = regions[region_name]
+    region_data = regions[region_name]
+    props = video.probe_video_properties(video_path)
+    if props and props.get("width") and props.get("height"):
+        region_coords = _denormalize_region(region_data, props["width"], props["height"])
+    else:
+        region_coords = {
+            k: region_data[k] for k in ("x", "y", "w", "h") if k in region_data
+        }
     parameters = data.get("parameters", {})
 
     # Similarity tasks: extract reference frame from video at given timestamp

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -61,12 +61,21 @@ def test_list_regions_empty(client):
 def test_create_region(client):
     resp = client.post(
         "/screenspace/api/regions",
-        json={"name": "healthbar", "x": 100, "y": 20, "w": 300, "h": 30},
+        json={
+            "name": "healthbar",
+            "x": 100,
+            "y": 20,
+            "w": 300,
+            "h": 30,
+            "canvas_width": 1920,
+            "canvas_height": 1080,
+        },
     )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
-    assert data["region"]["x"] == 100
+    assert data["region"]["source_width"] == 1920
+    assert abs(data["region"]["x"] - 100 / 1920) < 1e-9
 
     list_resp = client.get("/screenspace/api/regions")
     assert "healthbar" in list_resp.get_json()["regions"]
@@ -81,6 +90,8 @@ def test_create_region_with_description(client):
             "y": 0,
             "w": 50,
             "h": 20,
+            "canvas_width": 1920,
+            "canvas_height": 1080,
             "description": "Score display",
         },
     )
@@ -120,6 +131,69 @@ def test_delete_region(client):
 def test_delete_nonexistent_region(client):
     resp = client.delete("/screenspace/api/regions/nope")
     assert resp.status_code == 404
+
+
+def test_create_region_normalizes_coords(client):
+    resp = client.post(
+        "/screenspace/api/regions",
+        json={
+            "name": "center",
+            "x": 960,
+            "y": 540,
+            "w": 192,
+            "h": 108,
+            "canvas_width": 1920,
+            "canvas_height": 1080,
+        },
+    )
+    data = resp.get_json()
+    assert data["ok"] is True
+    r = data["region"]
+    assert abs(r["x"] - 0.5) < 1e-9
+    assert abs(r["y"] - 0.5) < 1e-9
+    assert abs(r["w"] - 0.1) < 1e-9
+    assert abs(r["h"] - 0.1) < 1e-9
+    assert r["source_width"] == 1920
+    assert r["source_height"] == 1080
+
+
+def test_create_region_legacy_no_canvas_dims(client):
+    resp = client.post(
+        "/screenspace/api/regions",
+        json={"name": "legacy", "x": 100, "y": 20, "w": 300, "h": 30},
+    )
+    data = resp.get_json()
+    assert data["ok"] is True
+    r = data["region"]
+    assert r["x"] == 100
+    assert r["y"] == 20
+    assert r["w"] == 300
+    assert r["h"] == 30
+    assert "source_width" not in r
+
+
+def test_denormalize_region():
+    from screenspace_server import _denormalize_region
+
+    region = {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.1, "source_width": 1920, "source_height": 1080}
+    px = _denormalize_region(region, 1920, 1080)
+    assert px == {"x": 960, "y": 540, "w": 192, "h": 108}
+
+
+def test_denormalize_legacy_region():
+    from screenspace_server import _denormalize_region
+
+    region = {"x": 100, "y": 20, "w": 300, "h": 30}
+    px = _denormalize_region(region, 1280, 720)
+    assert px == {"x": 100, "y": 20, "w": 300, "h": 30}
+
+
+def test_denormalize_cross_resolution():
+    from screenspace_server import _denormalize_region
+
+    region = {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.1, "source_width": 1920, "source_height": 1080}
+    px = _denormalize_region(region, 1280, 720)
+    assert px == {"x": 640, "y": 360, "w": 128, "h": 72}
 
 
 # ---- Tasks ----


### PR DESCRIPTION
## Summary
- Store Screenspace region coordinates as normalized 0–1 fractions instead of absolute pixels, so regions drawn on one video resolution map correctly to different-resolution recordings of the same product
- Server normalizes on save (divides by canvas dimensions) and denormalizes on task creation (multiplies by target video's ffprobe dimensions); legacy pixel-format regions pass through unchanged
- Scale overlay chrome (borders, dash patterns, label text) by the canvas-to-display ratio so visual appearance is stable across video resolutions

## Test plan
- [x] All 273 existing tests pass
- [x] New tests for normalization round-trip, legacy backward compat, and cross-resolution scaling
- [ ] Manual: draw a region on one participant, switch to a different-resolution participant, verify region renders at the same proportional position and overlay labels appear the same size