### PR TITLE
Add Open button to Studio viewer generation popup

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1605,6 +1605,12 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   color: #dc2626;
 }
 
+.status-actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
 /* Confirm overlay */
 
 #confirmOverlay {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -257,7 +257,10 @@
       <div id="statusSpinner" class="spinner"></div>
       <h3 id="statusTitle">Processing...</h3>
       <p id="statusMessage"></p>
-      <button id="statusDismiss" class="btn hidden">Dismiss</button>
+      <div class="status-actions">
+        <button id="statusDismiss" class="btn btn-small hidden">Dismiss</button>
+        <button id="statusOpen" class="btn btn-small btn-primary hidden">Open</button>
+      </div>
     </div>
   </div>
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2138,6 +2138,16 @@
     });
 
     qs("#statusDismiss").addEventListener("click", hideOverlay);
+    qs("#statusOpen").addEventListener("click", function () {
+      if (_lastViewerFile) {
+        fetch("api/open-viewer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ file: _lastViewerFile }),
+        });
+      }
+      hideOverlay();
+    });
 
     qs("#confirmOverlay").addEventListener("click", function (e) {
       if (e.target === qs("#confirmOverlay")) hideConfirm();
@@ -2502,7 +2512,7 @@
       .then(function (data) {
         state.generating = false;
         if (data.ok) {
-          showResult("Viewer created: " + (data.file || ""), null);
+          showResult("Viewer created: " + (data.file || ""), null, data.file);
         } else {
           showResult(null, data.error || "Viewer build failed");
         }
@@ -2565,7 +2575,7 @@
           var msg = "Timeline viewer created: " + (data.file || "");
           if (data.generated) msg = "Generated " + data.generated + " clip(s). " + msg;
           updateViewerButton();
-          showResult(msg, null);
+          showResult(msg, null, data.file);
         } else {
           showResult(null, data.error || "Timeline viewer build failed");
         }
@@ -2707,7 +2717,7 @@
       .then(function (data) {
         state.generating = false;
         if (data.ok) {
-          showResult("Gallery viewer created: " + (data.file || ""), null);
+          showResult("Gallery viewer created: " + (data.file || ""), null, data.file);
         } else {
           showResult(null, data.error || "Gallery build failed");
         }
@@ -2728,25 +2738,36 @@
 
   // ---- Status overlay ----
 
+  var _lastViewerFile = "";
+
   function showOverlay(message) {
     qs("#statusSpinner").style.display = "";
     qs("#statusTitle").textContent = message;
     qs("#statusMessage").textContent = "";
     qs("#statusMessage").className = "";
     qs("#statusDismiss").classList.add("hidden");
+    qs("#statusOpen").classList.add("hidden");
+    _lastViewerFile = "";
     qs("#statusOverlay").classList.remove("hidden");
   }
 
-  function showResult(successMsg, errorMsg) {
+  function showResult(successMsg, errorMsg, filePath) {
     qs("#statusSpinner").style.display = "none";
     if (errorMsg) {
       qs("#statusTitle").textContent = "Error";
       qs("#statusMessage").textContent = errorMsg;
       qs("#statusMessage").className = "error-text";
+      qs("#statusOpen").classList.add("hidden");
     } else {
       qs("#statusTitle").textContent = "Done";
       qs("#statusMessage").textContent = successMsg || "";
       qs("#statusMessage").className = "";
+      if (filePath) {
+        _lastViewerFile = filePath;
+        qs("#statusOpen").classList.remove("hidden");
+      } else {
+        qs("#statusOpen").classList.add("hidden");
+      }
     }
     qs("#statusDismiss").classList.remove("hidden");
   }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.78"
+VERSIONNUM: str = "0.9.79"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/server.py
+++ b/server.py
@@ -843,6 +843,27 @@ def api_gallery() -> FlaskResponse:
         return jsonify({"ok": False, "error": str(e)}), 500
 
 
+@studio_bp.route("/api/open-viewer", methods=["POST"])
+def api_open_viewer() -> FlaskResponse:
+    """Open a generated viewer HTML file in the default browser."""
+    data = request.get_json(silent=True) or {}
+    file_path = data.get("file", "")
+    if not file_path:
+        return jsonify({"ok": False, "error": "No file specified"}), 400
+
+    p = Path(file_path).resolve()
+    output_dir = Path(utils.get_effective_output_dir()).resolve()
+
+    if p.suffix != ".html" or not str(p).startswith(str(output_dir)):
+        return jsonify({"ok": False, "error": "Invalid file path"}), 403
+
+    if not p.is_file():
+        return jsonify({"ok": False, "error": "File not found"}), 404
+
+    webbrowser.open(p.as_uri())
+    return jsonify({"ok": True})
+
+
 @studio_bp.route("/api/manifest", methods=["GET", "POST"])
 def api_manifest() -> FlaskResponse:
     if request.method == "GET":


### PR DESCRIPTION
## Summary
- Adds an "Open" button alongside "Dismiss" in the Studio status popup after viewer generation (timeline, gallery, artifact viewers)
- Clicking "Open" triggers a `POST /api/open-viewer` server endpoint that opens the generated HTML file in the default browser via `webbrowser.open()`, preserving relative media paths
- The "Open" button only appears on success with a file path; error states show only "Dismiss"

## Test plan
- [ ] Generate a timeline viewer in Studio and verify both "Open" and "Dismiss" buttons appear
- [ ] Click "Open" and confirm the viewer opens in the default browser with working media
- [ ] Trigger an error and verify only "Dismiss" appears
- [ ] Test with gallery and artifact viewers as well