### PR TITLE
Add "Detect first" toggle to Screenspace analysis tools

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -879,6 +879,11 @@ body {
   min-width: 0;
 }
 
+.param-control input[type="checkbox"] {
+  margin: 0;
+  accent-color: var(--color-accent);
+}
+
 .param-control input[type="range"] {
   width: 80px;
   accent-color: var(--color-accent);

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2037,6 +2037,10 @@
 
     if (type !== "timelapse") {
       addParamRow(container, "Event label", textInput("paramEventLabel", "e.g. low_health"));
+      var dfCb = document.createElement("input");
+      dfCb.type = "checkbox";
+      dfCb.id = "paramDetectFirst";
+      addParamRow(container, "Detect first", dfCb);
     }
 
     updateRunButton();
@@ -2437,6 +2441,10 @@
     var labelEl = qs("#paramEventLabel");
     if (labelEl && labelEl.value.trim()) {
       params.event_label = labelEl.value.trim();
+    }
+    var dfEl = qs("#paramDetectFirst");
+    if (dfEl && dfEl.checked) {
+      params.detect_first = true;
     }
     return params;
   }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.77"
+VERSIONNUM: str = "0.9.78"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace.py
+++ b/screenspace.py
@@ -1113,6 +1113,8 @@ class ScreenspaceWorker:
                         t["result"].append(result_dict)
                     if isinstance(t.get("_raw_results"), list):
                         t["_raw_results"].append(result_dict)
+                    if t.get("parameters", {}).get("detect_first"):
+                        t["_cancelled"] = True
 
         try:
             result = self._dispatch(task, _on_progress, _cancel_flag, _on_result)
@@ -1123,7 +1125,21 @@ class ScreenspaceWorker:
                         t["status"] = TASK_STATUS_PAUSED
                         t["result"] = result
                     elif t.get("_cancelled"):
-                        t["status"] = TASK_STATUS_CANCELLED
+                        if t.get("parameters", {}).get("detect_first"):
+                            t["status"] = TASK_STATUS_COMPLETED
+                            partial = t.pop("_partial_results", None)
+                            if partial and isinstance(result, list):
+                                result = partial + result
+                            t["result"] = result
+                            t["progress"] = 1.0
+                            t.pop("_progress_offset", None)
+                            t.pop("_progress_scale", None)
+                            raw = t.pop("_raw_results", [])
+                            t["_generated_events"] = self._generate_events_from_results(
+                                t, raw
+                            )
+                        else:
+                            t["status"] = TASK_STATUS_CANCELLED
                     else:
                         t["status"] = TASK_STATUS_COMPLETED
                         partial = t.pop("_partial_results", None)


### PR DESCRIPTION
## Summary
- Adds a "Detect first" checkbox (defaults to off) at the bottom of the parameter panel for all non-timelapse Screenspace tools (color, change, similarity, text, numbers).
- When enabled, the analysis stops after the first matching event is found, saving processing time and reducing noise.
- The backend reuses the existing cancellation mechanism — `_on_result` sets the cancel flag after the first result, and the completion handler treats detect-first cancellations as completed tasks (not user-cancelled), generating events normally.

## Test plan
- [ ] Open Screenspace, verify "Detect first" checkbox appears for all tools except timelapse
- [ ] Run a scan with "Detect first" checked — verify only 1 event returned and task status is "completed"
- [ ] Run the same scan unchecked — verify all matching events returned as before
- [ ] `uv run pytest -c tests/pytest.ini` passes