### PR TITLE
Add filmstrip thumbnail mode to Timeline and Clips viewers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ CLI mode flags are mutually exclusive for selection (`-b/-l/-r/-C/-c/-p/-k/-S/-M
 
 `--studio` launches a Flask-based web interface for interactive artifact generation. Requires a spreadsheet (Google Sheets or Excel); can combine with `-s`, `-i/-o`, `-v`. Cannot combine with mode flags, format flags, `--viewer`, or `--regenerate`. `--insights` launches the Insights Builder for authoring research findings from generated artifacts; no spreadsheet required. Can combine with `-i/-o`, `-v`. Cannot combine with mode flags, format flags, `--viewer`, `--regenerate`, or `--studio`. `--manifest` writes a cumulative artifact manifest (`clipgen_manifest.json`) alongside generated clips; required by `--insights` and `--regenerate`. `--regenerate` re-creates all media artifacts and reels from a saved manifest without a spreadsheet.
 
-`--screenspace` launches the Screenspace frame analysis interface. Works with or without a spreadsheet (auto-discovers participant videos from the input directory). Can combine with `-s`, `-i/-o`, `-v`. Cannot combine with mode flags, format flags, `--viewer`, `--regenerate`, `--studio`, or `--insights`. `--titlecards` / `--no-titlecards` override `TITLECARDS_ENABLED` for the current run, prepending a generated title card to each output clip.
+`--screenspace` launches the Screenspace frame analysis interface. Works with or without a spreadsheet (auto-discovers participant videos from the input directory). Can combine with `-s`, `-i/-o`, `-v`. Cannot combine with mode flags, format flags, `--viewer`, `--regenerate`, `--studio`, or `--insights`. `--titlecards` / `--no-titlecards` override `TITLECARDS_ENABLED` for the current run, prepending a generated title card to each output clip. `--filmstrip` / `--no-filmstrip` override `FILMSTRIP_ENABLED` for the current run, toggling thumbnail images on timeline markers in the generated HTML viewer.
 
 Interactive-only modes without dedicated CLI flags:
 
@@ -192,6 +192,7 @@ Interactive-only modes without dedicated CLI flags:
 - `SPRITE_SHEET_THUMB_WIDTH` – `160` – pixel width of each sprite thumbnail
 - `SPRITE_SHEET_MIN_INTERVAL` – `1` – minimum seconds between sprite frames
 - `TITLECARDS_ENABLED` – `False`; set `True` or pass `--titlecards` to prepend a generated title card to each clip
+- `FILMSTRIP_ENABLED` – `False`; set `True` or pass `--filmstrip` to show thumbnail images on timeline markers in the HTML viewer
 - `TITLECARD_DURATION_SECONDS` – `2`; duration in seconds for the generated title card
 - `SCREENSPACE_MANIFEST_FILENAME` – `"screenspace_manifest.json"` – Screenspace state persistence file
 - `SCREENSPACE_DEFAULT_INTERVAL` – `1.0` – default frame sampling interval (seconds) for analysis tasks
@@ -223,8 +224,9 @@ Reference spreadsheet layout is described in [README.md](README.md).
 
 - **Opt-in**: CLI flag `--viewer` or interactive `viewer` mode from the mode selection prompt.
 - **Assets**: Static template in [assets/web/](assets/web/) (`viewer.html`, `viewer.js`, `viewer.css`). Per-run, Python copies these into the artifact directory and injects a `<script>window.CLIPGEN_DATA={...};</script>` block replacing the `<!-- CLIPGEN_DATA_HERE -->` placeholder.
-- **Data contract** (`window.CLIPGEN_DATA`): JSON object with `meta` (study, participant, generatedAt, mode, sourceSpreadsheet, sourceFileType), `artifacts` (array of {id, type, file, start, end, study, participant, category, description, cellRow, cellCol, cellA1, annotations, sourceVideo}), and `timeline` ({duration, startOffset}).
+- **Data contract** (`window.CLIPGEN_DATA`): JSON object with `meta` (study, participant, generatedAt, mode, sourceSpreadsheet, sourceFileType, filmstripEnabled), `artifacts` (array of {id, type, file, start, end, study, participant, category, description, cellRow, cellCol, cellA1, annotations, sourceVideo}), and `timeline` ({duration, startOffset}).
 - **Key functions**: `build_artifact_records_for_clip()`, `finalize_timeline_data()`, `generate_timeline_viewer()` – all in [viewer.py](viewer.py).
+- **Filmstrip mode**: Toggle button in the viewer header replaces colored timeline markers with thumbnail images from the artifacts. Screenshots/GIFs load directly; clip thumbnails are extracted client-side via canvas. Persists via `localStorage`. Default controlled by `config.FILMSTRIP_ENABLED` / `--filmstrip`.
 - Reel mode artifact collection is stubbed (returns empty artifacts list) for future enhancement.
 
 ## Gallery HTML Viewer

--- a/assets/web/timeline-viewer.html
+++ b/assets/web/timeline-viewer.html
@@ -10,10 +10,15 @@
   <header id="pageHeader">
     <div id="pageHeaderTop">
       <h1>clipgen <span class="header-light">Participant Timelines</span></h1>
-      <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
-        <span class="theme-toggle-icon theme-icon-sun"></span>
-        <span class="theme-toggle-icon theme-icon-moon"></span>
-      </button>
+      <div class="header-buttons">
+        <button id="filmstripToggle" type="button" aria-label="Toggle filmstrip thumbnails" aria-pressed="false">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1 3.5C1 2.67157 1.67157 2 2.5 2H13.5C14.3284 2 15 2.67157 15 3.5V12.5C15 13.3284 14.3284 14 13.5 14H2.5C1.67157 14 1 13.3284 1 12.5V3.5ZM2.5 3.75C2.5 3.61193 2.61193 3.5 2.75 3.5H4.25C4.38807 3.5 4.5 3.61193 4.5 3.75V4.75C4.5 4.88807 4.38807 5 4.25 5H2.75C2.61193 5 2.5 4.88807 2.5 4.75V3.75ZM6.25 3.5C6.11193 3.5 6 3.61193 6 3.75V7.25C6 7.38807 6.11193 7.5 6.25 7.5H9.75C9.88807 7.5 10 7.38807 10 7.25V3.75C10 3.61193 9.88807 3.5 9.75 3.5H6.25ZM6 8.75C6 8.61193 6.11193 8.5 6.25 8.5H9.75C9.88807 8.5 10 8.61193 10 8.75V12.25C10 12.3881 9.88807 12.5 9.75 12.5H6.25C6.11193 12.5 6 12.3881 6 12.25V8.75ZM11.75 3.5C11.6119 3.5 11.5 3.61193 11.5 3.75V4.75C11.5 4.88807 11.6119 5 11.75 5H13.25C13.3881 5 13.5 4.88807 13.5 4.75V3.75C13.5 3.61193 13.3881 3.5 13.25 3.5H11.75ZM2.5 11.25C2.5 11.1119 2.61193 11 2.75 11H4.25C4.38807 11 4.5 11.1119 4.5 11.25V12.25C4.5 12.3881 4.38807 12.5 4.25 12.5H2.75C2.61193 12.5 2.5 12.3881 2.5 12.25V11.25ZM11.75 11C11.6119 11 11.5 11.1119 11.5 11.25V12.25C11.5 12.3881 11.6119 12.5 11.75 12.5H13.25C13.3881 12.5 13.5 12.3881 13.5 12.25V11.25C13.5 11.1119 13.3881 11 13.25 11H11.75ZM2.5 8.75C2.5 8.61193 2.61193 8.5 2.75 8.5H4.25C4.38807 8.5 4.5 8.61193 4.5 8.75V9.75C4.5 9.88807 4.38807 10 4.25 10H2.75C2.61193 10 2.5 9.88807 2.5 9.75V8.75ZM11.75 8.5C11.6119 8.5 11.5 8.61193 11.5 8.75V9.75C11.5 9.88807 11.6119 10 11.75 10H13.25C13.3881 10 13.5 9.88807 13.5 9.75V8.75C13.5 8.61193 13.3881 8.5 13.25 8.5H11.75ZM2.5 6.25C2.5 6.11193 2.61193 6 2.75 6H4.25C4.38807 6 4.5 6.11193 4.5 6.25V7.25C4.5 7.38807 4.38807 7.5 4.25 7.5H2.75C2.61193 7.5 2.5 7.38807 2.5 7.25V6.25ZM11.75 6C11.6119 6 11.5 6.11193 11.5 6.25V7.25C11.5 7.38807 11.6119 7.5 11.75 7.5H13.25C13.3881 7.5 13.5 7.38807 13.5 7.25V6.25C13.5 6.11193 13.3881 6 13.25 6H11.75Z" fill="currentColor"/></svg>
+        </button>
+        <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
+          <span class="theme-toggle-icon theme-icon-sun"></span>
+          <span class="theme-toggle-icon theme-icon-moon"></span>
+        </button>
+      </div>
     </div>
     <div id="headerMeta">
       <span id="studyName"></span>

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -100,31 +100,50 @@ body {
 #studyName:not(:empty)::before { content: "Study:"; font-weight: 600; }
 #generatedAt:not(:empty)::before { content: "Generated:"; font-weight: 600; }
 
-#themeToggle {
+.header-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+#themeToggle,
+#filmstripToggle {
   position: relative;
   width: 32px;
   height: 32px;
   border-radius: 999px;
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
+  color: var(--color-text-dim);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
 }
 
-#themeToggle:hover {
+#filmstripToggle svg { width: 16px; height: 16px; }
+
+#filmstripToggle[aria-pressed="true"] {
+  border-color: var(--color-accent);
+  background: var(--color-selected);
+  color: var(--color-accent);
+}
+
+#themeToggle:hover,
+#filmstripToggle:hover {
   background: var(--color-surface);
   box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
 }
 
-#themeToggle:active {
+#themeToggle:active,
+#filmstripToggle:active {
   transform: scale(0.96);
 }
 
-#themeToggle:focus-visible {
+#themeToggle:focus-visible,
+#filmstripToggle:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
@@ -283,6 +302,30 @@ body {
 .artifact-marker.filtered-out {
   opacity: 0.12;
   pointer-events: none;
+}
+
+.artifact-marker.filmstrip-thumb {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-width: 1px;
+  border-color: rgba(0, 0, 0, 0.2);
+  border-style: solid;
+}
+
+.artifact-marker.filmstrip-thumb.filmstrip-sev-border {
+  border-bottom-width: 3px;
+}
+
+.artifact-marker.filmstrip-loading {
+  background: linear-gradient(90deg, var(--color-surface-alt) 25%, var(--color-surface) 50%, var(--color-surface-alt) 75%);
+  background-size: 200% 100%;
+  animation: filmstrip-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes filmstrip-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 .timeline-track-wrap {
@@ -906,6 +949,10 @@ body {
   .artifact-media.thumb-loaded img {
     animation: none;
   }
+
+  .artifact-marker.filmstrip-loading {
+    animation: none;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -950,6 +997,10 @@ body {
       0 0 0 2px var(--color-selected-ring),
       0 0 0 5px rgba(56, 189, 248, 0.9),
       0 0 18px rgba(0, 0, 0, 0.45);
+  }
+
+  .artifact-marker.filmstrip-thumb {
+    border-color: rgba(255, 255, 255, 0.15);
   }
 }
 
@@ -1011,6 +1062,10 @@ html[data-theme="dark"] {
 
 html[data-theme="dark"] .artifact-marker:hover {
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.55);
+}
+
+html[data-theme="dark"] .artifact-marker.filmstrip-thumb {
+  border-color: rgba(255, 255, 255, 0.15);
 }
 
 html[data-theme="dark"] .artifact-marker.selected {

--- a/assets/web/viewer.html
+++ b/assets/web/viewer.html
@@ -10,10 +10,15 @@
   <header id="pageHeader">
     <div id="pageHeaderTop">
       <h1>clipgen <span class="header-light">Timeline Viewer</span></h1>
-      <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
-        <span class="theme-toggle-icon theme-icon-sun"></span>
-        <span class="theme-toggle-icon theme-icon-moon"></span>
-      </button>
+      <div class="header-buttons">
+        <button id="filmstripToggle" type="button" aria-label="Toggle filmstrip thumbnails" aria-pressed="false">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1 3.5C1 2.67157 1.67157 2 2.5 2H13.5C14.3284 2 15 2.67157 15 3.5V12.5C15 13.3284 14.3284 14 13.5 14H2.5C1.67157 14 1 13.3284 1 12.5V3.5ZM2.5 3.75C2.5 3.61193 2.61193 3.5 2.75 3.5H4.25C4.38807 3.5 4.5 3.61193 4.5 3.75V4.75C4.5 4.88807 4.38807 5 4.25 5H2.75C2.61193 5 2.5 4.88807 2.5 4.75V3.75ZM6.25 3.5C6.11193 3.5 6 3.61193 6 3.75V7.25C6 7.38807 6.11193 7.5 6.25 7.5H9.75C9.88807 7.5 10 7.38807 10 7.25V3.75C10 3.61193 9.88807 3.5 9.75 3.5H6.25ZM6 8.75C6 8.61193 6.11193 8.5 6.25 8.5H9.75C9.88807 8.5 10 8.61193 10 8.75V12.25C10 12.3881 9.88807 12.5 9.75 12.5H6.25C6.11193 12.5 6 12.3881 6 12.25V8.75ZM11.75 3.5C11.6119 3.5 11.5 3.61193 11.5 3.75V4.75C11.5 4.88807 11.6119 5 11.75 5H13.25C13.3881 5 13.5 4.88807 13.5 4.75V3.75C13.5 3.61193 13.3881 3.5 13.25 3.5H11.75ZM2.5 11.25C2.5 11.1119 2.61193 11 2.75 11H4.25C4.38807 11 4.5 11.1119 4.5 11.25V12.25C4.5 12.3881 4.38807 12.5 4.25 12.5H2.75C2.61193 12.5 2.5 12.3881 2.5 12.25V11.25ZM11.75 11C11.6119 11 11.5 11.1119 11.5 11.25V12.25C11.5 12.3881 11.6119 12.5 11.75 12.5H13.25C13.3881 12.5 13.5 12.3881 13.5 12.25V11.25C13.5 11.1119 13.3881 11 13.25 11H11.75ZM2.5 8.75C2.5 8.61193 2.61193 8.5 2.75 8.5H4.25C4.38807 8.5 4.5 8.61193 4.5 8.75V9.75C4.5 9.88807 4.38807 10 4.25 10H2.75C2.61193 10 2.5 9.88807 2.5 9.75V8.75ZM11.75 8.5C11.6119 8.5 11.5 8.61193 11.5 8.75V9.75C11.5 9.88807 11.6119 10 11.75 10H13.25C13.3881 10 13.5 9.88807 13.5 9.75V8.75C13.5 8.61193 13.3881 8.5 13.25 8.5H11.75ZM2.5 6.25C2.5 6.11193 2.61193 6 2.75 6H4.25C4.38807 6 4.5 6.11193 4.5 6.25V7.25C4.5 7.38807 4.38807 7.5 4.25 7.5H2.75C2.61193 7.5 2.5 7.38807 2.5 7.25V6.25ZM11.75 6C11.6119 6 11.5 6.11193 11.5 6.25V7.25C11.5 7.38807 11.6119 7.5 11.75 7.5H13.25C13.3881 7.5 13.5 7.38807 13.5 7.25V6.25C13.5 6.11193 13.3881 6 13.25 6H11.75Z" fill="currentColor"/></svg>
+        </button>
+        <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
+          <span class="theme-toggle-icon theme-icon-sun"></span>
+          <span class="theme-toggle-icon theme-icon-moon"></span>
+        </button>
+      </div>
     </div>
     <div id="headerMeta">
       <span id="studyName"></span>

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -18,6 +18,12 @@
   var _thumbObserver = null;
   var _thumbCache = {};
 
+  var _filmstripEnabled = false;
+  var _filmstripObserver = null;
+  var _filmstripThumbQueue = [];
+  var _filmstripThumbProcessing = false;
+  var FILMSTRIP_STORAGE_KEY = "clipgen-viewer-filmstrip";
+
   var SORT_DEFAULT_DIR = {
     severity: "desc",
     chrono: "asc",
@@ -246,6 +252,183 @@
     }
   }
 
+  // ---- Filmstrip mode ----
+
+  function initFilmstripToggle() {
+    var defaultOn = data && data.meta && data.meta.filmstripEnabled;
+    var stored = null;
+    try { stored = window.localStorage.getItem(FILMSTRIP_STORAGE_KEY); } catch (_) {}
+    if (stored === "true") _filmstripEnabled = true;
+    else if (stored === "false") _filmstripEnabled = false;
+    else _filmstripEnabled = !!defaultOn;
+
+    var btn = qs("#filmstripToggle");
+    if (btn) {
+      btn.addEventListener("click", toggleFilmstrip);
+      updateFilmstripButton();
+    }
+  }
+
+  function updateFilmstripButton() {
+    var btn = qs("#filmstripToggle");
+    if (btn) btn.setAttribute("aria-pressed", _filmstripEnabled ? "true" : "false");
+  }
+
+  function toggleFilmstrip() {
+    _filmstripEnabled = !_filmstripEnabled;
+    try { window.localStorage.setItem(FILMSTRIP_STORAGE_KEY, _filmstripEnabled ? "true" : "false"); } catch (_) {}
+    updateFilmstripButton();
+    if (_filmstripEnabled) applyFilmstripMode();
+    else removeFilmstripMode();
+  }
+
+  function applyFilmstripMode() {
+    if (_filmstripObserver) { _filmstripObserver.disconnect(); _filmstripObserver = null; }
+    _filmstripThumbQueue = [];
+    _filmstripThumbProcessing = false;
+
+    var markers = qsa(".artifact-marker");
+    if (!markers.length) return;
+
+    var needsObserver = [];
+
+    markers.forEach(function (m) {
+      var id = m.dataset.id;
+      var a = findArtifact(id);
+      if (!a) return;
+
+      var hasSev = !!(a.severity || "").trim();
+
+      if (a.type === "screen" || a.type === "gif") {
+        m.style.backgroundImage = "url(" + encodeURI(a.file) + ")";
+        m.classList.add("filmstrip-thumb");
+        if (hasSev) m.classList.add("filmstrip-sev-border");
+      } else if (a.type === "clip") {
+        if (_thumbCache[a.id]) {
+          m.style.backgroundImage = "url(" + _thumbCache[a.id] + ")";
+          m.classList.add("filmstrip-thumb");
+          if (hasSev) m.classList.add("filmstrip-sev-border");
+        } else {
+          m.classList.add("filmstrip-loading");
+          if (hasSev) m.classList.add("filmstrip-sev-border");
+          needsObserver.push({ el: m, artifact: a });
+        }
+      }
+    });
+
+    if (!needsObserver.length) return;
+
+    function enqueueMarker(item) {
+      _filmstripThumbQueue.push(item);
+      processFilmstripThumbQueue();
+    }
+
+    if (typeof IntersectionObserver !== "undefined") {
+      _filmstripObserver = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (!entry.isIntersecting) return;
+          _filmstripObserver.unobserve(entry.target);
+          var id = entry.target.dataset.id;
+          var a = findArtifact(id);
+          if (a) enqueueMarker({ el: entry.target, artifact: a });
+        });
+      }, { rootMargin: "200px 0px" });
+      needsObserver.forEach(function (item) { _filmstripObserver.observe(item.el); });
+    } else {
+      needsObserver.forEach(enqueueMarker);
+    }
+  }
+
+  function generateFilmstripThumb(markerEl, artifact, callback) {
+    var done = false;
+    function finish() {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      video.onerror = null;
+      video.onloadedmetadata = null;
+      video.onseeked = null;
+      video.src = "";
+      video.load();
+      callback();
+    }
+
+    var video = document.createElement("video");
+    video.preload = "metadata";
+    video.muted = true;
+    video.playsInline = true;
+    video.src = artifact.file;
+
+    var timer = setTimeout(finish, 8000);
+
+    video.onerror = function () {
+      markerEl.classList.remove("filmstrip-loading");
+      finish();
+    };
+
+    video.onloadedmetadata = function () {
+      var dur = video.duration;
+      if (!dur || !isFinite(dur)) { markerEl.classList.remove("filmstrip-loading"); finish(); return; }
+      var seek = Math.min(Math.max(dur * 0.25, 0.5), 5, dur - 0.01);
+      video.currentTime = Math.max(0, seek);
+    };
+
+    video.onseeked = function () {
+      try {
+        var canvas = document.createElement("canvas");
+        canvas.width = 160;
+        canvas.height = 90;
+        var ctx = canvas.getContext("2d");
+        ctx.drawImage(video, 0, 0, 160, 90);
+        canvas.toBlob(function (blob) {
+          if (!blob) { markerEl.classList.remove("filmstrip-loading"); finish(); return; }
+          var url = URL.createObjectURL(blob);
+          _thumbCache[artifact.id] = url;
+          if (_filmstripEnabled && markerEl.classList.contains("filmstrip-loading")) {
+            markerEl.style.backgroundImage = "url(" + url + ")";
+            markerEl.classList.remove("filmstrip-loading");
+            markerEl.classList.add("filmstrip-thumb");
+          }
+          finish();
+        }, "image/jpeg", 0.7);
+      } catch (e) {
+        markerEl.classList.remove("filmstrip-loading");
+        finish();
+      }
+    };
+  }
+
+  function processFilmstripThumbQueue() {
+    if (_filmstripThumbProcessing || !_filmstripThumbQueue.length) return;
+    _filmstripThumbProcessing = true;
+    var item = _filmstripThumbQueue.shift();
+    if (_thumbCache[item.artifact.id]) {
+      if (_filmstripEnabled && item.el.classList.contains("filmstrip-loading")) {
+        item.el.style.backgroundImage = "url(" + _thumbCache[item.artifact.id] + ")";
+        item.el.classList.remove("filmstrip-loading");
+        item.el.classList.add("filmstrip-thumb");
+      }
+      _filmstripThumbProcessing = false;
+      processFilmstripThumbQueue();
+      return;
+    }
+    generateFilmstripThumb(item.el, item.artifact, function () {
+      _filmstripThumbProcessing = false;
+      processFilmstripThumbQueue();
+    });
+  }
+
+  function removeFilmstripMode() {
+    if (_filmstripObserver) { _filmstripObserver.disconnect(); _filmstripObserver = null; }
+    _filmstripThumbQueue = [];
+    _filmstripThumbProcessing = false;
+
+    qsa(".artifact-marker.filmstrip-thumb, .artifact-marker.filmstrip-loading").forEach(function (m) {
+      m.classList.remove("filmstrip-thumb", "filmstrip-sev-border", "filmstrip-loading");
+      m.style.backgroundImage = "";
+    });
+  }
+
   // ---- Initialization ----
 
   var THEME_STORAGE_KEY = "clipgen-viewer-theme";
@@ -286,6 +469,9 @@
       initSortToolbar();
       bindFilterEvents();
     }
+
+    initFilmstripToggle();
+    if (_filmstripEnabled) applyFilmstripMode();
   });
 
   function initThemeToggle() {

--- a/cli.py
+++ b/cli.py
@@ -329,6 +329,22 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
 
     parser.set_defaults(titlecards=None)
 
+    filmstrip_grp = parser.add_argument_group("filmstrip (choose at most one)")
+    filmstrip_group = filmstrip_grp.add_mutually_exclusive_group()
+    filmstrip_group.add_argument(
+        "--filmstrip",
+        dest="filmstrip",
+        action="store_true",
+        help="Enable filmstrip thumbnail mode on timeline markers in the HTML viewer",
+    )
+    filmstrip_group.add_argument(
+        "--no-filmstrip",
+        dest="filmstrip",
+        action="store_false",
+        help="Disable filmstrip thumbnail mode on timeline markers in the HTML viewer",
+    )
+    parser.set_defaults(filmstrip=None)
+
     return parser.parse_args()
 
 
@@ -1089,6 +1105,10 @@ def main() -> None:
     # Optional per-run override for titlecards setting
     if getattr(args, "titlecards", None) is not None:
         config.TITLECARDS_ENABLED = bool(args.titlecards)
+
+    # Optional per-run override for filmstrip setting
+    if getattr(args, "filmstrip", None) is not None:
+        config.FILMSTRIP_ENABLED = bool(args.filmstrip)
 
     # Optional per-run overrides for input/output directories
     if getattr(args, "input", None) is not None:

--- a/config.py
+++ b/config.py
@@ -9,8 +9,9 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.61"
+VERSIONNUM: str = "0.9.62"
 TITLECARDS_ENABLED: bool = False
+FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2
 WORKSHEET_PRIORITY: List[str] = [
     "Sheet1",
@@ -189,6 +190,7 @@ SETTINGS_DESCRIPTIONS: Dict[str, str] = {
     "HIGHLIGHTS_REEL_DURATION_SECONDS": "Maximum duration in seconds for the highlights reel time budget.",
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
+    "FILMSTRIP_ENABLED": "Show thumbnail images on timeline markers instead of solid colors (in the HTML viewer).",
 }
 
 # Studio-exposed settings with UI metadata (group, type, constraints).

--- a/server.py
+++ b/server.py
@@ -6,7 +6,6 @@ start_combined_server(), and exposes REST endpoints for sheet data
 access, artifact generation, reel building, and viewer creation.
 """
 
-import hashlib
 import json
 import sys
 import webbrowser

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -28,6 +28,7 @@ def _base_args(**overrides):
         "spreadsheet": None,
         "viewer": False,
         "titlecards": None,
+        "filmstrip": None,
         "screenspace": False,
     }
     args.update(overrides)
@@ -63,6 +64,23 @@ def test_parse_arguments_titlecards_flags(monkeypatch):
     monkeypatch.setattr("sys.argv", ["clipgen.py", "--no-titlecards"])
     args = cli.parse_arguments()
     assert args.titlecards is False
+
+
+def test_parse_arguments_filmstrip_flags(monkeypatch):
+    # Default: no flag → None (use config default)
+    monkeypatch.setattr("sys.argv", ["clipgen.py"])
+    args = cli.parse_arguments()
+    assert getattr(args, "filmstrip", None) is None
+
+    # --filmstrip → True
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--filmstrip"])
+    args = cli.parse_arguments()
+    assert args.filmstrip is True
+
+    # --no-filmstrip → False
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--no-filmstrip"])
+    args = cli.parse_arguments()
+    assert args.filmstrip is False
 
 
 def test_parse_cli_mode_args_parses_mixed_line_separators():

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -3,7 +3,6 @@ import time
 
 import config
 import insights
-import utils
 
 
 def _redirect_output(tmp_path, monkeypatch):

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1,6 +1,5 @@
 """Tests for Screenspace server API endpoints."""
 
-import json
 
 import pytest
 

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -48,6 +48,18 @@ def test_finalize_timeline_data_empty_artifacts():
     assert data["artifacts"] == []
 
 
+def test_finalize_timeline_data_includes_filmstrip_meta(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "FILMSTRIP_ENABLED", False)
+    data = viewer.finalize_timeline_data([])
+    assert data["meta"]["filmstripEnabled"] is False
+
+    monkeypatch.setattr(config, "FILMSTRIP_ENABLED", True)
+    data = viewer.finalize_timeline_data([])
+    assert data["meta"]["filmstripEnabled"] is True
+
+
 def test_finalize_timeline_data_includes_reels():
     reels = [{"id": "reel_1", "file": "r.mp4"}]
     data = viewer.finalize_timeline_data([], reels=reels)

--- a/viewer.py
+++ b/viewer.py
@@ -113,6 +113,7 @@ def finalize_timeline_data(
             "mode": mode,
             "sourceSpreadsheet": worksheet_title,
             "sourceFileType": "excel" if is_excel else "google",
+            "filmstripEnabled": config.FILMSTRIP_ENABLED,
         },
         "artifacts": artifacts,
         "timeline": {


### PR DESCRIPTION
## Summary
- Adds a toggle button (filmstrip icon) in the viewer header that replaces colored timeline markers with thumbnail images from artifacts
- Screenshots/GIFs load directly as background images; clip thumbnails are lazily extracted client-side via canvas with IntersectionObserver
- Severity is preserved as a thin colored bottom border on filmstrip markers
- Preference persists via localStorage; default controlled by `config.FILMSTRIP_ENABLED` and `--filmstrip`/`--no-filmstrip` CLI flags
- Applied to both viewer templates: `viewer.html` (Clips Viewer) and `timeline-viewer.html` (Participant Timelines)

## Test plan
- [ ] Generate a clips viewer with clip/screenshot/gif artifacts and verify filmstrip toggle works (on/off, thumbnails load, severity borders visible)
- [ ] Generate a participant timeline viewer and verify the same behavior
- [ ] Verify localStorage persistence across page reloads
- [ ] Verify dark mode and reduced-motion compatibility
- [ ] `uv run pytest -c tests/pytest.ini` passes