### PR TITLE
Web code review: bug fix, scrub performance, and quality improvements

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -16,6 +16,10 @@
     timelapse: "#ec4899",
   };
 
+  var TIMELINE_CANVAS_HEIGHT = 64;
+
+  var _paletteDocListeners = null;
+
   var REGION_COLORS = [
     "#3b82f6", "#ef4444", "#22c55e", "#f59e0b",
     "#8b5cf6", "#06b6d4", "#ec4899", "#14b8a6",
@@ -55,6 +59,24 @@
     runParticipants: [],
     runRegions: [],
   };
+
+  var _cachedThemeColors = null;
+
+  function refreshThemeColors() {
+    var cs = getComputedStyle(document.documentElement);
+    _cachedThemeColors = {
+      surfaceAlt: cs.getPropertyValue("--color-surface-alt").trim() || "#f1ece4",
+      border: cs.getPropertyValue("--color-border").trim() || "#e0ddd7",
+      textDim: cs.getPropertyValue("--color-text-dim").trim() || "#6b7280",
+      accent: cs.getPropertyValue("--color-accent").trim() || "#1d4f72",
+      fontMono: cs.getPropertyValue("--font-mono").trim() || "monospace",
+    };
+  }
+
+  function getThemeColors() {
+    if (!_cachedThemeColors) refreshThemeColors();
+    return _cachedThemeColors;
+  }
 
   // ---- Helpers ----
 
@@ -215,6 +237,7 @@
     root.setAttribute("data-theme", next);
     try { window.localStorage.setItem(THEME_STORAGE_KEY, next); } catch (_) {}
     updateThemeToggleButton(next);
+    refreshThemeColors();
     renderTimeline();
   }
 
@@ -427,12 +450,29 @@
 
   // ---- Frame viewer ----
 
-  function loadFrame(timestamp) {
-    if (!state.selectedParticipant) return;
-    if (state.frameLoading) return;
-    state.frameLoading = true;
+  function seekPlayhead(timestamp) {
     state.currentTimestamp = timestamp;
     qs("#timestampInput").value = formatTimestamp(timestamp);
+    renderTimeline();
+  }
+
+  var _pendingFrameTs = null;
+  var _loadedFrameTs = null;
+
+  function loadFrame(timestamp) {
+    if (!state.selectedParticipant) return;
+    seekPlayhead(timestamp);
+    if (state.frameLoading) {
+      _pendingFrameTs = timestamp;
+      return;
+    }
+    _fetchFrame(timestamp);
+  }
+
+  function _fetchFrame(timestamp) {
+    state.frameLoading = true;
+    _pendingFrameTs = null;
+    _loadedFrameTs = timestamp;
 
     var img = new Image();
     img.onload = function () {
@@ -451,9 +491,15 @@
       ctx.drawImage(img, 0, 0);
       renderOverlay();
       renderTimeline();
+      if (_pendingFrameTs !== null && _pendingFrameTs !== _loadedFrameTs) {
+        _fetchFrame(_pendingFrameTs);
+      }
     };
     img.onerror = function () {
       state.frameLoading = false;
+      if (_pendingFrameTs !== null && _pendingFrameTs !== _loadedFrameTs) {
+        _fetchFrame(_pendingFrameTs);
+      }
     };
     img.src = frameUrl(state.selectedParticipant, timestamp);
   }
@@ -983,6 +1029,7 @@
 
     var dragStart = null;
     var scrubbing = false;
+    var scrubRaf = 0;
     canvas.addEventListener("mousedown", function (e) {
       if (state.timelineZoom > 1) {
         // Zoomed in: drag to pan
@@ -998,7 +1045,15 @@
     document.addEventListener("mousemove", function (e) {
       if (scrubbing) {
         var ts = timelineXToTime(e);
-        if (ts !== null) loadFrame(ts);
+        if (ts !== null) {
+          seekPlayhead(ts);
+          if (!scrubRaf) {
+            scrubRaf = requestAnimationFrame(function () {
+              scrubRaf = 0;
+              loadFrame(state.currentTimestamp);
+            });
+          }
+        }
         return;
       }
       if (!dragStart) return;
@@ -1013,7 +1068,11 @@
       renderTimeline();
     });
     document.addEventListener("mouseup", function () {
-      scrubbing = false;
+      if (scrubbing) {
+        scrubbing = false;
+        if (scrubRaf) { cancelAnimationFrame(scrubRaf); scrubRaf = 0; }
+        loadFrame(state.currentTimestamp);
+      }
       if (dragStart) {
         setTimeout(function () { state.timelineDragging = false; }, 50);
         dragStart = null;
@@ -1068,7 +1127,7 @@
     var canvas = qs("#timelineCanvas");
     var rect = canvas.getBoundingClientRect();
     canvas.width = Math.floor(rect.width);
-    canvas.height = 64;
+    canvas.height = TIMELINE_CANVAS_HEIGHT;
     renderTimeline();
   }
 
@@ -1105,21 +1164,16 @@
     var h = canvas.height;
     var dur = state.videoInfo ? state.videoInfo.duration : 0;
 
-    // Resolve CSS variables for theming
-    var cs = getComputedStyle(document.documentElement);
-    var surfaceAlt = cs.getPropertyValue("--color-surface-alt").trim() || "#f1ece4";
-    var borderColor = cs.getPropertyValue("--color-border").trim() || "#e0ddd7";
-    var textDim = cs.getPropertyValue("--color-text-dim").trim() || "#6b7280";
-    var accent = cs.getPropertyValue("--color-accent").trim() || "#1d4f72";
+    var tc = getThemeColors();
 
     ctx.clearRect(0, 0, w, h);
 
     // Background
-    ctx.fillStyle = surfaceAlt;
+    ctx.fillStyle = tc.surfaceAlt;
     ctx.fillRect(0, 0, w, h);
 
     if (dur <= 0) {
-      ctx.fillStyle = textDim;
+      ctx.fillStyle = tc.textDim;
       ctx.font = "12px -apple-system, sans-serif";
       ctx.textAlign = "center";
       ctx.fillText("No video loaded", w / 2, h / 2 + 4);
@@ -1138,9 +1192,9 @@
     // Time ruler ticks
     var tickInterval = computeTickInterval(visLen);
     var firstTick = Math.ceil(visStart / tickInterval) * tickInterval;
-    ctx.strokeStyle = borderColor;
-    ctx.fillStyle = textDim;
-    ctx.font = "10px " + (cs.getPropertyValue("--font-mono").trim() || "monospace");
+    ctx.strokeStyle = tc.border;
+    ctx.fillStyle = tc.textDim;
+    ctx.font = "10px " + tc.fontMono;
     ctx.textAlign = "center";
     ctx.lineWidth = 1;
     for (var t = firstTick; t <= visEnd; t += tickInterval) {
@@ -1214,14 +1268,14 @@
 
     // Playhead
     var px = timeToX(state.currentTimestamp);
-    ctx.strokeStyle = accent;
+    ctx.strokeStyle = tc.accent;
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(px, 0);
     ctx.lineTo(px, h);
     ctx.stroke();
     // Playhead triangle
-    ctx.fillStyle = accent;
+    ctx.fillStyle = tc.accent;
     ctx.beginPath();
     ctx.moveTo(px - 5, 0);
     ctx.lineTo(px + 5, 0);
@@ -1356,6 +1410,7 @@
 
       // Palette canvas events
       var paletteDragging = false;
+      var brightDragging = false;
       function pickFromPalette(e) {
         var rect = palette.getBoundingClientRect();
         var x = clamp(e.clientX - rect.left, 0, rect.width);
@@ -1370,13 +1425,8 @@
         paletteDragging = true;
         pickFromPalette(e);
       });
-      document.addEventListener("mousemove", function (e) {
-        if (paletteDragging) pickFromPalette(e);
-      });
-      document.addEventListener("mouseup", function () { paletteDragging = false; });
 
       // Brightness strip events
-      var brightDragging = false;
       function pickFromBrightness(e) {
         var rect = bright.getBoundingClientRect();
         var x = clamp(e.clientX - rect.left, 0, rect.width);
@@ -1390,10 +1440,20 @@
         brightDragging = true;
         pickFromBrightness(e);
       });
-      document.addEventListener("mousemove", function (e) {
+
+      // Remove previous document-level listeners before adding new ones
+      if (_paletteDocListeners) {
+        document.removeEventListener("mousemove", _paletteDocListeners.move);
+        document.removeEventListener("mouseup", _paletteDocListeners.up);
+      }
+      function onDocMove(e) {
+        if (paletteDragging) pickFromPalette(e);
         if (brightDragging) pickFromBrightness(e);
-      });
-      document.addEventListener("mouseup", function () { brightDragging = false; });
+      }
+      function onDocUp() { paletteDragging = false; brightDragging = false; }
+      document.addEventListener("mousemove", onDocMove);
+      document.addEventListener("mouseup", onDocUp);
+      _paletteDocListeners = { move: onDocMove, up: onDocUp };
 
       // Hex input event
       hexInput.addEventListener("input", function () {
@@ -2337,9 +2397,8 @@
       setInputValue("#paramColorH", params.target_color ? params.target_color.h : 90);
       setInputValue("#paramColorS", params.target_color ? params.target_color.s : 200);
       setInputValue("#paramColorV", params.target_color ? params.target_color.v : 200);
-      setInputValue("#paramColorTolH", params.tolerance ? params.tolerance.h : 15);
-      setInputValue("#paramColorTolS", params.tolerance ? params.tolerance.s : 40);
-      setInputValue("#paramColorTolV", params.tolerance ? params.tolerance.v : 40);
+      var savedTol = params.tolerance ? Math.round(params.tolerance.h * 100 / 90) : 30;
+      setInputValue("#paramColorTol", savedTol);
       setInputValue("#paramColorInterval", params.interval || 1.0);
       updateColorPreview();
     } else if (task.type === "change") {

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -28,6 +28,7 @@
   --color-cell-text: #dbeafe;
   --color-cell-valid: #93c5fd;
   --color-cell-selected: #c4b5fd;
+  --color-heatmap: 168, 130, 214;
   --color-cell-hover: rgba(29, 79, 114, 0.06);
   --sev-critical: #b91c1c;
   --sev-high: #dc2626;
@@ -1601,6 +1602,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
     --color-cell-valid: #1d4ed8;
     --color-cell-selected: #6d28d9;
     --color-cell-hover: rgba(56, 189, 248, 0.08);
+    --color-heatmap: 192, 160, 235;
     --sev-critical: #f87171;
     --sev-high: #fb7185;
     --sev-medium: #fdba74;
@@ -1632,6 +1634,7 @@ html[data-theme="dark"] {
   --color-cell-text: #1e3a5f;
   --color-cell-valid: #1d4ed8;
   --color-cell-selected: #6d28d9;
+  --color-heatmap: 192, 160, 235;
   --color-cell-hover: rgba(56, 189, 248, 0.08);
   --sev-critical: #f87171;
   --sev-high: #fb7185;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1019,10 +1019,11 @@
     for (var k = 0; k < values.length; k++) {
       if (values[k] !== null && values[k] > max) max = values[k];
     }
+    var hm = getComputedStyle(document.documentElement).getPropertyValue("--color-heatmap").trim() || "168, 130, 214";
     for (var m = 0; m < cells.length; m++) {
       if (values[m] !== null && max > 0) {
         var t = values[m] / max;
-        cells[m].style.backgroundColor = "rgba(168, 130, 214, " + (t * 0.45).toFixed(3) + ")";
+        cells[m].style.backgroundColor = "rgba(" + hm + ", " + (t * 0.45).toFixed(3) + ")";
       } else {
         cells[m].style.backgroundColor = "";
       }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.66"
+VERSIONNUM: str = "0.9.67"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -27,6 +27,7 @@ _manifest: Dict[str, Any] = {}
 _worker: Optional[screenspace.ScreenspaceWorker] = None
 _output_dir: str = ""
 _participants: List[Dict[str, Any]] = []
+_video_cap_cache: Dict[str, Any] = {"path": None, "cap": None}
 
 _assets_dir = Path(__file__).resolve().parent / "assets" / "web"
 
@@ -83,6 +84,25 @@ def _find_participant_video(participant_id: str) -> Optional[str]:
     return None
 
 
+def _get_video_cap(video_path: str) -> Optional[cv2.VideoCapture]:
+    """Return a cached VideoCapture for *video_path*, opening a new one if needed."""
+    if _video_cap_cache["path"] == video_path and _video_cap_cache["cap"] is not None:
+        cap = _video_cap_cache["cap"]
+        if cap.isOpened():
+            return cap
+    # Evict old entry
+    if _video_cap_cache["cap"] is not None:
+        _video_cap_cache["cap"].release()
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        _video_cap_cache["path"] = None
+        _video_cap_cache["cap"] = None
+        return None
+    _video_cap_cache["path"] = video_path
+    _video_cap_cache["cap"] = cap
+    return cap
+
+
 @screenspace_bp.route("/api/video/frame/<participant>/<float:timestamp>")
 def api_video_frame(participant: str, timestamp: float) -> FlaskResponse:
     """Extract and return a single JPEG frame at the given timestamp."""
@@ -92,13 +112,12 @@ def api_video_frame(participant: str, timestamp: float) -> FlaskResponse:
             {"ok": False, "error": f"No video for participant {participant}"}
         ), 404
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    cap = _get_video_cap(video_path)
+    if cap is None:
         return jsonify({"ok": False, "error": "Could not open video file"}), 500
 
     cap.set(cv2.CAP_PROP_POS_MSEC, timestamp * 1000.0)
     ret, frame = cap.read()
-    cap.release()
 
     if not ret:
         return jsonify({"ok": False, "error": "Could not read frame at timestamp"}), 400


### PR DESCRIPTION
## Summary

- **Bug fix**: Screenspace color tolerance slider was not restored when editing a task — the code targeted three non-existent per-channel inputs instead of the unified `#paramColorTol` slider.
- **Performance**: Decoupled the Screenspace timeline playhead from frame loading so it tracks the cursor instantly during scrub. Frame requests are coalesced (latest position is always fetched on completion) and RAF-throttled. Server-side `VideoCapture` is cached across frame requests to eliminate repeated file open/close overhead.
- **Code quality**: Cached `getComputedStyle` results for timeline rendering, fixed event listener accumulation in color palette drag handlers, extracted magic canvas height to a named constant, and moved the hardcoded Studio heatmap color to a themeable `--color-heatmap` CSS variable with dark mode support.

## Test plan

- [ ] Screenspace: create a Color task with non-default tolerance, run it, click to restore — verify tolerance slider shows the original value
- [ ] Screenspace: drag the timeline playhead — verify it tracks the cursor instantly; frame preview catches up smoothly
- [ ] Studio: activate a function column (count/sum) and toggle dark mode — verify heatmap color adapts
- [ ] `uv run pytest -c tests/pytest.ini` passes (278 tests)