### PR TITLE
Move Screenspace Intake to tab in Studio Sheet Preview (#85)

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -226,6 +226,48 @@ body {
   margin-bottom: var(--space-2);
 }
 
+.preview-tabs {
+  display: flex;
+  flex: 1;
+}
+
+.preview-tab {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  transition: color var(--duration-fast), border-color var(--duration-fast);
+}
+
+.preview-tab:hover {
+  color: var(--color-text);
+}
+
+.preview-tab.active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
+}
+
+.intake-tab-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 600;
+  margin-left: var(--space-1);
+}
+
+#intakePanel {
+  flex: 1;
+  overflow: auto;
+  padding: 0 var(--space-1);
+}
+
 #filterToggle svg {
   transition: color var(--duration-fast);
 }
@@ -1899,8 +1941,7 @@ html[data-theme="dark"] .settings-panel {
   #dropAreas,
   #reelArea,
   #stashedReelsArea,
-  #stashedArtifactsArea,
-  #intakeArea {
+  #stashedArtifactsArea {
     margin-left: var(--space-2);
     margin-right: var(--space-2);
     max-width: 100%;
@@ -1909,39 +1950,6 @@ html[data-theme="dark"] .settings-panel {
 }
 
 /* ---- Screenspace Intake ---- */
-
-#intakeArea {
-  border-top: 1px solid var(--color-border);
-  padding: var(--space-2) var(--space-3);
-}
-
-#intakeArea h3 {
-  font-size: var(--text-sm);
-  margin: 0 0 var(--space-2) 0;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  cursor: pointer;
-  user-select: none;
-}
-
-.collapse-chevron {
-  flex-shrink: 0;
-  transition: transform var(--duration-fast);
-  transform: rotate(90deg);
-}
-
-#intakeArea.intake-collapsed .collapse-chevron {
-  transform: rotate(0deg);
-}
-
-#intakeArea.intake-collapsed h3 {
-  margin-bottom: 0;
-}
-
-#intakeArea.intake-collapsed #intakeBody {
-  display: none;
-}
 
 #intakeControls {
   display: flex;
@@ -1967,15 +1975,6 @@ html[data-theme="dark"] .settings-panel {
   border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
-}
-
-.intake-new-badge {
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: var(--radius-full);
-  background: var(--color-accent);
-  color: #fff;
-  font-weight: 600;
 }
 
 .intake-card {
@@ -2095,6 +2094,9 @@ html[data-theme="dark"] .settings-panel {
 }
 
 .intake-filter-det {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   font-size: 10px;
   padding: 1px 6px;
   border: 1px solid var(--det-color, var(--color-border));
@@ -2105,6 +2107,20 @@ html[data-theme="dark"] .settings-panel {
   font-weight: 600;
   text-transform: uppercase;
   transition: background var(--duration-fast), color var(--duration-fast);
+}
+
+.intake-det-icon {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  background-color: currentColor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
 }
 
 .intake-filter-det:hover {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -64,7 +64,10 @@
 
   <section id="sheetPreview">
     <div class="sheet-preview-header">
-      <h3>Sheet Preview</h3>
+      <div class="preview-tabs">
+        <button class="preview-tab active" data-tab="sheet">Sheet Preview</button>
+        <button class="preview-tab hidden" data-tab="intake">Screenspace Intake <span id="intakeTabBadge" class="intake-tab-badge hidden">0</span></button>
+      </div>
       <button id="filterToggle" class="btn btn-small btn-icon" title="Filter rows">
         <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
           <path d="M14 2C14 1.44772 13.5523 1 13 1H3C2.44772 1 2 1.44772 2 2V4.17157C2 4.70201 2.21071 5.21071 2.58579 5.58579L5.41421 8.41421C5.78929 8.78929 6 9.29799 6 9.82843V14.191C6 14.5627 6.39116 14.8044 6.72361 14.6382L8.89443 13.5528C9.572 13.214 10 12.5215 10 11.7639V9.82843C10 9.29799 10.2107 8.78929 10.5858 8.41421L13.4142 5.58579C13.7893 5.21071 14 4.70201 14 4.17157V2Z"/>
@@ -76,6 +79,27 @@
     <div id="sheetGrid">
       <div id="sheetLoading">
         Loading sheet data...
+      </div>
+    </div>
+    <div id="intakePanel" class="hidden">
+      <div class="area-controls" id="intakeControls">
+        <label class="intake-cluster-label">Cluster <input id="intakeClusterThreshold" type="number" min="1" max="60" value="5" class="intake-cluster-input">s</label>
+        <button id="intakeAddAllBtn" class="btn btn-small" disabled>Add All to Artifacts</button>
+        <button id="intakeReelAllBtn" class="btn btn-small" disabled>Add All to Reel</button>
+      </div>
+      <div class="intake-filters">
+        <input id="intakeFilterSearch" type="text" placeholder="Search events&#x2026;" class="intake-filter-search">
+        <div class="intake-filter-pills">
+          <button class="intake-filter-det" data-detector="color" style="--det-color:#8b5cf6"><span class="intake-det-icon" data-icon="eye-dropper"></span>color</button>
+          <button class="intake-filter-det" data-detector="change" style="--det-color:#f97316"><span class="intake-det-icon" data-icon="bolt"></span>change</button>
+          <button class="intake-filter-det" data-detector="similarity" style="--det-color:#0ea5e9"><span class="intake-det-icon" data-icon="photo"></span>similarity</button>
+          <button class="intake-filter-det" data-detector="text" style="--det-color:#10b981"><span class="intake-det-icon" data-icon="language"></span>text</button>
+          <button class="intake-filter-det" data-detector="numbers" style="--det-color:#eab308"><span class="intake-det-icon" data-icon="hashtag"></span>numbers</button>
+        </div>
+        <label class="intake-filter-new-label"><input id="intakeFilterNew" type="checkbox"> New only</label>
+      </div>
+      <div id="intakeList" class="drop-target">
+        <div class="drop-target-empty">Screenspace events will appear here</div>
       </div>
     </div>
   </section>
@@ -187,35 +211,6 @@
     <div id="stashedReelsList"></div>
   </section>
 
-  <section id="intakeArea" class="hidden">
-    <h3 id="intakeHeader">
-      <svg class="collapse-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
-        <path d="M4.5 2L9 6L4.5 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-      </svg>
-      Screenspace Intake <span id="intakeCount">(0)</span> <span id="intakeNewBadge" class="intake-new-badge hidden">new</span>
-    </h3>
-    <div id="intakeBody">
-      <div class="area-controls" id="intakeControls">
-        <label class="intake-cluster-label">Cluster <input id="intakeClusterThreshold" type="number" min="1" max="60" value="5" class="intake-cluster-input">s</label>
-        <button id="intakeAddAllBtn" class="btn btn-small" disabled>Add All to Artifacts</button>
-        <button id="intakeReelAllBtn" class="btn btn-small" disabled>Add All to Reel</button>
-      </div>
-      <div class="intake-filters">
-        <input id="intakeFilterSearch" type="text" placeholder="Search events\u2026" class="intake-filter-search">
-        <div class="intake-filter-pills">
-          <button class="intake-filter-det" data-detector="color" style="--det-color:#e74c3c">color</button>
-          <button class="intake-filter-det" data-detector="change" style="--det-color:#f39c12">change</button>
-          <button class="intake-filter-det" data-detector="similarity" style="--det-color:#3498db">similarity</button>
-          <button class="intake-filter-det" data-detector="text" style="--det-color:#10b981">text</button>
-          <button class="intake-filter-det" data-detector="numbers" style="--det-color:#eab308">numbers</button>
-        </div>
-        <label class="intake-filter-new-label"><input id="intakeFilterNew" type="checkbox"> New only</label>
-      </div>
-      <div id="intakeList" class="drop-target">
-        <div class="drop-target-empty">Screenspace events will appear here</div>
-      </div>
-    </div>
-  </section>
   </div>
 
   <div id="settingsOverlay" class="hidden">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -34,6 +34,7 @@
     intakeFilterText: "",
     intakeFilterDetector: "",
     intakeFilterNew: false,
+    activePreviewTab: "sheet",
   };
 
   var SEVERITY_ORDER = [
@@ -522,6 +523,43 @@
     }
   }
 
+  // ---- Preview tabs ----
+
+  function initPreviewTabs() {
+    var tabs = qsa(".preview-tab");
+    for (var i = 0; i < tabs.length; i++) {
+      tabs[i].addEventListener("click", function () {
+        var target = this.dataset.tab;
+        if (target === state.activePreviewTab) return;
+        state.activePreviewTab = target;
+        var allTabs = qsa(".preview-tab");
+        for (var j = 0; j < allTabs.length; j++) allTabs[j].classList.remove("active");
+        this.classList.add("active");
+        syncPreviewTab();
+      });
+    }
+  }
+
+  function syncPreviewTab() {
+    var grid = qs("#sheetGrid");
+    var filterBar = qs("#filterBar");
+    var filterToggle = qs("#filterToggle");
+    var intakePanel = qs("#intakePanel");
+
+    if (state.activePreviewTab === "sheet") {
+      grid.classList.remove("hidden");
+      intakePanel.classList.add("hidden");
+      if (filterToggle) filterToggle.classList.remove("hidden");
+      if (state.filtersVisible && filterBar) filterBar.classList.remove("hidden");
+    } else {
+      grid.classList.add("hidden");
+      if (filterBar) filterBar.classList.add("hidden");
+      if (filterToggle) filterToggle.classList.add("hidden");
+      intakePanel.classList.remove("hidden");
+    }
+    computeGridMaxHeight();
+  }
+
   // ---- Theme ----
 
   function initThemeToggle() {
@@ -895,7 +933,10 @@
     var maxAllowed = Math.max(0, available - MIN_GRID);
     state.dividerOffset = Math.min(state.dividerOffset, maxAllowed);
 
-    grid.style.maxHeight = Math.max(MIN_GRID, available - state.dividerOffset) + "px";
+    var maxH = Math.max(MIN_GRID, available - state.dividerOffset) + "px";
+    grid.style.maxHeight = maxH;
+    var intakePanel = qs("#intakePanel");
+    if (intakePanel) intakePanel.style.maxHeight = maxH;
   }
 
   function initPanelDivider() {
@@ -2909,6 +2950,8 @@
         if (data.screenspace) {
           var link = qs("#screenspaceLink");
           if (link) link.classList.remove("hidden");
+          var intakeTab = qs('.preview-tab[data-tab="intake"]');
+          if (intakeTab) intakeTab.classList.remove("hidden");
         }
       })
       .catch(function () {});
@@ -2922,6 +2965,14 @@
     similarity: "#0ea5e9",
     text: "#10b981",
     numbers: "#eab308",
+  };
+
+  var INTAKE_DETECTOR_ICON_FILES = {
+    color: "eye-dropper",
+    change: "bolt",
+    similarity: "photo",
+    text: "language",
+    numbers: "hashtag",
   };
 
   function clusterIntakeEvents(events, thresholdSec) {
@@ -2999,29 +3050,26 @@
   }
 
   function renderIntake(hasNew) {
-    var area = qs("#intakeArea");
     var list = qs("#intakeList");
-    var countEl = qs("#intakeCount");
     var addAllBtn = qs("#intakeAddAllBtn");
     var reelAllBtn = qs("#intakeReelAllBtn");
-    var badge = qs("#intakeNewBadge");
+    var tabBadge = qs("#intakeTabBadge");
 
     if (!state.intakeClusters.length) {
-      if (!area.classList.contains("hidden")) {
-        area.classList.add("hidden");
-        computeGridMaxHeight();
-      }
+      if (tabBadge) tabBadge.classList.add("hidden");
+      list.innerHTML = "";
+      list.appendChild(el("div", "drop-target-empty", "Screenspace events will appear here"));
+      addAllBtn.disabled = true;
+      reelAllBtn.disabled = true;
       return;
     }
-    var wasHidden = area.classList.contains("hidden");
-    area.classList.remove("hidden");
-    if (wasHidden) computeGridMaxHeight();
+    if (tabBadge) {
+      tabBadge.textContent = state.intakeClusters.length;
+      tabBadge.classList.remove("hidden");
+    }
     var clusters = filteredIntakeClusters();
-    countEl.textContent = "(" + clusters.length + "/" + state.intakeClusters.length + ")";
     addAllBtn.disabled = clusters.length === 0;
     reelAllBtn.disabled = clusters.length === 0;
-
-    if (hasNew && badge) badge.classList.remove("hidden");
 
     list.innerHTML = "";
     if (clusters.length === 0) {
@@ -3130,19 +3178,16 @@
   }
 
   function initIntake() {
-    var area = qs("#intakeArea");
-    if (localStorage.getItem("studio-intake-collapsed")) {
-      area.classList.add("intake-collapsed");
-    }
-    qs("#intakeHeader").addEventListener("click", function () {
-      area.classList.toggle("intake-collapsed");
-      if (area.classList.contains("intake-collapsed")) {
-        localStorage.setItem("studio-intake-collapsed", "1");
-      } else {
-        localStorage.removeItem("studio-intake-collapsed");
+    // Set mask-image on filter pill icons
+    var iconSpans = qsa(".intake-det-icon");
+    for (var k = 0; k < iconSpans.length; k++) {
+      var iconName = iconSpans[k].dataset.icon;
+      if (iconName) {
+        var iconUrl = 'url("../screenspace/icons/' + iconName + '.svg")';
+        iconSpans[k].style.maskImage = iconUrl;
+        iconSpans[k].style.webkitMaskImage = iconUrl;
       }
-      computeGridMaxHeight();
-    });
+    }
 
     var list = qs("#intakeList");
     list.addEventListener("click", function (e) {
@@ -3217,6 +3262,7 @@
   document.addEventListener("DOMContentLoaded", function () {
     initThemeToggle();
     initFilterToggle();
+    initPreviewTabs();
     initDropTargets();
     initWheelScroll();
     bindReelReorder();

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.72"
+VERSIONNUM: str = "0.9.73"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2


### PR DESCRIPTION
## Summary
- Replaces the collapsible bottom-panel Screenspace Intake strip with a tab bar in the Sheet Preview header area
- Two tabs: "Sheet Preview" (default) and "Screenspace Intake" (shown only when Screenspace is active)
- Adds SVG icons to detector filter pills (eye-dropper, bolt, photo, language, hashtag) matching Screenspace's iconography via CSS mask-image
- Corrects filter pill colors to match Screenspace's `TASK_COLORS` palette

## Test plan
- [ ] Launch Studio with `--screenspace` and verify the Intake tab appears
- [ ] Launch Studio without `--screenspace` and verify only Sheet Preview tab is visible
- [ ] Switch between tabs and confirm grid/intake content toggles correctly
- [ ] Verify filter pills show correct SVG icons and colors
- [ ] Test intake card actions (Add to Artifacts, Add to Reel, Dismiss)
- [ ] Confirm panel divider resizing works for both tab views