### PR TITLE
Screenspace: rename Run Analysis → Run, anchor button to top-right

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -522,8 +522,12 @@ body {
 #workflowBody {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.4rem;
   padding: 0.6rem 0;
+}
+
+#runBtn {
+  align-self: flex-end;
 }
 
 #workflowParams {
@@ -532,6 +536,7 @@ body {
   gap: 0.25rem;
   flex: 1;
   min-height: 0;
+  min-width: 0;
   overflow-y: auto;
 }
 
@@ -552,6 +557,8 @@ body {
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .param-control input[type="range"] {
@@ -576,7 +583,8 @@ body {
 }
 
 .param-control input[type="text"] {
-  width: 12rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .param-value {
@@ -673,8 +681,8 @@ body {
   content: attr(data-tooltip);
   position: absolute;
   bottom: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
+  right: 0;
+  left: auto;
   padding: 0.3rem 0.6rem;
   background: var(--color-text);
   color: var(--color-bg);

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -99,13 +99,13 @@
         </button>
       </div>
       <div id="workflowBody">
-        <div id="workflowParams"></div>
         <button id="runBtn" class="btn btn-primary btn-icon" disabled data-tooltip="Select a region first">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M3 3.732a1 1 0 0 1 1.514-.857l8.07 4.268a1 1 0 0 1 0 1.714l-8.07 4.268A1 1 0 0 1 3 12.268V3.732Z"/>
           </svg>
-          Run Analysis
+          Run
         </button>
+        <div id="workflowParams"></div>
       </div>
     </section>
     <div id="taskQueuePanel">


### PR DESCRIPTION
Renames the workflow run button from "Run Analysis" to "Run" and moves it to the top-right of the tool area, so its position is consistent across all tools regardless of how many parameters each one has.

The button is now the first item in `#workflowBody` (flex-column) with `align-self: flex-end`, placing it as a slim right-aligned strip above the parameters. This gives the parameters the full panel width, avoiding overflow issues that occurred with a side-by-side grid layout.

Also fixes the disabled-state tooltip being clipped by the Task Queue column border — it now right-aligns and extends leftward. Additionally, `.param-control` gains `flex: 1` so it fills its row, and the text search input switches from a fixed `12rem` width to `flex: 1`.