### PR TITLE
Fix filmstrip thumbnails stopping after 2-4 frames

### DIFF
--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -345,10 +345,12 @@
     var MAX_FRAMES = 12;
 
     var done = false;
+    var perFrameTimer = null;
     function finish() {
       if (done) return;
       done = true;
       clearTimeout(timer);
+      clearTimeout(perFrameTimer);
       video.onerror = null;
       video.onloadedmetadata = null;
       video.onseeked = null;
@@ -396,12 +398,16 @@
       }
 
       var frameIndex = 0;
-      video.onseeked = function () {
+      var seekGen = 0;
+
+      function captureAndAdvance() {
+        clearTimeout(perFrameTimer);
         try { ctx.drawImage(video, frameIndex * thumbW, 0, thumbW, STRIP_HEIGHT); } catch (_) {}
         frameIndex++;
         if (frameIndex < seekTimes.length) {
-          video.currentTime = seekTimes[frameIndex];
+          seekToFrame(frameIndex);
         } else {
+          video.onseeked = null;
           canvas.toBlob(function (blob) {
             if (!blob) { markerEl.classList.remove("filmstrip-loading"); finish(); return; }
             var url = URL.createObjectURL(blob);
@@ -414,9 +420,22 @@
             finish();
           }, "image/jpeg", 0.7);
         }
-      };
+      }
 
-      video.currentTime = seekTimes[0];
+      function seekToFrame(idx) {
+        var gen = ++seekGen;
+        video.onseeked = function () {
+          if (gen !== seekGen) return;
+          captureAndAdvance();
+        };
+        perFrameTimer = setTimeout(function () {
+          if (gen !== seekGen) return;
+          captureAndAdvance();
+        }, 800);
+        video.currentTime = seekTimes[idx];
+      }
+
+      seekToFrame(0);
     };
   }
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.65"
+VERSIONNUM: str = "0.9.66"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2


### PR DESCRIPTION
## Summary

The sequential `video.onseeked` chain in `generateFilmstripThumb()` was fragile — browsers can fire duplicate `seeked` events (skipping frames) or miss them entirely (halting the chain). This replaced it with a `seekToFrame`/`captureAndAdvance` pattern using a generation counter to reject stale/duplicate callbacks and a per-frame 800ms timeout as a fallback when `seeked` never fires.

## Test plan

- [ ] Generate a timeline viewer with `--viewer --filmstrip` and confirm filmstrip thumbnails render completely (all frame slots filled, not just 2-4)
- [ ] Test in both Chrome and Safari
- [ ] Test with short (2-5s) and longer (30s+) clips