### PR TITLE
Improve perceived performance in Studio and Screenspace frontends

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -575,9 +575,18 @@ body {
   gap: var(--space-2);
 }
 
-#timelineRow #timelineCanvas {
+#timelineCanvasWrapper {
   flex: 1;
   min-width: 0;
+  position: relative;
+}
+
+#playheadCanvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  pointer-events: none;
 }
 
 #timelineSeek {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -50,7 +50,10 @@
 
     <section id="timelineSection">
       <div id="timelineRow">
-        <canvas id="timelineCanvas"></canvas>
+        <div id="timelineCanvasWrapper">
+          <canvas id="timelineCanvas"></canvas>
+          <canvas id="playheadCanvas"></canvas>
+        </div>
         <div id="timelineSeek">
           <input id="timestampInput" type="text" placeholder="0:00" spellcheck="false">
           <div id="timelineStepBtns">

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -4,7 +4,7 @@
   "use strict";
 
   var THEME_STORAGE_KEY = "clipgen-screenspace-theme";
-  var POLL_INTERVAL = 2000;
+  var POLL_INTERVAL = 3000;
   var FRAME_STEP = 1.0;
 
   var TASK_COLORS = {
@@ -106,6 +106,9 @@
   };
 
   var _timelineHitRects = [];
+  var _overlayRaf = 0;
+  var _cachedOverlayRect = null;
+  var _lastPollFingerprint = "";
 
   var _cachedThemeColors = null;
 
@@ -570,7 +573,7 @@
   function seekPlayhead(timestamp) {
     state.currentTimestamp = timestamp;
     qs("#timestampInput").value = formatTimestamp(timestamp);
-    renderTimeline();
+    renderPlayhead();
   }
 
   var _pendingFrameTs = null;
@@ -653,14 +656,30 @@
 
   // ---- Region drawing ----
 
-  function canvasCoords(canvas, event) {
-    var rect = canvas.getBoundingClientRect();
+  function canvasCoords(canvas, event, cachedRect) {
+    var rect = cachedRect || canvas.getBoundingClientRect();
     var scaleX = canvas.width / rect.width;
     var scaleY = canvas.height / rect.height;
     return {
       x: Math.round((event.clientX - rect.left) * scaleX),
       y: Math.round((event.clientY - rect.top) * scaleY),
     };
+  }
+
+  function scheduleOverlayRender() {
+    if (_overlayRaf) return;
+    _overlayRaf = requestAnimationFrame(function () {
+      _overlayRaf = 0;
+      renderOverlay();
+    });
+  }
+
+  function flushOverlayRender() {
+    if (_overlayRaf) {
+      cancelAnimationFrame(_overlayRaf);
+      _overlayRaf = 0;
+    }
+    renderOverlay();
   }
 
   function normalizeRect(x1, y1, x2, y2) {
@@ -738,8 +757,9 @@
         showToast("Sampled color from frame");
         return;
       }
-      var pos = canvasCoords(overlay, e);
-      var displayW = overlay.getBoundingClientRect().width || overlay.width;
+      _cachedOverlayRect = overlay.getBoundingClientRect();
+      var pos = canvasCoords(overlay, e, _cachedOverlayRect);
+      var displayW = _cachedOverlayRect.width || overlay.width;
       var s = overlay.width / displayW;
       var ctx = overlay.getContext("2d");
       var hit = findHitRegion(pos.x, pos.y, s, ctx);
@@ -774,8 +794,9 @@
 
     overlay.addEventListener("mousemove", function (e) {
       if (state.pipetteActive) return;
-      var pos = canvasCoords(overlay, e);
-      var displayW = overlay.getBoundingClientRect().width || overlay.width;
+      var rect = _cachedOverlayRect || overlay.getBoundingClientRect();
+      var pos = canvasCoords(overlay, e, rect);
+      var displayW = rect.width || overlay.width;
       var s = overlay.width / displayW;
       if (state.resizingRegion) {
         var rName = state.resizingRegion.name;
@@ -784,7 +805,7 @@
         var newW = clamp(pos.x - rPx.x, minSize, overlay.width - rPx.x);
         var newH = clamp(pos.y - rPx.y, minSize, overlay.height - rPx.y);
         state.regions[rName] = Object.assign({}, state.regions[rName], { w: newW / overlay.width, h: newH / overlay.height });
-        renderOverlay();
+        scheduleOverlayRender();
         return;
       }
       if (state.draggingRegion) {
@@ -793,31 +814,32 @@
         var newX = clamp(pos.x - d.offsetX, 0, overlay.width - dPx.w);
         var newY = clamp(pos.y - d.offsetY, 0, overlay.height - dPx.h);
         state.regions[d.name] = Object.assign({}, state.regions[d.name], { x: newX / overlay.width, y: newY / overlay.height });
-        renderOverlay();
+        scheduleOverlayRender();
         return;
       }
       if (state.drawingRegion) {
         state.drawingRegion.endX = pos.x;
         state.drawingRegion.endY = pos.y;
-        renderOverlay();
+        scheduleOverlayRender();
         return;
       }
       var ctx = overlay.getContext("2d");
       var hit = findHitRegion(pos.x, pos.y, s, ctx);
       state.hoveredRegion = hit;
       overlay.style.cursor = hit ? (hit.handle === "resize" ? "nwse-resize" : "grab") : "crosshair";
-      renderOverlay();
+      scheduleOverlayRender();
     });
 
     overlay.addEventListener("mouseup", function (e) {
       if (state.pipetteActive) return;
+      _cachedOverlayRect = null;
       if (state.resizingRegion) {
         var rName = state.resizingRegion.name;
         state.resizingRegion = null;
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         saveRegionUpdate(rName);
-        renderOverlay();
+        flushOverlayRender();
         updateRegionButtons();
         return;
       }
@@ -827,7 +849,7 @@
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         saveRegionUpdate(dName);
-        renderOverlay();
+        flushOverlayRender();
         updateRegionButtons();
         return;
       }
@@ -843,15 +865,16 @@
       if (r.w > 5 && r.h > 5) {
         state.pendingRegion = r;
       }
-      renderOverlay();
+      flushOverlayRender();
       updateRegionButtons();
     });
 
     // Document-level listeners so drag/resize continues outside the canvas
     document.addEventListener("mousemove", function (e) {
       if (!state.resizingRegion && !state.draggingRegion) return;
-      var pos = canvasCoords(overlay, e);
-      var displayW = overlay.getBoundingClientRect().width || overlay.width;
+      var rect = _cachedOverlayRect || overlay.getBoundingClientRect();
+      var pos = canvasCoords(overlay, e, rect);
+      var displayW = rect.width || overlay.width;
       var s = overlay.width / displayW;
       if (state.resizingRegion) {
         var rName = state.resizingRegion.name;
@@ -860,25 +883,26 @@
         var newW = clamp(pos.x - rPx.x, minSize, overlay.width - rPx.x);
         var newH = clamp(pos.y - rPx.y, minSize, overlay.height - rPx.y);
         state.regions[rName] = Object.assign({}, state.regions[rName], { w: newW / overlay.width, h: newH / overlay.height });
-        renderOverlay();
+        scheduleOverlayRender();
       } else if (state.draggingRegion) {
         var d = state.draggingRegion;
         var dPx = regionToPixels(state.regions[d.name]);
         var newX = clamp(pos.x - d.offsetX, 0, overlay.width - dPx.w);
         var newY = clamp(pos.y - d.offsetY, 0, overlay.height - dPx.h);
         state.regions[d.name] = Object.assign({}, state.regions[d.name], { x: newX / overlay.width, y: newY / overlay.height });
-        renderOverlay();
+        scheduleOverlayRender();
       }
     });
 
     document.addEventListener("mouseup", function () {
+      _cachedOverlayRect = null;
       if (state.resizingRegion) {
         var rName = state.resizingRegion.name;
         state.resizingRegion = null;
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         saveRegionUpdate(rName);
-        renderOverlay();
+        flushOverlayRender();
         updateRegionButtons();
       } else if (state.draggingRegion) {
         var dName = state.draggingRegion.name;
@@ -886,7 +910,7 @@
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         saveRegionUpdate(dName);
-        renderOverlay();
+        flushOverlayRender();
         updateRegionButtons();
       }
     });
@@ -1294,7 +1318,7 @@
       var w = Math.abs(d.endX - d.startX);
       var h = Math.abs(d.endY - d.startY);
       if (w > 20 && h > 20) {
-        ctx.font = Math.round(11 * s) + "px " + getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim();
+        ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
         ctx.fillStyle = "rgba(255,255,255,0.9)";
         ctx.fillText(w + "\u00d7" + h, Math.min(d.startX, d.endX) + Math.round(4 * s), Math.max(d.startY, d.endY) + Math.round(14 * s));
       }
@@ -1309,7 +1333,7 @@
       ctx.strokeRect(p.x, p.y, p.w, p.h);
       ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
       ctx.fillRect(p.x, p.y, p.w, p.h);
-      ctx.font = Math.round(11 * s) + "px " + getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim();
+      ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
       ctx.fillStyle = "rgba(255,255,255,0.9)";
       ctx.fillText(p.w + "\u00d7" + p.h + " px", p.x + Math.round(4 * s), p.y + p.h + Math.round(14 * s));
     }
@@ -1329,7 +1353,10 @@
     qs("#zoomOutBtn").appendChild(svgMinusIcon());
     var canvas = qs("#timelineCanvas");
     sizeTimelineCanvas();
-    window.addEventListener("resize", sizeTimelineCanvas);
+    window.addEventListener("resize", function () {
+      _cachedOverlayRect = null;
+      sizeTimelineCanvas();
+    });
 
     canvas.addEventListener("click", function (e) {
       if (state.timelineDragging) return;
@@ -1486,7 +1513,11 @@
     var rect = canvas.getBoundingClientRect();
     canvas.width = Math.floor(rect.width);
     canvas.height = TIMELINE_CANVAS_HEIGHT;
+    var ph = qs("#playheadCanvas");
+    ph.width = canvas.width;
+    ph.height = canvas.height;
     renderTimeline();
+    renderPlayhead();
   }
 
   function timelineXToTime(event) {
@@ -1629,15 +1660,29 @@
       }
     });
 
-    // Playhead
-    var px = timeToX(state.currentTimestamp);
+    renderTimelineLegend();
+    renderPlayhead();
+  }
+
+  function renderPlayhead() {
+    var canvas = qs("#playheadCanvas");
+    if (!canvas.width || !canvas.height) return;
+    var ctx = canvas.getContext("2d");
+    var w = canvas.width;
+    var h = canvas.height;
+    var dur = state.videoInfo ? state.videoInfo.duration : 0;
+    ctx.clearRect(0, 0, w, h);
+    if (dur <= 0) return;
+    var visLen = dur / state.timelineZoom;
+    var visStart = state.timelineOffset;
+    var px = ((state.currentTimestamp - visStart) / visLen) * w;
+    var tc = getThemeColors();
     ctx.strokeStyle = tc.accent;
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(px, 0);
     ctx.lineTo(px, h);
     ctx.stroke();
-    // Playhead triangle
     ctx.fillStyle = tc.accent;
     ctx.beginPath();
     ctx.moveTo(px - 5, 0);
@@ -1645,8 +1690,6 @@
     ctx.lineTo(px, 6);
     ctx.closePath();
     ctx.fill();
-
-    renderTimelineLegend();
   }
 
   function hitTestTimeline(clientX, clientY) {
@@ -3119,7 +3162,7 @@
       container.innerHTML = '<div class="panel-empty">No ' + state.taskFilter + ' tasks.</div>';
       return;
     }
-    container.innerHTML = "";
+    var frag = document.createDocumentFragment();
     filtered.forEach(function (task) {
       var card = el("div", "task-card task-card-" + task.status);
       card.dataset.taskId = task.id;
@@ -3202,8 +3245,10 @@
       dismissBtn.appendChild(svgDismissIcon());
       card.appendChild(dismissBtn);
 
-      container.appendChild(card);
+      frag.appendChild(card);
     });
+    container.innerHTML = "";
+    container.appendChild(frag);
   }
 
   // ---- Polling ----
@@ -3234,8 +3279,15 @@
           state.queuePaused = data.paused;
           updatePauseButton();
         }
-        renderTaskList();
-        renderTimeline();
+        var fp = JSON.stringify(data.tasks.map(function (t) {
+          return t.id + ":" + t.status + ":" + t.progress;
+        }));
+        var changed = fp !== _lastPollFingerprint;
+        _lastPollFingerprint = fp;
+        if (changed) {
+          renderTaskList();
+          renderTimeline();
+        }
         // Auto-update results for selected running task
         if (oldSelected) {
           var selTask = findTask(oldSelected);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -345,7 +345,7 @@
         catBtn.innerHTML =
           (count === 0 ? "All" : count + " selected") +
           ' <span class="chevron">\u25BE</span>';
-        renderGrid();
+        applyGridFilters();
         computeGridMaxHeight();
       });
 
@@ -364,7 +364,7 @@
         var cbs = catPanel.querySelectorAll("input[type=checkbox]");
         for (var j = 0; j < cbs.length; j++) cbs[j].checked = false;
         catBtn.innerHTML = 'All <span class="chevron">\u25BE</span>';
-        renderGrid();
+        applyGridFilters();
         computeGridMaxHeight();
       });
       catGroup.appendChild(catClear);
@@ -409,7 +409,7 @@
       function onSevChange() {
         state.filters.sevMin = sevMin.value;
         state.filters.sevMax = sevMax.value;
-        renderGrid();
+        applyGridFilters();
         computeGridMaxHeight();
       }
       sevMin.addEventListener("change", onSevChange);
@@ -430,7 +430,7 @@
         state.filters.sevMax = "";
         sevMin.value = "";
         sevMax.value = "";
-        renderGrid();
+        applyGridFilters();
         computeGridMaxHeight();
       });
       sevGroup.appendChild(sevClear);
@@ -461,7 +461,7 @@
       var maxVal = fnMax.value.trim();
       state.filters.fnMin = minVal !== "" ? parseFloat(minVal) : null;
       state.filters.fnMax = maxVal !== "" ? parseFloat(maxVal) : null;
-      renderGrid();
+      applyGridFilters();
       computeGridMaxHeight();
     }
     fnMin.addEventListener("input", onFnChange);
@@ -482,7 +482,7 @@
       state.filters.fnMax = null;
       fnMin.value = "";
       fnMax.value = "";
-      renderGrid();
+      applyGridFilters();
       computeGridMaxHeight();
     });
     fnGroup.appendChild(fnClear);
@@ -502,7 +502,7 @@
         bar.classList.add("hidden");
         if (hasActiveFilters()) {
           clearAllFilters();
-          renderGrid();
+          applyGridFilters();
         }
       }
       computeGridMaxHeight();
@@ -553,12 +553,19 @@
       if (filterToggle) filterToggle.classList.remove("hidden");
       if (refreshBtn) refreshBtn.classList.remove("hidden");
       if (state.filtersVisible && filterBar) filterBar.classList.remove("hidden");
+      // Pause intake polling when leaving intake tab
+      if (state.intakePollTimer) { clearInterval(state.intakePollTimer); state.intakePollTimer = null; }
     } else {
       grid.classList.add("hidden");
       if (filterBar) filterBar.classList.add("hidden");
       if (filterToggle) filterToggle.classList.add("hidden");
       if (refreshBtn) refreshBtn.classList.add("hidden");
       intakePanel.classList.remove("hidden");
+      // Resume intake polling when entering intake tab
+      if (!state.intakePollTimer && !document.hidden) {
+        pollIntakeEvents();
+        state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
+      }
     }
     computeGridMaxHeight();
   }
@@ -794,6 +801,8 @@
     return false;
   }
 
+  var _gridEventsBound = false;
+
   function renderGrid() {
     var d = state.sheetData;
     var grid = qs("#sheetGrid");
@@ -802,6 +811,8 @@
     var showSeverity = hasSeverityData(d.rows);
     var metaCols = showSeverity ? 5 : 4;
     var totalCols = metaCols + d.participants.length;
+    state._gridTotalCols = totalCols;
+    state._gridShowSeverity = showSeverity;
     var table = el("table");
 
     // Colgroup for fixed column widths — participant columns share equal width
@@ -892,9 +903,31 @@
     thead.appendChild(hrow);
     table.appendChild(thead);
 
-    // Group consecutive empty rows into separators
-    var filteredRows = getFilteredRows(d.rows);
     var tbody = el("tbody");
+    tbody.id = "gridTbody";
+    table.appendChild(tbody);
+    grid.appendChild(table);
+
+    applyGridFilters();
+
+    if (!_gridEventsBound) {
+      bindGridEvents();
+      bindDragFromGrid();
+      _gridEventsBound = true;
+    }
+    if (state.activeFunction) updateFunctionColumn();
+  }
+
+  function applyGridFilters() {
+    var d = state.sheetData;
+    if (!d) return;
+    var tbody = qs("#gridTbody");
+    if (!tbody) return;
+    var totalCols = state._gridTotalCols;
+    var showSeverity = state._gridShowSeverity;
+
+    var filteredRows = getFilteredRows(d.rows);
+    var frag = document.createDocumentFragment();
     var i = 0;
     while (i < filteredRows.length) {
       var row = filteredRows[i];
@@ -912,17 +945,15 @@
         );
         sepTd.setAttribute("colspan", String(totalCols));
         sepTr.appendChild(sepTd);
-        tbody.appendChild(sepTr);
+        frag.appendChild(sepTr);
       } else {
-        tbody.appendChild(renderDataRow(row, d.participants, showSeverity));
+        frag.appendChild(renderDataRow(row, d.participants, showSeverity));
         i++;
       }
     }
-    table.appendChild(tbody);
-    grid.appendChild(table);
-
-    bindGridEvents();
-    bindDragFromGrid();
+    tbody.innerHTML = "";
+    tbody.appendChild(frag);
+    updateCellClasses();
     if (state.activeFunction) updateFunctionColumn();
   }
 
@@ -1124,6 +1155,14 @@
     }
   }
 
+  function updateSingleCellClass(participant, row) {
+    var td = qs('.ts-cell[data-participant="' + participant + '"][data-row="' + row + '"]');
+    if (!td) return;
+    var inArt = findInQueue(state.artifactQueue, participant, row) >= 0;
+    var inReel = findInQueue(state.reelQueue, participant, row) >= 0;
+    td.classList.toggle("selected", inArt || inReel);
+  }
+
   function getCellInfo(td) {
     return {
       participant: td.getAttribute("data-participant"),
@@ -1141,7 +1180,7 @@
       for (var i = 0; i < entries.length; i++) state.artifactQueue.push(entries[i]);
     }
     renderArtifactQueue();
-    updateCellClasses();
+    updateSingleCellClass(info.participant, info.row);
   }
 
   function toggleReelCell(info) {
@@ -1152,7 +1191,7 @@
       for (var i = 0; i < entries.length; i++) state.reelQueue.push(entries[i]);
     }
     renderReelQueue();
-    updateCellClasses();
+    updateSingleCellClass(info.participant, info.row);
   }
 
   function addToQueue(targetQueue, info, renderFn) {
@@ -1169,7 +1208,7 @@
     }
     if (added) {
       renderFn();
-      updateCellClasses();
+      updateSingleCellClass(info.participant, info.row);
     }
   }
 
@@ -3374,10 +3413,12 @@
 
     // Filter controls
     var searchEl = qs("#intakeFilterSearch");
+    var _intakeSearchTimer = 0;
     if (searchEl) {
       searchEl.addEventListener("input", function () {
         state.intakeFilterText = this.value;
-        renderIntake(false);
+        clearTimeout(_intakeSearchTimer);
+        _intakeSearchTimer = setTimeout(function () { renderIntake(false); }, 250);
       });
     }
     var detBtns = qsa(".intake-filter-det");
@@ -3402,6 +3443,16 @@
     // Start polling immediately — silently fails if Screenspace is unavailable
     pollIntakeEvents();
     state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
+
+    // Pause polling when browser tab or intake panel is not visible
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) {
+        if (state.intakePollTimer) { clearInterval(state.intakePollTimer); state.intakePollTimer = null; }
+      } else if (state.activePreviewTab === "intake") {
+        pollIntakeEvents();
+        if (!state.intakePollTimer) state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
+      }
+    });
   }
 
   document.addEventListener("click", function (ev) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.77"
+VERSIONNUM: str = "0.9.78"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import copy
 import uuid
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -60,7 +61,9 @@ _manifest: Dict[str, Any] = {}
 _worker: Optional["screenspace.ScreenspaceWorker"] = None
 _output_dir: str = ""
 _participants: List[Dict[str, Any]] = []
-_video_cap_cache: Dict[str, Any] = {"path": None, "cap": None}
+_video_cap_cache: OrderedDict[str, Any] = OrderedDict()
+_VIDEO_CAP_MAX = 3
+_video_metadata_cache: Dict[str, Dict[str, Any]] = {}
 
 _assets_dir = Path(__file__).resolve().parent / "assets" / "web"
 
@@ -121,20 +124,21 @@ def _get_video_cap(video_path: str) -> Optional["cv2.VideoCapture"]:
     """Return a cached VideoCapture for *video_path*, opening a new one if needed."""
     import cv2
 
-    if _video_cap_cache["path"] == video_path and _video_cap_cache["cap"] is not None:
-        cap = _video_cap_cache["cap"]
+    if video_path in _video_cap_cache:
+        cap = _video_cap_cache[video_path]
         if cap.isOpened():
+            _video_cap_cache.move_to_end(video_path)
             return cap
-    # Evict old entry
-    if _video_cap_cache["cap"] is not None:
-        _video_cap_cache["cap"].release()
+        # Stale entry
+        cap.release()
+        del _video_cap_cache[video_path]
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
-        _video_cap_cache["path"] = None
-        _video_cap_cache["cap"] = None
         return None
-    _video_cap_cache["path"] = video_path
-    _video_cap_cache["cap"] = cap
+    _video_cap_cache[video_path] = cap
+    if len(_video_cap_cache) > _VIDEO_CAP_MAX:
+        _, old_cap = _video_cap_cache.popitem(last=False)
+        old_cap.release()
     return cap
 
 
@@ -175,6 +179,9 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
 @screenspace_bp.route("/api/video/info/<participant>")
 def api_video_info(participant: str) -> FlaskResponse:
     """Return video metadata (duration, resolution, fps)."""
+    if participant in _video_metadata_cache:
+        return jsonify({"ok": True, "info": _video_metadata_cache[participant]})
+
     video_path = _find_participant_video(participant)
     if video_path is None:
         return jsonify(
@@ -201,6 +208,7 @@ def api_video_info(participant: str) -> FlaskResponse:
         "width": width if width > 0 else None,
         "height": height if height > 0 else None,
     }
+    _video_metadata_cache[participant] = info
 
     return jsonify({"ok": True, "info": info})
 

--- a/server.py
+++ b/server.py
@@ -1337,6 +1337,20 @@ def start_combined_server(
         screenspace_server.screenspace_bp, url_prefix="/screenspace"
     )
 
+    @combined.after_request
+    def _set_cache_headers(response):
+        # Skip if a route already set Cache-Control (e.g. thumbnails, sprites)
+        if "Cache-Control" in response.headers:
+            return response
+        ct = response.content_type or ""
+        if ct.startswith("text/html"):
+            response.headers["Cache-Control"] = "no-cache"
+        elif ct.startswith(("text/css", "application/javascript", "text/javascript")):
+            response.headers["Cache-Control"] = "public, max-age=3600"
+        elif ct.startswith("image/svg"):
+            response.headers["Cache-Control"] = "public, max-age=86400"
+        return response
+
     @combined.route("/")
     def root():
         return redirect(f"/{default_page}/")


### PR DESCRIPTION
## Summary

- **Screenspace canvas**: RAF-throttle overlay rendering during drag/resize/draw, cache layout queries, split playhead into a separate canvas layer so scrubbing skips full timeline redraws, and cache video metadata on the backend to eliminate VideoCapture open/close on participant switch.
- **Studio grid**: Split `renderGrid()` into full build + `applyGridFilters()` so filter changes only rebuild the tbody (also fixes duplicate event listener binding). Add targeted `updateSingleCellClass()` for O(1) cell updates on queue toggles.
- **Polling**: Fingerprint-based skip for unchanged poll data, increased Screenspace interval to 3s, pause Studio intake polling when tab/panel not visible, debounce intake search (250ms).
- **Server**: Add `Cache-Control` headers for static files (HTML no-cache, JS/CSS 1hr, SVG 24hr) and expand Screenspace VideoCapture cache to LRU of 3.

## Test plan

- [ ] Open Screenspace, draw/drag/resize regions — should feel smooth with no stutter
- [ ] Scrub the timeline — playhead should track without full redraw flicker
- [ ] Switch participants — should be near-instant (cached metadata)
- [ ] Open Studio, toggle category/severity filters — grid should update without full table rebuild flash
- [ ] Click cells to add/remove from queue — selected state should update instantly
- [ ] Switch away from intake tab — verify no polling in Network tab
- [ ] Run `uv run pytest -c tests/pytest.ini` — 313 tests pass