### PR TITLE
Screenspace: optimize analysis performance across all scan modes

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.61"
+VERSIONNUM: str = "0.9.62"
 TITLECARDS_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [
@@ -105,6 +105,8 @@ SCREENSPACE_SSIM_THRESHOLD: float = 0.90
 SCREENSPACE_CHANGE_RATIO_THRESHOLD: float = 0.03
 SCREENSPACE_MORPH_KERNEL: int = 3
 SCREENSPACE_OCR_FUZZY_THRESHOLD: float = 0.8
+SCREENSPACE_PHASH_THRESHOLD: int = 15
+SCREENSPACE_SEQUENTIAL_READ_MAX_INTERVAL: float = 3.0
 
 # Highlights reel constants
 HIGHLIGHTS_REEL_DURATION_SECONDS: int = 180  # 3-minute budget for highlights reel
@@ -196,13 +198,37 @@ SETTINGS_DESCRIPTIONS: Dict[str, str] = {
 STUDIO_SETTINGS: Dict[str, Dict[str, Any]] = {
     "REENCODING": {"group": "Video Output", "type": "bool"},
     "AUDIO_NORMALIZE": {"group": "Video Output", "type": "bool"},
-    "FILEFORMAT": {"group": "Video Output", "type": "select", "options": [".mp4", ".webm", ".mkv"]},
+    "FILEFORMAT": {
+        "group": "Video Output",
+        "type": "select",
+        "options": [".mp4", ".webm", ".mkv"],
+    },
     "MAX_FILESIZE_MB": {"group": "Video Output", "type": "int", "min": 0, "step": 1},
-    "DEFAULT_DURATION_SECONDS": {"group": "Clip Behavior", "type": "int", "min": 1, "step": 1},
-    "MAX_CLIP_DURATION_SECONDS": {"group": "Clip Behavior", "type": "int", "min": 1, "step": 1},
+    "DEFAULT_DURATION_SECONDS": {
+        "group": "Clip Behavior",
+        "type": "int",
+        "min": 1,
+        "step": 1,
+    },
+    "MAX_CLIP_DURATION_SECONDS": {
+        "group": "Clip Behavior",
+        "type": "int",
+        "min": 1,
+        "step": 1,
+    },
     "TITLECARDS_ENABLED": {"group": "Titlecards", "type": "bool"},
-    "TITLECARD_DURATION_SECONDS": {"group": "Titlecards", "type": "int", "min": 1, "step": 1},
-    "HIGHLIGHTS_REEL_DURATION_SECONDS": {"group": "Generation", "type": "int", "min": 10, "step": 10},
+    "TITLECARD_DURATION_SECONDS": {
+        "group": "Titlecards",
+        "type": "int",
+        "min": 1,
+        "step": 1,
+    },
+    "HIGHLIGHTS_REEL_DURATION_SECONDS": {
+        "group": "Generation",
+        "type": "int",
+        "min": 10,
+        "step": 10,
+    },
     "MANIFEST_ENABLED": {"group": "Generation", "type": "bool"},
     "STUDIO_CELL_EXPAND_HOVER": {"group": "Sheet Preview", "type": "bool"},
 }

--- a/screenspace.py
+++ b/screenspace.py
@@ -62,6 +62,11 @@ def average_color_hsv(region_pixels: np.ndarray) -> Dict[str, float]:
     Returns:
         Dict with keys ``h`` (0-180), ``s`` (0-255), ``v`` (0-255).
     """
+    h, w = region_pixels.shape[:2]
+    if h > 64 or w > 64:
+        region_pixels = cv2.resize(
+            region_pixels, (min(w, 64), min(h, 64)), interpolation=cv2.INTER_AREA
+        )
     hsv = cv2.cvtColor(region_pixels, cv2.COLOR_BGR2HSV)
     mean = np.mean(hsv, axis=(0, 1))
     return {"h": float(mean[0]), "s": float(mean[1]), "v": float(mean[2])}
@@ -125,6 +130,13 @@ def regions_are_similar(
     """
     if threshold <= 0.0:
         threshold = config.SCREENSPACE_SSIM_THRESHOLD
+    max_dim = 256
+    h, w = region_a.shape[:2]
+    if h > max_dim or w > max_dim:
+        scale = max_dim / max(h, w)
+        new_w, new_h = int(w * scale), int(h * scale)
+        region_a = cv2.resize(region_a, (new_w, new_h), interpolation=cv2.INTER_AREA)
+        region_b = cv2.resize(region_b, (new_w, new_h), interpolation=cv2.INTER_AREA)
     k = config.SCREENSPACE_BLUR_KERNEL
     a_blur = cv2.GaussianBlur(region_a, (k, k), 0)
     b_blur = cv2.GaussianBlur(region_b, (k, k), 0)
@@ -149,33 +161,68 @@ def scan_video_frames(
     *,
     start_seconds: float = 0.0,
     end_seconds: Optional[float] = None,
+    fps: float = 0.0,
+    duration: float = 0.0,
 ) -> None:
     """Iterate through video at interval, extract region, call callback.
 
     The *callback* receives ``(timestamp_seconds, region_pixels)`` and may
     return ``False`` to stop iteration early.
+
+    When *fps* and *duration* are provided, skips internal metadata reads.
+    Uses sequential frame reading (grab/retrieve) for small intervals
+    to avoid expensive H.264 seeking.
     """
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return
 
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    duration = total_frames / fps if fps > 0 else 0.0
+    if fps <= 0:
+        fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    if duration <= 0:
+        total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+        duration = total_frames / fps if fps > 0 else 0.0
     if end_seconds is None or end_seconds > duration:
         end_seconds = duration
 
-    ts = start_seconds
-    while ts <= end_seconds:
-        cap.set(cv2.CAP_PROP_POS_MSEC, ts * 1000.0)
-        ret, frame = cap.read()
-        if not ret:
-            break
-        cropped = extract_region(frame, region)
-        result = callback(ts, cropped)
-        if result is False:
-            break
-        ts += interval_seconds
+    use_sequential = interval_seconds <= config.SCREENSPACE_SEQUENTIAL_READ_MAX_INTERVAL
+
+    if use_sequential:
+        frame_interval = max(1, round(interval_seconds * fps))
+        if start_seconds > 0:
+            cap.set(cv2.CAP_PROP_POS_MSEC, start_seconds * 1000.0)
+        frame_idx = 0
+        end_frame = int(end_seconds * fps)
+        start_frame = int(start_seconds * fps)
+        while True:
+            grabbed = cap.grab()
+            if not grabbed:
+                break
+            abs_frame = start_frame + frame_idx
+            if abs_frame > end_frame:
+                break
+            if frame_idx % frame_interval == 0:
+                ret, frame = cap.retrieve()
+                if not ret:
+                    break
+                ts = start_seconds + frame_idx / fps
+                cropped = extract_region(frame, region)
+                result = callback(ts, cropped)
+                if result is False:
+                    break
+            frame_idx += 1
+    else:
+        ts = start_seconds
+        while ts <= end_seconds:
+            cap.set(cv2.CAP_PROP_POS_MSEC, ts * 1000.0)
+            ret, frame = cap.read()
+            if not ret:
+                break
+            cropped = extract_region(frame, region)
+            result = callback(ts, cropped)
+            if result is False:
+                break
+            ts += interval_seconds
 
     cap.release()
 
@@ -240,13 +287,13 @@ def scan_color(
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return []
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    duration = total_frames / fps if fps > 0 else 0.0
+    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
     cap.release()
 
-    if end_seconds is None or end_seconds > duration:
-        end_seconds = duration
+    if end_seconds is None or end_seconds > vid_duration:
+        end_seconds = vid_duration
     total_range = end_seconds - start_seconds
 
     matches: List[float] = []
@@ -267,6 +314,8 @@ def scan_color(
         _cb,
         start_seconds=start_seconds,
         end_seconds=end_seconds,
+        fps=vid_fps,
+        duration=vid_duration,
     )
 
     if on_progress:
@@ -300,13 +349,13 @@ def scan_changes(
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return []
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    duration = total_frames / fps if fps > 0 else 0.0
+    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
     cap.release()
 
-    if end_seconds is None or end_seconds > duration:
-        end_seconds = duration
+    if end_seconds is None or end_seconds > vid_duration:
+        end_seconds = vid_duration
     total_range = end_seconds - start_seconds
 
     results: List[Dict[str, Any]] = []
@@ -331,6 +380,8 @@ def scan_changes(
         _cb,
         start_seconds=start_seconds,
         end_seconds=end_seconds,
+        fps=vid_fps,
+        duration=vid_duration,
     )
 
     if on_progress:
@@ -363,24 +414,28 @@ def scan_similarity(
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return []
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    duration = total_frames / fps if fps > 0 else 0.0
+    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
     cap.release()
 
-    if end_seconds is None or end_seconds > duration:
-        end_seconds = duration
+    if end_seconds is None or end_seconds > vid_duration:
+        end_seconds = vid_duration
     total_range = end_seconds - start_seconds
 
     results: List[Dict[str, Any]] = []
+    ref_phash = compute_phash(reference_frame)
+    phash_threshold = config.SCREENSPACE_PHASH_THRESHOLD
 
     def _cb(ts: float, pixels: np.ndarray) -> Optional[bool]:
         if cancel_flag and cancel_flag():
             return False
         if pixels.shape == reference_frame.shape:
-            is_sim, score = regions_are_similar(pixels, reference_frame, threshold)
-            if is_sim:
-                results.append({"timestamp": ts, "score": round(score, 4)})
+            frame_phash = compute_phash(pixels)
+            if ref_phash - frame_phash <= phash_threshold:
+                is_sim, score = regions_are_similar(pixels, reference_frame, threshold)
+                if is_sim:
+                    results.append({"timestamp": ts, "score": round(score, 4)})
         if on_progress and total_range > 0:
             on_progress((ts - start_seconds) / total_range)
         return None
@@ -392,6 +447,8 @@ def scan_similarity(
         _cb,
         start_seconds=start_seconds,
         end_seconds=end_seconds,
+        fps=vid_fps,
+        duration=vid_duration,
     )
 
     if on_progress:
@@ -435,26 +492,33 @@ def scan_text(
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return []
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    duration = total_frames / fps if fps > 0 else 0.0
+    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
     cap.release()
 
-    if end_seconds is None or end_seconds > duration:
-        end_seconds = duration
+    if end_seconds is None or end_seconds > vid_duration:
+        end_seconds = vid_duration
     total_range = end_seconds - start_seconds
 
     results: List[Dict[str, Any]] = []
     search_lower = search_string.lower()
+    prev_gray: List[Optional[np.ndarray]] = [None]
 
     def _cb(ts: float, pixels: np.ndarray) -> Optional[bool]:
         if cancel_flag and cancel_flag():
             return False
+        gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        if prev_gray[0] is not None:
+            diff = float(np.mean(cv2.absdiff(prev_gray[0], gray)))
+            if diff < 2.0:
+                if on_progress and total_range > 0:
+                    on_progress((ts - start_seconds) / total_range)
+                return None
+        prev_gray[0] = gray
         ocr_results = reader.readtext(pixels, detail=1)
         for _, text, conf in ocr_results:
-            ratio = difflib.SequenceMatcher(
-                None, search_lower, text.lower()
-            ).ratio()
+            ratio = difflib.SequenceMatcher(None, search_lower, text.lower()).ratio()
             if ratio >= fuzzy_threshold:
                 results.append(
                     {
@@ -475,6 +539,8 @@ def scan_text(
         _cb,
         start_seconds=start_seconds,
         end_seconds=end_seconds,
+        fps=vid_fps,
+        duration=vid_duration,
     )
 
     if on_progress:
@@ -526,16 +592,17 @@ def scan_numbers(
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return []
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    duration = total_frames / fps if fps > 0 else 0.0
+    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
     cap.release()
 
-    if end_seconds is None or end_seconds > duration:
-        end_seconds = duration
+    if end_seconds is None or end_seconds > vid_duration:
+        end_seconds = vid_duration
     total_range = end_seconds - start_seconds
 
     results: List[Dict[str, Any]] = []
+    prev_gray: List[Optional[np.ndarray]] = [None]
 
     def _check(value: float) -> bool:
         if operator == "eq":
@@ -549,13 +616,24 @@ def scan_numbers(
         elif operator == "lte":
             return value <= target_value
         elif operator == "range":
-            return (range_min is not None and range_max is not None
-                    and range_min <= value <= range_max)
+            return (
+                range_min is not None
+                and range_max is not None
+                and range_min <= value <= range_max
+            )
         return False
 
     def _cb(ts: float, pixels: np.ndarray) -> Optional[bool]:
         if cancel_flag and cancel_flag():
             return False
+        gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        if prev_gray[0] is not None:
+            diff = float(np.mean(cv2.absdiff(prev_gray[0], gray)))
+            if diff < 2.0:
+                if on_progress and total_range > 0:
+                    on_progress((ts - start_seconds) / total_range)
+                return None
+        prev_gray[0] = gray
         ocr_results = reader.readtext(pixels, detail=1)
         for _, text, _conf in ocr_results:
             cleaned = text.replace(",", "")
@@ -575,6 +653,8 @@ def scan_numbers(
         _cb,
         start_seconds=start_seconds,
         end_seconds=end_seconds,
+        fps=vid_fps,
+        duration=vid_duration,
     )
 
     if on_progress:
@@ -804,9 +884,7 @@ class ScreenspaceWorker:
                 params["start_seconds"] = resume_at
                 task["status"] = TASK_STATUS_QUEUED
 
-            self._queue.put(
-                (task.get("priority", 100), task["created_at"], task["id"])
-            )
+            self._queue.put((task.get("priority", 100), task["created_at"], task["id"]))
 
     def remove_task(self, task_id: str) -> bool:
         """Cancel (if active) and fully remove a task."""
@@ -861,9 +939,7 @@ class ScreenspaceWorker:
         def _cancel_flag() -> bool:
             with self._lock:
                 t = self._tasks.get(task_id)
-                return bool(
-                    t and (t.get("_cancelled") or t.get("_paused_flag"))
-                )
+                return bool(t and (t.get("_cancelled") or t.get("_paused_flag")))
 
         try:
             result = self._dispatch(task, _on_progress, _cancel_flag)

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -114,19 +114,24 @@ def api_video_info(participant: str) -> FlaskResponse:
             {"ok": False, "error": f"No video for participant {participant}"}
         ), 404
 
-    duration = video.get_file_duration(video_path)
-    props = video.probe_video_properties(video_path)
-
-    info: Dict[str, Any] = {"participant": participant, "duration": duration}
-    if props:
-        info["width"] = props.get("width")
-        info["height"] = props.get("height")
-        info["video_codec"] = props.get("video_codec")
-
     cap = cv2.VideoCapture(video_path)
-    if cap.isOpened():
-        info["fps"] = cap.get(cv2.CAP_PROP_FPS)
-        cap.release()
+    if not cap.isOpened():
+        return jsonify({"ok": False, "error": "Could not open video file"}), 500
+
+    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    duration = round(total_frames / vid_fps) if vid_fps > 0 else 0
+    cap.release()
+
+    info: Dict[str, Any] = {
+        "participant": participant,
+        "duration": duration,
+        "fps": vid_fps,
+        "width": width if width > 0 else None,
+        "height": height if height > 0 else None,
+    }
 
     return jsonify({"ok": True, "info": info})
 
@@ -304,7 +309,9 @@ def api_tasks_create() -> FlaskResponse:
     region_data = regions[region_name]
     props = video.probe_video_properties(video_path)
     if props and props.get("width") and props.get("height"):
-        region_coords = _denormalize_region(region_data, props["width"], props["height"])
+        region_coords = _denormalize_region(
+            region_data, props["width"], props["height"]
+        )
     else:
         region_coords = {
             k: region_data[k] for k in ("x", "y", "w", "h") if k in region_data

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -71,6 +71,7 @@ def test_concatenate_clips_reencode_fallback(monkeypatch):
 
 
 def test_probe_video_properties_parses_output(monkeypatch):
+    video._video_properties_cache.clear()
     fake_json = json.dumps(
         {
             "streams": [
@@ -85,9 +86,7 @@ def test_probe_video_properties_parses_output(monkeypatch):
         }
     )
     monkeypatch.setattr(video.Path, "is_file", lambda self: True)
-    monkeypatch.setattr(
-        video.subprocess, "check_output", lambda _cmd, **_kw: fake_json
-    )
+    monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: fake_json)
 
     result = video.probe_video_properties("clip.mp4")
     assert result == {
@@ -99,6 +98,7 @@ def test_probe_video_properties_parses_output(monkeypatch):
 
 
 def test_probe_video_properties_no_audio(monkeypatch):
+    video._video_properties_cache.clear()
     fake_json = json.dumps(
         {
             "streams": [
@@ -112,9 +112,7 @@ def test_probe_video_properties_no_audio(monkeypatch):
         }
     )
     monkeypatch.setattr(video.Path, "is_file", lambda self: True)
-    monkeypatch.setattr(
-        video.subprocess, "check_output", lambda _cmd, **_kw: fake_json
-    )
+    monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: fake_json)
 
     result = video.probe_video_properties("clip.mp4")
     assert result is not None
@@ -124,6 +122,7 @@ def test_probe_video_properties_no_audio(monkeypatch):
 
 
 def test_probe_video_properties_failure(monkeypatch):
+    video._video_properties_cache.clear()
     monkeypatch.setattr(video.Path, "is_file", lambda self: True)
 
     def raise_cpe(_cmd, **_kw):
@@ -134,6 +133,7 @@ def test_probe_video_properties_failure(monkeypatch):
 
 
 def test_probe_video_properties_file_not_found(monkeypatch):
+    video._video_properties_cache.clear()
     monkeypatch.setattr(video.Path, "is_file", lambda self: False)
     assert video.probe_video_properties("missing.mp4") is None
 
@@ -171,12 +171,20 @@ def test_concatenate_clips_resolution_mismatch_uses_filter_complex(monkeypatch):
     monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
 
     props_by_path = {
-        "a.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": "aac"},
-        "b.mp4": {"width": 1280, "height": 720, "video_codec": "h264", "audio_codec": "aac"},
+        "a.mp4": {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": "aac",
+        },
+        "b.mp4": {
+            "width": 1280,
+            "height": 720,
+            "video_codec": "h264",
+            "audio_codec": "aac",
+        },
     }
-    monkeypatch.setattr(
-        video, "probe_video_properties", lambda p: props_by_path.get(p)
-    )
+    monkeypatch.setattr(video, "probe_video_properties", lambda p: props_by_path.get(p))
 
     captured = []
 
@@ -205,15 +213,26 @@ def test_concatenate_clips_warns_on_mismatch(monkeypatch):
     monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
 
     props_by_path = {
-        "a.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": "aac"},
-        "b.mp4": {"width": 1280, "height": 720, "video_codec": "hevc", "audio_codec": "aac"},
+        "a.mp4": {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": "aac",
+        },
+        "b.mp4": {
+            "width": 1280,
+            "height": 720,
+            "video_codec": "hevc",
+            "audio_codec": "aac",
+        },
     }
+    monkeypatch.setattr(video, "probe_video_properties", lambda p: props_by_path.get(p))
     monkeypatch.setattr(
-        video, "probe_video_properties", lambda p: props_by_path.get(p)
-    )
-    monkeypatch.setattr(
-        video, "run_ffmpeg_process",
-        lambda cmd, **_kw: subprocess.CompletedProcess(args=cmd, returncode=0, stderr=""),
+        video,
+        "run_ffmpeg_process",
+        lambda cmd, **_kw: subprocess.CompletedProcess(
+            args=cmd, returncode=0, stderr=""
+        ),
     )
 
     warnings = []
@@ -240,12 +259,20 @@ def test_concatenate_clips_mixed_audio_presence(monkeypatch):
     monkeypatch.setattr(video, "get_file_duration", lambda _p: 10)
 
     props_by_path = {
-        "a.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": "aac"},
-        "b.mp4": {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": None},
+        "a.mp4": {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": "aac",
+        },
+        "b.mp4": {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": None,
+        },
     }
-    monkeypatch.setattr(
-        video, "probe_video_properties", lambda p: props_by_path.get(p)
-    )
+    monkeypatch.setattr(video, "probe_video_properties", lambda p: props_by_path.get(p))
 
     captured = []
 
@@ -282,11 +309,22 @@ def test_concatenate_clips_all_no_audio(monkeypatch):
     # Same resolution, but audio mismatch is about presence—need at least one
     # mismatch to trigger filter_complex. Use resolution mismatch instead.
     call_count = [0]
+
     def props_alternating(_p):
         call_count[0] += 1
         if call_count[0] % 2 == 1:
-            return {"width": 1920, "height": 1080, "video_codec": "h264", "audio_codec": None}
-        return {"width": 1280, "height": 720, "video_codec": "h264", "audio_codec": None}
+            return {
+                "width": 1920,
+                "height": 1080,
+                "video_codec": "h264",
+                "audio_codec": None,
+            }
+        return {
+            "width": 1280,
+            "height": 720,
+            "video_codec": "h264",
+            "audio_codec": None,
+        }
 
     monkeypatch.setattr(video, "probe_video_properties", props_alternating)
 

--- a/video.py
+++ b/video.py
@@ -21,6 +21,7 @@ import utils
 INVALID_END_TIMESTAMP = None
 
 _file_duration_cache: Dict[str, int] = {}
+_video_properties_cache: Dict[str, Dict[str, Any]] = {}
 
 
 def _ffmpeg_install_guidance_lines() -> List[str]:
@@ -611,6 +612,10 @@ def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
             "audio_codec": "aac",
         }
 
+    resolved = str(Path(filepath).resolve())
+    if resolved in _video_properties_cache:
+        return _video_properties_cache[resolved]
+
     if not Path(filepath).is_file():
         return None
 
@@ -650,12 +655,14 @@ def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
     if not video_codec or width <= 0 or height <= 0:
         return None
 
-    return {
+    result = {
         "width": width,
         "height": height,
         "video_codec": video_codec,
         "audio_codec": audio_codec,
     }
+    _video_properties_cache[resolved] = result
+    return result
 
 
 def get_duration(start_time: str, end_time: Optional[str]) -> Optional[int]:
@@ -946,9 +953,7 @@ def _detect_clip_mismatches(
         utils.warning_print(f"Video codec mismatch across reel clips: {detail}.")
 
     if has_audio_presence_mismatch:
-        utils.warning_print(
-            "Audio stream mismatch: some clips have no audio track."
-        )
+        utils.warning_print("Audio stream mismatch: some clips have no audio track.")
 
     return (props_list, has_resolution_mismatch, has_audio_presence_mismatch)
 
@@ -1041,9 +1046,7 @@ def concatenate_clips(
             )
             return False
 
-    utils.standard_print(
-        f"Concatenating {len(clip_paths)} clips into {output_file}."
-    )
+    utils.standard_print(f"Concatenating {len(clip_paths)} clips into {output_file}.")
     if config.DEBUGGING:
         utils.debug_print("Debugging enabled, not calling ffmpeg for concat.")
         return False
@@ -1054,9 +1057,7 @@ def concatenate_clips(
         utils.warning_print(
             "Re-encoding all clips to produce a compatible reel (this may take longer)."
         )
-        return _concatenate_filter_complex(
-            clip_paths, props_list, output_file
-        )
+        return _concatenate_filter_complex(clip_paths, props_list, output_file)
 
     return _concatenate_demuxer(clip_paths, output_file, reencode_on_fail)
 


### PR DESCRIPTION
## Summary

- Replace random-access seeking with sequential `grab()`/`retrieve()` in `scan_video_frames()` for intervals ≤ 3s, avoiding expensive H.264 keyframe decoding on every frame
- Eliminate double `VideoCapture` opens per scan task by passing pre-read fps/duration into `scan_video_frames()`
- Add pHash pre-filter for similarity scans to skip costly SSIM on obviously different frames (uses existing but previously unused `compute_phash()`)
- Skip OCR on unchanged frames in text/numbers scans via fast mean pixel diff check (~0.1ms vs ~500-1000ms per OCR call)
- Downsample large regions before color averaging (>64px → 64px) and SSIM (>256px max dim) for proportional speedup
- Cache `probe_video_properties()` results (matching existing `_file_duration_cache` pattern) and consolidate `api_video_info()` from 3 file accesses to a single `cv2.VideoCapture` open

## Test plan
- [x] All 276 existing tests pass
- [ ] Manual test with `--screenspace` on a real 1080p video: run Color, Change, Similarity, Text scans and verify results match expected behavior
- [ ] Verify pause/resume preserves partial results correctly with the new sequential reading mode
- [ ] Confirm `api_video_info` returns correct duration/resolution/fps