### PR TITLE
Add hover-to-preview video playback in Timeline Viewer

### DIFF
--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -930,6 +930,67 @@ body {
   color: var(--color-text-dim);
 }
 
+/* Video preview (hover-to-preview) */
+
+.video-preview-wrap {
+  position: relative;
+  background: #000;
+  border-radius: var(--radius);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.video-preview-wrap video {
+  display: block;
+  width: 100%;
+  max-height: 400px;
+  object-fit: contain;
+}
+
+.video-play-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  border: none;
+  cursor: pointer;
+  transition: background var(--duration-fast);
+}
+
+.video-play-overlay:hover {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.video-play-overlay svg {
+  width: 56px;
+  height: 56px;
+  color: white;
+  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4));
+}
+
+.video-play-overlay.hidden {
+  display: none;
+}
+
+.video-time-badge {
+  position: absolute;
+  bottom: var(--space-2);
+  left: var(--space-2);
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  pointer-events: none;
+}
+
+.video-time-badge.hidden {
+  display: none;
+}
+
 /* Empty state */
 
 #emptyState {
@@ -980,6 +1041,10 @@ body {
 
   .artifact-marker.filmstrip-loading {
     animation: none;
+  }
+
+  .video-play-overlay {
+    transition: none;
   }
 }
 
@@ -1155,6 +1220,14 @@ html[data-theme="dark"] .artifact-marker.selected {
   background: #000;
   border-radius: var(--radius);
   overflow: hidden;
+}
+
+#playerPreview .video-preview-wrap {
+  width: 100%;
+}
+
+#playerPreview .video-preview-wrap video {
+  max-height: 480px;
 }
 
 #playerPreview video,

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -28,6 +28,11 @@
   var _screenspaceVisible = true;
   var SCREENSPACE_STORAGE_KEY = "clipgen-viewer-screenspace";
 
+  var _preview = null; // { id, videoEl, wrapEl } — currently previewed artifact
+  var _hoverDebounce = null;
+  var _seekRaf = 0;
+  var _lastSeekProportion = null;
+
   var SORT_DEFAULT_DIR = {
     severity: "desc",
     chrono: "asc",
@@ -1016,6 +1021,33 @@
 
   // ---- Timeline rendering ----
 
+  function bindMarkerEvents(marker, a) {
+    marker.addEventListener("mouseenter", function (ev) {
+      onMarkerHover(ev);
+      clearTimeout(_hoverDebounce);
+      var target = ev.currentTarget;
+      var cx = ev.clientX;
+      _hoverDebounce = setTimeout(function () {
+        var p = getMarkerProportion(target, cx);
+        previewArtifact(a.id, a.type === "clip" ? p : 0);
+      }, 60);
+    });
+    marker.addEventListener("mousemove", function (ev) {
+      moveTooltip(ev);
+      if (_preview && _preview.id === a.id && _preview.videoEl) {
+        var p = getMarkerProportion(ev.currentTarget, ev.clientX);
+        updatePreviewSeek(p);
+      }
+    });
+    marker.addEventListener("mouseleave", function () {
+      hideTooltip();
+      clearTimeout(_hoverDebounce);
+    });
+    marker.addEventListener("click", function () {
+      selectArtifact(a.id);
+    });
+  }
+
   function renderTimeline() {
     var track = qs("#timelineTrack");
     if (!track) return;
@@ -1036,12 +1068,7 @@
       marker.style.left = startPct + "%";
       marker.style.width = widthPct + "%";
 
-      marker.addEventListener("mouseenter", onMarkerHover);
-      marker.addEventListener("mousemove", moveTooltip);
-      marker.addEventListener("mouseleave", hideTooltip);
-      marker.addEventListener("click", function () {
-        selectArtifact(a.id);
-      });
+      bindMarkerEvents(marker, a);
 
       track.appendChild(marker);
       markers.push({ el: marker, artifact: a });
@@ -1307,11 +1334,7 @@
 
   // ---- Selection & detail ----
 
-  function selectArtifact(id) {
-    if (state.selectedId === id) {
-      clearSelection();
-      return;
-    }
+  function selectArtifactVisuals(id) {
     state.selectedId = id;
 
     qsa(".artifact-marker.selected").forEach(function (m) {
@@ -1342,6 +1365,22 @@
         }
       }
     }
+  }
+
+  function selectArtifact(id) {
+    if (state.selectedId === id) {
+      clearSelection();
+      return;
+    }
+
+    // If preview is already showing this artifact, promote it to active playback
+    if (_preview && _preview.id === id && _preview.videoEl) {
+      activatePreview();
+      selectArtifactVisuals(id);
+      return;
+    }
+
+    selectArtifactVisuals(id);
 
     var artifact = findArtifact(id);
     if (!artifact) return;
@@ -1355,6 +1394,7 @@
 
   function clearSelection() {
     state.selectedId = null;
+    _preview = null;
     qsa(".artifact-marker.selected").forEach(function (m) {
       m.classList.remove("selected");
       var storedZ = m.dataset.collapsedZ;
@@ -1391,35 +1431,12 @@
     if (empty) empty.classList.add("hidden");
     if (content) content.classList.remove("hidden");
 
-    applySeverityPill(qs("#detailSeverityPill"), a);
-
-    var badge = qs("#detailType");
-    if (badge) {
-      badge.textContent = (a.type || "clip").toUpperCase();
-      badge.className = "detail-badge " + (a.type || "clip");
-    }
-
-    setText("#detailDescription", a.description || "(no description)");
-    setText("#detailCategory", a.category || "–");
-    setText("#detailParticipant", a.participant || "–");
-    setText("#detailTime",
-      formatTime(a.start) + (a.end != null ? " – " + formatTime(a.end) : ""));
-    setText("#detailCell", a.cellA1 || (a.cellRow ? "R" + a.cellRow + "C" + a.cellCol : "–"));
-    setText("#detailSource", a.sourceVideo || "–");
-    setText("#detailFile", a.file || "–");
-    var intakeRow = qs("#detailIntakeRow");
-    if (intakeRow) {
-      if (a.source === "screenspace" && a.intake_label) {
-        setText("#detailIntakeLabel", a.intake_label);
-        intakeRow.classList.remove("hidden");
-      } else {
-        intakeRow.classList.add("hidden");
-      }
-    }
+    populateDetailMeta(a);
 
     var preview = qs("#detailPreview");
     if (!preview) return;
     preview.innerHTML = "";
+    _preview = null;
 
     if (!a.file) return;
 
@@ -1439,6 +1456,205 @@
       vid.preload = "metadata";
       vid.src = a.file;
       preview.appendChild(vid);
+    }
+  }
+
+  // ---- Hover preview ----
+
+  function getMarkerProportion(markerEl, clientX) {
+    var rect = markerEl.getBoundingClientRect();
+    if (rect.width <= 0) return 0;
+    return Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+  }
+
+  function previewArtifact(id, seekProportion) {
+    var a = findArtifact(id);
+    if (!a || !a.file) return;
+
+    // Don't interrupt active playback
+    if (state.selectedId && _preview && _preview.videoEl && !_preview.videoEl.paused) return;
+
+    // Already previewing this artifact — just update seek
+    if (_preview && _preview.id === id) {
+      if (_preview.videoEl && seekProportion != null) {
+        updatePreviewSeek(seekProportion);
+      }
+      return;
+    }
+
+    // Determine which preview container to use
+    var isPlayerLayout = !!qs("#playerPane");
+    var preview, empty, content;
+    if (isPlayerLayout) {
+      preview = qs("#playerPreview");
+      empty = qs("#playerEmpty");
+      content = qs("#playerContent");
+    } else {
+      preview = qs("#detailPreview");
+      empty = qs("#detailEmpty");
+      content = qs("#detailContent");
+    }
+    if (!preview) return;
+
+    // Show the detail/player pane
+    if (empty) empty.classList.add("hidden");
+    if (content) content.classList.remove("hidden");
+
+    // Populate metadata
+    if (isPlayerLayout) {
+      populatePlayerMeta(a);
+    } else {
+      populateDetailMeta(a);
+    }
+
+    // Clear existing preview
+    preview.innerHTML = "";
+    _preview = null;
+
+    if (a.type === "screen") {
+      var img = document.createElement("img");
+      img.src = a.file;
+      img.alt = a.description || "screenshot";
+      preview.appendChild(img);
+      _preview = { id: id, videoEl: null, wrapEl: null };
+      return;
+    }
+
+    if (a.type === "gif") {
+      var gifImg = document.createElement("img");
+      gifImg.src = a.file;
+      gifImg.alt = a.description || "gif";
+      preview.appendChild(gifImg);
+      _preview = { id: id, videoEl: null, wrapEl: null };
+      return;
+    }
+
+    // Clip: create video preview with play overlay
+    var wrap = el("div", "video-preview-wrap");
+    var vid = document.createElement("video");
+    vid.preload = "auto";
+    vid.muted = true;
+    vid.playsInline = true;
+    vid.src = a.file;
+
+    var overlay = document.createElement("button");
+    overlay.className = "video-play-overlay";
+    overlay.type = "button";
+    overlay.setAttribute("aria-label", "Play video");
+    overlay.innerHTML = '<svg width="56" height="56" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">' +
+      '<path d="M3 3.73241C3 2.54878 4.30673 1.83146 5.30531 2.46692L12.0114 6.73441C12.9376 7.32384 12.9376 8.67597 12.0114 9.2654L5.30532 13.5329C4.30673 14.1684 3 13.451 3 12.2674V3.73241Z"/>' +
+      '</svg>';
+
+    var timeBadge = el("span", "video-time-badge", "--:--");
+
+    var proportion = seekProportion != null ? seekProportion : 0;
+
+    vid.onloadedmetadata = function () {
+      var dur = vid.duration;
+      if (!dur || !isFinite(dur)) return;
+      var seekTime = dur * Math.max(0, Math.min(1, proportion));
+      vid.currentTime = seekTime;
+      timeBadge.textContent = formatTime(seekTime) + " / " + formatTime(dur);
+    };
+
+    vid.onerror = function () {
+      if (wrap.parentNode) wrap.parentNode.removeChild(wrap);
+      _preview = { id: id, videoEl: null, wrapEl: null };
+    };
+
+    function doActivate() {
+      activatePreview();
+      var markerId = _preview ? _preview.id : id;
+      selectArtifactVisuals(markerId);
+    }
+
+    overlay.addEventListener("click", function (ev) {
+      ev.stopPropagation();
+      doActivate();
+    });
+    vid.addEventListener("click", function () {
+      if (vid.paused) doActivate();
+    });
+
+    wrap.appendChild(vid);
+    wrap.appendChild(overlay);
+    wrap.appendChild(timeBadge);
+    preview.appendChild(wrap);
+
+    _preview = { id: id, videoEl: vid, wrapEl: wrap, overlay: overlay, timeBadge: timeBadge };
+    _lastSeekProportion = proportion;
+  }
+
+  function updatePreviewSeek(proportionX) {
+    if (!_preview || !_preview.videoEl) return;
+    var vid = _preview.videoEl;
+    if (!vid.duration || !isFinite(vid.duration)) return;
+    if (vid.readyState < 1) return; // metadata not yet loaded
+
+    if (_seekRaf) return;
+    _seekRaf = requestAnimationFrame(function () {
+      _seekRaf = 0;
+      var clamped = Math.max(0, Math.min(1, proportionX));
+      var seekTime = vid.duration * clamped;
+      vid.currentTime = seekTime;
+      if (_preview && _preview.timeBadge) {
+        _preview.timeBadge.textContent = formatTime(seekTime) + " / " + formatTime(vid.duration);
+      }
+      _lastSeekProportion = clamped;
+    });
+  }
+
+  function activatePreview() {
+    if (!_preview || !_preview.videoEl) return;
+    var vid = _preview.videoEl;
+    vid.muted = false;
+    vid.controls = true;
+    vid.play();
+    if (_preview.overlay) _preview.overlay.classList.add("hidden");
+    if (_preview.timeBadge) _preview.timeBadge.classList.add("hidden");
+  }
+
+  function populateDetailMeta(a) {
+    applySeverityPill(qs("#detailSeverityPill"), a);
+    var badge = qs("#detailType");
+    if (badge) {
+      badge.textContent = (a.type || "clip").toUpperCase();
+      badge.className = "detail-badge " + (a.type || "clip");
+    }
+    setText("#detailDescription", a.description || "(no description)");
+    setText("#detailCategory", a.category || "\u2013");
+    setText("#detailParticipant", a.participant || "\u2013");
+    setText("#detailTime",
+      formatTime(a.start) + (a.end != null ? " \u2013 " + formatTime(a.end) : ""));
+    setText("#detailCell", a.cellA1 || (a.cellRow ? "R" + a.cellRow + "C" + a.cellCol : "\u2013"));
+    setText("#detailSource", a.sourceVideo || "\u2013");
+    setText("#detailFile", a.file || "\u2013");
+    var intakeRow = qs("#detailIntakeRow");
+    if (intakeRow) {
+      if (a.source === "screenspace" && a.intake_label) {
+        setText("#detailIntakeLabel", a.intake_label);
+        intakeRow.classList.remove("hidden");
+      } else {
+        intakeRow.classList.add("hidden");
+      }
+    }
+  }
+
+  function populatePlayerMeta(a) {
+    applySeverityPill(qs("#playerSeverityPill"), a);
+    var badge = qs("#playerType");
+    if (badge) {
+      badge.textContent = (a.type || "clip").toUpperCase();
+      badge.className = "detail-badge " + (a.type || "clip");
+    }
+    setText("#playerDescription", a.description || "(no description)");
+    var metaEl = qs("#playerMeta");
+    if (metaEl) {
+      var parts = [];
+      if (a.participant) parts.push(escHtml(a.participant));
+      parts.push(formatTime(a.start) + (a.end != null ? " \u2013 " + formatTime(a.end) : ""));
+      if (a.category) parts.push(escHtml(a.category));
+      metaEl.innerHTML = parts.join("&ensp;\u00B7&ensp;");
     }
   }
 
@@ -1601,12 +1817,7 @@
         marker.style.left = startPct + "%";
         marker.style.width = widthPct + "%";
 
-        marker.addEventListener("mouseenter", onMarkerHover);
-        marker.addEventListener("mousemove", moveTooltip);
-        marker.addEventListener("mouseleave", hideTooltip);
-        marker.addEventListener("click", function () {
-          selectArtifact(a.id);
-        });
+        bindMarkerEvents(marker, a);
 
         track.appendChild(marker);
         markers.push({ el: marker, artifact: a });
@@ -1674,28 +1885,12 @@
     if (empty) empty.classList.add("hidden");
     if (content) content.classList.remove("hidden");
 
-    applySeverityPill(qs("#playerSeverityPill"), a);
-
-    var badge = qs("#playerType");
-    if (badge) {
-      badge.textContent = (a.type || "clip").toUpperCase();
-      badge.className = "detail-badge " + (a.type || "clip");
-    }
-
-    setText("#playerDescription", a.description || "(no description)");
-
-    var metaEl = qs("#playerMeta");
-    if (metaEl) {
-      var parts = [];
-      if (a.participant) parts.push(escHtml(a.participant));
-      parts.push(formatTime(a.start) + (a.end != null ? " – " + formatTime(a.end) : ""));
-      if (a.category) parts.push(escHtml(a.category));
-      metaEl.innerHTML = parts.join("&ensp;·&ensp;");
-    }
+    populatePlayerMeta(a);
 
     var preview = qs("#playerPreview");
     if (!preview) return;
     preview.innerHTML = "";
+    _preview = null;
 
     if (!a.file) return;
 

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1572,9 +1572,11 @@
       ev.stopPropagation();
       doActivate();
     });
-    vid.addEventListener("click", function () {
+    function onVidClick() {
       if (vid.paused) doActivate();
-    });
+    }
+    vid.addEventListener("click", onVidClick);
+    vid._previewClickHandler = onVidClick;
 
     wrap.appendChild(vid);
     wrap.appendChild(overlay);
@@ -1607,6 +1609,11 @@
   function activatePreview() {
     if (!_preview || !_preview.videoEl) return;
     var vid = _preview.videoEl;
+    // Remove click-to-play so it doesn't fight native controls
+    if (vid._previewClickHandler) {
+      vid.removeEventListener("click", vid._previewClickHandler);
+      vid._previewClickHandler = null;
+    }
     vid.muted = false;
     vid.controls = true;
     vid.play();

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.77"
+VERSIONNUM: str = "0.9.78"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Hovering over artifact markers in the Timeline Viewer now shows a paused video preview in the detail/player pane, with a play button overlay and time badge
- Moving the mouse across a clip marker scrubs through the video proportionally (RAF-throttled); screenshots/GIFs show their image directly
- Clicking the marker or play overlay starts playback with audio from the previewed position using native browser controls
- Refactored metadata population and selection logic into shared helpers (`populateDetailMeta`, `populatePlayerMeta`, `selectArtifactVisuals`) to support both preview and selection paths
- Works in both viewer layouts (sidebar detail pane and full-width participant timelines player pane)

## Test plan
- [ ] Generate a viewer with `--viewer` containing clips, screenshots, and GIFs
- [ ] Hover clip markers — verify paused frame preview with play overlay and time badge appears in detail/player pane
- [ ] Move mouse across clip marker — verify frame scrubs proportionally
- [ ] Click to play — verify audio, native controls, and pause all work correctly
- [ ] Hover screenshots/GIFs — verify image appears in detail pane
- [ ] Rapid hover across many markers — no errors, debounce works
- [ ] Test both `viewer.html` and `timeline-viewer.html` layouts
- [ ] `uv run pytest -c tests/pytest.ini` passes (313 tests)