### PR TITLE
Filter Screenspace timeline markers by selected participant

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1596,6 +1596,7 @@
     _timelineHitRects = [];
     state.tasks.forEach(function (task) {
       if ((task.status !== "completed" && task.status !== "running") || !task.result) return;
+      if (task.participant && task.participant !== state.selectedParticipant) return;
       var color = taskTypeColor(task.type);
       var dimmed = focused && task.id !== focused;
       if (task.type === "color" && task.status === "completed") {


### PR DESCRIPTION
## Summary
- Screenspace event markers on the timeline now only appear for the currently selected participant
- Previously, markers from all participants (e.g. P11) were visible on every participant's timeline (e.g. P01), which was confusing
- Adds a single participant check in `renderTimeline()` consistent with the existing pattern used elsewhere in the file

## Test plan
- [ ] Launch Screenspace with a multi-participant study
- [ ] Run an analysis on one participant (e.g. P11)
- [ ] Switch to a different participant (e.g. P01) — markers should disappear
- [ ] Switch back to P11 — markers should reappear