### PR TITLE
Add CI lint and typecheck, skip tests on non-Python changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,10 @@ jobs:
           python-version: "3.12"
 
       - name: Ruff check
-        run: uv run ruff check
+        run: uvx ruff check
 
       - name: Ruff format check
-        run: uv run ruff format --check
+        run: uvx ruff format --check
 
   typecheck:
     runs-on: ubuntu-latest
@@ -61,4 +61,4 @@ jobs:
           python-version: "3.12"
 
       - name: Type check
-        run: uv run ty check
+        run: uvx ty check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,20 @@
-name: tests
+name: checks
 
 on:
   push:
+    branches:
+      - master
+    paths:
+      - "**.py"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/tests.yml"
   pull_request:
+    paths:
+      - "**.py"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/tests.yml"
 
 jobs:
   smoke-tests:
@@ -18,3 +30,35 @@ jobs:
 
       - name: Run smoke tests
         run: uv run pytest -c tests/pytest.ini
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Ruff check
+        run: uv run ruff check
+
+      - name: Ruff format check
+        run: uv run ruff format --check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Type check
+        run: uv run ty check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,6 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,5 +60,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: uv sync
+
       - name: Type check
         run: uvx ty check

--- a/clipgen.py
+++ b/clipgen.py
@@ -1706,9 +1706,7 @@ def _dispatch_interactive_mode(
     if mode == "screenspace":
         import server
 
-        server.start_combined_server(
-            worksheet=worksheet, default_page="screenspace"
-        )
+        server.start_combined_server(worksheet=worksheet, default_page="screenspace")
         return None
     if mode == "timeline-viewer":
         clips_list = spreadsheet.generate_list(worksheet, "batch", skip_prompts=True)

--- a/config.py
+++ b/config.py
@@ -79,7 +79,9 @@ DEFAULT_DURATION_SECONDS: int = 60
 DEFAULT_GIF_DURATION_SECONDS: int = 5
 GALLERY_INTERVAL_SECONDS: int = 10  # Default interval between gallery captures
 GALLERY_GIF_DURATION_SECONDS: int = 3  # Default per-GIF duration in gallery mode
-GALLERY_PARALLEL_WORKERS: int = 4  # Max concurrent ffmpeg processes for gallery GIF extraction
+GALLERY_PARALLEL_WORKERS: int = (
+    4  # Max concurrent ffmpeg processes for gallery GIF extraction
+)
 MAX_FILESIZE_MB: int = 0  # Maximum output file size in MB (0 = disabled)
 MIN_SOURCE_VIDEO_SIZE_MB: int = 100  # Minimum file size (MB) to consider as a source video candidate during fuzzy matching
 MANIFEST_FILENAME: str = "clipgen_manifest.json"

--- a/google_api.py
+++ b/google_api.py
@@ -17,7 +17,7 @@ def _is_transient_api_error(exc: gspread.exceptions.APIError) -> bool:
         code = exc.response.status_code
     except AttributeError:
         return False
-    return code >= 500
+    return code is not None and code >= 500
 
 
 def get_worksheet(spreadsheet: gspread.Spreadsheet) -> gspread.Worksheet:

--- a/insights_server.py
+++ b/insights_server.py
@@ -26,7 +26,7 @@ FlaskResponse = Union[Response, Tuple[Response, int]]
 
 _artifacts: List[Dict[str, Any]] = []
 _insights_data: Dict[str, Any] = {}
-_output_dir: str = ""
+_output_dir: Union[str, Path] = ""
 _sprite_cache: Dict[str, bytes] = {}
 
 _assets_dir = Path(__file__).resolve().parent / "assets" / "web"

--- a/insights_server.py
+++ b/insights_server.py
@@ -242,5 +242,3 @@ def _init_insights_state() -> None:
     # Set study in insights meta from artifacts if not already set
     if not _insights_data.get("meta", {}).get("study") and _artifacts:
         _insights_data.setdefault("meta", {})["study"] = _artifacts[0].get("study", "")
-
-

--- a/screenspace.py
+++ b/screenspace.py
@@ -39,7 +39,7 @@ _ocr_readers: Dict[tuple, Any] = {}
 
 def _get_ocr_reader(languages: List[str]) -> Any:
     """Return a cached EasyOCR Reader for the given language set."""
-    import easyocr  # type: ignore[import-untyped]
+    import easyocr
 
     key = tuple(sorted(languages))
     if key not in _ocr_readers:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -227,13 +227,14 @@ def api_regions_create() -> FlaskResponse:
 
     canvas_w = data.get("canvas_width")
     canvas_h = data.get("canvas_height")
+    region: Dict[str, Any]
     if (
         isinstance(canvas_w, (int, float))
         and isinstance(canvas_h, (int, float))
         and canvas_w > 0
         and canvas_h > 0
     ):
-        region: Dict[str, Any] = _normalize_region(
+        region = _normalize_region(
             data["x"], data["y"], data["w"], data["h"], int(canvas_w), int(canvas_h)
         )
     else:

--- a/server.py
+++ b/server.py
@@ -1040,7 +1040,7 @@ def start_combined_server(
     )
 
     @combined.route("/")
-    def root() -> Response:
+    def root():
         return redirect(f"/{default_page}/")
 
     @combined.route("/api/status")

--- a/server.py
+++ b/server.py
@@ -219,7 +219,9 @@ def _save_manifest_quiet() -> None:
 
 
 def _load_stashes() -> List[Dict[str, Any]]:
-    stash_path = Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
+    stash_path = (
+        Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
+    )
     if not stash_path.is_file():
         return []
     try:
@@ -232,7 +234,9 @@ def _load_stashes() -> List[Dict[str, Any]]:
 
 
 def _save_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
-    stash_path = Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
+    stash_path = (
+        Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
+    )
     try:
         stash_path.parent.mkdir(parents=True, exist_ok=True)
         stash_path.write_text(
@@ -246,7 +250,8 @@ def _save_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
 
 def _load_artifact_stashes() -> List[Dict[str, Any]]:
     stash_path = (
-        Path(utils.get_effective_output_dir()) / config.ARTIFACT_STASHES_MANIFEST_FILENAME
+        Path(utils.get_effective_output_dir())
+        / config.ARTIFACT_STASHES_MANIFEST_FILENAME
     )
     if not stash_path.is_file():
         return []
@@ -261,7 +266,8 @@ def _load_artifact_stashes() -> List[Dict[str, Any]]:
 
 def _save_artifact_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
     stash_path = (
-        Path(utils.get_effective_output_dir()) / config.ARTIFACT_STASHES_MANIFEST_FILENAME
+        Path(utils.get_effective_output_dir())
+        / config.ARTIFACT_STASHES_MANIFEST_FILENAME
     )
     try:
         stash_path.parent.mkdir(parents=True, exist_ok=True)
@@ -276,7 +282,9 @@ def _save_artifact_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
 
 def _load_studio_settings() -> Dict[str, Any]:
     """Load studio_settings.json and apply non-default values to config module."""
-    settings_path = Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
+    settings_path = (
+        Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
+    )
     if not settings_path.is_file():
         return {}
     try:
@@ -310,7 +318,9 @@ def _load_studio_settings() -> Dict[str, Any]:
 
 def _save_studio_settings(overrides: Dict[str, Any]) -> Optional[Path]:
     """Write only non-default settings to studio_settings.json."""
-    settings_path = Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
+    settings_path = (
+        Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
+    )
     to_save = {}
     for name, value in overrides.items():
         if name in _settings_defaults and value != _settings_defaults[name]:
@@ -344,9 +354,7 @@ def _find_existing_artifacts(
         and a.get("cellCol") == cell_col
         and a.get("type") == artifact_type
     ]
-    return [
-        a for a in matches if Path(utils.resolve_output_path(a["file"])).is_file()
-    ]
+    return [a for a in matches if Path(utils.resolve_output_path(a["file"])).is_file()]
 
 
 @studio_bp.route("/api/generate", methods=["POST"])
@@ -370,7 +378,9 @@ def api_generate() -> FlaskResponse:
         cell_input = ", ".join(cell_strings)
         cell_specs = spreadsheet.parse_cell_specifications(cell_input)
         if not cell_specs:
-            return jsonify({"ok": False, "error": "Could not parse cell specifications"}), 400
+            return jsonify(
+                {"ok": False, "error": "Could not parse cell specifications"}
+            ), 400
 
         clips = spreadsheet.generate_list(
             _worksheet, "cell", cell_specs=cell_specs, skip_prompts=True
@@ -400,15 +410,18 @@ def api_generate() -> FlaskResponse:
                     clip["cell"].row, clip["cell"].col, output_format
                 )
                 if existing:
-                    yield json.dumps(
-                        {
-                            "cell": cell_str,
-                            "ok": True,
-                            "generated": len(existing),
-                            "artifacts": existing,
-                            "skipped": True,
-                        }
-                    ) + "\n"
+                    yield (
+                        json.dumps(
+                            {
+                                "cell": cell_str,
+                                "ok": True,
+                                "generated": len(existing),
+                                "artifacts": existing,
+                                "skipped": True,
+                            }
+                        )
+                        + "\n"
+                    )
                     continue
 
                 try:
@@ -416,20 +429,36 @@ def api_generate() -> FlaskResponse:
                         [clip], output_format=output_format
                     )
                     _generated_artifacts.extend(artifacts)
-                    yield json.dumps(
-                        {"cell": cell_str, "ok": generated > 0, "generated": generated, "artifacts": artifacts}
-                    ) + "\n"
+                    yield (
+                        json.dumps(
+                            {
+                                "cell": cell_str,
+                                "ok": generated > 0,
+                                "generated": generated,
+                                "artifacts": artifacts,
+                            }
+                        )
+                        + "\n"
+                    )
                 except Exception as e:
-                    yield json.dumps({"cell": cell_str, "ok": False, "error": str(e)}) + "\n"
+                    yield (
+                        json.dumps({"cell": cell_str, "ok": False, "error": str(e)})
+                        + "\n"
+                    )
             for cs in cell_strings:
                 if cs not in clip_cells:
-                    yield json.dumps({"cell": cs, "ok": False, "error": "No clip found"}) + "\n"
+                    yield (
+                        json.dumps({"cell": cs, "ok": False, "error": "No clip found"})
+                        + "\n"
+                    )
             _save_manifest_quiet()
         finally:
             config.TITLECARDS_ENABLED = original_tc_enabled
             config.TITLECARD_DURATION_SECONDS = original_tc_duration
 
-    return Response(stream(), mimetype="application/x-ndjson", headers={"X-Accel-Buffering": "no"})
+    return Response(
+        stream(), mimetype="application/x-ndjson", headers={"X-Accel-Buffering": "no"}
+    )
 
 
 @studio_bp.route("/api/highlights-preview", methods=["POST"])
@@ -542,9 +571,10 @@ def api_reel() -> FlaskResponse:
         if components:
             expected_id = clipgen.compute_reel_id(components)
             for reel in _generated_reels:
-                if reel.get("id") == expected_id and Path(
-                    utils.resolve_output_path(reel["file"])
-                ).is_file():
+                if (
+                    reel.get("id") == expected_id
+                    and Path(utils.resolve_output_path(reel["file"])).is_file()
+                ):
                     return jsonify(
                         {
                             "ok": True,
@@ -663,7 +693,9 @@ def api_gallery() -> FlaskResponse:
 
     video_path = _resolve_source_video(participant)
     if video_path is None or not video_path.is_file():
-        return jsonify({"ok": False, "error": f"Source video not found for {participant}"}), 404
+        return jsonify(
+            {"ok": False, "error": f"Source video not found for {participant}"}
+        ), 404
 
     try:
         artifacts = video.generate_interval_captures(
@@ -938,7 +970,12 @@ def api_settings_put() -> FlaskResponse:
 
 def _init_studio_state(worksheet: Any) -> None:
     """Initialize module-level state for Studio routes."""
-    global _worksheet, _sheet_context, _generated_artifacts, _generated_reels, _thumbnail_cache
+    global \
+        _worksheet, \
+        _sheet_context, \
+        _generated_artifacts, \
+        _generated_reels, \
+        _thumbnail_cache
 
     _load_studio_settings()
     _worksheet = worksheet

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
 
 import files
 import utils
@@ -170,8 +169,8 @@ def test_baseline_row_detection_and_relative_conversion():
     # Expect clip records for both participants
     assert len(clips) == 2
 
-    p01_clip = cast(ClipRecord, clips[0])
-    p02_clip = cast(ClipRecord, clips[1])
+    p01_clip = clips[0]
+    p02_clip = clips[1]
 
     # P01 column has a baseline in the marker row, P02 does not
     assert p01_clip.get("timestamp_baseline") == "09:12:00"
@@ -214,8 +213,8 @@ def test_no_baseline_row_means_relative_timestamps_only():
     clips = spreadsheet.get_line_timestamps(ctx, 3)
 
     assert len(clips) == 2
-    p01_clip = cast(ClipRecord, clips[0])
-    p02_clip = cast(ClipRecord, clips[1])
+    p01_clip = clips[0]
+    p02_clip = clips[1]
 
     assert "timestamp_baseline" not in p01_clip
     assert "timestamp_baseline" not in p02_clip

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -40,7 +40,9 @@ def test_update_insight_merges_fields():
     original_id = ins["id"]
     time.sleep(0.01)
 
-    result = insights.update_insight([ins], original_id, {"title": "New", "severity": "Critical"})
+    result = insights.update_insight(
+        [ins], original_id, {"title": "New", "severity": "Critical"}
+    )
 
     assert result is ins
     assert ins["title"] == "New"

--- a/tests/test_insights_api.py
+++ b/tests/test_insights_api.py
@@ -1,9 +1,9 @@
 import pytest
 
 Flask = pytest.importorskip("flask").Flask
-import insights
-import insights_server
-import viewer
+import insights  # noqa: E402
+import insights_server  # noqa: E402
+import viewer  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -279,6 +279,7 @@ class TestScreenspaceWorker:
         worker.enqueue(task)
         assert worker.cancel(task["id"]) is True
         t = worker.get_task(task["id"])
+        assert t is not None
         assert t["status"] == "cancelled"
 
     def test_cancel_nonexistent(self):
@@ -308,6 +309,7 @@ class TestScreenspaceWorker:
                     break
                 time.sleep(0.1)
             t = worker.get_task(task["id"])
+            assert t is not None
             assert t["status"] in ("completed", "failed")
         finally:
             worker.stop()
@@ -327,6 +329,7 @@ class TestScreenspaceWorker:
         worker.enqueue(t2)
         assert worker.reorder([t2["id"], t1["id"]]) is True
         got = worker.get_task(t2["id"])
+        assert got is not None
         assert got["priority"] == 1
 
     def test_get_task_returns_none_for_unknown(self):
@@ -396,6 +399,7 @@ class TestScreenspaceWorker:
             worker._tasks[task["id"]]["result"] = [{"timestamp": 5.0}]
         worker.resume()
         t = worker.get_task(task["id"])
+        assert t is not None
         assert t["status"] == "queued"
         assert t.get("parameters", {}).get("start_seconds") == 50.0
 

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -243,7 +243,12 @@ class TestScreenspaceWorker:
     def test_enqueue_and_get(self):
         worker = screenspace.ScreenspaceWorker()
         task = screenspace.create_task(
-            "color", "P01", "s_P01.mp4", "/v.mp4", "hb", {"x": 0, "y": 0, "w": 10, "h": 10}
+            "color",
+            "P01",
+            "s_P01.mp4",
+            "/v.mp4",
+            "hb",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
         )
         tid = worker.enqueue(task)
         assert tid == task["id"]
@@ -291,7 +296,10 @@ class TestScreenspaceWorker:
                 "/nonexistent/nope.mp4",
                 "r",
                 {"x": 0, "y": 0, "w": 10, "h": 10},
-                parameters={"target_color": {"h": 0, "s": 0, "v": 0}, "tolerance": {"h": 10, "s": 10, "v": 10}},
+                parameters={
+                    "target_color": {"h": 0, "s": 0, "v": 0},
+                    "tolerance": {"h": 10, "s": 10, "v": 10},
+                },
             )
             worker.enqueue(task)
             for _ in range(50):
@@ -349,7 +357,6 @@ class TestScreenspaceWorker:
             worker._tasks[task["id"]]["status"] = screenspace.TASK_STATUS_RUNNING
         assert worker.remove_task(task["id"]) is True
         assert worker.get_task(task["id"]) is None
-
 
     def test_pause_resume_flags(self):
         worker = screenspace.ScreenspaceWorker()

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -287,6 +287,7 @@ def test_cancel_task_not_found(client):
 
 def test_dismiss_queued_task(client):
     worker = screenspace_server._worker
+    assert worker is not None
     task = screenspace.create_task(
         "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
     )
@@ -303,6 +304,7 @@ def test_dismiss_queued_task(client):
 
 def test_dismiss_completed_task(client):
     worker = screenspace_server._worker
+    assert worker is not None
     task = screenspace.create_task(
         "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
     )

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1,21 +1,18 @@
 """Tests for Screenspace server API endpoints."""
 
-
 import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
-import config
-import screenspace
-import screenspace_server
+import config  # noqa: E402
+import screenspace  # noqa: E402
+import screenspace_server  # noqa: E402
 
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     app = Flask(__name__)
-    app.register_blueprint(
-        screenspace_server.screenspace_bp, url_prefix="/screenspace"
-    )
+    app.register_blueprint(screenspace_server.screenspace_bp, url_prefix="/screenspace")
 
     monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
     screenspace_server._manifest = {"regions": {}, "tasks": []}
@@ -174,7 +171,14 @@ def test_create_region_legacy_no_canvas_dims(client):
 def test_denormalize_region():
     from screenspace_server import _denormalize_region
 
-    region = {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.1, "source_width": 1920, "source_height": 1080}
+    region = {
+        "x": 0.5,
+        "y": 0.5,
+        "w": 0.1,
+        "h": 0.1,
+        "source_width": 1920,
+        "source_height": 1080,
+    }
     px = _denormalize_region(region, 1920, 1080)
     assert px == {"x": 960, "y": 540, "w": 192, "h": 108}
 
@@ -190,7 +194,14 @@ def test_denormalize_legacy_region():
 def test_denormalize_cross_resolution():
     from screenspace_server import _denormalize_region
 
-    region = {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.1, "source_width": 1920, "source_height": 1080}
+    region = {
+        "x": 0.5,
+        "y": 0.5,
+        "w": 0.1,
+        "h": 0.1,
+        "source_width": 1920,
+        "source_height": 1080,
+    }
     px = _denormalize_region(region, 1280, 720)
     assert px == {"x": 640, "y": 360, "w": 128, "h": 72}
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -728,6 +728,7 @@ def test_api_generate_titlecard_override(client, monkeypatch):
         },
     )
     assert resp.status_code == 200
+    resp.data  # consume streamed response so generator finally-block runs
     assert captured["enabled"] is True
     assert captured["duration"] == 5
     assert config.TITLECARDS_ENABLED == original_enabled

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 Flask = pytest.importorskip("flask").Flask
-import server
+import server  # noqa: E402
 
 
 @pytest.fixture
@@ -46,7 +46,9 @@ def test_api_generate_400_when_no_cells(client, monkeypatch):
 
 def test_api_generate_400_for_invalid_format(client, monkeypatch):
     monkeypatch.setattr(server, "_worksheet", object())
-    resp = client.post("/studio/api/generate", json={"cells": ["P01.3"], "format": "pdf"})
+    resp = client.post(
+        "/studio/api/generate", json={"cells": ["P01.3"], "format": "pdf"}
+    )
     assert resp.status_code == 400
     data = resp.get_json()
     assert "Invalid format" in data["error"]
@@ -177,7 +179,9 @@ def test_api_thumbnail_caches(client, monkeypatch, tmp_path):
 def test_api_manifest_get_returns_artifacts(client, monkeypatch):
     import viewer
 
-    fake_artifacts = [{"id": "a5c2s0", "type": "clip", "participant": "P01", "cellRow": 5}]
+    fake_artifacts = [
+        {"id": "a5c2s0", "type": "clip", "participant": "P01", "cellRow": 5}
+    ]
     monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: fake_artifacts)
     monkeypatch.setattr(viewer, "load_manifest_reels", lambda: [])
     resp = client.get("/studio/api/manifest")
@@ -244,7 +248,9 @@ def test_api_generate_skips_existing_artifacts(client, monkeypatch, tmp_path):
         lambda *a, **kw: process_called.append(1) or (1, []),
     )
 
-    resp = client.post("/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"})
+    resp = client.post(
+        "/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"}
+    )
     assert resp.status_code == 200
     lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
     assert lines[0]["ok"] is True
@@ -274,13 +280,21 @@ def test_api_generate_regenerates_when_file_missing(client, monkeypatch, tmp_pat
     monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
     monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
 
-    new_artifact = {"id": "a5c2s0", "type": "clip", "file": "new.mp4", "cellRow": 5, "cellCol": 2}
+    new_artifact = {
+        "id": "a5c2s0",
+        "type": "clip",
+        "file": "new.mp4",
+        "cellRow": 5,
+        "cellCol": 2,
+    }
     monkeypatch.setattr(
         "clipgen.process_clips",
         lambda *a, **kw: (1, [new_artifact]),
     )
 
-    resp = client.post("/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"})
+    resp = client.post(
+        "/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"}
+    )
     lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
     assert lines[0]["ok"] is True
     assert "skipped" not in lines[0]
@@ -352,7 +366,9 @@ def test_api_gallery_500_when_no_context(client):
 
 def test_api_gallery_400_when_no_participant(client, monkeypatch):
     monkeypatch.setattr(server, "_sheet_context", object())
-    resp = client.post("/studio/api/gallery", json={"participant": "", "format": "screen"})
+    resp = client.post(
+        "/studio/api/gallery", json={"participant": "", "format": "screen"}
+    )
     assert resp.status_code == 400
     data = resp.get_json()
     assert "No participant" in data["error"]
@@ -360,7 +376,9 @@ def test_api_gallery_400_when_no_participant(client, monkeypatch):
 
 def test_api_gallery_400_for_invalid_format(client, monkeypatch):
     monkeypatch.setattr(server, "_sheet_context", object())
-    resp = client.post("/studio/api/gallery", json={"participant": "P01", "format": "clip"})
+    resp = client.post(
+        "/studio/api/gallery", json={"participant": "P01", "format": "clip"}
+    )
     assert resp.status_code == 400
     data = resp.get_json()
     assert "Invalid format" in data["error"]
@@ -709,7 +727,6 @@ def test_api_generate_titlecard_override(client, monkeypatch):
             "titlecard_duration": 5,
         },
     )
-    lines = [json.loads(ln) for ln in resp.data.decode().strip().split("\n")]
     assert resp.status_code == 200
     assert captured["enabled"] is True
     assert captured["duration"] == 5

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -238,7 +238,7 @@ def test_concatenate_clips_warns_on_mismatch(monkeypatch):
     warnings = []
     original_warning = video.utils.warning_print
 
-    def capture_warning(msg, details=None):
+    def capture_warning(msg: str, details: list[str] | None = None):
         warnings.append(msg)
         original_warning(msg, details)
 

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -1,7 +1,9 @@
 import viewer
 
 
-def _make_artifact(artifact_id, *, start=10.0, end=20.0, study="study", participant="P01"):
+def _make_artifact(
+    artifact_id, *, start=10.0, end=20.0, study="study", participant="P01"
+):
     return {
         "id": artifact_id,
         "type": "clip",
@@ -28,7 +30,12 @@ def _make_artifact(artifact_id, *, start=10.0, end=20.0, study="study", particip
 def test_finalize_timeline_data_duration_and_structure():
     arts = [_make_artifact("a1", end=20.0), _make_artifact("a2", end=50.0)]
     data = viewer.finalize_timeline_data(
-        arts, study="s", participant="P01", worksheet_title="Sheet1", is_excel=True, mode="batch"
+        arts,
+        study="s",
+        participant="P01",
+        worksheet_title="Sheet1",
+        is_excel=True,
+        mode="batch",
     )
 
     assert set(data.keys()) == {"meta", "artifacts", "timeline"}
@@ -72,7 +79,11 @@ def test_finalize_timeline_data_includes_reels():
 def test_finalize_gallery_data_structure():
     gallery_artifacts = [{"file": "frame_10.png", "timestamp": 10.0}]
     data = viewer.finalize_gallery_data(
-        gallery_artifacts, source_video="vid.mp4", video_duration=120, output_format="screen", interval=5
+        gallery_artifacts,
+        source_video="vid.mp4",
+        video_duration=120,
+        output_format="screen",
+        interval=5,
     )
 
     assert data["meta"]["mode"] == "gallery"

--- a/utils.py
+++ b/utils.py
@@ -195,7 +195,7 @@ def _styled_print(
     prefix: str = "",
     prefix_style: str | None = None,
     message_style: str | None = None,
-    details: list[str | None] = None,
+    details: list[str] | None = None,
     details_style: str | None = None,
     panel_border_style: str | None = None,
 ) -> None:
@@ -222,7 +222,7 @@ def _styled_print(
             print(f"  {detail}")
 
 
-def error_print(message: str, details: list[str | None] = None) -> None:
+def error_print(message: str, details: list[str] | None = None) -> None:
     """Print error messages. Always displayed regardless of verbosity.
 
     Args:
@@ -239,7 +239,7 @@ def error_print(message: str, details: list[str | None] = None) -> None:
     )
 
 
-def warning_print(message: str, details: list[str | None] = None) -> None:
+def warning_print(message: str, details: list[str] | None = None) -> None:
     """Print warning messages. Always displayed regardless of verbosity.
 
     Args:
@@ -704,7 +704,7 @@ def add_duration(start_time: str) -> str | None:
     )
 
 
-def _parse_single_timestamp_token(token: str) -> tuple[str, str | None]:
+def _parse_single_timestamp_token(token: str) -> tuple[str, str | None] | None:
     """Parse one token into a (start_time, end_time) pair, or None if invalid/skip.
 
     Handles: dash range (start-end), single timestamp with colon (add default
@@ -759,7 +759,7 @@ def has_non_ignored_timestamp_content(cell_value: str) -> bool:
 
 
 def parse_cell_annotations(
-    cell_value: str, annotation_map: dict[str, str | None] = None
+    cell_value: str, annotation_map: dict[str, str | None] | None = None
 ) -> tuple[str, dict[str, set[int]], set[str]]:
     """Extract inline annotation tokens and map them to parsed timestamp indexes.
 

--- a/video.py
+++ b/video.py
@@ -1237,7 +1237,9 @@ def _batch_extract_screenshots(
             config.FFMPEG_SCREENSHOT_QUALITY,
             os.path.join(tmpdir, "frame_%04d.png"),
         ]
-        utils.debug_print(f"ffmpeg batch screenshot command: {' '.join(ffmpeg_command)}")
+        utils.debug_print(
+            f"ffmpeg batch screenshot command: {' '.join(ffmpeg_command)}"
+        )
 
         ffmpeg_result = run_ffmpeg_process(
             ffmpeg_command,


### PR DESCRIPTION
## Summary
- Add `paths` filters to push/pull_request triggers so smoke tests only run when Python files, test config, or the workflow itself change — skipping unnecessary runs for asset/markdown-only pushes.
- Scope `push` trigger to `master` only to eliminate duplicate CI runs on feature branches with open PRs.
- Add a **ruff** lint + format check job to enforce code style in CI.
- Add a **ty** typecheck job (`continue-on-error` for now due to pre-existing type errors).
- Fix existing ruff violations (`E402` noqa for `importorskip` patterns, remove unused variable) and auto-format with `ruff format`.

## Test plan
- [ ] Push a markdown-only change to a PR branch — verify no CI runs trigger
- [ ] Push a `.py` change to a PR branch — verify all three jobs run (smoke-tests, lint, typecheck)
- [ ] Verify lint and smoke-tests pass; typecheck shows warnings but does not block