### PR TITLE
Screenspace: pausable task queue with partial results (#52)

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -704,6 +704,23 @@ body {
   font-size: 0.78rem;
 }
 
+.panel-header-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0.15rem 0.3rem;
+  border-radius: 3px;
+  transition: background 0.15s, color 0.15s;
+  display: inline-flex;
+  align-items: center;
+}
+
+.panel-header-btn:hover {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-accent);
+}
+
 .panel-empty {
   font-size: 0.78rem;
   color: var(--color-text-dim);
@@ -765,6 +782,10 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 120px;
+}
+
+.task-card-paused {
+  border-left-color: #eab308;
 }
 
 .task-card-cancelled {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -92,6 +92,7 @@
     <div id="taskQueuePanel">
       <div class="panel-header">
         <h3>Task Queue <span id="taskCount">(0)</span></h3>
+        <button id="taskQueuePauseBtn" class="panel-header-btn" title="Pause queue"></button>
       </div>
       <div id="taskList">
         <div class="panel-empty">No tasks yet. Configure a workflow and click Run.</div>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -42,6 +42,7 @@
     selectedTaskId: null,
     selectedTaskResults: null,
     pollTimer: null,
+    queuePaused: false,
     timelineDragging: false,
     panelHeight: 260,
   };
@@ -1277,9 +1278,44 @@
     return svg;
   }
 
+  function svgPauseIcon() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "14");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    var p1 = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    p1.setAttribute("x", "3.5");
+    p1.setAttribute("y", "2");
+    p1.setAttribute("width", "3");
+    p1.setAttribute("height", "12");
+    p1.setAttribute("rx", "1");
+    svg.appendChild(p1);
+    var p2 = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    p2.setAttribute("x", "9.5");
+    p2.setAttribute("y", "2");
+    p2.setAttribute("width", "3");
+    p2.setAttribute("height", "12");
+    p2.setAttribute("rx", "1");
+    svg.appendChild(p2);
+    return svg;
+  }
+
+  function svgPlayIcon() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "14");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M3 3.732a1 1 0 0 1 1.514-.857l8.07 4.268a1 1 0 0 1 0 1.714l-8.07 4.268A1 1 0 0 1 3 12.268V3.732Z");
+    svg.appendChild(path);
+    return svg;
+  }
+
   function sortTasks() {
     // completed/failed at top (oldest first), then running, then queued (by priority), cancelled last
-    var statusOrder = { completed: 0, failed: 1, running: 2, queued: 3, cancelled: 4 };
+    var statusOrder = { completed: 0, failed: 1, running: 2, paused: 3, queued: 4, cancelled: 5 };
     state.tasks.sort(function (a, b) {
       var sa = statusOrder[a.status] !== undefined ? statusOrder[a.status] : 5;
       var sb = statusOrder[b.status] !== undefined ? statusOrder[b.status] : 5;
@@ -1327,9 +1363,9 @@
         return;
       }
 
-      // Select completed task to view results
+      // Select completed/paused task to view results
       var task = findTask(taskId);
-      if (task && task.status === "completed") {
+      if (task && (task.status === "completed" || task.status === "paused")) {
         state.selectedTaskId = taskId;
         loadAndShowResults(taskId);
         renderTaskList();
@@ -1579,6 +1615,36 @@
     return null;
   }
 
+  function updatePauseButton() {
+    var btn = qs("#taskQueuePauseBtn");
+    if (!btn) return;
+    btn.innerHTML = "";
+    if (state.queuePaused) {
+      btn.appendChild(svgPlayIcon());
+      btn.title = "Resume queue";
+    } else {
+      btn.appendChild(svgPauseIcon());
+      btn.title = "Pause queue";
+    }
+  }
+
+  function initPauseButton() {
+    var btn = qs("#taskQueuePauseBtn");
+    if (!btn) return;
+    updatePauseButton();
+    btn.addEventListener("click", function () {
+      var endpoint = state.queuePaused ? "api/tasks/resume" : "api/tasks/pause";
+      apiPost(endpoint)
+        .then(function (data) {
+          if (data.ok) {
+            state.queuePaused = data.paused;
+            updatePauseButton();
+          }
+        })
+        .catch(function (err) { showToast("Error: " + err.message); });
+    });
+  }
+
   function renderTaskList() {
     sortTasks();
     var container = qs("#taskList");
@@ -1616,7 +1682,7 @@
       meta.textContent = task.participant + " \u00b7 " + (task.region || "");
       info.appendChild(meta);
 
-      if (task.status === "running") {
+      if (task.status === "running" || task.status === "paused") {
         var prog = el("div", "task-card-progress");
         var fill = el("div", "task-card-progress-fill");
         fill.style.width = Math.round((task.progress || 0) * 100) + "%";
@@ -1628,6 +1694,11 @@
       // Status text
       var statusText = task.status;
       if (task.status === "running") statusText = Math.round((task.progress || 0) * 100) + "%";
+      if (task.status === "paused") {
+        var pPct = Math.round((task.progress || 0) * 100);
+        var pLen = Array.isArray(task.result) ? task.result.length : 0;
+        statusText = "paused " + pPct + "%" + (pLen ? " \u00b7 " + pLen + " result" + (pLen !== 1 ? "s" : "") : "");
+      }
       if (task.status === "failed" && task.error) {
         statusText = task.error;
         card.title = task.error;
@@ -1663,7 +1734,7 @@
 
   function pollTasks() {
     var hasActive = state.tasks.some(function (t) {
-      return t.status === "queued" || t.status === "running";
+      return t.status === "queued" || t.status === "running" || t.status === "paused";
     });
     if (!hasActive) {
       clearInterval(state.pollTimer);
@@ -1678,6 +1749,10 @@
         var oldTask = oldSelected ? findTask(oldSelected) : null;
         var wasRunning = oldTask && (oldTask.status === "queued" || oldTask.status === "running");
         state.tasks = data.tasks;
+        if (data.paused !== undefined) {
+          state.queuePaused = data.paused;
+          updatePauseButton();
+        }
         renderTaskList();
         renderTimeline();
         // Auto-load results when selected task completes
@@ -1929,6 +2004,7 @@
     initWorkflowTabs();
     initRunButton();
     initTaskQueue();
+    initPauseButton();
     initResultsPanel();
     initPanelDivider();
     initKeyboard();

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.58"
+VERSIONNUM: str = "0.9.59"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [

--- a/screenspace.py
+++ b/screenspace.py
@@ -13,6 +13,7 @@ import json
 import queue
 import re
 import threading
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -651,6 +652,7 @@ TASK_STATUS_RUNNING = "running"
 TASK_STATUS_COMPLETED = "completed"
 TASK_STATUS_FAILED = "failed"
 TASK_STATUS_CANCELLED = "cancelled"
+TASK_STATUS_PAUSED = "paused"
 
 _SENTINEL = object()
 
@@ -694,6 +696,7 @@ class ScreenspaceWorker:
         self._lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
         self._running = False
+        self._paused = threading.Event()
         self.on_task_complete: Optional[Callable[[], None]] = None
 
     def start(self) -> None:
@@ -718,12 +721,12 @@ class ScreenspaceWorker:
         return task_id
 
     def cancel(self, task_id: str) -> bool:
-        """Cancel a queued or running task. Returns True if cancelled."""
+        """Cancel a queued, running, or paused task. Returns True if cancelled."""
         with self._lock:
             task = self._tasks.get(task_id)
             if task is None:
                 return False
-            if task["status"] == TASK_STATUS_QUEUED:
+            if task["status"] in (TASK_STATUS_QUEUED, TASK_STATUS_PAUSED):
                 task["status"] = TASK_STATUS_CANCELLED
                 return True
             if task["status"] == TASK_STATUS_RUNNING:
@@ -757,6 +760,54 @@ class ScreenspaceWorker:
                     task["priority"] = i + 1
         return True
 
+    @property
+    def is_paused(self) -> bool:
+        """Return whether the queue is paused."""
+        return self._paused.is_set()
+
+    def pause(self) -> None:
+        """Pause the queue. Stops the running task so it yields partial results."""
+        self._paused.set()
+        with self._lock:
+            for task in self._tasks.values():
+                if task["status"] == TASK_STATUS_RUNNING:
+                    task["_paused_flag"] = True
+
+    def resume(self) -> None:
+        """Resume the queue. Re-enqueues paused tasks from where they left off."""
+        self._paused.clear()
+        to_resume: List[Dict[str, Any]] = []
+        with self._lock:
+            for task in self._tasks.values():
+                if task["status"] == TASK_STATUS_PAUSED:
+                    to_resume.append(task)
+
+        for task in to_resume:
+            progress = task.get("progress", 0.0)
+            params = task.get("parameters", {})
+            start = params.get("start_seconds", 0.0)
+            end = params.get("end_seconds")
+            if end is None:
+                cap = cv2.VideoCapture(task["video_path"])
+                fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+                total = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+                end = total / fps if fps > 0 else 0.0
+                cap.release()
+            resume_at = start + progress * (end - start)
+
+            with self._lock:
+                task["_partial_results"] = task.get("result", [])
+                task["_progress_offset"] = progress
+                task["_progress_scale"] = max(1.0 - progress, 0.001)
+                task.pop("result", None)
+                task.pop("_paused_flag", None)
+                params["start_seconds"] = resume_at
+                task["status"] = TASK_STATUS_QUEUED
+
+            self._queue.put(
+                (task.get("priority", 100), task["created_at"], task["id"])
+            )
+
     def remove_task(self, task_id: str) -> bool:
         """Cancel (if active) and fully remove a task."""
         with self._lock:
@@ -772,11 +823,17 @@ class ScreenspaceWorker:
         """Worker loop."""
         while self._running:
             try:
-                _, _, task_id = self._queue.get(timeout=1)
+                item = self._queue.get(timeout=1)
             except queue.Empty:
                 continue
+            priority, created_at, task_id = item
             if task_id is _SENTINEL:
                 break
+
+            if self._paused.is_set():
+                self._queue.put(item)
+                time.sleep(0.25)
+                continue
 
             with self._lock:
                 task = self._tasks.get(task_id)
@@ -796,25 +853,37 @@ class ScreenspaceWorker:
         def _on_progress(progress: float) -> None:
             with self._lock:
                 t = self._tasks.get(task_id)
-                if t:
-                    t["progress"] = min(progress, 1.0)
+                if t and not t.get("_paused_flag"):
+                    offset = t.get("_progress_offset", 0.0)
+                    scale = t.get("_progress_scale", 1.0)
+                    t["progress"] = min(offset + progress * scale, 1.0)
 
         def _cancel_flag() -> bool:
             with self._lock:
                 t = self._tasks.get(task_id)
-                return bool(t and t.get("_cancelled"))
+                return bool(
+                    t and (t.get("_cancelled") or t.get("_paused_flag"))
+                )
 
         try:
             result = self._dispatch(task, _on_progress, _cancel_flag)
             with self._lock:
                 t = self._tasks.get(task_id)
                 if t:
-                    if t.get("_cancelled"):
+                    if t.get("_paused_flag"):
+                        t["status"] = TASK_STATUS_PAUSED
+                        t["result"] = result
+                    elif t.get("_cancelled"):
                         t["status"] = TASK_STATUS_CANCELLED
                     else:
                         t["status"] = TASK_STATUS_COMPLETED
+                        partial = t.pop("_partial_results", None)
+                        if partial and isinstance(result, list):
+                            result = partial + result
                         t["result"] = result
                         t["progress"] = 1.0
+                        t.pop("_progress_offset", None)
+                        t.pop("_progress_scale", None)
                     t["completed_at"] = datetime.now(timezone.utc).isoformat()
         except Exception as exc:
             with self._lock:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -194,7 +194,8 @@ def api_tasks_list() -> FlaskResponse:
     """List all tasks with status and progress."""
     tasks = _worker.get_all_tasks() if _worker else []
     clean = [_clean_task(t) for t in tasks]
-    return jsonify({"ok": True, "tasks": clean})
+    paused = _worker.is_paused if _worker else False
+    return jsonify({"ok": True, "tasks": clean, "paused": paused})
 
 
 @screenspace_bp.route("/api/tasks/<task_id>")
@@ -318,6 +319,24 @@ def api_tasks_reorder() -> FlaskResponse:
         return jsonify({"ok": False, "error": "task_ids list required"}), 400
     _worker.reorder(data["task_ids"])
     return jsonify({"ok": True})
+
+
+@screenspace_bp.route("/api/tasks/pause", methods=["POST"])
+def api_tasks_pause() -> FlaskResponse:
+    """Pause the task queue."""
+    if not _worker:
+        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+    _worker.pause()
+    return jsonify({"ok": True, "paused": True})
+
+
+@screenspace_bp.route("/api/tasks/resume", methods=["POST"])
+def api_tasks_resume() -> FlaskResponse:
+    """Resume the task queue."""
+    if not _worker:
+        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+    _worker.resume()
+    return jsonify({"ok": True, "paused": False})
 
 
 @screenspace_bp.route("/api/tasks/<task_id>/results")

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -351,6 +351,48 @@ class TestScreenspaceWorker:
         assert worker.get_task(task["id"]) is None
 
 
+    def test_pause_resume_flags(self):
+        worker = screenspace.ScreenspaceWorker()
+        assert worker.is_paused is False
+        worker.pause()
+        assert worker.is_paused is True
+        worker.resume()
+        assert worker.is_paused is False
+
+    def test_pause_sets_paused_flag_on_running_task(self):
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+        )
+        worker.enqueue(task)
+        with worker._lock:
+            worker._tasks[task["id"]]["status"] = screenspace.TASK_STATUS_RUNNING
+        worker.pause()
+        with worker._lock:
+            assert worker._tasks[task["id"]].get("_paused_flag") is True
+
+    def test_resume_requeues_paused_task(self):
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "color",
+            "P01",
+            "s.mp4",
+            "/v.mp4",
+            "r",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+            parameters={"start_seconds": 0.0, "end_seconds": 100.0},
+        )
+        worker.enqueue(task)
+        with worker._lock:
+            worker._tasks[task["id"]]["status"] = screenspace.TASK_STATUS_PAUSED
+            worker._tasks[task["id"]]["progress"] = 0.5
+            worker._tasks[task["id"]]["result"] = [{"timestamp": 5.0}]
+        worker.resume()
+        t = worker.get_task(task["id"])
+        assert t["status"] == "queued"
+        assert t.get("parameters", {}).get("start_seconds") == 50.0
+
+
 class TestScanNumbers:
     def test_unknown_operator_raises(self):
         with pytest.raises(ValueError, match="Unknown.*operator"):


### PR DESCRIPTION
## Summary
- Adds a pause/play toggle button next to the Task Queue heading in Screenspace
- Pausing stops the currently running analysis and preserves partial results (viewable immediately by clicking the task card)
- Resuming re-enqueues paused tasks from where they left off, with progress bar continuing from the pause point and partial + new results merged on completion
- New `"paused"` task status with yellow border indicator and status text showing progress percentage and partial result count

## Test plan
- [ ] `uv run pytest -c tests/pytest.ini tests/test_screenspace.py tests/test_screenspace_api.py` passes
- [ ] Launch `--screenspace`, enqueue tasks, pause mid-execution, verify partial results show and progress bar stays at actual stopping point
- [ ] Resume and verify processing continues from where it left off with merged results