### PR TITLE
Speed up startup by reducing Google Sheets API calls and deferring imports

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,14 +13,11 @@ import sys
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Tuple
 
-import gspread
 from icecream import ic
 
 import clipgen
 import config
-import excel_io
 import files
-import google_api
 import spreadsheet
 import utils
 import video
@@ -434,6 +431,8 @@ def authenticate_google() -> Any:
     Returns:
         Google client connection object
     """
+    import gspread
+
     try:
         utils.debug_print("Attempting login...")
         gspread_client = gspread.oauth(credentials_filename="credentials.json")
@@ -473,6 +472,8 @@ def select_worksheet(
     Returns:
         Worksheet object
     """
+    import excel_io
+
     worksheet = None
     if args.spreadsheet:
         # CLI-specified spreadsheet
@@ -1221,6 +1222,8 @@ def main() -> None:
         sys.exit(0)
 
     # Authenticate with Google (once per run)
+    import google_api
+
     gspread_client = authenticate_google()
     doc_list = google_api.get_all_spreadsheets(gspread_client)
 

--- a/clipgen.py
+++ b/clipgen.py
@@ -24,16 +24,13 @@ import gspread
 from icecream import ic
 
 import config
-import excel_io
 import files
 import google_api
 import interactive
 import spreadsheet
-import transcripts
 import utils
 import video
 import viewer
-import titlecards
 from utils import ClipRecord
 
 # Active progress bar reference, set during clip pipeline so nested functions
@@ -241,6 +238,8 @@ def _handle_spreadsheet_command(
         return None
     # Handle 'excel' for local .xlsx
     if input_name.strip().lower() == config.COMMAND_EXCEL:
+        import excel_io
+
         return excel_io.select_excel_file()
     # Handle URL
     if input_name.startswith(config.COMMAND_HTTP_PREFIX):
@@ -616,8 +615,12 @@ def _process_single_clip_segments(
                 reencode=config.REENCODING,
             )
             if ok and config.TITLECARDS_ENABLED:
+                import titlecards
+
                 ok = titlecards.prepend_titlecard_to_clip(clip, out_name)
             if ok:
+                import titlecards
+
                 ok = titlecards.append_endcard_to_clip(out_name)
         elif output_format == "screen":
             ok = video.extract_screenshot(
@@ -706,6 +709,8 @@ def _transcribe_segments(
     transcript_cache: Dict[str, Any],
 ) -> None:
     """Transcribe segments of a clip and write transcript files."""
+    import transcripts
+
     if base_video not in transcript_cache:
         transcript_cache[base_video] = transcripts.transcribe_video(
             str(utils.resolve_input_path(base_video))

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.76"
+VERSIONNUM: str = "0.9.77"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/interactive.py
+++ b/interactive.py
@@ -490,10 +490,12 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
     """
 
     def _load_browse_data() -> tuple:
-        header_result = spreadsheet.validate_spreadsheet_headers(sheet)
+        sheet_data = sheet.get_all_values()
+        if len(sheet_data) <= 1:
+            return (None, None)
+        header_result = spreadsheet.validate_spreadsheet_headers(sheet_data)
         if header_result is None:
             return (None, None)
-        sheet_data = sheet.get_all_values()
         return (header_result, sheet_data)
 
     header_result, sheet_data = (
@@ -507,16 +509,10 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
     id_cell, observation_cell, category_cell = header_result
     utils.debug_print(f"Sheet dumped into memory at {utils.get_current_time()}")
 
-    # Check if sheet is empty or has only headers
-    if len(sheet_data) <= 1:
-        utils.error_print("Spreadsheet appears to be empty (no data rows found).")
-        return
-
     # Get participant info
-    header_row = sheet.row_values(id_cell.row)
-    num_participants = spreadsheet.get_num_participants(
-        header_row, id_cell, sheet.col_count
-    )
+    header_row = sheet_data[id_cell.row - 1]
+    col_count = max(len(row) for row in sheet_data)
+    num_participants = spreadsheet.get_num_participants(header_row, id_cell, col_count)
 
     if num_participants == 0:
         utils.warning_print(

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -39,14 +39,16 @@ import copy
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-import cv2
+if TYPE_CHECKING:
+    import cv2
+    import screenspace
+
 from flask import Blueprint, Response, jsonify, request, send_from_directory
 
 import config
 import files
-import screenspace
 import utils
 import video
 
@@ -55,7 +57,7 @@ FlaskResponse = Union[Response, Tuple[Response, int]]
 # ---- Module-level state (set once by _init_screenspace_state) ----
 
 _manifest: Dict[str, Any] = {}
-_worker: Optional[screenspace.ScreenspaceWorker] = None
+_worker: Optional["screenspace.ScreenspaceWorker"] = None
 _output_dir: str = ""
 _participants: List[Dict[str, Any]] = []
 _video_cap_cache: Dict[str, Any] = {"path": None, "cap": None}
@@ -115,8 +117,10 @@ def _find_participant_video(participant_id: str) -> Optional[str]:
     return None
 
 
-def _get_video_cap(video_path: str) -> Optional[cv2.VideoCapture]:
+def _get_video_cap(video_path: str) -> Optional["cv2.VideoCapture"]:
     """Return a cached VideoCapture for *video_path*, opening a new one if needed."""
+    import cv2
+
     if _video_cap_cache["path"] == video_path and _video_cap_cache["cap"] is not None:
         cap = _video_cap_cache["cap"]
         if cap.isOpened():
@@ -152,6 +156,8 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     if cap is None:
         return jsonify({"ok": False, "error": "Could not open video file"}), 500
 
+    import cv2
+
     cap.set(cv2.CAP_PROP_POS_MSEC, ts * 1000.0)
     ret, frame = cap.read()
 
@@ -174,6 +180,8 @@ def api_video_info(participant: str) -> FlaskResponse:
         return jsonify(
             {"ok": False, "error": f"No video for participant {participant}"}
         ), 404
+
+    import cv2
 
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
@@ -283,6 +291,8 @@ def api_regions_create() -> FlaskResponse:
     if "description" in data:
         region["description"] = str(data["description"])
 
+    import screenspace
+
     _manifest.setdefault("regions", {})[name] = region
     screenspace.save_screenspace_manifest(
         _manifest.get("regions", {}),
@@ -300,6 +310,8 @@ def api_regions_delete(name: str) -> FlaskResponse:
     regions = _manifest.get("regions", {})
     if name not in regions:
         return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 404
+
+    import screenspace
 
     del regions[name]
     screenspace.save_screenspace_manifest(
@@ -334,6 +346,8 @@ def api_stashes_create() -> FlaskResponse:
         "createdAt": datetime.now(timezone.utc).isoformat(),
         "regions": copy.deepcopy(regions),
     }
+    import screenspace
+
     _manifest.setdefault("stashes", []).append(stash)
     _manifest["regions"] = {}
     screenspace.save_screenspace_manifest(
@@ -357,6 +371,8 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
     if stash is None:
         return jsonify({"ok": False, "error": "Stash not found"}), 404
 
+    import screenspace
+
     name = data.get("name", "").strip()
     if name:
         stash["name"] = name
@@ -378,6 +394,8 @@ def api_stashes_delete(stash_id: str) -> FlaskResponse:
     if idx is None:
         return jsonify({"ok": False, "error": "Stash not found"}), 404
 
+    import screenspace
+
     stashes.pop(idx)
     screenspace.save_screenspace_manifest(
         _manifest.get("regions", {}),
@@ -395,6 +413,8 @@ def api_stashes_restore(stash_id: str) -> FlaskResponse:
     idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
     if idx is None:
         return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+    import screenspace
 
     stash = stashes.pop(idx)
     _manifest["regions"] = copy.deepcopy(stash["regions"])
@@ -488,8 +508,12 @@ def api_tasks_create() -> FlaskResponse:
         }
     parameters = data.get("parameters", {})
 
+    import screenspace
+
     # Similarity tasks: extract reference frame from video at given timestamp
     if task_type == "similarity":
+        import cv2
+
         ref_ts = parameters.get("reference_timestamp")
         if ref_ts is None:
             return jsonify(
@@ -685,6 +709,8 @@ def _init_screenspace_state(
     Loads manifest, resolves participant video paths, and starts the
     background worker thread.
     """
+    import screenspace
+
     global _manifest, _worker, _output_dir, _participants
 
     _output_dir = str(utils.get_effective_output_dir())
@@ -738,6 +764,8 @@ def _discover_participant_videos(study_name: str) -> None:
 
 def _persist_manifest() -> None:
     """Save manifest after a task completes."""
+    import screenspace
+
     if _worker:
         new_events = _worker.drain_new_events()
         if new_events:

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -33,7 +33,7 @@ Clip record (returned by generation functions):
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 
 import gspread
 from icecream import ic
@@ -77,19 +77,40 @@ class SheetContext:
 # ---- Validation and context building ----
 
 
-def validate_spreadsheet_headers(sheet: Any) -> Optional[Tuple[Any, Any, Any]]:
-    """Validate that required headers exist in the spreadsheet.
+class _CellLike(NamedTuple):
+    """Minimal cell reference with 1-based row and col."""
+
+    row: int
+    col: int
+
+
+def _find_in_data(sheet_data: List[List[str]], text: str) -> Optional[_CellLike]:
+    """Find first cell with exact text match in pre-loaded sheet data.
+
+    Returns _CellLike(row, col) with 1-based coordinates, or None.
+    """
+    for row_idx, row in enumerate(sheet_data):
+        for col_idx, cell_value in enumerate(row):
+            if cell_value == text:
+                return _CellLike(row=row_idx + 1, col=col_idx + 1)
+    return None
+
+
+def validate_spreadsheet_headers(
+    sheet_data: List[List[str]],
+) -> Optional[Tuple[_CellLike, _CellLike, _CellLike]]:
+    """Validate that required headers exist in pre-loaded sheet data.
 
     Args:
-        sheet: The gspread worksheet object
+        sheet_data: Pre-loaded sheet data (list of lists from get_all_values()).
 
     Returns:
         tuple: (id_cell, observation_cell, category_cell) if all headers found,
                None if any header is missing
     """
-    id_cell = sheet.find(config.ID_HEADER)
-    observation_cell = sheet.find(config.OBSERVATION_HEADER)
-    category_cell = sheet.find(config.CATEGORY_HEADER)
+    id_cell = _find_in_data(sheet_data, config.ID_HEADER)
+    observation_cell = _find_in_data(sheet_data, config.OBSERVATION_HEADER)
+    category_cell = _find_in_data(sheet_data, config.CATEGORY_HEADER)
 
     missing_headers = []
     if id_cell is None:
@@ -109,6 +130,8 @@ def validate_spreadsheet_headers(sheet: Any) -> Optional[Tuple[Any, Any, Any]]:
         )
         return None
 
+    if id_cell is None or observation_cell is None or category_cell is None:
+        return None
     return (id_cell, observation_cell, category_cell)
 
 
@@ -173,16 +196,9 @@ def get_num_participants(header_row: List[str], id_cell: Any, col_count: int) ->
 def build_sheet_context(sheet: Any) -> Optional[SheetContext]:
     """Validate headers, load sheet data, and build a SheetContext.
 
+    Makes exactly one API call (get_all_values); all header lookups use local data.
     Returns None if validation fails (missing headers, empty sheet, no participants).
     """
-    header_result = validate_spreadsheet_headers(sheet)
-    if header_result is None:
-        return None
-
-    id_cell, observation_cell, category_cell = header_result
-    if config.DEBUGGING:
-        ic(id_cell, observation_cell, category_cell)
-
     sheet_data = sheet.get_all_values()
     utils.debug_print(f"Sheet dumped into memory at {utils.get_current_time()}")
 
@@ -193,6 +209,14 @@ def build_sheet_context(sheet: Any) -> Optional[SheetContext]:
         )
         return None
 
+    header_result = validate_spreadsheet_headers(sheet_data)
+    if header_result is None:
+        return None
+
+    id_cell, observation_cell, category_cell = header_result
+    if config.DEBUGGING:
+        ic(id_cell, observation_cell, category_cell)
+
     baseline_row_idx = _detect_baseline_row(sheet_data)
 
     study_name = sheet_data[0][0]
@@ -201,24 +225,16 @@ def build_sheet_context(sheet: Any) -> Optional[SheetContext]:
     utils.standard_print(f"\nBeginning work on {study_name}.")
     study_name = utils.normalize_study_name(study_name)
 
-    num_participants = get_num_participants(
-        sheet.row_values(id_cell.row), id_cell, sheet.col_count
-    )
+    header_row = sheet_data[id_cell.row - 1]
+    col_count = max(len(row) for row in sheet_data)
+    num_participants = get_num_participants(header_row, id_cell, col_count)
 
-    filename_cell = None
+    filename_cell = _find_in_data(sheet_data, config.FILENAME_HEADER)
     filename_row_idx: Optional[int] = None
-    try:
-        filename_cell = sheet.find(config.FILENAME_HEADER)
-    except Exception:
-        filename_cell = None
     if filename_cell is not None:
         filename_row_idx = filename_cell.row - 1
 
-    severity_cell = None
-    try:
-        severity_cell = sheet.find(config.SEVERITY_HEADER)
-    except Exception:
-        severity_cell = None
+    severity_cell = _find_in_data(sheet_data, config.SEVERITY_HEADER)
 
     if num_participants == 0:
         utils.warning_print(

--- a/tests/test_spreadsheet_generation.py
+++ b/tests/test_spreadsheet_generation.py
@@ -176,3 +176,35 @@ def test_baseline_and_relative_timestamps_integration(monkeypatch):
 
     # P02 clip has no baseline and should remain relative as entered.
     assert prepared_p02[0]["times"] == [("00:20", "00:40")]
+
+
+# ---- Local header lookup tests ----
+
+
+def test_find_in_data_finds_exact_match():
+    data = [["Study"], ["ID", "P01", "P02", "Observation", "Category"]]
+    result = spreadsheet._find_in_data(data, "Observation")
+    assert result is not None
+    assert result.row == 2
+    assert result.col == 4
+
+
+def test_find_in_data_returns_none_for_missing():
+    data = [["ID", "P01"]]
+    assert spreadsheet._find_in_data(data, "Missing") is None
+
+
+def test_validate_headers_with_local_data():
+    data = [["Study"], ["ID", "P01", "P02", "Observation", "Category"]]
+    result = spreadsheet.validate_spreadsheet_headers(data)
+    assert result is not None
+    id_cell, obs_cell, cat_cell = result
+    assert id_cell.row == 2 and id_cell.col == 1
+    assert obs_cell.row == 2 and obs_cell.col == 4
+    assert cat_cell.row == 2 and cat_cell.col == 5
+
+
+def test_validate_headers_missing_required(capsys):
+    data = [["Study"], ["ID", "P01", "P02"]]
+    result = spreadsheet.validate_spreadsheet_headers(data)
+    assert result is None


### PR DESCRIPTION
## Summary

- Restructures `build_sheet_context()` to make 1 Google Sheets API call (`get_all_values`) instead of 7, saving ~3-6s on every spreadsheet-backed startup. All header lookups (`find`) and `row_values` are now done against local data.
- Defers heavy imports (`cv2`, `screenspace`, `gspread`, `openpyxl`, `titlecards`, `transcripts`) to function-level so they only load when actually needed, shaving ~350ms off standalone mode startup.
- Applies the same single-API-call optimization to the browse mode path in `interactive.py`.
- Adds 4 tests for the new local header lookup helpers.

## Test plan
- [x] `uv run pytest -c tests/pytest.ini` — 310 tests pass
- [x] `uv run ruff check --fix && uv run ruff format` — clean
- [x] `uv run ty check` — clean
- [ ] Manual: launch `--studio`, `--insights`, `--screenspace` and verify startup feels faster