### PR TITLE
Screenspace: allow deselecting task cards by clicking again

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1397,12 +1397,20 @@
         return;
       }
 
-      // Select completed/paused task to view results
+      // Select completed/paused task to view results; click again to deselect
       var task = findTask(taskId);
       if (task && (task.status === "completed" || task.status === "paused")) {
-        state.selectedTaskId = taskId;
-        loadAndShowResults(taskId);
-        renderTaskList();
+        if (state.selectedTaskId === taskId) {
+          state.selectedTaskId = null;
+          state.selectedTaskResults = null;
+          renderResults();
+          renderTaskList();
+          renderTimeline();
+        } else {
+          state.selectedTaskId = taskId;
+          loadAndShowResults(taskId);
+          renderTaskList();
+        }
       }
     });
 


### PR DESCRIPTION
Clicking an already-selected task card now deselects it, clearing the Results panel and restoring full opacity to all timeline markers. Previously, the only way to clear a selection was to click a different task or dismiss the card.