### PR TITLE
Add study, participant, and event type to intake artifact filenames

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.76"
+VERSIONNUM: str = "0.9.77"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/server.py
+++ b/server.py
@@ -1046,7 +1046,9 @@ def api_generate_intake() -> FlaskResponse:
         span_hash = hashlib.md5(f"{participant}_{start}_{end}".encode()).hexdigest()[:8]
         safe_event_type = utils.sanitize_filename(event_type) if event_type else ""
         desc_part = f"{safe_event_type} " if safe_event_type else ""
-        out_name = f"{study} {participant} {desc_part}intake {span_hash}{config.FILEFORMAT}"
+        out_name = (
+            f"{study} {participant} {desc_part}intake {span_hash}{config.FILEFORMAT}"
+        )
         out_path = str(output_dir / out_name)
         out_path = files.get_unique_filename(out_path)
 

--- a/server.py
+++ b/server.py
@@ -1023,6 +1023,7 @@ def api_generate_intake() -> FlaskResponse:
 
     output_format = data.get("format", "clip")
     output_dir = Path(utils.get_effective_output_dir())
+    study = _sheet_context.study_name if _sheet_context else ""
     results: List[Dict[str, Any]] = []
 
     for item in items:
@@ -1043,7 +1044,9 @@ def api_generate_intake() -> FlaskResponse:
             continue
 
         span_hash = hashlib.md5(f"{participant}_{start}_{end}".encode()).hexdigest()[:8]
-        out_name = f"intake_{span_hash}{config.FILEFORMAT}"
+        safe_event_type = utils.sanitize_filename(event_type) if event_type else ""
+        desc_part = f"{safe_event_type} " if safe_event_type else ""
+        out_name = f"{study} {participant} {desc_part}intake {span_hash}{config.FILEFORMAT}"
         out_path = str(output_dir / out_name)
         out_path = files.get_unique_filename(out_path)
 
@@ -1062,7 +1065,7 @@ def api_generate_intake() -> FlaskResponse:
                 "start": start,
                 "end": end,
                 "thumbnail": "",
-                "study": "",
+                "study": study,
                 "participant": participant,
                 "category": "",
                 "severity": "",
@@ -1151,8 +1154,10 @@ def api_reel_direct() -> FlaskResponse:
         if not clip_paths:
             return jsonify({"ok": False, "error": "No clips could be generated"}), 400
 
+        reel_study = _sheet_context.study_name if _sheet_context else ""
+        reel_base = f"{reel_study} intake reel" if reel_study else "intake_reel"
         reel_name = files.get_unique_filename(
-            str(output_dir / f"intake_reel{config.FILEFORMAT}")
+            str(output_dir / f"{reel_base}{config.FILEFORMAT}")
         )
         ok = video.concatenate_clips(clip_paths, reel_name, reencode_on_fail=True)
 


### PR DESCRIPTION
## Summary
- Intake artifact filenames now follow the regular naming pattern (`{study} {participant} {event_type} intake {hash}.mp4`) instead of opaque `intake_{hash}.mp4` names.
- Intake reel filenames now include the study name prefix.
- The artifact record `study` field is populated with the actual study name from the sheet context.
- Version bumped to 0.9.77.

## Test plan
- [x] All 306 existing tests pass
- [ ] Generate intake artifacts in Studio and verify filenames include study, participant, and event type
- [ ] Generate an intake reel and verify the filename includes the study name