### PR TITLE
Screenspace: multi-participant run selection and video switching (#59)

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -526,6 +526,87 @@ body {
   padding: 0.6rem 0;
 }
 
+/* Run participant picker */
+
+.run-picker-wrap {
+  position: relative;
+}
+
+.run-picker-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.72rem;
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.run-picker-btn:hover {
+  border-color: var(--color-accent);
+}
+
+.run-picker-btn .chevron {
+  font-size: 0.6rem;
+  color: var(--color-text-dim);
+  transition: transform 0.15s;
+}
+
+.run-picker-btn.open .chevron {
+  transform: rotate(180deg);
+}
+
+.run-picker-panel {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  padding: 0.3rem 0;
+  min-width: 8rem;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.run-picker-panel label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.run-picker-panel label:hover {
+  background: var(--color-selected);
+}
+
+.run-picker-panel input[type="checkbox"] {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.run-picker-toggle-all {
+  font-size: 0.68rem;
+  color: var(--color-accent);
+  cursor: pointer;
+  padding: 0.2rem 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+  display: block;
+}
+
+.run-picker-toggle-all:hover {
+  text-decoration: underline;
+}
+
 #workflowParams {
   display: flex;
   flex-direction: column;
@@ -1254,6 +1335,10 @@ html[data-theme="dark"] .btn-primary:hover {
 
 html[data-theme="dark"] .region-chip.active {
   background: rgba(255, 255, 255, 0.08);
+}
+
+html[data-theme="dark"] .run-picker-panel {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
 /* Responsive */

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -100,6 +100,7 @@
       </div>
       <div id="workflowBody">
         <div id="workflowParams"></div>
+        <div id="runParticipantPicker" class="run-picker-wrap"></div>
         <button id="runBtn" class="btn btn-primary btn-icon" disabled data-tooltip="Select a region first">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M3 3.732a1 1 0 0 1 1.514-.857l8.07 4.268a1 1 0 0 1 0 1.714l-8.07 4.268A1 1 0 0 1 3 12.268V3.732Z"/>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -48,6 +48,7 @@
     panelHeight: 260,
     previewMaxWidth: 100,
     taskFilter: null,
+    runParticipants: [],
   };
 
   // ---- Helpers ----
@@ -246,7 +247,79 @@
     });
   }
 
-  function selectParticipant(pid) {
+  function renderRunParticipantPicker() {
+    var wrap = qs("#runParticipantPicker");
+    if (!wrap) return;
+    wrap.innerHTML = "";
+    if (state.participants.length <= 1) return;
+
+    var btn = el("button", "run-picker-btn");
+    btn.type = "button";
+    updatePickerBtnText(btn);
+
+    var panel = el("div", "run-picker-panel hidden");
+
+    var toggleAll = el("span", "run-picker-toggle-all");
+    toggleAll.textContent = state.runParticipants.length === state.participants.length ? "Deselect all" : "Select all";
+    toggleAll.addEventListener("click", function () {
+      var allSelected = state.runParticipants.length === state.participants.length;
+      state.runParticipants = allSelected ? [] : state.participants.map(function (p) { return p.id; });
+      var cbs = panel.querySelectorAll("input[type=checkbox]");
+      for (var i = 0; i < cbs.length; i++) cbs[i].checked = !allSelected;
+      toggleAll.textContent = allSelected ? "Select all" : "Deselect all";
+      updatePickerBtnText(btn);
+      updateRunButton();
+    });
+    panel.appendChild(toggleAll);
+
+    state.participants.forEach(function (p) {
+      var lbl = document.createElement("label");
+      var cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.value = p.id;
+      cb.checked = state.runParticipants.indexOf(p.id) >= 0;
+      cb.addEventListener("change", function () {
+        if (cb.checked) {
+          if (state.runParticipants.indexOf(p.id) < 0) state.runParticipants.push(p.id);
+        } else {
+          state.runParticipants = state.runParticipants.filter(function (id) { return id !== p.id; });
+        }
+        toggleAll.textContent = state.runParticipants.length === state.participants.length ? "Deselect all" : "Select all";
+        updatePickerBtnText(btn);
+        updateRunButton();
+      });
+      lbl.appendChild(cb);
+      lbl.appendChild(document.createTextNode(p.id));
+      panel.appendChild(lbl);
+    });
+
+    btn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      var open = !panel.classList.contains("hidden");
+      panel.classList.toggle("hidden", open);
+      btn.classList.toggle("open", !open);
+    });
+
+    wrap.appendChild(btn);
+    wrap.appendChild(panel);
+  }
+
+  function updatePickerBtnText(btn) {
+    var n = state.runParticipants.length;
+    var text = n === 0 ? "No participants"
+      : n === 1 ? state.runParticipants[0]
+      : n + " participants";
+    btn.innerHTML = text + ' <span class="chevron">&#x25BE;</span>';
+  }
+
+  function closeRunPicker() {
+    var panel = qs(".run-picker-panel");
+    var btn = qs(".run-picker-btn");
+    if (panel) panel.classList.add("hidden");
+    if (btn) btn.classList.remove("open");
+  }
+
+  function selectParticipant(pid, initialTimestamp) {
     state.selectedParticipant = pid;
     state.currentTimestamp = 0;
     state.videoInfo = null;
@@ -265,7 +338,7 @@
         if (data.info.fps) parts.push(Math.round(data.info.fps) + "fps");
         qs("#videoInfo").textContent = parts.join(" \u00b7 ");
         renderTimeline();
-        loadFrame(0);
+        loadFrame(initialTimestamp !== undefined ? initialTimestamp : 0);
       })
       .catch(function () { showToast("Failed to load video info"); });
   }
@@ -1154,12 +1227,12 @@
   function updateRunButton() {
     var btn = qs("#runBtn");
     var hasRegion = !!state.activeRegion;
-    var hasParticipant = !!state.selectedParticipant;
-    btn.disabled = !hasRegion || !hasParticipant;
+    var hasParticipants = state.runParticipants.length > 0 || !!state.selectedParticipant;
+    btn.disabled = !hasRegion || !hasParticipants;
     if (!hasRegion) {
       btn.setAttribute("data-tooltip", "Select a region first");
-    } else if (!hasParticipant) {
-      btn.setAttribute("data-tooltip", "Select a participant first");
+    } else if (!hasParticipants) {
+      btn.setAttribute("data-tooltip", "Select participants to run");
     } else {
       btn.removeAttribute("data-tooltip");
     }
@@ -1169,7 +1242,12 @@
 
   function initRunButton() {
     qs("#runBtn").addEventListener("click", function () {
-      if (!state.activeRegion || !state.selectedParticipant) return;
+      if (!state.activeRegion) return;
+      var participants = state.runParticipants.length > 0
+        ? state.runParticipants
+        : (state.selectedParticipant ? [state.selectedParticipant] : []);
+      if (participants.length === 0) return;
+
       var type = state.activeWorkflow;
       var params = gatherWorkflowParams(type);
       if (params === null) return;
@@ -1177,25 +1255,29 @@
       if (state.inMarker !== null) params.start_seconds = state.inMarker;
       if (state.outMarker !== null) params.end_seconds = state.outMarker;
 
-      var body = {
-        type: type,
-        participant: state.selectedParticipant,
-        region: state.activeRegion,
-        parameters: params,
-      };
-
-      apiPost("api/tasks", body)
-        .then(function (data) {
-          if (data.ok) {
-            state.tasks.push(data.task);
-            renderTaskList();
-            showToast("Task queued: " + type);
-            startPolling();
-          } else {
-            showToast(data.error || "Failed to create task");
-          }
-        })
-        .catch(function (err) { showToast("Error: " + err.message); });
+      var chain = Promise.resolve();
+      participants.forEach(function (pid) {
+        chain = chain.then(function () {
+          var body = {
+            type: type,
+            participant: pid,
+            region: state.activeRegion,
+            parameters: params,
+          };
+          return apiPost("api/tasks", body).then(function (data) {
+            if (data.ok) {
+              state.tasks.push(data.task);
+              renderTaskList();
+            } else {
+              showToast(data.error || "Failed to create task for " + pid);
+            }
+          });
+        });
+      });
+      chain.then(function () {
+        showToast(participants.length + " task" + (participants.length !== 1 ? "s" : "") + " queued: " + type);
+        startPolling();
+      }).catch(function (err) { showToast("Error: " + err.message); });
     });
   }
 
@@ -1423,6 +1505,9 @@
           renderTaskList();
           renderTimeline();
         } else {
+          if (task.participant && task.participant !== state.selectedParticipant) {
+            selectParticipant(task.participant);
+          }
           state.selectedTaskId = taskId;
           loadAndShowResults(taskId);
           renderTaskList();
@@ -1896,7 +1981,13 @@
       var row = e.target.closest(".result-row");
       if (!row || !row.dataset.timestamp) return;
       var ts = parseFloat(row.dataset.timestamp);
-      if (!isNaN(ts)) loadFrame(ts);
+      if (isNaN(ts)) return;
+      var task = state.selectedTaskId ? findTask(state.selectedTaskId) : null;
+      if (task && task.participant && task.participant !== state.selectedParticipant) {
+        selectParticipant(task.participant, ts);
+        return;
+      }
+      loadFrame(ts);
     });
 
     qs("#exportJsonBtn").addEventListener("click", function () { exportResults("json"); });
@@ -2205,7 +2296,16 @@
     // Participant select
     qs("#participantSelect").addEventListener("change", function () {
       var pid = this.value;
-      if (pid) selectParticipant(pid);
+      if (pid) {
+        selectParticipant(pid);
+        state.runParticipants = [pid];
+        renderRunParticipantPicker();
+      }
+    });
+
+    // Close run picker on outside click
+    document.addEventListener("click", function (e) {
+      if (!e.target.closest(".run-picker-wrap")) closeRunPicker();
     });
 
     // Load initial data
@@ -2215,8 +2315,11 @@
         state.participants = (data.participants || []).filter(function (p) { return p.has_video; });
         renderParticipantSelect();
         if (state.participants.length > 0) {
-          selectParticipant(state.participants[0].id);
+          var first = state.participants[0].id;
+          selectParticipant(first);
+          state.runParticipants = [first];
         }
+        renderRunParticipantPicker();
       })
       .catch(function () { showToast("Failed to load participants"); });
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.60"
+VERSIONNUM: str = "0.9.61"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [


### PR DESCRIPTION
## Summary

- Adds a checkbox dropdown next to the Run button for selecting which participants to run analysis tasks on (hidden when only one participant exists)
- Clicking Run queues one task per selected participant sequentially via the existing `api/tasks` endpoint
- Selecting a task card or clicking a result row from a different participant auto-switches the video preview to that participant's source video
- Includes Select all / Deselect all toggle and click-outside-to-close behavior

## Test plan

- [ ] Open Screenspace with multiple participant videos; verify picker appears and defaults to Source participant
- [ ] Select multiple participants, click Run; verify one task per participant is queued
- [ ] Click a completed task card for a different participant; verify video switches
- [ ] Click a result row timestamp; verify correct participant's frame loads
- [ ] Change Source dropdown; verify picker resets to just that participant
- [ ] With a single participant, verify picker is hidden and Run works as before