### PR TITLE
Fix filmstrip thumbnails not filling timeline markers

### DIFF
--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -304,8 +304,8 @@ body {
 }
 
 .artifact-marker.filmstrip-thumb {
-  background-size: auto 100%;
-  background-position: left top;
+  background-size: cover;
+  background-position: left center;
   background-repeat: no-repeat;
   border-width: 1px;
   border-color: rgba(0, 0, 0, 0.2);

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -22,7 +22,7 @@
   var _filmstripObserver = null;
   var _filmstripThumbQueue = [];
   var _filmstripThumbActive = 0;
-  var FILMSTRIP_CONCURRENCY = 3;
+  var FILMSTRIP_CONCURRENCY = 2;
   var FILMSTRIP_STORAGE_KEY = "clipgen-viewer-filmstrip";
 
   var SORT_DEFAULT_DIR = {
@@ -343,7 +343,7 @@
   function generateFilmstripThumb(markerEl, artifact, callback) {
     var STRIP_HEIGHT = 88;
     var MIN_FRAMES = 2;
-    var MAX_FRAMES = 12;
+    var MAX_FRAMES = 20;
 
     var done = false;
     var perFrameTimer = null;
@@ -355,9 +355,8 @@
       video.onerror = null;
       video.onloadedmetadata = null;
       video.onseeked = null;
-      video.src = "";
-      video.load();
       callback();
+      try { video.src = ""; video.load(); } catch (_) {}
     }
 
     var video = document.createElement("video");
@@ -366,7 +365,7 @@
     video.playsInline = true;
     video.src = artifact.file;
 
-    var timer = setTimeout(finish, 15000);
+    var timer = setTimeout(finish, 20000);
 
     video.onerror = function () {
       markerEl.classList.remove("filmstrip-loading");
@@ -384,8 +383,10 @@
 
       var aspect = (video.videoWidth / video.videoHeight) || (16 / 9);
       var thumbW = Math.round(STRIP_HEIGHT * aspect);
+      var markerH = markerEl.offsetHeight || STRIP_HEIGHT;
       var markerW = markerEl.offsetWidth || thumbW;
-      var numFrames = Math.min(MAX_FRAMES, Math.max(MIN_FRAMES, Math.ceil(markerW / thumbW)));
+      var displayThumbW = thumbW * markerH / STRIP_HEIGHT;
+      var numFrames = Math.min(MAX_FRAMES, Math.max(MIN_FRAMES, Math.ceil(markerW / displayThumbW)));
 
       var canvas = document.createElement("canvas");
       canvas.width = thumbW * numFrames;
@@ -452,10 +453,15 @@
         continue;
       }
       _filmstripThumbActive++;
-      generateFilmstripThumb(item.el, item.artifact, function () {
+      try {
+        generateFilmstripThumb(item.el, item.artifact, function () {
+          _filmstripThumbActive--;
+          processFilmstripThumbQueue();
+        });
+      } catch (_) {
+        item.el.classList.remove("filmstrip-loading");
         _filmstripThumbActive--;
-        processFilmstripThumbQueue();
-      });
+      }
     }
   }
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.67"
+VERSIONNUM: str = "0.9.68"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2


### PR DESCRIPTION
## Summary

- Fix `numFrames` formula to account for CSS scaling: the old formula used canvas-resolution frame width (156px) but CSS `background-size: auto 100%` scales the strip to the marker's actual height (24px for participant tracks), so wide markers only got a small thumbnail strip on the left
- Harden concurrent queue: move `callback()` before video cleanup in `finish()`, add try-catch guards around `generateFilmstripThumb` calls, and reduce concurrency from 3 to 2
- Use `background-size: cover` to eliminate right-edge gaps caused by border-induced content-box vs offset-box mismatches
- Raise `MAX_FRAMES` from 12 to 20 and safety timeout from 15s to 20s to support wider markers at shorter heights

## Test plan

- [ ] Regenerate a timeline viewer with many artifacts across multiple participants
- [ ] Enable filmstrip mode — thumbnails should fill the full width of every marker with no right-edge gap
- [ ] Toggle filmstrip off and on — should re-process correctly
- [ ] Verify no console errors during thumbnail generation