### PR TITLE
Migrate all CSS files to design token system

### DIFF
--- a/assets/web/gallery.css
+++ b/assets/web/gallery.css
@@ -43,25 +43,25 @@ body {
 /* Header */
 
 #pageHeader {
-  padding: 1.2rem 1.5rem 0.8rem;
+  padding: var(--space-5) var(--space-5) var(--space-3);
   max-width: 1120px;
-  margin: 1.5rem auto 0;
+  margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 1px solid var(--color-panel-border);
   border-bottom: none;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
 }
 
 #pageHeaderTop {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 #pageHeader h1 {
-  font-size: 1.25rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   letter-spacing: 0.02em;
 }
@@ -73,14 +73,14 @@ body {
 
 #headerMeta {
   display: flex;
-  gap: 1.2rem;
-  margin-top: 0.3rem;
-  font-size: 0.85rem;
+  gap: var(--space-5);
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
 #headerMeta span:not(:empty)::before {
-  margin-right: 0.3rem;
+  margin-right: var(--space-2);
 }
 
 #sourceVideo:not(:empty)::before { content: "Source:"; font-weight: 600; }
@@ -92,7 +92,7 @@ body {
   position: relative;
   width: 32px;
   height: 32px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   display: inline-flex;
@@ -100,7 +100,7 @@ body {
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
 }
 
 #themeToggle:hover {
@@ -121,8 +121,8 @@ body {
   position: absolute;
   width: 16px;
   height: 16px;
-  border-radius: 999px;
-  transition: opacity 0.22s ease, transform 0.22s ease;
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
 
 .theme-icon-sun {
@@ -156,13 +156,13 @@ body {
 #galleryInfo {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 0.6rem 1.5rem;
+  padding: var(--space-3) var(--space-5);
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
   border-right: 1px solid var(--color-panel-border);
   display: flex;
-  gap: 1.5rem;
-  font-size: 0.85rem;
+  gap: var(--space-5);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
@@ -171,14 +171,14 @@ body {
 #galleryGrid {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 1rem 1.5rem 2rem;
+  padding: var(--space-4) var(--space-5) var(--space-6);
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0 0 18px 18px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .gallery-card {
@@ -188,12 +188,12 @@ body {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   cursor: pointer;
-  transition: transform 0.12s ease, box-shadow 0.18s ease;
+  transition: transform var(--duration-fast) ease, box-shadow var(--duration-fast) ease;
 }
 
 .gallery-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px var(--color-panel-shadow);
+  box-shadow: var(--shadow-lg);
 }
 
 .gallery-card img {
@@ -208,11 +208,11 @@ body {
   position: absolute;
   bottom: 0;
   left: 0;
-  padding: 0.2rem 0.5rem;
+  padding: var(--space-1) var(--space-2);
   background: rgba(0, 0, 0, 0.7);
   color: #ffffff;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   border-radius: 0 var(--radius) 0 0;
   pointer-events: none;
 }
@@ -221,10 +221,10 @@ body {
 
 #emptyState {
   max-width: 1120px;
-  margin: 2rem auto;
+  margin: var(--space-6) auto;
   text-align: center;
   color: var(--color-text-dim);
-  font-size: 1.1rem;
+  font-size: var(--text-lg);
 }
 
 .hidden {
@@ -236,7 +236,7 @@ body {
 #lightbox {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-modal);
   background: var(--color-overlay-bg);
   backdrop-filter: blur(8px);
   display: flex;
@@ -270,7 +270,7 @@ body {
   font-size: 2.5rem;
   cursor: pointer;
   opacity: 0.7;
-  transition: opacity 0.15s ease;
+  transition: opacity var(--duration-fast) ease;
   line-height: 1;
 }
 
@@ -289,8 +289,8 @@ body {
   font-size: 3rem;
   cursor: pointer;
   opacity: 0.5;
-  transition: opacity 0.15s ease;
-  padding: 1rem;
+  transition: opacity var(--duration-fast) ease;
+  padding: var(--space-4);
   line-height: 1;
 }
 
@@ -309,7 +309,7 @@ body {
   transform: translateX(-50%);
   color: #ffffff;
   font-family: var(--font-mono);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   text-align: center;
   opacity: 0.8;
 }

--- a/assets/web/insights-builder.css
+++ b/assets/web/insights-builder.css
@@ -61,25 +61,25 @@ body {
 /* ---- Header ---- */
 
 #builderHeader {
-  padding: 1.2rem 1.5rem 0.5rem;
+  padding: var(--space-5) var(--space-5) var(--space-2);
   max-width: 1120px;
-  margin: 1.5rem auto 0;
+  margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 1px solid var(--color-panel-border);
   border-bottom: none;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
 }
 
 #headerTop {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 #builderHeader h1 {
-  font-size: 1.15rem;
+  font-size: var(--text-lg);
   font-weight: 700;
   white-space: nowrap;
 }
@@ -92,26 +92,26 @@ body {
 #headerActions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 #unsavedIndicator {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-causes);
   font-weight: 600;
-  padding: 0.2rem 0.5rem;
+  padding: var(--space-1) var(--space-2);
   background: rgba(234, 88, 12, 0.08);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 #headerMeta {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
-  margin-top: 0.2rem;
+  margin-top: var(--space-1);
 }
 
 .meta-sep {
-  margin: 0 0.4rem;
+  margin: 0 var(--space-2);
 }
 
 /* ---- Buttons ---- */
@@ -119,16 +119,16 @@ body {
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.8rem;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
   font-weight: 500;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   background: var(--color-surface);
   color: var(--color-text);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  transition: background var(--duration-fast), border-color var(--duration-fast), opacity var(--duration-fast);
   white-space: nowrap;
 }
 
@@ -152,8 +152,8 @@ body {
 }
 
 .btn-small {
-  padding: 0.2rem 0.5rem;
-  font-size: 0.72rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
 }
 
 .btn-danger {
@@ -171,7 +171,7 @@ body {
   position: relative;
   width: 32px;
   height: 32px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   display: inline-flex;
@@ -179,7 +179,7 @@ body {
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
   flex-shrink: 0;
 }
 
@@ -201,8 +201,8 @@ body {
   position: absolute;
   width: 16px;
   height: 16px;
-  border-radius: 999px;
-  transition: opacity 0.22s ease, transform 0.22s ease;
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
 
 .theme-icon-sun {
@@ -237,10 +237,10 @@ body {
   display: flex;
   min-height: calc(100vh - 200px);
   max-width: 1120px;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto var(--space-8);
   background: var(--color-panel-bg);
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-xl);
   border: 1px solid var(--color-panel-border);
   border-top: none;
   overflow: hidden;
@@ -258,7 +258,7 @@ body {
   background: var(--color-panel-bg);
   position: relative;
   overflow: hidden;
-  transition: width 0.15s ease, min-width 0.15s ease;
+  transition: width var(--duration-fast) ease, min-width var(--duration-fast) ease;
 }
 
 #mediaLibrary.collapsed {
@@ -271,7 +271,7 @@ body {
 }
 
 #mediaLibrary .sidebar-collapsible {
-  transition: opacity 0.1s ease;
+  transition: opacity var(--duration-fast) ease;
 }
 
 #mediaLibrary.collapsed #filterPanel,
@@ -299,12 +299,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.6rem 0.8rem;
+  padding: var(--space-3) var(--space-3);
   border-bottom: 1px solid var(--color-border);
 }
 
 #sidebarHeader h2 {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 600;
 }
 
@@ -312,13 +312,13 @@ body {
   width: 24px;
   height: 24px;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.15s;
+  transition: transform var(--duration-fast);
   flex-shrink: 0;
 }
 
@@ -329,7 +329,7 @@ body {
   bottom: 0;
   width: 5px;
   cursor: col-resize;
-  z-index: 10;
+  z-index: var(--z-float);
 }
 
 #resizeHandle:hover,
@@ -341,41 +341,41 @@ body {
 /* ---- Filter panel ---- */
 
 #filterPanel {
-  padding: 0.6rem 0.8rem;
+  padding: var(--space-3) var(--space-3);
   border-bottom: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 .filter-row {
   display: flex;
-  gap: 0.4rem;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
 #filterPanel select {
   flex: 1;
   min-width: 0;
-  padding: 0.3rem 0.4rem;
-  font-size: 0.75rem;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-xs);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
 }
 
 #typeFilters {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-items: center;
 }
 
 #typeFilters label {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   display: flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: var(--space-1);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -387,10 +387,10 @@ body {
 
 #filterSearch {
   width: 100%;
-  padding: 0.35rem 0.5rem;
-  font-size: 0.75rem;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-xs);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
 }
@@ -405,14 +405,14 @@ body {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding: 0.3rem 0.8rem;
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--color-border);
 }
 
 .artifact-sort-bar {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: var(--space-1);
   flex-shrink: 0;
 }
 
@@ -421,11 +421,11 @@ body {
   min-width: 26px;
   height: 26px;
   padding: 0 4px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   color: var(--color-text);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
@@ -433,7 +433,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0;
-  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, color var(--duration-fast) ease;
 }
 
 .artifact-sort-btn:hover {
@@ -442,7 +442,7 @@ body {
 }
 
 .artifact-sort-btn .sort-dir {
-  font-size: 0.62rem;
+  font-size: var(--text-xs);
   font-weight: 700;
   margin-left: 1px;
   opacity: 0.95;
@@ -459,10 +459,10 @@ body {
 #artifactGrid {
   flex: 1;
   overflow-y: auto;
-  padding: 0.5rem;
+  padding: var(--space-2);
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-content: start;
 }
 
@@ -478,7 +478,7 @@ body {
   border-radius: var(--radius);
   overflow: hidden;
   cursor: grab;
-  transition: box-shadow 0.15s, border-color 0.15s;
+  transition: box-shadow var(--duration-fast), border-color var(--duration-fast);
 }
 
 .artifact-card:hover {
@@ -508,24 +508,24 @@ body {
 }
 
 .artifact-meta {
-  padding: 0.4rem 0.5rem;
+  padding: var(--space-2) var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .artifact-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .badge {
   display: inline-block;
-  padding: 0.1rem 0.35rem;
-  font-size: 0.65rem;
+  padding: 0.1rem var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 600;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
 }
 
@@ -568,7 +568,7 @@ body {
 .badge-severity.sev-unknown { background: var(--sev-unknown); }
 
 .artifact-desc {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -576,7 +576,7 @@ body {
 }
 
 .artifact-time {
-  font-size: 0.65rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-family: var(--font-mono);
 }
@@ -585,10 +585,10 @@ body {
 
 .sev-pill {
   display: inline-block;
-  padding: 0.1rem 0.4rem;
-  font-size: 0.68rem;
+  padding: 0.1rem var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 700;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: #fff;
 }
 
@@ -606,18 +606,18 @@ body {
 #insightEditor {
   flex: 1;
   overflow-y: auto;
-  padding: 1rem 1.5rem;
+  padding: var(--space-4) var(--space-5);
 }
 
 #editorToolbar {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
 }
 
 .empty-state {
   text-align: center;
-  padding: 3rem 1rem;
+  padding: var(--space-8) var(--space-4);
   color: var(--color-text-dim);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
 }
 
 /* ---- Insight Cards ---- */
@@ -626,18 +626,18 @@ body {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
   overflow: hidden;
 }
 
 .insight-collapsed {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 0.8rem;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-3);
   cursor: pointer;
   user-select: none;
-  transition: background 0.1s;
+  transition: background var(--duration-fast);
 }
 
 .insight-collapsed:hover {
@@ -645,8 +645,8 @@ body {
 }
 
 .insight-chevron {
-  font-size: 0.7rem;
-  transition: transform 0.15s;
+  font-size: var(--text-xs);
+  transition: transform var(--duration-fast);
   flex-shrink: 0;
   color: var(--color-text-dim);
 }
@@ -657,7 +657,7 @@ body {
 
 .insight-collapsed-title {
   font-weight: 600;
-  font-size: 0.88rem;
+  font-size: var(--text-base);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -665,15 +665,15 @@ body {
 }
 
 .insight-collapsed-count {
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   white-space: nowrap;
 }
 
 .insight-status-badge {
-  font-size: 0.65rem;
-  padding: 0.1rem 0.35rem;
-  border-radius: 3px;
+  font-size: var(--text-xs);
+  padding: 0.1rem var(--space-2);
+  border-radius: var(--radius-sm);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -692,7 +692,7 @@ body {
 
 .insight-body {
   display: none;
-  padding: 0 0.8rem 0.8rem;
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 .insight-card.expanded .insight-body {
@@ -701,28 +701,28 @@ body {
 
 .insight-fields {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.6rem;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
   flex-wrap: wrap;
 }
 
 .insight-fields input[type="text"] {
   flex: 1;
   min-width: 200px;
-  padding: 0.4rem 0.5rem;
-  font-size: 0.85rem;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-sm);
   font-weight: 600;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
 }
 
 .insight-fields select {
-  padding: 0.4rem 0.5rem;
-  font-size: 0.8rem;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-sm);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
 }
@@ -730,31 +730,31 @@ body {
 .insight-summary {
   width: 100%;
   min-height: 60px;
-  padding: 0.5rem;
-  font-size: 0.82rem;
+  padding: var(--space-2);
+  font-size: var(--text-sm);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
   resize: vertical;
   font-family: inherit;
   line-height: 1.5;
-  margin-bottom: 0.8rem;
+  margin-bottom: var(--space-3);
 }
 
 /* ---- Buckets ---- */
 
 .bucket-section {
-  margin-bottom: 0.8rem;
+  margin-bottom: var(--space-3);
 }
 
 .bucket-label {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  padding-bottom: 0.3rem;
-  margin-bottom: 0.4rem;
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 .bucket-label-causes {
@@ -775,28 +775,28 @@ body {
 .bucket-narrative {
   width: 100%;
   min-height: 40px;
-  padding: 0.4rem 0.5rem;
-  font-size: 0.8rem;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-sm);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
   resize: vertical;
   font-family: inherit;
   line-height: 1.5;
-  margin-bottom: 0.4rem;
+  margin-bottom: var(--space-2);
 }
 
 .bucket-dropzone {
   min-height: 50px;
   border: 2px dashed var(--color-border);
   border-radius: var(--radius);
-  padding: 0.4rem;
+  padding: var(--space-2);
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-content: start;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color var(--duration-fast), background var(--duration-fast);
 }
 
 .bucket-dropzone.drag-over {
@@ -822,9 +822,9 @@ body {
 .bucket-empty-hint {
   width: 100%;
   text-align: center;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
-  padding: 0.5rem;
+  padding: var(--space-2);
 }
 
 /* ---- Inline preview cards (in buckets) ---- */
@@ -833,7 +833,7 @@ body {
   width: 200px;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
   position: relative;
   cursor: grab;
@@ -887,7 +887,7 @@ body {
 }
 
 .preview-info {
-  padding: 0.3rem 0.4rem;
+  padding: var(--space-2) var(--space-2);
 }
 
 .preview-info .artifact-badges {
@@ -895,13 +895,13 @@ body {
 }
 
 .preview-desc {
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   color: var(--color-text);
   line-height: 1.4;
 }
 
 .preview-time {
-  font-size: 0.62rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-family: var(--font-mono);
 }
@@ -916,13 +916,13 @@ body {
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.55);
   color: #fff;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-fast);
   z-index: 2;
 }
 
@@ -933,23 +933,23 @@ body {
 /* ---- Timeline context ---- */
 
 .insight-timeline-context {
-  margin-top: 0.6rem;
+  margin-top: var(--space-3);
 }
 
 .insight-timeline-context label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-weight: 600;
   display: block;
-  margin-bottom: 0.2rem;
+  margin-bottom: var(--space-1);
 }
 
 .insight-timeline-context input {
   width: 100%;
-  padding: 0.35rem 0.5rem;
-  font-size: 0.8rem;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-sm);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
 }
@@ -960,46 +960,46 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 0.8rem;
-  padding-top: 0.6rem;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
   border-top: 1px solid var(--color-border);
 }
 
 .insight-save-btn {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
 }
 
 /* ---- Popover ---- */
 
 .popover {
   position: fixed;
-  z-index: 200;
+  z-index: var(--z-dropdown);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   box-shadow: 0 4px 16px var(--color-panel-shadow);
-  padding: 0.4rem;
+  padding: var(--space-2);
 }
 
 .popover-buckets {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .popover-btn {
   display: block;
   width: 100%;
-  padding: 0.35rem 0.7rem;
-  font-size: 0.78rem;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
   font-weight: 600;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
   cursor: pointer;
   text-align: left;
-  transition: background 0.1s;
+  transition: background var(--duration-fast);
 }
 
 .popover-btn:hover {
@@ -1013,15 +1013,15 @@ body {
 .popover-insight-item {
   display: block;
   width: 100%;
-  padding: 0.3rem 0.5rem;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   cursor: pointer;
   text-align: left;
-  margin-bottom: 0.25rem;
-  transition: background 0.1s;
+  margin-bottom: var(--space-1);
+  transition: background var(--duration-fast);
 }
 
 .popover-insight-item:hover {
@@ -1032,16 +1032,16 @@ body {
 
 .toast {
   position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
-  padding: 0.6rem 1rem;
+  bottom: var(--space-5);
+  right: var(--space-5);
+  padding: var(--space-3) var(--space-4);
   background: var(--color-accent);
   color: #fff;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   border-radius: var(--radius);
-  box-shadow: 0 4px 12px var(--color-panel-shadow);
-  z-index: 300;
-  transition: opacity 0.3s, transform 0.3s;
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-dropdown);
+  transition: opacity var(--duration-slow), transform var(--duration-slow);
 }
 
 .toast.hidden {
@@ -1053,13 +1053,13 @@ body {
 /* ---- Utility ---- */
 
 .nav-link {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-accent);
   text-decoration: none;
-  padding: 0.25rem 0.6rem;
-  border-radius: 6px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--duration-fast), border-color var(--duration-fast);
 }
 
 .nav-link:hover {
@@ -1144,8 +1144,8 @@ html[data-theme="dark"] {
 @media (max-width: 768px) {
   #builderHeader,
   #builderLayout {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-left: var(--space-2);
+    margin-right: var(--space-2);
     max-width: 100%;
   }
 

--- a/assets/web/insights-viewer.css
+++ b/assets/web/insights-viewer.css
@@ -56,25 +56,25 @@ body {
 /* ---- Header ---- */
 
 #viewerHeader {
-  padding: 1.2rem 1.5rem 0.8rem;
+  padding: var(--space-5) var(--space-5) var(--space-3);
   max-width: 900px;
-  margin: 1.5rem auto 0;
+  margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 1px solid var(--color-panel-border);
   border-bottom: none;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
 }
 
 #headerTop {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 #viewerHeader h1 {
-  font-size: 1.25rem;
+  font-size: var(--text-xl);
   font-weight: 700;
 }
 
@@ -84,9 +84,9 @@ body {
 }
 
 #headerMeta {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
-  margin-top: 0.2rem;
+  margin-top: var(--space-1);
 }
 
 /* ---- Theme toggle (matches viewer/gallery) ---- */
@@ -95,7 +95,7 @@ body {
   position: relative;
   width: 32px;
   height: 32px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   display: inline-flex;
@@ -103,7 +103,7 @@ body {
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
 }
 
 #themeToggle:hover {
@@ -124,8 +124,8 @@ body {
   position: absolute;
   width: 16px;
   height: 16px;
-  border-radius: 999px;
-  transition: opacity 0.22s ease, transform 0.22s ease;
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
 
 .theme-icon-sun {
@@ -162,7 +162,7 @@ body {
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
   border-right: 1px solid var(--color-panel-border);
-  padding: 1rem 1.5rem 2rem;
+  padding: var(--space-4) var(--space-5) var(--space-6);
   min-height: 50vh;
 }
 
@@ -171,16 +171,16 @@ body {
 .index-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .index-card {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  padding: 0.8rem 1rem;
+  padding: var(--space-3) var(--space-4);
   cursor: pointer;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
 }
 
 .index-card:hover {
@@ -191,24 +191,24 @@ body {
 .index-card-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.3rem;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 .index-card-title {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: var(--text-md);
   flex: 1;
 }
 
 .index-card-summary {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
-  margin-bottom: 0.3rem;
+  margin-bottom: var(--space-2);
 }
 
 .index-card-count {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -216,10 +216,10 @@ body {
 
 .sev-pill {
   display: inline-block;
-  padding: 0.1rem 0.4rem;
-  font-size: 0.68rem;
+  padding: 0.1rem var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 700;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: #fff;
   white-space: nowrap;
 }
@@ -237,10 +237,10 @@ body {
 
 .detail-back {
   display: inline-block;
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-accent);
   text-decoration: none;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
   cursor: pointer;
 }
 
@@ -249,45 +249,45 @@ body {
 }
 
 .detail-title {
-  font-size: 1.3rem;
+  font-size: var(--text-xl);
   font-weight: 700;
-  margin-bottom: 0.3rem;
+  margin-bottom: var(--space-2);
 }
 
 .detail-meta {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.8rem;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
 }
 
 .detail-summary {
-  font-size: 0.92rem;
+  font-size: var(--text-base);
   color: var(--color-text);
-  margin-bottom: 1.2rem;
+  margin-bottom: var(--space-5);
   line-height: 1.6;
 }
 
 .detail-timeline-context {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
   font-style: italic;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
 }
 
 /* ---- Bucket sections (detail) ---- */
 
 .detail-bucket {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
 }
 
 .detail-bucket-label {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  padding-bottom: 0.3rem;
-  margin-bottom: 0.5rem;
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 .detail-bucket-label-causes { color: var(--color-causes); border-bottom: 2px solid var(--color-causes); }
@@ -295,23 +295,23 @@ body {
 .detail-bucket-label-impacts { color: var(--color-impacts); border-bottom: 2px solid var(--color-impacts); }
 
 .detail-narrative {
-  font-size: 0.88rem;
+  font-size: var(--text-base);
   color: var(--color-text);
-  margin-bottom: 0.6rem;
+  margin-bottom: var(--space-3);
   line-height: 1.6;
 }
 
 .detail-artifacts-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem;
+  gap: var(--space-3);
 }
 
 .detail-artifact-card {
   width: 220px;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -331,28 +331,28 @@ body {
 }
 
 .detail-artifact-info {
-  padding: 0.3rem 0.5rem;
+  padding: var(--space-2) var(--space-2);
 }
 
 .detail-artifact-info .badge {
   display: inline-block;
-  padding: 0.1rem 0.3rem;
-  font-size: 0.62rem;
+  padding: 0.1rem var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 600;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface-alt);
   color: var(--color-text-dim);
-  margin-right: 0.2rem;
+  margin-right: var(--space-1);
 }
 
 .detail-artifact-desc {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text);
-  margin-top: 0.2rem;
+  margin-top: var(--space-1);
 }
 
 .detail-artifact-time {
-  font-size: 0.65rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-family: var(--font-mono);
 }
@@ -362,17 +362,17 @@ body {
 #viewerFooter {
   max-width: 900px;
   margin: 0 auto;
-  padding: 1rem 1.5rem;
+  padding: var(--space-4) var(--space-5);
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0 0 18px 18px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   text-align: center;
 }
 
 #viewerFooter a {
   color: var(--color-accent);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   text-decoration: none;
 }
 

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -59,25 +59,25 @@ body {
 
 #ssHeader {
   flex-shrink: 0;
-  padding: 1.2rem 1.5rem 0.8rem;
+  padding: var(--space-5) var(--space-5) var(--space-3);
   max-width: 1120px;
   width: 100%;
-  margin: 1.5rem auto 0;
+  margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 1px solid var(--color-panel-border);
   border-bottom: none;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
 }
 
 #headerTop {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 #ssHeader h1 {
-  font-size: 1.25rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   letter-spacing: -0.01em;
 }
@@ -90,18 +90,18 @@ body {
 #headerActions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
   margin-left: auto;
 }
 
 .nav-link {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-accent);
   text-decoration: none;
-  padding: 0.25rem 0.6rem;
-  border-radius: 6px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--duration-fast), border-color var(--duration-fast);
 }
 
 .nav-link:hover {
@@ -110,16 +110,16 @@ body {
 }
 
 .participant-label {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 #participantSelect {
-  font-size: 0.78rem;
-  padding: 0.2rem 0.4rem;
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -127,7 +127,7 @@ body {
 }
 
 .video-info {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-dim);
 }
@@ -138,7 +138,7 @@ body {
   position: relative;
   width: 32px;
   height: 32px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   display: inline-flex;
@@ -146,7 +146,7 @@ body {
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
   flex-shrink: 0;
 }
 
@@ -168,8 +168,8 @@ body {
   position: absolute;
   width: 16px;
   height: 16px;
-  border-radius: 999px;
-  transition: opacity 0.22s ease, transform 0.22s ease;
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
 
 .theme-icon-sun {
@@ -207,10 +207,10 @@ body {
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
   border-right: 1px solid var(--color-panel-border);
-  padding: 1rem 1.5rem;
+  padding: var(--space-4) var(--space-5);
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
+  gap: var(--space-3);
   overflow-y: auto;
   flex: 1;
   min-height: 0;
@@ -221,7 +221,7 @@ body {
 #viewerSection {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 #frameContainer {
@@ -259,7 +259,7 @@ body {
   align-items: center;
   justify-content: center;
   color: #6b7280;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   pointer-events: none;
 }
 
@@ -272,9 +272,9 @@ body {
   width: 20px;
   height: 20px;
   cursor: nwse-resize;
-  z-index: 5;
+  z-index: var(--z-float);
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-fast);
 }
 
 .preview-resize-handle::before {
@@ -297,9 +297,9 @@ body {
 
 #timestampInput {
   width: 5.5rem;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-family: var(--font-mono);
-  padding: 0.25rem 0.4rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -317,7 +317,7 @@ body {
 #regionBar {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
   flex-wrap: wrap;
   min-height: 1.8rem;
 }
@@ -325,22 +325,22 @@ body {
 #regionChips {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--space-1);
   flex-wrap: wrap;
 }
 
 .region-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.2rem;
-  padding: 0.15rem 0.5rem;
-  border-radius: 12px;
-  font-size: 0.72rem;
+  gap: var(--space-1);
+  padding: 0.15rem var(--space-2);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-xs);
   font-weight: 500;
   cursor: pointer;
   border: 1.5px solid currentColor;
   opacity: 0.7;
-  transition: opacity 0.15s, background 0.15s;
+  transition: opacity var(--duration-fast), background var(--duration-fast);
 }
 
 .region-chip:hover {
@@ -360,7 +360,7 @@ body {
 }
 
 .region-hint {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-style: italic;
 }
@@ -370,13 +370,13 @@ body {
 #timelineSection {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: var(--space-1);
 }
 
 #timelineRow {
   display: flex;
   align-items: stretch;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 #timelineRow #timelineCanvas {
@@ -389,13 +389,13 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.2rem;
+  gap: var(--space-1);
   flex-shrink: 0;
 }
 
 #timelineStepBtns {
   display: flex;
-  gap: 0.2rem;
+  gap: var(--space-1);
 }
 
 #timelineCanvas {
@@ -409,7 +409,7 @@ body {
 #timelineControls {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--space-1);
   flex-wrap: wrap;
 }
 
@@ -417,11 +417,11 @@ body {
   width: 1px;
   height: 1rem;
   background: var(--color-border);
-  margin: 0 0.2rem;
+  margin: 0 var(--space-1);
 }
 
 .marker-info {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-dim);
   margin-left: auto;
@@ -430,22 +430,22 @@ body {
 #timelineLegend {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: var(--space-3);
   margin-left: auto;
-  font-size: 0.68rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: var(--space-1);
 }
 
 .legend-dot {
   width: 8px;
   height: 8px;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
@@ -466,16 +466,16 @@ body {
 .wf-tab {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.35rem 0.6rem;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 500;
   color: var(--color-text-dim);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--duration-fast), border-color var(--duration-fast);
 }
 
 .wf-tab svg {
@@ -527,8 +527,8 @@ body {
 #workflowBody {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  padding: 0.6rem 0;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
 }
 
 #workflowActionRow {
@@ -545,7 +545,7 @@ body {
   display: flex;
   align-items: center;
   gap: 2px;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -562,12 +562,12 @@ body {
 .run-picker-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
-  padding: 0.25rem 0.5rem;
-  font-size: 0.72rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
   color: var(--color-text);
   cursor: pointer;
   white-space: nowrap;
@@ -588,9 +588,9 @@ body {
 }
 
 .run-picker-btn .chevron {
-  font-size: 0.6rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
-  transition: transform 0.15s;
+  transition: transform var(--duration-fast);
 }
 
 .run-picker-btn.open .chevron {
@@ -601,12 +601,12 @@ body {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  z-index: 20;
+  z-index: var(--z-float);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-  padding: 0.3rem 0;
+  padding: var(--space-1) 0;
   min-width: 8rem;
   max-width: 16rem;
   max-height: 14rem;
@@ -616,10 +616,10 @@ body {
 .run-picker-panel label {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   overflow: hidden;
 }
 
@@ -640,10 +640,10 @@ body {
 }
 
 .run-picker-toggle-all {
-  font-size: 0.68rem;
+  font-size: var(--text-xs);
   color: var(--color-accent);
   cursor: pointer;
-  padding: 0.2rem 0.5rem;
+  padding: var(--space-1) var(--space-2);
   border-bottom: 1px solid var(--color-border);
   display: block;
 }
@@ -655,7 +655,7 @@ body {
 #workflowParams {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
   flex: 1;
   min-height: 0;
   min-width: 0;
@@ -665,12 +665,12 @@ body {
 .param-row {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.2rem 0;
+  gap: var(--space-3);
+  padding: var(--space-1) 0;
 }
 
 .param-label {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   min-width: 5.5rem;
   color: var(--color-text-dim);
 }
@@ -678,7 +678,7 @@ body {
 .param-control {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
   flex: 1;
   min-width: 0;
 }
@@ -691,8 +691,8 @@ body {
 .param-control input[type="number"],
 .param-control input[type="text"],
 .param-control select {
-  font-size: 0.78rem;
-  padding: 0.2rem 0.4rem;
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -710,7 +710,7 @@ body {
 }
 
 .param-value {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-dim);
   min-width: 2.5rem;
@@ -719,7 +719,7 @@ body {
 .color-preview {
   width: 24px;
   height: 24px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   flex-shrink: 0;
 }
@@ -727,8 +727,8 @@ body {
 .color-picker-group {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.2rem 0;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
 }
 
 .color-palette-canvas {
@@ -743,7 +743,7 @@ body {
 .color-brightness-strip {
   width: 100%;
   height: 14px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   cursor: pointer;
   display: block;
@@ -752,13 +752,13 @@ body {
 .color-input-row {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 .color-hex-input {
   font-family: var(--font-mono);
-  font-size: 0.78rem;
-  padding: 0.2rem 0.4rem;
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -767,7 +767,7 @@ body {
 }
 
 .btn-pipette {
-  padding: 0.25rem 0.4rem;
+  padding: var(--space-1) var(--space-2);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -786,7 +786,7 @@ body {
 .ref-frame-preview {
   width: 80px;
   height: 45px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: #0a0a0a;
   object-fit: cover;
@@ -795,15 +795,15 @@ body {
 /* Buttons (matches Studio) */
 
 .btn {
-  padding: 0.4rem 0.9rem;
+  padding: var(--space-2) var(--space-4);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  transition: background-color var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
 }
 
 .btn:hover {
@@ -840,14 +840,14 @@ body {
 }
 
 .btn-small {
-  padding: 0.25rem 0.6rem;
-  font-size: 0.72rem;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
 }
 
 .btn-icon {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 .btn-icon svg {
@@ -864,17 +864,17 @@ body {
   bottom: calc(100% + 6px);
   right: 0;
   left: auto;
-  padding: 0.3rem 0.6rem;
+  padding: var(--space-1) var(--space-3);
   background: var(--color-text);
   color: var(--color-bg);
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   font-weight: 400;
   white-space: nowrap;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.15s;
-  z-index: 20;
+  transition: opacity var(--duration-fast);
+  z-index: var(--z-float);
 }
 
 .btn[data-tooltip]:disabled:hover::after {
@@ -897,7 +897,7 @@ body {
   justify-content: center;
   flex-shrink: 0;
   user-select: none;
-  transition: background-color 0.15s;
+  transition: background-color var(--duration-fast);
 }
 
 #panelDivider:hover,
@@ -908,9 +908,9 @@ body {
 .divider-handle {
   width: 36px;
   height: 4px;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   background: var(--color-border);
-  transition: background-color 0.15s, width 0.15s;
+  transition: background-color var(--duration-fast), width var(--duration-fast);
 }
 
 #panelDivider:hover .divider-handle,
@@ -928,14 +928,14 @@ body {
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 0.8rem 1.5rem 1.2rem;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-3) var(--space-5) var(--space-5);
   display: grid;
   grid-template-columns: 1.7fr 1fr 1fr;
-  gap: 1.5rem;
+  gap: var(--space-5);
   flex-shrink: 0;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
   height: 340px;
   min-height: 120px;
   overflow: hidden;
@@ -952,7 +952,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.4rem;
+  margin-bottom: var(--space-2);
 }
 
 .panel-header-actions {
@@ -963,7 +963,7 @@ body {
 
 .task-filter-btn {
   opacity: 0.4;
-  transition: opacity 0.15s, background 0.15s, color 0.15s;
+  transition: opacity var(--duration-fast), background var(--duration-fast), color var(--duration-fast);
 }
 .task-filter-btn:hover {
   opacity: 0.7;
@@ -978,14 +978,14 @@ body {
 }
 
 .panel-header h3 {
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   font-weight: 600;
 }
 
 .panel-header h3 span {
   font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 .panel-header-btn {
@@ -994,8 +994,8 @@ body {
   color: var(--color-text-dim);
   cursor: pointer;
   padding: 0.15rem 0.3rem;
-  border-radius: 3px;
-  transition: background 0.15s, color 0.15s;
+  border-radius: var(--radius-sm);
+  transition: background var(--duration-fast), color var(--duration-fast);
   display: inline-flex;
   align-items: center;
 }
@@ -1006,9 +1006,9 @@ body {
 }
 
 .panel-empty {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
-  padding: 1.5rem 0;
+  padding: var(--space-5) 0;
   text-align: center;
 }
 
@@ -1017,7 +1017,7 @@ body {
 #taskList {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: var(--space-1);
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -1026,14 +1026,14 @@ body {
 .task-card {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.6rem;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   border-left: 3px solid var(--color-border);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-fast);
 }
 
 .task-card:hover {
@@ -1109,7 +1109,7 @@ body {
 }
 
 .task-card-meta {
-  font-size: 0.68rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-family: var(--font-mono);
 }
@@ -1117,19 +1117,19 @@ body {
 .task-card-progress {
   height: 3px;
   background: var(--color-border);
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
 .task-card-progress-fill {
   height: 100%;
   background: var(--color-accent);
-  border-radius: 2px;
-  transition: width 0.3s;
+  border-radius: var(--radius-sm);
+  transition: width var(--duration-slow);
 }
 
 .task-card-status {
-  font-size: 0.68rem;
+  font-size: var(--text-xs);
   flex-shrink: 0;
   color: var(--color-text-dim);
 }
@@ -1152,7 +1152,7 @@ body {
   flex-shrink: 0;
   padding: 0.1rem 0;
   opacity: 0.5;
-  transition: opacity 0.15s, color 0.15s;
+  transition: opacity var(--duration-fast), color var(--duration-fast);
 }
 
 .task-card-drag-handle:hover {
@@ -1212,8 +1212,8 @@ body {
   color: var(--color-text-dim);
   cursor: pointer;
   padding: 0.1rem 0.3rem;
-  border-radius: 3px;
-  transition: background 0.15s, color 0.15s;
+  border-radius: var(--radius-sm);
+  transition: background var(--duration-fast), color var(--duration-fast);
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
@@ -1231,8 +1231,8 @@ body {
   color: var(--color-text-dim);
   cursor: pointer;
   padding: 0.1rem 0.3rem;
-  border-radius: 3px;
-  transition: background 0.15s, color 0.15s;
+  border-radius: var(--radius-sm);
+  transition: background var(--duration-fast), color var(--duration-fast);
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
@@ -1257,12 +1257,12 @@ body {
 .result-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.3rem 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border-bottom: 1px solid var(--color-border);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-fast);
 }
 
 .result-row:hover {
@@ -1275,7 +1275,7 @@ body {
 
 .result-timestamp {
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1283,7 +1283,7 @@ body {
 .result-detail {
   flex: 1;
   min-width: 0;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1292,7 +1292,7 @@ body {
 
 .result-score {
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   flex-shrink: 0;
 }
@@ -1301,25 +1301,25 @@ body {
   width: 40px;
   height: 4px;
   background: var(--color-border);
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
   flex-shrink: 0;
 }
 
 .result-bar-fill {
   height: 100%;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
 }
 
 #resultsActions {
   display: flex;
-  gap: 0.3rem;
+  gap: var(--space-1);
 }
 
 /* Timelapse result player */
 
 .timelapse-result {
-  padding: 0.5rem;
+  padding: var(--space-2);
 }
 
 .timelapse-result video,
@@ -1337,38 +1337,38 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: var(--z-dropdown);
 }
 
 .modal-card {
   background: var(--color-surface);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--color-panel-border);
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 1.5rem;
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-5);
   width: 340px;
   max-width: 92vw;
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
+  gap: var(--space-3);
 }
 
 .modal-card h3 {
-  font-size: 1rem;
+  font-size: var(--text-md);
   font-weight: 600;
 }
 
 .modal-label {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.78rem;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
 .modal-label input {
-  font-size: 0.85rem;
-  padding: 0.35rem 0.5rem;
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -1381,7 +1381,7 @@ body {
 }
 
 .modal-coords {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-dim);
 }
@@ -1389,26 +1389,26 @@ body {
 .modal-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 0.3rem;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
 }
 
 /* Toast */
 
 .toast {
   position: fixed;
-  bottom: 1.5rem;
+  bottom: var(--space-5);
   left: 50%;
   transform: translateX(-50%);
   background: var(--color-text);
   color: var(--color-bg);
-  padding: 0.5rem 1rem;
+  padding: var(--space-2) var(--space-4);
   border-radius: var(--radius);
-  font-size: 0.82rem;
-  z-index: 200;
+  font-size: var(--text-sm);
+  z-index: var(--z-dropdown);
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity var(--duration-normal);
 }
 
 .toast:not(.hidden) {
@@ -1509,8 +1509,8 @@ html[data-theme="dark"] .run-picker-panel {
   #ssMain,
   #panelDivider,
   #bottomPanel {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-left: var(--space-2);
+    margin-right: var(--space-2);
     max-width: 100%;
   }
   #bottomPanel {

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -62,27 +62,27 @@ body {
 
 #studioHeader {
   flex-shrink: 0;
-  padding: 1.2rem 1.5rem 0.8rem;
+  padding: var(--space-5) var(--space-5) var(--space-3);
   max-width: 1120px;
   width: 100%;
-  margin: 1.5rem auto 0;
+  margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 1px solid var(--color-panel-border);
   border-bottom: none;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
 }
 
 #studioHeaderTop {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 #headerActions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
   margin-left: auto;
 }
 
@@ -91,13 +91,13 @@ body {
 }
 
 .nav-link {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-accent);
   text-decoration: none;
-  padding: 0.25rem 0.6rem;
-  border-radius: 6px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--duration-fast), border-color var(--duration-fast);
 }
 
 .nav-link:hover {
@@ -106,7 +106,7 @@ body {
 }
 
 #studioHeader h1 {
-  font-size: 1.25rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   letter-spacing: -0.01em;
 }
@@ -118,16 +118,16 @@ body {
 
 #headerMeta {
   display: flex;
-  gap: 1.5rem;
-  margin-top: 0.3rem;
-  font-size: 0.82rem;
+  gap: var(--space-5);
+  margin-top: var(--space-1);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
 #headerMeta span {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--space-1);
 }
 
 /* Theme toggle (matches viewer.css) */
@@ -136,7 +136,7 @@ body {
   position: relative;
   width: 32px;
   height: 32px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   display: inline-flex;
@@ -144,7 +144,7 @@ body {
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
   flex-shrink: 0;
 }
 
@@ -166,8 +166,8 @@ body {
   position: absolute;
   width: 16px;
   height: 16px;
-  border-radius: 999px;
-  transition: opacity 0.22s ease, transform 0.22s ease;
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
 
 .theme-icon-sun {
@@ -208,25 +208,25 @@ body {
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
   border-right: 1px solid var(--color-panel-border);
-  padding: 0 1.5rem 1.2rem;
+  padding: 0 var(--space-5) var(--space-5);
 }
 
 #sheetPreview h3 {
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   font-weight: 600;
   margin-bottom: 0;
-  padding-top: 0.5rem;
+  padding-top: var(--space-2);
 }
 
 .sheet-preview-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 #filterToggle svg {
-  transition: color 0.15s;
+  transition: color var(--duration-fast);
 }
 
 /* Filter bar */
@@ -234,17 +234,17 @@ body {
 #filterBar {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.4rem 0;
-  margin-bottom: 0.5rem;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  margin-bottom: var(--space-2);
   flex-wrap: wrap;
 }
 
 .filter-group {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.78rem;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
 }
 
 .filter-group-label {
@@ -256,7 +256,7 @@ body {
 
 .filter-range-sep {
   color: var(--color-text-dim);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
 }
 
 .filter-select {
@@ -264,9 +264,9 @@ body {
   -webkit-appearance: none;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
-  padding: 0.2rem 0.4rem;
-  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
   color: var(--color-text);
   cursor: pointer;
   min-width: 0;
@@ -290,9 +290,9 @@ body {
 .filter-number {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
-  padding: 0.2rem 0.3rem;
-  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-1);
+  font-size: var(--text-xs);
   color: var(--color-text);
   width: 3.5rem;
   font-family: var(--font-mono);
@@ -321,12 +321,12 @@ body {
 .filter-cat-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
-  padding: 0.2rem 0.4rem;
-  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
   color: var(--color-text);
   cursor: pointer;
   white-space: nowrap;
@@ -337,9 +337,9 @@ body {
 }
 
 .filter-cat-btn .chevron {
-  font-size: 0.6rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
-  transition: transform 0.15s;
+  transition: transform var(--duration-fast);
 }
 
 .filter-cat-btn.open .chevron {
@@ -350,12 +350,12 @@ body {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  z-index: 20;
+  z-index: var(--z-dropdown);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-  padding: 0.3rem 0;
+  padding: var(--space-1) 0;
   min-width: 10rem;
   max-height: 14rem;
   overflow-y: auto;
@@ -364,10 +364,10 @@ body {
 .filter-cat-panel label {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -393,8 +393,8 @@ body {
   padding: 0 2px;
   line-height: 1;
   flex-shrink: 0;
-  border-radius: 2px;
-  transition: color 0.15s;
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast);
 }
 
 .filter-clear:hover {
@@ -407,14 +407,14 @@ body {
 }
 
 #sheetLoading {
-  padding: 2rem;
+  padding: var(--space-6);
   text-align: center;
   color: var(--color-text-dim);
 }
 
 #viewerArtifactCount {
   font-weight: 400;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
@@ -427,7 +427,7 @@ body {
 #sheetGrid table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.82rem;
+  font-size: var(--text-xs);
   table-layout: fixed;
 }
 
@@ -447,7 +447,7 @@ body {
   justify-content: center;
   flex-shrink: 0;
   user-select: none;
-  transition: background-color 0.15s;
+  transition: background-color var(--duration-fast);
 }
 
 #panelDivider:hover,
@@ -458,9 +458,9 @@ body {
 .divider-handle {
   width: 36px;
   height: 4px;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   background: var(--color-border);
-  transition: background-color 0.15s, width 0.15s;
+  transition: background-color var(--duration-fast), width var(--duration-fast);
 }
 
 #panelDivider:hover .divider-handle,
@@ -472,17 +472,17 @@ body {
 #sheetGrid thead th {
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: var(--z-float);
   background: var(--color-surface-alt);
   border-bottom: 2px solid var(--color-border);
-  padding: 0.45rem 0.6rem;
+  padding: var(--space-2) var(--space-3);
   text-align: left;
   font-weight: 600;
   white-space: nowrap;
 }
 
 #sheetGrid tbody td {
-  padding: 0.35rem 0.6rem;
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--color-border);
   vertical-align: top;
 }
@@ -491,7 +491,7 @@ body {
   width: 3rem;
   text-align: center;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -499,7 +499,7 @@ body {
   width: 3.5rem;
   text-align: center;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -514,9 +514,9 @@ body {
   -webkit-appearance: none;
   background: transparent;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: 0.15rem 0.3rem;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text);
   cursor: pointer;
   flex: 1;
@@ -538,7 +538,7 @@ body {
   border: none;
   color: var(--color-text-dim);
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   line-height: 1;
   padding: 0 2px;
   flex-shrink: 0;
@@ -559,14 +559,14 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--color-text-dim);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 .col-severity {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 500;
 }
 
@@ -585,7 +585,7 @@ body {
 .col-participant {
   cursor: pointer;
   user-select: none;
-  transition: color 0.15s, background-color 0.15s;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
 }
 
 .col-row-num-header:hover,
@@ -596,7 +596,7 @@ body {
 .col-row-num-clickable {
   cursor: pointer;
   user-select: none;
-  transition: color 0.15s, background-color 0.15s;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
 }
 
 .col-row-num-clickable:hover {
@@ -617,7 +617,7 @@ col.col-participant-col {
 
 .col-participant {
   text-align: center;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 /* Timestamp cells */
@@ -626,8 +626,8 @@ col.col-participant-col {
   cursor: pointer;
   text-align: center;
   font-family: var(--font-mono);
-  font-size: 0.72rem;
-  transition: background-color 0.15s ease;
+  font-size: var(--text-xs);
+  transition: background-color var(--duration-fast) ease;
   user-select: none;
   white-space: nowrap;
   overflow: hidden;
@@ -659,11 +659,11 @@ col.col-participant-col {
 
 .ts-cell-float {
   position: fixed;
-  z-index: 10;
+  z-index: var(--z-float);
   box-sizing: border-box;
   font-family: var(--font-mono);
-  font-size: 0.72rem;
-  padding: 0.35rem 0.6rem;
+  font-size: var(--text-xs);
+  padding: var(--space-2) var(--space-3);
   text-align: center;
   white-space: nowrap;
   pointer-events: none;
@@ -676,10 +676,10 @@ col.col-participant-col {
 /* Empty row separator */
 
 .empty-rows-separator td {
-  padding: 0.1rem 0.6rem;
+  padding: 0.1rem var(--space-3);
   text-align: center;
   color: var(--color-text-dim);
-  font-size: 0.68rem;
+  font-size: var(--text-xs);
   font-style: italic;
   border-bottom: 1px solid var(--color-border);
   background: transparent;
@@ -702,42 +702,42 @@ col.col-participant-col {
   border: 1px solid var(--color-panel-border);
   border-top: none;
   border-radius: 0;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 1rem 1.5rem 1.5rem;
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-4) var(--space-5) var(--space-5);
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .drop-area {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .drop-area h3 {
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 .drop-area h3 span {
   font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
 }
 
 .drop-target {
   min-height: 120px;
   border: 2px dashed var(--color-border);
   border-radius: var(--radius);
-  padding: 0.5rem;
+  padding: var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
-  transition: border-color 0.15s, background-color 0.15s;
+  gap: var(--space-1);
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
   overflow-y: auto;
   max-height: 250px;
 }
@@ -754,7 +754,7 @@ col.col-participant-col {
   height: 100%;
   min-height: 80px;
   color: var(--color-text-dim);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   text-align: center;
 }
 
@@ -770,8 +770,8 @@ col.col-participant-col {
   overflow-y: hidden;
   max-height: none;
   min-height: 100px;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-2);
 }
 
 /* Shared card base (artifact + reel) */
@@ -785,7 +785,7 @@ col.col-participant-col {
   overflow: hidden;
   cursor: grab;
   position: relative;
-  transition: box-shadow 0.15s, border-color 0.15s;
+  transition: box-shadow var(--duration-fast), border-color var(--duration-fast);
   user-select: none;
   will-change: transform;
 }
@@ -820,25 +820,25 @@ col.col-participant-col {
   right: 3px;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
-  font-size: 0.62rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   padding: 1px 4px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   line-height: 1.3;
 }
 
 .queue-card-meta {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.2rem 0.35rem;
-  font-size: 0.7rem;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
 }
 
 .queue-card-ref {
   font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
 }
 
 .queue-card-remove {
@@ -856,7 +856,7 @@ col.col-participant-col {
   justify-content: center;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-fast);
   padding: 0;
 }
 
@@ -878,7 +878,7 @@ col.col-participant-col {
   align-items: center;
   justify-content: center;
   color: #dc2626;
-  font-size: 1.4rem;
+  font-size: var(--text-2xl);
   font-weight: 700;
 }
 
@@ -886,13 +886,13 @@ col.col-participant-col {
 
 #reelArea {
   max-width: 1120px;
-  margin: 0 auto 1.5rem;
+  margin: 0 auto var(--space-5);
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 1rem 1.5rem 1.5rem;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-4) var(--space-5) var(--space-5);
 }
 
 #reelArea:has(+ #stashedReelsArea:not(.hidden)) {
@@ -901,24 +901,24 @@ col.col-participant-col {
 }
 
 #reelArea h3 {
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 #reelArea h3 span {
   font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
 }
 
 #reelHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-2);
 }
 
 #reelList {
@@ -927,13 +927,13 @@ col.col-participant-col {
   overflow-y: hidden;
   max-height: none;
   min-height: 100px;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-2);
 }
 
 #reelDuration {
   font-weight: 400;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
@@ -941,7 +941,7 @@ col.col-participant-col {
 
 .reel-card-order {
   font-family: var(--font-mono);
-  font-size: 0.62rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   min-width: 1rem;
   text-align: center;
@@ -959,42 +959,42 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 #stashedReelsArea {
   max-width: 1120px;
-  margin: 0 auto 1.5rem;
+  margin: 0 auto var(--space-5);
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 0.8rem 1.5rem 1rem;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-3) var(--space-5) var(--space-4);
 }
 
 #stashedReelsHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-2);
 }
 
 #stashedReelsHeader h3 {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 #stashedReelsHeader h3 span {
   font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 #stashedReelsList {
   display: flex;
   flex-direction: row;
-  gap: 0.5rem;
+  gap: var(--space-2);
   overflow-x: auto;
-  padding: 0.3rem 0;
+  padding: var(--space-1) 0;
 }
 
 .stash-card {
@@ -1003,10 +1003,10 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
-  padding: 0.5rem 0.6rem;
+  padding: var(--space-2) var(--space-3);
   cursor: pointer;
   position: relative;
-  transition: box-shadow 0.15s, border-color 0.15s;
+  transition: box-shadow var(--duration-fast), border-color var(--duration-fast);
   user-select: none;
 }
 
@@ -1017,16 +1017,16 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .stash-card-name {
   display: block;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: text;
   padding: 1px 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   border: 1px solid transparent;
-  transition: border-color 0.15s;
+  transition: border-color var(--duration-fast);
 }
 
 .stash-card-name:hover {
@@ -1035,12 +1035,12 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .stash-card-name-input {
   display: block;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   width: 100%;
   padding: 1px 2px;
   border: 1px solid var(--color-accent);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
   outline: none;
@@ -1049,10 +1049,10 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .stash-card-info {
   display: flex;
-  gap: 0.5rem;
-  font-size: 0.7rem;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
-  margin-top: 0.25rem;
+  margin-top: var(--space-1);
   font-family: var(--font-mono);
 }
 
@@ -1066,12 +1066,12 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   border-radius: 50%;
   width: 18px;
   height: 18px;
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   line-height: 18px;
   text-align: center;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-fast);
   padding: 0;
 }
 
@@ -1100,37 +1100,37 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   border: 1px solid var(--color-panel-border);
   border-top: none;
   border-radius: 0;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
-  padding: 0.8rem 1.5rem 1rem;
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-3) var(--space-5) var(--space-4);
 }
 
 #stashedArtifactsHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-2);
 }
 
 #stashedArtifactsHeader h3 {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 #stashedArtifactsHeader h3 span {
   font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 #stashedArtifactsList {
   display: flex;
   flex-direction: row;
-  gap: 0.5rem;
+  gap: var(--space-2);
   overflow-x: auto;
-  padding: 0.3rem 0;
+  padding: var(--space-1) 0;
 }
 
 /* Stash drop zone styling */
@@ -1154,7 +1154,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .area-controls {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-items: center;
   flex-wrap: wrap;
 }
@@ -1171,16 +1171,16 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 #addToReelBtn {
   align-self: flex-end;
-  margin-top: 0.35rem;
+  margin-top: var(--space-2);
 }
 
 .area-controls select {
-  padding: 0.35rem 0.5rem;
+  padding: var(--space-2) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 
@@ -1189,8 +1189,8 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 .titlecard-group {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  font-size: 0.78rem;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
   cursor: pointer;
   white-space: nowrap;
@@ -1208,16 +1208,16 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .titlecard-duration-input {
   width: 3rem;
-  padding: 0.25rem 0.35rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
 }
 
 .titlecard-label-unit {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -1227,15 +1227,15 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 }
 
 .btn {
-  padding: 0.4rem 0.9rem;
+  padding: var(--space-2) var(--space-4);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  transition: background-color var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
 }
 
 .btn:hover {
@@ -1261,8 +1261,8 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 }
 
 .btn-small {
-  padding: 0.25rem 0.6rem;
-  font-size: 0.72rem;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
 }
 
 .btn-icon svg {
@@ -1281,17 +1281,17 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   bottom: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
-  padding: 0.3rem 0.6rem;
+  padding: var(--space-1) var(--space-3);
   background: var(--color-text);
   color: var(--color-bg);
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   font-weight: 400;
   white-space: nowrap;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.15s;
-  z-index: 20;
+  transition: opacity var(--duration-fast);
+  z-index: var(--z-float);
 }
 
 .btn[data-tooltip]:disabled:hover::after {
@@ -1314,7 +1314,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 .btn-icon {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 .sparkles-icon {
@@ -1325,11 +1325,11 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 10;
+  z-index: var(--z-float);
   max-height: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-height 0.25s ease, opacity 0.2s ease, margin-top 0.25s ease;
+  transition: max-height var(--duration-normal) ease, opacity var(--duration-normal) ease, margin-top var(--duration-normal) ease;
   margin-top: 0;
   background: var(--color-panel-bg);
   border-radius: calc(var(--radius) - 2px);
@@ -1339,27 +1339,27 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 .highlights-drawer.open {
   max-height: 3rem;
   opacity: 1;
-  margin-top: 0.35rem;
+  margin-top: var(--space-2);
   pointer-events: auto;
 }
 
 .highlights-drawer-label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
   white-space: nowrap;
 }
 
 .highlights-drawer-input {
   width: 5rem;
-  padding: 0.3rem 0.4rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-family: var(--font-mono);
 }
 
@@ -1376,19 +1376,19 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   position: absolute;
   top: 100%;
   right: 0;
-  z-index: 10;
+  z-index: var(--z-float);
   max-height: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-height 0.25s ease, opacity 0.2s ease, margin-top 0.25s ease;
+  transition: max-height var(--duration-normal) ease, opacity var(--duration-normal) ease, margin-top var(--duration-normal) ease;
   margin-top: 0;
   background: var(--color-panel-bg);
   border: 1px solid transparent;
   border-radius: calc(var(--radius) - 2px);
-  padding: 0 0.5rem;
+  padding: 0 var(--space-2);
   pointer-events: none;
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-items: center;
   white-space: nowrap;
 }
@@ -1396,39 +1396,39 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 .gallery-drawer.open {
   max-height: 3rem;
   opacity: 1;
-  margin-top: 0.35rem;
-  padding: 0.35rem 0.5rem;
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-2);
   pointer-events: auto;
   border-color: var(--color-border);
 }
 
 .gallery-drawer-label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--space-1);
   white-space: nowrap;
 }
 
 .gallery-drawer-select {
-  padding: 0.25rem 0.35rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.75rem;
-  max-width: 5rem;
+  font-size: var(--text-xs);
+  max-width: 8rem;
 }
 
 .gallery-drawer-input {
   width: 3.5rem;
-  padding: 0.25rem 0.35rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
 }
 
@@ -1522,7 +1522,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 #statusOverlay {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: var(--z-dropdown);
   background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
@@ -1535,8 +1535,8 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .status-card {
   background: var(--color-surface);
-  border-radius: 12px;
-  padding: 2rem 2.5rem;
+  border-radius: var(--radius-lg);
+  padding: var(--space-6) var(--space-8);
   max-width: 420px;
   width: 90%;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
@@ -1544,16 +1544,16 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .status-card h3 {
-  font-size: 1rem;
+  font-size: var(--text-md);
   font-weight: 600;
 }
 
 .status-card p {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
   word-break: break-all;
 }
@@ -1725,7 +1725,7 @@ html[data-theme="dark"] .filter-cat-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: var(--z-dropdown);
 }
 
 #settingsOverlay.hidden {
@@ -1734,9 +1734,9 @@ html[data-theme="dark"] .filter-cat-btn {
 
 .settings-panel {
   background: var(--color-surface);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--color-panel-border);
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
   width: 520px;
   max-width: 92vw;
   max-height: 80vh;
@@ -1748,28 +1748,28 @@ html[data-theme="dark"] .filter-cat-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.2rem;
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
 }
 
 .settings-header h3 {
-  font-size: 1rem;
+  font-size: var(--text-md);
   font-weight: 600;
 }
 
 #settingsContent {
   flex: 1;
   overflow-y: auto;
-  padding: 0.8rem 1.2rem;
+  padding: var(--space-3) var(--space-5);
 }
 
 .settings-group-label {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-dim);
-  margin: 1rem 0 0.4rem;
+  margin: var(--space-4) 0 var(--space-2);
 }
 
 .settings-group-label:first-child {
@@ -1780,8 +1780,8 @@ html[data-theme="dark"] .filter-cat-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.8rem;
-  padding: 0.45rem 0;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -1791,7 +1791,7 @@ html[data-theme="dark"] .filter-cat-btn {
 
 .settings-row.settings-changed {
   border-left: 2px solid var(--color-accent);
-  padding-left: 0.6rem;
+  padding-left: var(--space-3);
 }
 
 .settings-label {
@@ -1800,12 +1800,12 @@ html[data-theme="dark"] .filter-cat-btn {
 }
 
 .settings-label-name {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   font-weight: 500;
 }
 
 .settings-label-desc {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   line-height: 1.3;
 }
@@ -1816,22 +1816,22 @@ html[data-theme="dark"] .filter-cat-btn {
 
 .settings-control input[type="number"] {
   width: 5rem;
-  padding: 0.3rem 0.4rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-family: var(--font-mono);
 }
 
 .settings-control select {
-  padding: 0.3rem 0.4rem;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
   color: var(--color-text);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 .settings-toggle {
@@ -1841,10 +1841,10 @@ html[data-theme="dark"] .filter-cat-btn {
   appearance: none;
   -webkit-appearance: none;
   background: var(--color-border);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   outline: none;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background var(--duration-normal);
   border: none;
 }
 
@@ -1861,7 +1861,7 @@ html[data-theme="dark"] .filter-cat-btn {
   height: 16px;
   background: #fff;
   border-radius: 50%;
-  transition: transform 0.2s;
+  transition: transform var(--duration-normal);
 }
 
 .settings-toggle:checked::after {
@@ -1872,14 +1872,14 @@ html[data-theme="dark"] .filter-cat-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.6rem 1.2rem;
+  padding: var(--space-3) var(--space-5);
   border-top: 1px solid var(--color-border);
 }
 
 .settings-save-status {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
-  transition: opacity 0.3s;
+  transition: opacity var(--duration-slow);
 }
 
 html[data-theme="dark"] .settings-panel {
@@ -1897,8 +1897,8 @@ html[data-theme="dark"] .settings-panel {
   #reelArea,
   #stashedReelsArea,
   #stashedArtifactsArea {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-left: var(--space-2);
+    margin-right: var(--space-2);
     max-width: 100%;
   }
 

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -56,25 +56,25 @@ body {
 /* Header */
 
 #pageHeader {
-  padding: 1.2rem 1.5rem 0.8rem;
+  padding: var(--space-5) var(--space-5) var(--space-3);
   max-width: 1120px;
-  margin: 1.5rem auto 0;
+  margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 1px solid var(--color-panel-border);
   border-bottom: none;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  box-shadow: var(--shadow-xl);
 }
 
 #pageHeaderTop {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 #pageHeader h1 {
-  font-size: 1.25rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   letter-spacing: 0.02em;
 }
@@ -86,14 +86,14 @@ body {
 
 #headerMeta {
   display: flex;
-  gap: 1.2rem;
-  margin-top: 0.3rem;
-  font-size: 0.85rem;
+  gap: var(--space-5);
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
 #headerMeta span:not(:empty)::before {
-  margin-right: 0.3rem;
+  margin-right: var(--space-2);
 }
 
 #studyName:not(:empty)::before { content: "Study:"; font-weight: 600; }
@@ -102,7 +102,7 @@ body {
 .header-buttons {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 #themeToggle,
@@ -110,7 +110,7 @@ body {
   position: relative;
   width: 32px;
   height: 32px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   color: var(--color-text-dim);
@@ -119,7 +119,7 @@ body {
   justify-content: center;
   padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.1s ease, box-shadow 0.2s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
 }
 
 #filmstripToggle svg { width: 16px; height: 16px; }
@@ -151,8 +151,8 @@ body {
   position: absolute;
   width: 16px;
   height: 16px;
-  border-radius: 999px;
-  transition: opacity 0.22s ease, transform 0.22s ease;
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
 
 .theme-icon-sun {
@@ -184,7 +184,7 @@ body {
 /* Timeline */
 
 #timelinePane {
-  padding: 1.2rem 1.5rem 0.6rem;
+  padding: var(--space-5) var(--space-5) var(--space-3);
   max-width: 1120px;
   margin: 0 auto;
   background: var(--color-panel-bg);
@@ -200,7 +200,7 @@ body {
   overflow: visible;
   cursor: crosshair;
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
-  transition: height 0.3s ease;
+  transition: height var(--duration-slow) ease;
 }
 
 .artifact-marker {
@@ -208,13 +208,13 @@ body {
   top: 6px;
   height: 44px;
   min-width: 6px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.9;
   border-width: 2px;
   border-style: solid;
   box-sizing: border-box;
-  transition: opacity 0.15s, transform 0.1s, box-shadow 0.2s, top 0.3s ease;
+  transition: opacity var(--duration-fast), transform var(--duration-fast), box-shadow var(--duration-normal), top var(--duration-slow) ease;
 }
 
 .artifact-marker.clip {
@@ -284,13 +284,13 @@ body {
 .artifact-marker:hover {
   opacity: 1;
   transform: scaleY(1.12);
-  z-index: 1000;
+  z-index: var(--z-modal);
   box-shadow: 0 4px 14px rgba(15, 23, 42, 0.22);
 }
 
 .artifact-marker.selected {
   opacity: 1;
-  z-index: 1001;
+  z-index: var(--z-modal);
   box-shadow:
     0 0 0 2px var(--color-selected-ring),
     0 0 0 5px rgba(29, 79, 114, 0.88),
@@ -330,7 +330,7 @@ body {
 .timeline-track-wrap {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .timeline-track-wrap #timelineTrack {
@@ -340,7 +340,7 @@ body {
 .track-expand-btn {
   width: 28px;
   height: 28px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   color: var(--color-text-dim);
@@ -351,7 +351,7 @@ body {
   padding: 0;
   flex-shrink: 0;
   margin-top: 14px;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, color var(--duration-fast) ease;
 }
 
 .track-expand-btn:disabled {
@@ -379,7 +379,7 @@ body {
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
-  transition: transform 0.25s ease;
+  transition: transform var(--duration-normal) ease;
 }
 
 .track-expand-btn.expanded svg {
@@ -393,17 +393,17 @@ body {
 #timelineTicks {
   display: flex;
   justify-content: space-between;
-  padding: 0.25rem 0;
-  font-size: 0.75rem;
+  padding: var(--space-1) 0;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-dim);
 }
 
 #timelineLegend {
   display: flex;
-  gap: 1rem;
-  margin-top: 0.3rem;
-  font-size: 0.8rem;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
 }
 
@@ -411,9 +411,9 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.65rem 1rem;
-  margin-top: 0.45rem;
-  font-size: 0.75rem;
+  gap: var(--space-3) var(--space-4);
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -424,14 +424,14 @@ body {
 .severity-legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 .legend-severity-swatch {
   display: inline-block;
   width: 12px;
   height: 12px;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
@@ -447,14 +447,14 @@ body {
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--space-2);
 }
 
 .legend-swatch {
   display: inline-block;
   width: 12px;
   height: 12px;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   box-sizing: border-box;
   background: var(--color-surface-alt);
 }
@@ -477,10 +477,10 @@ body {
   display: flex;
   min-height: calc(100vh - 200px);
   max-width: 1120px;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto var(--space-8);
   background: var(--color-panel-bg);
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-xl);
   border: 1px solid var(--color-panel-border);
   border-top: none;
 }
@@ -489,21 +489,21 @@ body {
   width: 340px;
   min-width: 260px;
   border-right: 1px solid var(--color-border);
-  padding: 1rem;
+  padding: var(--space-4);
   overflow-y: auto;
   max-height: calc(100vh - 200px);
   flex-shrink: 0;
 }
 
 #sidebar h3 {
-  font-size: 0.95rem;
-  margin-bottom: 0.5rem;
+  font-size: var(--text-md);
+  margin-bottom: var(--space-2);
 }
 
 #artifactCount {
   font-weight: 400;
   color: var(--color-text-dim);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
 }
 
 .artifact-list-header {
@@ -511,8 +511,8 @@ body {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 0.35rem 0.6rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-2);
 }
 
 #sidebar .artifact-list-header h3 {
@@ -522,7 +522,7 @@ body {
 .artifact-sort-bar {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: var(--space-1);
   flex-shrink: 0;
 }
 
@@ -531,11 +531,11 @@ body {
   min-width: 26px;
   height: 26px;
   padding: 0 4px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   color: var(--color-text);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
@@ -543,7 +543,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0;
-  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, color var(--duration-fast) ease;
 }
 
 .artifact-sort-btn:hover {
@@ -552,7 +552,7 @@ body {
 }
 
 .artifact-sort-btn .sort-dir {
-  font-size: 0.62rem;
+  font-size: var(--text-xs);
   font-weight: 700;
   margin-left: 1px;
   opacity: 0.95;
@@ -567,51 +567,51 @@ body {
 /* Filters */
 
 #filters {
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--color-border);
 }
 
 #filters h3 {
-  margin-bottom: 0.6rem;
+  margin-bottom: var(--space-3);
 }
 
 #filters label {
   display: block;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
-  margin-top: 0.5rem;
-  margin-bottom: 0.2rem;
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-1);
 }
 
 #filters select {
   width: 100%;
-  padding: 0.35rem 0.5rem;
+  padding: var(--space-2) var(--space-2);
   background: var(--color-surface);
   color: var(--color-text);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
 }
 
 #filterType {
   border: none;
   padding: 0;
-  margin-top: 0.5rem;
+  margin-top: var(--space-2);
 }
 
 #filterType legend {
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
-  margin-bottom: 0.2rem;
+  margin-bottom: var(--space-1);
 }
 
 #filterType label {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  margin-right: 0.8rem;
-  font-size: 0.85rem;
+  gap: var(--space-2);
+  margin-right: var(--space-3);
+  font-size: var(--text-sm);
   color: var(--color-text);
 }
 
@@ -630,7 +630,7 @@ body {
 #artifactList {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 .artifact-card {
@@ -639,7 +639,7 @@ body {
   border-radius: var(--radius);
   overflow: hidden;
   cursor: pointer;
-  transition: box-shadow 0.15s, border-color 0.15s;
+  transition: box-shadow var(--duration-fast), border-color var(--duration-fast);
 }
 
 .artifact-card:hover {
@@ -649,7 +649,7 @@ body {
 
 .artifact-card.selected {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px var(--color-accent);
+  box-shadow: var(--shadow-focus);
 }
 
 .artifact-card.filtered-out {
@@ -688,7 +688,7 @@ body {
 }
 
 .artifact-media.thumb-loaded img {
-  animation: thumbFadeIn 0.25s ease;
+  animation: thumbFadeIn var(--duration-normal) ease;
 }
 
 @keyframes thumbFadeIn {
@@ -697,24 +697,24 @@ body {
 }
 
 .artifact-meta {
-  padding: 0.4rem 0.5rem;
+  padding: var(--space-2) var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .artifact-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .badge {
   display: inline-block;
-  padding: 0.1rem 0.35rem;
-  font-size: 0.65rem;
+  padding: 0.1rem var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 600;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
 }
 
@@ -771,7 +771,7 @@ body {
 .detail-badge.sev-unknown { background: var(--sev-unknown-bg); border-color: var(--sev-unknown-bg); color: #fff; }
 
 .artifact-desc {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -779,7 +779,7 @@ body {
 }
 
 .artifact-time {
-  font-size: 0.65rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
   font-family: var(--font-mono);
 }
@@ -788,7 +788,7 @@ body {
 
 #detailPane {
   flex: 1;
-  padding: 1.2rem 1.5rem;
+  padding: var(--space-5) var(--space-5);
   overflow-y: auto;
   max-height: calc(100vh - 200px);
 }
@@ -799,7 +799,7 @@ body {
   justify-content: center;
   height: 100%;
   color: var(--color-text-dim);
-  font-size: 0.95rem;
+  font-size: var(--text-md);
 }
 
 #detailContent.hidden,
@@ -813,19 +813,19 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 700;
   text-transform: uppercase;
-  padding: 0.15rem 0.6rem;
-  border-radius: 999px;
+  padding: 0.15rem var(--space-3);
+  border-radius: var(--radius-full);
 }
 
 .detail-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: var(--space-2);
   align-items: center;
-  margin-bottom: 0.3rem;
+  margin-bottom: var(--space-2);
 }
 
 .detail-badges .detail-badge {
@@ -847,20 +847,20 @@ body {
 .detail-badge.gif { background: var(--color-gif); color: #fff; }
 
 #detailHeader h2 {
-  font-size: 1.1rem;
+  font-size: var(--text-lg);
   font-weight: 600;
-  margin-top: 0.3rem;
+  margin-top: var(--space-2);
 }
 
 #detailMeta {
-  margin-top: 1rem;
+  margin-top: var(--space-4);
 }
 
 #detailMeta dl {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.3rem 1rem;
-  font-size: 0.85rem;
+  gap: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
 }
 
 #detailMeta dt {
@@ -874,7 +874,7 @@ body {
 }
 
 #detailPreview {
-  margin-top: 1.2rem;
+  margin-top: var(--space-5);
 }
 
 #detailPreview video,
@@ -891,19 +891,19 @@ body {
   position: fixed;
   background: var(--color-surface-alt);
   color: var(--color-text);
-  padding: 0.5rem 0.7rem;
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   max-width: 320px;
   pointer-events: none;
-  z-index: 2000;
+  z-index: var(--z-overlay);
   box-shadow: 0 4px 16px var(--color-tooltip-shadow);
   line-height: 1.4;
 }
 
 .tooltip-time {
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
@@ -913,7 +913,7 @@ body {
   padding: 4rem;
   text-align: center;
   color: var(--color-text-dim);
-  font-size: 1.1rem;
+  font-size: var(--text-lg);
 }
 
 /* Selected marker pulse (very gentle) */
@@ -944,7 +944,7 @@ body {
   }
 
   .artifact-marker {
-    transition: opacity 0.15s, box-shadow 0.2s;
+    transition: opacity var(--duration-fast), box-shadow var(--duration-normal);
   }
 
   .track-expand-btn svg {
@@ -1088,7 +1088,7 @@ html[data-theme="dark"] .artifact-marker.selected {
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
   border-right: 1px solid var(--color-panel-border);
-  padding: 1.5rem;
+  padding: var(--space-5);
 }
 
 #playerEmpty {
@@ -1102,7 +1102,7 @@ html[data-theme="dark"] .artifact-marker.selected {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.8rem;
+  gap: var(--space-3);
   width: 100%;
   aspect-ratio: 16 / 9;
   max-height: 480px;
@@ -1110,7 +1110,7 @@ html[data-theme="dark"] .artifact-marker.selected {
   border-radius: var(--radius);
   background: var(--color-surface);
   color: var(--color-text-dim);
-  font-size: 0.95rem;
+  font-size: var(--text-md);
 }
 
 #playerPlaceholder svg {
@@ -1142,46 +1142,46 @@ html[data-theme="dark"] .artifact-marker.selected {
 }
 
 #playerInfo {
-  margin-top: 0.8rem;
+  margin-top: var(--space-3);
 }
 
 #playerInfo h2 {
-  font-size: 1rem;
+  font-size: var(--text-md);
   font-weight: 600;
-  margin-top: 0.2rem;
+  margin-top: var(--space-1);
 }
 
 #playerMeta {
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--color-text-dim);
   font-family: var(--font-mono);
-  margin-top: 0.2rem;
+  margin-top: var(--space-1);
 }
 
 #participantTimelines {
   max-width: 1120px;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto var(--space-8);
   background: var(--color-panel-bg);
-  border-radius: 0 0 18px 18px;
-  box-shadow: 0 24px 60px var(--color-panel-shadow);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-xl);
   border: 1px solid var(--color-panel-border);
   border-top: none;
-  padding: 1rem 1.5rem 1.2rem;
+  padding: var(--space-4) var(--space-5) var(--space-5);
 }
 
 #timelinesHeader {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.8rem;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
 }
 
 .timelines-legend-group {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 .timelines-legend-group #timelineLegend {
@@ -1194,20 +1194,20 @@ html[data-theme="dark"] .artifact-marker.selected {
 }
 
 #timelinesHeader h3 {
-  font-size: 0.95rem;
+  font-size: var(--text-md);
   font-weight: 600;
 }
 
 #participantRows {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-2);
 }
 
 .participant-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.8rem;
+  gap: var(--space-3);
 }
 
 .participant-row .participant-label {
@@ -1221,7 +1221,7 @@ html[data-theme="dark"] .artifact-marker.selected {
 .participant-label {
   width: 52px;
   min-width: 52px;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   font-family: var(--font-mono);
   color: var(--color-text-dim);
@@ -1234,10 +1234,10 @@ html[data-theme="dark"] .artifact-marker.selected {
   position: relative;
   height: 32px;
   background: var(--color-surface);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   overflow: visible;
   cursor: crosshair;
-  transition: height 0.3s ease;
+  transition: height var(--duration-slow) ease;
 }
 
 .participant-track .artifact-marker {
@@ -1248,9 +1248,9 @@ html[data-theme="dark"] .artifact-marker.selected {
 #participantTicks {
   display: flex;
   justify-content: space-between;
-  padding: 0.25rem 0 0;
+  padding: var(--space-1) 0 0;
   margin-left: calc(52px + 0.8rem);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-dim);
 }
@@ -1260,7 +1260,7 @@ html[data-theme="dark"] .artifact-marker.selected {
 @media (max-width: 768px) {
   #layout {
     flex-direction: column;
-    border-radius: 0 0 14px 14px;
+    border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   }
 
   #sidebar {
@@ -1277,7 +1277,7 @@ html[data-theme="dark"] .artifact-marker.selected {
   .participant-label {
     width: 40px;
     min-width: 40px;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
   }
 
   #participantTicks {


### PR DESCRIPTION
## Summary

Converts ~738 hardcoded spacing, typography, border-radius, shadow, transition, and z-index values across all 6 CSS files (`gallery.css`, `insights-viewer.css`, `viewer.css`, `insights-builder.css`, `screenspace.css`, `studio.css`) to use the shared design tokens defined in `tokens.css`. This completes Phases 3 and 4 of the CSS design token migration plan. Also fixes a z-index regression where the category filter dropdown rendered behind the sticky table header, reduces sheet preview table font size for better fit, and widens the gallery format dropdown to avoid truncation.

## Test plan

- [x] `uv run pytest -c tests/pytest.ini` passes
- [ ] Launch `--studio`, `--insights`, `--screenspace` and verify both light/dark themes render correctly
- [ ] Generate a timeline viewer (`--viewer`), gallery (`--gallery`), and insights export — verify standalone HTML renders correctly
- [ ] Verify category filter dropdown appears above sticky table header in Studio