### PR TITLE
Screenspace: fix 404 on Results frame preview for integer timestamps

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -168,7 +168,7 @@
   }
 
   function frameUrl(pid, ts) {
-    return "api/video/frame/" + encodeURIComponent(pid) + "/" + ts;
+    return "api/video/frame/" + encodeURIComponent(pid) + "/" + Number(ts).toFixed(6);
   }
 
   // ---- Theme toggle (matches Studio) ----


### PR DESCRIPTION
Flask's `<float:>` route converter requires a decimal point in the URL segment. When analysis results produce round-number timestamps (e.g. `45.0`), JavaScript's string coercion drops the decimal, producing URLs like `/frame/P01/45` that don't match the route — returning 404. The fix ensures `frameUrl()` always formats timestamps with a decimal point via `toFixed(6)`.