### PR TITLE
Document SVG icon library and linting commands for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 - Features are often built incrementally across multiple sessions. Check for existing groundwork before starting from scratch.
 - Manifest-driven state persistence: JSON manifest files (clipgen, insights, screenspace, stashes, settings) follow the pattern of load-on-startup, save-after-mutations.
 - No hardcoded version numbers in evergreen docs (CLAUDE.md, README.md). Reference `VERSIONNUM` in `config.py` instead.
+- **Icons**: Prefer SVG icons from `assets/icons/` (316 Heroicons outline, kebab-case names like `pencil-square.svg`) over crafting new inline SVG paths or using text/emoji glyphs in web UIs.
+- **Linting/formatting**: Run `uv run ruff check --fix && uv run ruff format` after editing Python files. Run `uv run ty check` for type checking.
 
 ## Learned Workspace Facts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,10 @@ Use these tokens for **all new CSS**. When editing existing CSS, convert touched
 - **Transitions**: `--duration-fast` (150ms), `--duration-normal` (250ms), `--duration-slow` (350ms)
 - **Z-index**: `--z-float` (10), `--z-dropdown` (100), `--z-modal` (1000), `--z-overlay` (2000), `--z-toast` (3000)
 
+## SVG icons
+
+A library of 316 Heroicons (outline style, 24×24 viewBox) lives in [assets/icons/](assets/icons/). Filenames use kebab-case (e.g. `pencil-square.svg`, `eye-dropper.svg`, `arrow-right.svg`). When adding icons to a web UI, pick an icon from this library instead of writing new inline SVG paths or using text/emoji glyphs. See existing usage in `screenspace.js` (`svgEditIcon()`, `svgDragHandle()`, etc.) for the `createElementNS()` pattern.
+
 ## Conventions and patterns
 
 - **Coordinates:** gspread uses **1-based** row/col. `sheet.get_all_values()` is a list of lists with **0-based** indices: `sheet_data[row_idx][col_idx]`. Conversions: sheet row = `row_idx + 1`, sheet col = `col_idx + 1`.


### PR DESCRIPTION
## Summary
- Adds an "SVG icons" section to CLAUDE.md documenting the 316 Heroicons in `assets/icons/`, so agents use existing icons instead of inventing inline SVG paths or text glyphs.
- Adds icon and linting/formatting preferences to AGENTS.md ("Learned User Preferences") with explicit `ruff` and `ty` commands.

## Test plan
- [ ] Verify CLAUDE.md and AGENTS.md render correctly on GitHub