### PR TITLE
Screenspace: add spinner/pause icon to task card drag-handle slot

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -969,6 +969,47 @@ body {
   cursor: grabbing;
 }
 
+@keyframes task-card-spin {
+  to { transform: rotate(360deg); }
+}
+
+.task-card-spinner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0.1rem 0;
+  width: 10px;
+  height: 14px;
+}
+
+.task-card-spinner::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: task-card-spin 0.7s linear infinite;
+}
+
+.task-card-pause-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0.1rem 0;
+  width: 10px;
+  height: 14px;
+  color: #eab308;
+  opacity: 0.7;
+}
+
+.task-card-pause-icon svg {
+  width: 10px;
+  height: 10px;
+}
+
 /* Edit button */
 .task-card-edit {
   background: none;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1993,6 +1993,12 @@
         handle.addEventListener("mousedown", function () { card.setAttribute("draggable", "true"); });
         handle.addEventListener("mouseup", function () { card.removeAttribute("draggable"); });
         card.appendChild(handle);
+      } else if (task.status === "running") {
+        card.appendChild(el("span", "task-card-spinner"));
+      } else if (task.status === "paused") {
+        var pauseIcon = el("span", "task-card-pause-icon");
+        pauseIcon.appendChild(svgPauseIcon());
+        card.appendChild(pauseIcon);
       }
 
       // Type badge


### PR DESCRIPTION
Running tasks now show an animated spinner in the drag-handle position on their task card; paused tasks show a pause icon (yellow, matching the paused border color). Queued, completed, and failed tasks continue to show the drag handle as before. This keeps the leftmost slot consistently occupied across all task states so the card layout never shifts.