### PR TITLE
Add Screenspace region stashing with restore and hover preview

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -426,6 +426,141 @@ body {
   color: var(--color-accent);
 }
 
+/* Stash area */
+
+#stashArea {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.stash-card {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 280px;
+  padding: var(--space-1) var(--space-2) var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  transition: border-color var(--duration-fast);
+}
+
+.stash-card:hover {
+  border-color: var(--color-accent);
+}
+
+.stash-card-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  outline: none;
+  cursor: text;
+  border-radius: var(--radius-sm);
+  padding: 0 2px;
+  min-width: 0;
+  transition: background var(--duration-fast);
+}
+
+.stash-card-name:hover,
+.stash-card-name:focus {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.stash-card-sep {
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+
+.stash-card-count {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.stash-card-dots {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.stash-dot-fade {
+  -webkit-mask-image: linear-gradient(to right, black, transparent);
+  mask-image: linear-gradient(to right, black, transparent);
+}
+
+.stash-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+
+.stash-card:hover .stash-card-actions {
+  opacity: 1;
+}
+
+.stash-card-action-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  transition: color var(--duration-fast);
+}
+
+.stash-card-action-btn:hover {
+  color: var(--color-accent);
+}
+
+/* Stash folders in region picker */
+
+.stash-folder-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-1);
+}
+
+.stash-folder-header:hover {
+  color: var(--color-text);
+}
+
+.stash-folder-header .chevron {
+  font-size: 10px;
+  transition: transform var(--duration-fast);
+  display: inline-block;
+}
+
+.stash-folder-header.expanded .chevron {
+  transform: rotate(90deg);
+}
+
+.stash-folder-content {
+  display: none;
+}
+
+.stash-folder-content.expanded {
+  display: block;
+}
+
+.stash-folder-content label.stash-folder-item {
+  padding-left: var(--space-4);
+}
+
 /* Timeline */
 
 #timelineSection {
@@ -1595,6 +1730,11 @@ html[data-theme="dark"] .region-chip.active {
 
 html[data-theme="dark"] .run-picker-panel {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+html[data-theme="dark"] .stash-card-name:hover,
+html[data-theme="dark"] .stash-card-name:focus {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* Responsive */

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -43,6 +43,7 @@
           <button id="deleteRegionBtn" class="btn btn-small hidden">Delete</button>
           <button id="toggleLabelsBtn" class="region-toggle-btn hidden" title="Toggle region names"></button>
           <button id="toggleRegionsBtn" class="region-toggle-btn hidden" title="Toggle region visibility"></button>
+          <button id="stashRegionsBtn" class="region-toggle-btn hidden" title="Stash all regions"></button>
         </div>
       </div>
     </section>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -62,6 +62,8 @@
     showExcluded: true,
     showRegionLabels: true,
     showRegionOverlays: true,
+    stashes: [],
+    previewRegions: null,
   };
 
   var _cachedThemeColors = null;
@@ -351,18 +353,29 @@
     for (var i = 0; i < btns.length; i++) btns[i].classList.remove("open");
   }
 
+  function allAvailableRegionNames() {
+    var names = Object.keys(state.regions);
+    state.stashes.forEach(function (stash) {
+      Object.keys(stash.regions).forEach(function (n) {
+        if (names.indexOf(n) < 0) names.push(n);
+      });
+    });
+    return names;
+  }
+
   function renderRunRegionPicker() {
     var wrap = qs("#runRegionPicker");
     if (!wrap) return;
     wrap.innerHTML = "";
     var names = Object.keys(state.regions);
-    // Remove any runRegions that no longer exist
-    state.runRegions = state.runRegions.filter(function (r) { return names.indexOf(r) >= 0; });
+    var allNames = allAvailableRegionNames();
+    // Remove any runRegions that no longer exist in active or stashes
+    state.runRegions = state.runRegions.filter(function (r) { return allNames.indexOf(r) >= 0; });
     // Auto-select the active region when no explicit selection has been made
     if (state.runRegions.length === 0 && state.activeRegion && names.indexOf(state.activeRegion) >= 0) {
       state.runRegions = [state.activeRegion];
     }
-    if (names.length === 0) return;
+    if (allNames.length === 0) return;
 
     var btn = el("button", "run-picker-btn");
     btn.type = "button";
@@ -370,43 +383,94 @@
 
     var panel = el("div", "run-picker-panel hidden");
 
-    var toggleAll = el("span", "run-picker-toggle-all");
-    toggleAll.textContent = state.runRegions.length === names.length ? "Deselect all" : "Select all";
-    toggleAll.addEventListener("click", function () {
-      var allSelected = state.runRegions.length === names.length;
-      state.runRegions = allSelected ? [] : names.slice();
-      var cbs = panel.querySelectorAll("input[type=checkbox]");
-      for (var i = 0; i < cbs.length; i++) cbs[i].checked = !allSelected;
-      toggleAll.textContent = allSelected ? "Select all" : "Deselect all";
-      updateRegionPickerBtnText(btn);
-      updateRunButton();
-    });
-    panel.appendChild(toggleAll);
-
-    names.forEach(function (name, idx) {
-      var color = regionColorForIndex(idx);
-      var lbl = document.createElement("label");
-      var cb = document.createElement("input");
-      cb.type = "checkbox";
-      cb.value = name;
-      cb.checked = state.runRegions.indexOf(name) >= 0;
-      cb.addEventListener("change", function () {
-        if (cb.checked) {
-          if (state.runRegions.indexOf(name) < 0) state.runRegions.push(name);
-        } else {
-          state.runRegions = state.runRegions.filter(function (r) { return r !== name; });
-        }
-        toggleAll.textContent = state.runRegions.length === names.length ? "Deselect all" : "Select all";
+    if (names.length > 0) {
+      var toggleAll = el("span", "run-picker-toggle-all");
+      toggleAll.textContent = state.runRegions.length === names.length ? "Deselect all" : "Select all";
+      toggleAll.addEventListener("click", function () {
+        var allSelected = state.runRegions.length === names.length;
+        state.runRegions = allSelected ? [] : names.slice();
+        var cbs = panel.querySelectorAll(".run-picker-active-region input[type=checkbox]");
+        for (var i = 0; i < cbs.length; i++) cbs[i].checked = !allSelected;
+        toggleAll.textContent = allSelected ? "Select all" : "Deselect all";
         updateRegionPickerBtnText(btn);
         updateRunButton();
       });
-      lbl.appendChild(cb);
-      var dot = el("span", "region-chip-dot");
-      dot.style.background = color;
-      lbl.appendChild(dot);
-      var nameSpan = el("span", "run-picker-label-text", name);
-      lbl.appendChild(nameSpan);
-      panel.appendChild(lbl);
+      panel.appendChild(toggleAll);
+
+      names.forEach(function (name, idx) {
+        var color = regionColorForIndex(idx);
+        var lbl = document.createElement("label");
+        lbl.className = "run-picker-active-region";
+        var cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.value = name;
+        cb.checked = state.runRegions.indexOf(name) >= 0;
+        cb.addEventListener("change", function () {
+          if (cb.checked) {
+            if (state.runRegions.indexOf(name) < 0) state.runRegions.push(name);
+          } else {
+            state.runRegions = state.runRegions.filter(function (r) { return r !== name; });
+          }
+          toggleAll.textContent = state.runRegions.length === names.length ? "Deselect all" : "Select all";
+          updateRegionPickerBtnText(btn);
+          updateRunButton();
+        });
+        lbl.appendChild(cb);
+        var dot = el("span", "region-chip-dot");
+        dot.style.background = color;
+        lbl.appendChild(dot);
+        var nameSpan = el("span", "run-picker-label-text", name);
+        lbl.appendChild(nameSpan);
+        panel.appendChild(lbl);
+      });
+    }
+
+    // Stash folders
+    state.stashes.forEach(function (stash) {
+      var stashNames = Object.keys(stash.regions);
+      if (stashNames.length === 0) return;
+
+      var header = el("div", "stash-folder-header");
+      var chevron = el("span", "chevron", "\u25B8");
+      header.appendChild(chevron);
+      header.appendChild(document.createTextNode(stash.name + " (" + stashNames.length + ")"));
+
+      var content = el("div", "stash-folder-content");
+
+      header.addEventListener("click", function () {
+        var expanded = header.classList.toggle("expanded");
+        content.classList.toggle("expanded", expanded);
+      });
+
+      panel.appendChild(header);
+
+      stashNames.forEach(function (name, idx) {
+        var color = regionColorForIndex(idx);
+        var lbl = document.createElement("label");
+        lbl.className = "stash-folder-item";
+        var cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.value = name;
+        cb.checked = state.runRegions.indexOf(name) >= 0;
+        cb.addEventListener("change", function () {
+          if (cb.checked) {
+            if (state.runRegions.indexOf(name) < 0) state.runRegions.push(name);
+          } else {
+            state.runRegions = state.runRegions.filter(function (r) { return r !== name; });
+          }
+          updateRegionPickerBtnText(btn);
+          updateRunButton();
+        });
+        lbl.appendChild(cb);
+        var dot = el("span", "region-chip-dot");
+        dot.style.background = color;
+        lbl.appendChild(dot);
+        var nameSpan = el("span", "run-picker-label-text", name);
+        lbl.appendChild(nameSpan);
+        content.appendChild(lbl);
+      });
+
+      panel.appendChild(content);
     });
 
     btn.addEventListener("click", function (e) {
@@ -824,6 +888,11 @@
       renderOverlay();
     });
 
+    // Stash all regions
+    var stashBtn = qs("#stashRegionsBtn");
+    stashBtn.appendChild(svgArchiveIcon());
+    stashBtn.addEventListener("click", stashRegions);
+
     // Region name modal
     qs("#regionNameCancel").addEventListener("click", hideRegionNameModal);
     qs("#regionNameSave").addEventListener("click", function () {
@@ -896,6 +965,7 @@
     var toggleRegionsBtn = qs("#toggleRegionsBtn");
     toggleLabelsBtn.classList.toggle("hidden", !hasRegions);
     toggleRegionsBtn.classList.toggle("hidden", !hasRegions);
+    qs("#stashRegionsBtn").classList.toggle("hidden", !hasRegions);
     toggleLabelsBtn.classList.toggle("active", state.showRegionLabels);
     toggleRegionsBtn.classList.toggle("active", state.showRegionOverlays);
 
@@ -944,6 +1014,153 @@
     wrapper.classList.toggle("has-overflow", chips.scrollWidth > chips.clientWidth && chips.scrollLeft + chips.clientWidth < chips.scrollWidth - 1);
   }
 
+  // ---- Region stashing ----
+
+  function stashRegions() {
+    apiPost("api/stashes", {}).then(function (data) {
+      if (!data.ok) return;
+      state.stashes.push(data.stash);
+      state.regions = {};
+      state.activeRegion = null;
+      state.pendingRegion = null;
+      renderRegionChips();
+      renderOverlay();
+      updateRegionButtons();
+      updateRunButton();
+      renderStashCards();
+      showToast("Regions stashed");
+    });
+  }
+
+  function dismissStash(stashId) {
+    apiDelete("api/stashes/" + stashId).then(function (data) {
+      if (!data.ok) return;
+      state.stashes = state.stashes.filter(function (s) { return s.id !== stashId; });
+      // Remove any run-selected regions that belonged to this stash
+      renderRunRegionPicker();
+      renderStashCards();
+      showToast("Stash dismissed");
+    });
+  }
+
+  function restoreStash(stashId) {
+    apiPost("api/stashes/" + stashId + "/restore", {}).then(function (data) {
+      if (!data.ok) return;
+      state.regions = data.regions || {};
+      state.activeRegion = null;
+      state.pendingRegion = null;
+      state.stashes = state.stashes.filter(function (s) { return s.id !== stashId; });
+      renderRegionChips();
+      renderOverlay();
+      updateRegionButtons();
+      updateRunButton();
+      renderStashCards();
+      showToast("Regions restored");
+    });
+  }
+
+  function renameStash(stashId, newName) {
+    apiPut("api/stashes/" + stashId, { name: newName }).then(function (data) {
+      if (!data.ok) return;
+      for (var i = 0; i < state.stashes.length; i++) {
+        if (state.stashes[i].id === stashId) {
+          state.stashes[i].name = data.stash.name;
+          break;
+        }
+      }
+      renderRunRegionPicker();
+    });
+  }
+
+  function renderStashCards() {
+    var existing = qs("#stashArea");
+    if (state.stashes.length === 0) {
+      if (existing) existing.remove();
+      return;
+    }
+    var area = existing || el("div");
+    area.id = "stashArea";
+    area.innerHTML = "";
+
+    var MAX_DOTS = 5;
+
+    state.stashes.forEach(function (stash) {
+      var card = el("div", "stash-card");
+      var regionNames = Object.keys(stash.regions);
+
+      // Editable name
+      var nameEl = el("span", "stash-card-name", stash.name);
+      nameEl.setAttribute("contenteditable", "true");
+      nameEl.setAttribute("spellcheck", "false");
+      nameEl.addEventListener("blur", function () {
+        var trimmed = nameEl.textContent.trim();
+        if (trimmed && trimmed !== stash.name) {
+          renameStash(stash.id, trimmed);
+        } else {
+          nameEl.textContent = stash.name;
+        }
+      });
+      nameEl.addEventListener("keydown", function (e) {
+        if (e.key === "Enter") { e.preventDefault(); nameEl.blur(); }
+      });
+      card.appendChild(nameEl);
+
+      // Separator dot and count
+      card.appendChild(el("span", "stash-card-sep", "\u00b7"));
+      card.appendChild(el("span", "stash-card-count", regionNames.length + " region" + (regionNames.length !== 1 ? "s" : "")));
+
+      // Colored dots (max 5, with fade-out on 6th)
+      var dots = el("span", "stash-card-dots");
+      var showCount = Math.min(regionNames.length, MAX_DOTS);
+      for (var i = 0; i < showCount; i++) {
+        var dot = el("span", "region-chip-dot");
+        dot.style.background = regionColorForIndex(i);
+        dot.title = regionNames[i];
+        dots.appendChild(dot);
+      }
+      if (regionNames.length > MAX_DOTS) {
+        var fadeDot = el("span", "region-chip-dot stash-dot-fade");
+        fadeDot.style.background = regionColorForIndex(MAX_DOTS);
+        dots.appendChild(fadeDot);
+      }
+      card.appendChild(dots);
+
+      // Action buttons
+      var actions = el("span", "stash-card-actions");
+
+      var restoreBtn = el("button", "stash-card-action-btn");
+      restoreBtn.title = "Restore regions";
+      restoreBtn.appendChild(svgRestoreIcon());
+      restoreBtn.addEventListener("click", function () { restoreStash(stash.id); });
+      actions.appendChild(restoreBtn);
+
+      var dismissBtn = el("button", "stash-card-action-btn");
+      dismissBtn.title = "Dismiss stash";
+      dismissBtn.appendChild(svgDismissIcon());
+      dismissBtn.addEventListener("click", function () { dismissStash(stash.id); });
+      actions.appendChild(dismissBtn);
+
+      card.appendChild(actions);
+
+      // Hover preview: show stashed regions on the overlay
+      card.addEventListener("mouseenter", function () {
+        state.previewRegions = stash.regions;
+        renderOverlay();
+      });
+      card.addEventListener("mouseleave", function () {
+        state.previewRegions = null;
+        renderOverlay();
+      });
+
+      area.appendChild(card);
+    });
+
+    if (!existing) {
+      var viewerSection = qs("#viewerSection");
+      viewerSection.parentNode.insertBefore(area, viewerSection.nextSibling);
+    }
+  }
+
   function renderOverlay() {
     var canvas = qs("#overlayCanvas");
     if (!canvas.width || !canvas.height) return;
@@ -955,11 +1172,12 @@
     var displayW = canvas.getBoundingClientRect().width || canvas.width;
     var s = canvas.width / displayW;
 
-    // Draw saved regions
+    // Draw saved regions (or preview regions when hovering a stash)
+    var drawRegions = state.previewRegions || state.regions;
     if (state.showRegionOverlays) {
-      var names = Object.keys(state.regions);
+      var names = Object.keys(drawRegions);
       names.forEach(function (name, i) {
-        var r = regionToPixels(state.regions[name]);
+        var r = regionToPixels(drawRegions[name]);
         var color = regionColorForIndex(i);
         var isActive = (name === state.activeRegion);
         var isHovered = state.hoveredRegion && state.hoveredRegion.name === name;
@@ -2210,6 +2428,40 @@
     return svg;
   }
 
+  function svgArchiveIcon() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "14");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    // archive-box-arrow-down.svg from assets/icons
+    var p1 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p1.setAttribute("d", "M2 3C2 2.44772 2.44772 2 3 2H13C13.5523 2 14 2.44772 14 3V4C14 4.55228 13.5523 5 13 5H3C2.44772 5 2 4.55228 2 4V3Z");
+    svg.appendChild(p1);
+    var p2 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p2.setAttribute("fill-rule", "evenodd");
+    p2.setAttribute("clip-rule", "evenodd");
+    p2.setAttribute("d", "M13 6H3V12C3 13.1046 3.89543 14 5 14H11C12.1046 14 13 13.1046 13 12V6ZM8.75 7.75C8.75 7.33579 8.41421 7 8 7C7.58579 7 7.25 7.33579 7.25 7.75V10.4393L6.03033 9.21967C5.73744 8.92678 5.26256 8.92678 4.96967 9.21967C4.67678 9.51256 4.67678 9.98744 4.96967 10.2803L7.46967 12.7803C7.76256 13.0732 8.23744 13.0732 8.53033 12.7803L11.0303 10.2803C11.3232 9.98744 11.3232 9.51256 11.0303 9.21967C10.7374 8.92678 10.2626 8.92678 9.96967 9.21967L8.75 10.4393V7.75Z");
+    svg.appendChild(p2);
+    return svg;
+  }
+
+  function svgRestoreIcon() {
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "14");
+    svg.setAttribute("height", "14");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("fill", "currentColor");
+    // arrow-up-tray.svg from assets/icons
+    var p1 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p1.setAttribute("d", "M7.25 10.25C7.25 10.6642 7.58579 11 8 11C8.41421 11 8.75 10.6642 8.75 10.25L8.75 4.56066L10.9697 6.78033C11.2626 7.07322 11.7374 7.07322 12.0303 6.78033C12.3232 6.48744 12.3232 6.01256 12.0303 5.71967L8.53033 2.21967C8.23744 1.92678 7.76256 1.92678 7.46967 2.21967L3.96967 5.71967C3.67678 6.01256 3.67678 6.48744 3.96967 6.78033C4.26256 7.07322 4.73744 7.07322 5.03033 6.78033L7.25 4.56066L7.25 10.25Z");
+    svg.appendChild(p1);
+    var p2 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p2.setAttribute("d", "M3.5 9.75C3.5 9.33579 3.16421 9 2.75 9C2.33579 9 2 9.33579 2 9.75V11.25C2 12.7688 3.23122 14 4.75 14H11.25C12.7688 14 14 12.7688 14 11.25V9.75C14 9.33579 13.6642 9 13.25 9C12.8358 9 12.5 9.33579 12.5 9.75V11.25C12.5 11.9404 11.9404 12.5 11.25 12.5H4.75C4.05964 12.5 3.5 11.9404 3.5 11.25V9.75Z");
+    svg.appendChild(p2);
+    return svg;
+  }
+
   function sortTasks() {
     // completed/failed at top (oldest first), then running, then queued (by priority), cancelled last
     var statusOrder = { completed: 0, failed: 1, running: 2, paused: 3, queued: 4, cancelled: 5 };
@@ -3202,6 +3454,16 @@
           renderRegionChips();
           updateRegionButtons();
           renderOverlay();
+        }
+      })
+      .catch(function () {});
+
+    apiGet("api/stashes")
+      .then(function (data) {
+        if (data.ok) {
+          state.stashes = data.stashes || [];
+          renderStashCards();
+          renderRunRegionPicker();
         }
       })
       .catch(function () {});

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.73"
+VERSIONNUM: str = "0.9.74"
 TITLECARDS_ENABLED: bool = False
 FILMSTRIP_ENABLED: bool = False
 TITLECARD_DURATION_SECONDS: int = 2

--- a/screenspace.py
+++ b/screenspace.py
@@ -1246,7 +1246,7 @@ class ScreenspaceWorker:
 
 
 def _empty_screenspace_manifest() -> Dict[str, Any]:
-    return {"regions": {}, "tasks": [], "events": []}
+    return {"regions": {}, "tasks": [], "events": [], "stashes": []}
 
 
 def load_screenspace_manifest() -> Dict[str, Any]:
@@ -1269,6 +1269,7 @@ def load_screenspace_manifest() -> Dict[str, Any]:
         "regions": data.get("regions", {}),
         "tasks": data.get("tasks", []),
         "events": data.get("events", []),
+        "stashes": data.get("stashes", []),
     }
 
 
@@ -1276,6 +1277,7 @@ def save_screenspace_manifest(
     regions: Dict[str, Dict[str, Any]],
     tasks: List[Dict[str, Any]],
     events: Optional[List[Dict[str, Any]]] = None,
+    stashes: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[Path]:
     """Write the screenspace manifest to disk.
 
@@ -1300,6 +1302,7 @@ def save_screenspace_manifest(
                     "regions": regions,
                     "tasks": clean_tasks,
                     "events": events or [],
+                    "stashes": stashes or [],
                 },
                 ensure_ascii=False,
                 indent=2,

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -7,6 +7,9 @@ region management, task execution, video frame extraction, and media serving.
 
 from __future__ import annotations
 
+import copy
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -252,6 +255,7 @@ def api_regions_create() -> FlaskResponse:
         _manifest.get("regions", {}),
         _manifest.get("tasks", []),
         _manifest.get("events", []),
+        stashes=_manifest.get("stashes", []),
     )
 
     return jsonify({"ok": True, "region": region})
@@ -266,10 +270,108 @@ def api_regions_delete(name: str) -> FlaskResponse:
 
     del regions[name]
     screenspace.save_screenspace_manifest(
-        regions, _manifest.get("tasks", []), _manifest.get("events", [])
+        regions,
+        _manifest.get("tasks", []),
+        _manifest.get("events", []),
+        stashes=_manifest.get("stashes", []),
     )
 
     return jsonify({"ok": True})
+
+
+# ---- Stashes CRUD ----
+
+
+@screenspace_bp.route("/api/stashes")
+def api_stashes_list() -> FlaskResponse:
+    """List all region stashes."""
+    return jsonify({"ok": True, "stashes": _manifest.get("stashes", [])})
+
+
+@screenspace_bp.route("/api/stashes", methods=["POST"])
+def api_stashes_create() -> FlaskResponse:
+    """Stash all current regions and clear the active set."""
+    regions = _manifest.get("regions", {})
+    if not regions:
+        return jsonify({"ok": False, "error": "No regions to stash"}), 400
+
+    stash = {
+        "id": "stash_" + uuid.uuid4().hex[:8],
+        "name": "Stashed Regions",
+        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "regions": copy.deepcopy(regions),
+    }
+    _manifest.setdefault("stashes", []).append(stash)
+    _manifest["regions"] = {}
+    screenspace.save_screenspace_manifest(
+        _manifest.get("regions", {}),
+        _manifest.get("tasks", []),
+        _manifest.get("events", []),
+        stashes=_manifest.get("stashes", []),
+    )
+    return jsonify({"ok": True, "stash": stash})
+
+
+@screenspace_bp.route("/api/stashes/<stash_id>", methods=["PUT"])
+def api_stashes_update(stash_id: str) -> FlaskResponse:
+    """Update a stash (rename)."""
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"ok": False, "error": "JSON body required"}), 400
+
+    stashes = _manifest.get("stashes", [])
+    stash = next((s for s in stashes if s["id"] == stash_id), None)
+    if stash is None:
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    name = data.get("name", "").strip()
+    if name:
+        stash["name"] = name
+
+    screenspace.save_screenspace_manifest(
+        _manifest.get("regions", {}),
+        _manifest.get("tasks", []),
+        _manifest.get("events", []),
+        stashes=stashes,
+    )
+    return jsonify({"ok": True, "stash": stash})
+
+
+@screenspace_bp.route("/api/stashes/<stash_id>", methods=["DELETE"])
+def api_stashes_delete(stash_id: str) -> FlaskResponse:
+    """Dismiss a region stash."""
+    stashes = _manifest.get("stashes", [])
+    idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
+    if idx is None:
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    stashes.pop(idx)
+    screenspace.save_screenspace_manifest(
+        _manifest.get("regions", {}),
+        _manifest.get("tasks", []),
+        _manifest.get("events", []),
+        stashes=stashes,
+    )
+    return jsonify({"ok": True})
+
+
+@screenspace_bp.route("/api/stashes/<stash_id>/restore", methods=["POST"])
+def api_stashes_restore(stash_id: str) -> FlaskResponse:
+    """Restore a stash: replace active regions with stashed ones, remove stash."""
+    stashes = _manifest.get("stashes", [])
+    idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
+    if idx is None:
+        return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    stash = stashes.pop(idx)
+    _manifest["regions"] = copy.deepcopy(stash["regions"])
+    screenspace.save_screenspace_manifest(
+        _manifest["regions"],
+        _manifest.get("tasks", []),
+        _manifest.get("events", []),
+        stashes=stashes,
+    )
+    return jsonify({"ok": True, "regions": _manifest["regions"]})
 
 
 # ---- Tasks CRUD ----
@@ -321,6 +423,11 @@ def api_tasks_create() -> FlaskResponse:
         return jsonify({"ok": False, "error": "region is required"}), 400
 
     regions = _manifest.get("regions", {})
+    if region_name not in regions:
+        for stash in _manifest.get("stashes", []):
+            if region_name in stash.get("regions", {}):
+                regions = stash["regions"]
+                break
     if region_name not in regions:
         return jsonify({"ok": False, "error": f"Region '{region_name}' not found"}), 400
 
@@ -604,5 +711,8 @@ def _persist_manifest() -> None:
             _manifest.setdefault("events", []).extend(new_events)
         tasks = _worker.get_all_tasks()
         screenspace.save_screenspace_manifest(
-            _manifest.get("regions", {}), tasks, _manifest.get("events", [])
+            _manifest.get("regions", {}),
+            tasks,
+            _manifest.get("events", []),
+            stashes=_manifest.get("stashes", []),
         )

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -166,7 +166,7 @@ class TestMergeTimestampSpans:
 class TestManifest:
     def test_empty_manifest_structure(self):
         m = screenspace._empty_screenspace_manifest()
-        assert m == {"regions": {}, "tasks": [], "events": []}
+        assert m == {"regions": {}, "tasks": [], "events": [], "stashes": []}
 
     def test_roundtrip(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
@@ -201,21 +201,21 @@ class TestManifest:
     def test_load_missing_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         result = screenspace.load_screenspace_manifest()
-        assert result == {"regions": {}, "tasks": [], "events": []}
+        assert result == {"regions": {}, "tasks": [], "events": [], "stashes": []}
 
     def test_load_malformed_json(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         manifest_path = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
         manifest_path.write_text("not json")
         result = screenspace.load_screenspace_manifest()
-        assert result == {"regions": {}, "tasks": [], "events": []}
+        assert result == {"regions": {}, "tasks": [], "events": [], "stashes": []}
 
     def test_load_non_dict(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         manifest_path = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
         manifest_path.write_text(json.dumps([1, 2, 3]))
         result = screenspace.load_screenspace_manifest()
-        assert result == {"regions": {}, "tasks": [], "events": []}
+        assert result == {"regions": {}, "tasks": [], "events": [], "stashes": []}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -26,7 +26,7 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(
         screenspace,
         "save_screenspace_manifest",
-        lambda r, t, e=None: tmp_path / "m.json",
+        lambda r, t, e=None, stashes=None: tmp_path / "m.json",
     )
 
     with app.test_client() as c:


### PR DESCRIPTION
## Summary
- Adds region stashing: an archive icon in the region bar that saves all current regions to a named stash card and clears the workspace for a fresh set
- Stash cards appear between the region bar and timeline, showing an editable name, region count, and up to 5 colored dots (with fade-out truncation for larger sets)
- Cards support restore (replaces active regions), dismiss, rename, and hover preview (temporarily renders stashed regions on the video overlay)
- Stashed regions are selectable for analysis tasks via collapsible folders in the region dropdown picker, with server-side fallback lookup
- Manifest schema extended with a `stashes` key; new REST endpoints for full stash CRUD and atomic restore

## Test plan
- [x] All 309 existing tests pass
- [ ] Stash regions → card appears, workspace clears, overlay updates
- [ ] Hover stash card → stashed regions render on video preview, revert on leave
- [ ] Restore stash → active regions replaced, stash card removed, overlay redraws
- [ ] Dismiss stash → card removed, manifest updated
- [ ] Rename stash → persists across page reload
- [ ] Select stashed regions in dropdown → tasks execute with correct coordinates
- [ ] Dark mode renders stash cards correctly
- [ ] Cards with 6+ regions show truncated dots with fade-out