### PR TITLE
Always register Screenspace in the combined server

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1177,9 +1177,7 @@ def main() -> None:
     if getattr(args, "screenspace", False) and not args.spreadsheet:
         import server
 
-        server.start_combined_server(
-            worksheet=None, default_page="screenspace", screenspace=True
-        )
+        server.start_combined_server(worksheet=None, default_page="screenspace")
         sys.exit(0)
 
     # Standalone gallery: generate interval captures + gallery viewer, no spreadsheet needed
@@ -1232,9 +1230,7 @@ def main() -> None:
                 import server
 
                 server.start_combined_server(
-                    worksheet=worksheet,
-                    default_page="screenspace",
-                    screenspace=True,
+                    worksheet=worksheet, default_page="screenspace"
                 )
                 sys.exit(0)
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.65"
+VERSIONNUM: str = "0.9.66"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2

--- a/server.py
+++ b/server.py
@@ -970,15 +970,16 @@ def start_combined_server(
     worksheet: Any = None,
     port: Optional[int] = None,
     default_page: str = "studio",
-    screenspace: bool = False,
 ) -> None:
     """Start a combined Studio + Insights + Screenspace server on one port.
 
     When worksheet is provided, both Studio and Insights are available.
     When worksheet is None, only Insights is registered.
-    Screenspace is registered when the *screenspace* flag is True.
+    Screenspace is always registered (auto-discovers videos when no
+    spreadsheet is provided).
     """
     import insights_server
+    import screenspace_server
 
     combined = Flask(__name__, static_folder=None)
 
@@ -992,18 +993,14 @@ def start_combined_server(
         _init_studio_state(worksheet)
         combined.register_blueprint(studio_bp, url_prefix="/studio")
 
-    # Register Screenspace if requested
-    has_screenspace = screenspace
-    if has_screenspace:
-        import screenspace_server
-
-        screenspace_server._init_screenspace_state(
-            sheet_context=_sheet_context if has_studio else None,
-            participant_list=_resolve_participants() if has_studio else None,
-        )
-        combined.register_blueprint(
-            screenspace_server.screenspace_bp, url_prefix="/screenspace"
-        )
+    # Always register Screenspace (auto-discovers videos from input dir)
+    screenspace_server._init_screenspace_state(
+        sheet_context=_sheet_context if has_studio else None,
+        participant_list=_resolve_participants() if has_studio else None,
+    )
+    combined.register_blueprint(
+        screenspace_server.screenspace_bp, url_prefix="/screenspace"
+    )
 
     @combined.route("/")
     def root() -> Response:
@@ -1015,7 +1012,7 @@ def start_combined_server(
             {
                 "studio": has_studio,
                 "insights": True,
-                "screenspace": has_screenspace,
+                "screenspace": True,
             }
         )
 


### PR DESCRIPTION
## Summary
- Screenspace blueprint is now unconditionally registered by `start_combined_server()`, matching how Insights is always registered
- The Screenspace nav button in Studio and Insights Builder is now always visible, without requiring `--screenspace` on the CLI
- Removes the `screenspace` parameter from `start_combined_server()` and updates both CLI call sites

## Test plan
- [x] All 278 existing tests pass
- [ ] Launch with `--studio` only → verify Screenspace nav button is visible → click navigates to `/screenspace/` successfully
- [ ] Launch with `--insights` only → verify Screenspace nav button is visible