### PR TITLE
Filmstrip: fill marker width; disable expand for single-track timelines

### DIFF
--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -354,7 +354,13 @@ body {
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.track-expand-btn:hover {
+.track-expand-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
+}
+
+.track-expand-btn:hover:not(:disabled) {
   border-color: var(--color-accent);
   color: var(--color-accent);
   background: var(--color-surface);

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -342,8 +342,7 @@
   function generateFilmstripThumb(markerEl, artifact, callback) {
     var STRIP_HEIGHT = 88;
     var MIN_FRAMES = 2;
-    var MAX_FRAMES = 8;
-    var STEP_SECONDS = 10;
+    var MAX_FRAMES = 12;
 
     var done = false;
     function finish() {
@@ -380,8 +379,10 @@
       var clipDur = clipEnd - clipStart;
       if (clipDur <= 0) clipDur = dur;
 
-      var numFrames = Math.min(MAX_FRAMES, Math.max(MIN_FRAMES, Math.ceil(clipDur / STEP_SECONDS)));
-      var thumbW = Math.round(STRIP_HEIGHT * (video.videoWidth / video.videoHeight)) || 156;
+      var aspect = (video.videoWidth / video.videoHeight) || (16 / 9);
+      var thumbW = Math.round(STRIP_HEIGHT * aspect);
+      var markerW = markerEl.offsetWidth || thumbW;
+      var numFrames = Math.min(MAX_FRAMES, Math.max(MIN_FRAMES, Math.ceil(markerW / thumbW)));
 
       var canvas = document.createElement("canvas");
       canvas.width = thumbW * numFrames;
@@ -891,11 +892,31 @@
     }
   }
 
+  function updateExpandButtonState(trackEl) {
+    var btn = trackEl.parentNode && trackEl.parentNode.querySelector(".track-expand-btn");
+    if (!btn) return;
+    var markers = trackEl._trackMarkers;
+    if (!markers || !markers.length) { btn.disabled = true; return; }
+    var artifactList = markers.map(function (m) { return m.artifact; });
+    var packing = computeTrackAssignments(artifactList, state.duration);
+    var canExpand = packing.trackCount > 1;
+    btn.disabled = !canExpand;
+    if (!canExpand && state.expandedTracks[trackEl._trackId]) {
+      state.expandedTracks[trackEl._trackId] = false;
+      applyTrackLayout(trackEl);
+      btn.classList.remove("expanded");
+      btn.setAttribute("aria-expanded", "false");
+      btn.title = "Expand tracks";
+      btn.setAttribute("aria-label", btn.title);
+    }
+  }
+
   function toggleTrackExpand(trackEl) {
+    var btn = trackEl.parentNode && trackEl.parentNode.querySelector(".track-expand-btn");
+    if (btn && btn.disabled) return;
     var trackId = trackEl._trackId;
     state.expandedTracks[trackId] = !state.expandedTracks[trackId];
     applyTrackLayout(trackEl);
-    var btn = trackEl.parentNode.querySelector(".track-expand-btn");
     if (btn) {
       var expanded = !!state.expandedTracks[trackId];
       btn.classList.toggle("expanded", expanded);
@@ -941,6 +962,7 @@
     track._trackMarkers = markers;
     track._trackId = "unified";
     applyTrackLayout(track);
+    updateExpandButtonState(track);
 
     var wrapBtn = track.parentNode && track.parentNode.querySelector(".track-expand-btn");
     if (wrapBtn && !wrapBtn._bound) {
@@ -1459,6 +1481,7 @@
         return function () { toggleTrackExpand(t); };
       })(track));
       row.appendChild(expandBtn);
+      updateExpandButtonState(track);
 
       container.appendChild(row);
     });

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.63"
+VERSIONNUM: str = "0.9.64"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2


### PR DESCRIPTION
## Summary
- Filmstrip thumbnails now generate enough frames to fill the full marker width (based on marker pixel width / thumb aspect ratio, up to 12 frames), eliminating gaps at the right edge of wider markers
- Track expand/collapse button is automatically disabled (dimmed, non-interactive) when all artifacts fit on a single track without overlapping
- Applies to both the unified timeline and per-participant timeline rows

## Test plan
- [ ] Toggle filmstrip on a viewer with varying-width markers — verify thumbnails fill edge-to-edge
- [ ] Verify expand button is dimmed for participants with non-overlapping artifacts
- [ ] Verify expand button still works for participants with overlapping artifacts
- [ ] `uv run pytest -c tests/pytest.ini` passes