### PR TITLE
Add draggable resize handle to Screenspace video preview (#55)

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -232,6 +232,7 @@ body {
   border-radius: var(--radius);
   overflow: hidden;
   line-height: 0;
+  margin: 0 auto;
 }
 
 #frameCanvas,
@@ -261,6 +262,38 @@ body {
   color: #6b7280;
   font-size: 0.85rem;
   pointer-events: none;
+}
+
+/* Preview resize handle */
+
+.preview-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 20px;
+  height: 20px;
+  cursor: nwse-resize;
+  z-index: 5;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.preview-resize-handle::before {
+  content: "";
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 10px;
+  height: 10px;
+  background:
+    radial-gradient(circle, var(--color-text-dim) 1.5px, transparent 1.5px) 6px 6px / 4px 4px no-repeat,
+    radial-gradient(circle, var(--color-text-dim) 1.5px, transparent 1.5px) 6px 2px / 4px 4px no-repeat,
+    radial-gradient(circle, var(--color-text-dim) 1.5px, transparent 1.5px) 2px 6px / 4px 4px no-repeat;
+}
+
+#frameContainer:hover .preview-resize-handle,
+.preview-resize-handle.active {
+  opacity: 1;
 }
 
 #timestampInput {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -32,6 +32,7 @@
         <canvas id="frameCanvas"></canvas>
         <canvas id="overlayCanvas"></canvas>
         <div id="frameEmpty">Select a participant to view frames</div>
+        <div id="previewResizeHandle" class="preview-resize-handle"></div>
       </div>
       <div id="regionBar">
         <div id="regionChips"></div>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -45,6 +45,7 @@
     queuePaused: false,
     timelineDragging: false,
     panelHeight: 260,
+    previewMaxWidth: 100,
   };
 
   // ---- Helpers ----
@@ -2016,6 +2017,73 @@
     document.addEventListener("touchend", onUp);
   }
 
+  // ---- Preview resize ----
+
+  function initPreviewResize() {
+    var handle = qs("#previewResizeHandle");
+    var container = qs("#frameContainer");
+    if (!handle || !container) return;
+    var dragging = false;
+    var startX = 0;
+    var startWidthPx = 0;
+    var parentWidth = 0;
+
+    var MIN_PCT = 30;
+    var MAX_PCT = 100;
+
+    function onDown(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      dragging = true;
+      startX = e.clientX || (e.touches && e.touches[0].clientX) || 0;
+      startWidthPx = container.getBoundingClientRect().width;
+      parentWidth = container.parentElement.getBoundingClientRect().width;
+      handle.classList.add("active");
+      document.body.style.cursor = "nwse-resize";
+      document.body.style.userSelect = "none";
+    }
+
+    handle.addEventListener("mousedown", onDown);
+    handle.addEventListener("touchstart", onDown, { passive: false });
+
+    var rafPending = false;
+
+    function onMove(e) {
+      if (!dragging || rafPending) return;
+      rafPending = true;
+      var clientX = e.clientX || (e.touches && e.touches[0].clientX) || 0;
+      requestAnimationFrame(function () {
+        var delta = clientX - startX;
+        var newWidthPx = startWidthPx + delta;
+        var pct = Math.max(MIN_PCT, Math.min(MAX_PCT, (newWidthPx / parentWidth) * 100));
+        state.previewMaxWidth = Math.round(pct);
+        container.style.maxWidth = state.previewMaxWidth + "%";
+        rafPending = false;
+      });
+    }
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("touchmove", onMove, { passive: false });
+
+    function onUp() {
+      if (!dragging) return;
+      dragging = false;
+      handle.classList.remove("active");
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
+
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchend", onUp);
+
+    handle.addEventListener("dblclick", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      state.previewMaxWidth = MAX_PCT;
+      container.style.maxWidth = "";
+    });
+  }
+
   // ---- Init ----
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -2029,6 +2097,7 @@
     initPauseButton();
     initResultsPanel();
     initPanelDivider();
+    initPreviewResize();
     initKeyboard();
     checkNavLinks();
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.59"
+VERSIONNUM: str = "0.9.60"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary

Adds a small drag handle to the bottom-right corner of the Screenspace video preview area. Grabbing and dragging it lets users shrink or grow the video preview (and selection overlay) by controlling the container's `max-width` as a percentage (30–100%). The video stays centered and maintains its aspect ratio. Double-click resets to full width.

Follows the existing `initPanelDivider()` drag pattern. Region drawing coordinates remain accurate at any size since `canvasCoords()` and `regionToPixels()` already use scale-factor math based on internal canvas resolution.

## Test plan

- [ ] Open Screenspace, select a participant so a frame loads
- [ ] Hover bottom-right corner of video preview — grip dots appear
- [ ] Drag left to shrink, drag right to grow; verify centering and aspect ratio
- [ ] Double-click handle to reset to full width
- [ ] Draw a selection region after resizing — coordinates should be accurate
- [ ] Verify grip dots visible in both light and dark themes