### PR TITLE
Screenspace: increase bottom panel height and tighten tab padding

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -467,7 +467,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-2) var(--space-2);
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
@@ -936,7 +936,7 @@ body {
   gap: var(--space-5);
   flex-shrink: 0;
   margin-bottom: var(--space-5);
-  height: 340px;
+  height: 400px;
   min-height: 120px;
   overflow: hidden;
 }


### PR DESCRIPTION
Adjusts two layout values in the Screenspace CSS. `#bottomPanel` height is increased from 340px to 400px for more content space. `button.wf-tab` horizontal padding is reduced from `--space-3` to `--space-2` for tighter tab spacing.