### PR TITLE
Replace sidebar sprite scrubbing with direct video playback

### DIFF
--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -729,6 +729,17 @@ body {
   opacity: 0;
 }
 
+.artifact-media .card-scrub-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+
 .artifact-meta {
   padding: var(--space-2) var(--space-2);
   display: flex;

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -25,12 +25,7 @@
   var FILMSTRIP_CONCURRENCY = 2;
   var FILMSTRIP_STORAGE_KEY = "clipgen-viewer-filmstrip";
 
-  var _scrubCache = {};
-  var _scrubGenerating = {};
-  var _scrubRaf = 0;
-  var SCRUB_FRAME_COUNT = 10;
-  var SCRUB_FRAME_WIDTH = 320;
-  var SCRUB_FRAME_HEIGHT = 180;
+  var _cardScrub = null; // { mediaEl, videoEl, raf }
 
   var _screenspaceVisible = true;
   var SCREENSPACE_STORAGE_KEY = "clipgen-viewer-screenspace";
@@ -227,113 +222,9 @@
     });
   }
 
-  // ---- Sidebar scrub sprites ----
+  // ---- Sidebar video scrub ----
 
-  function generateScrubSprite(artifact, callback) {
-    if (_scrubCache[artifact.id]) { callback(_scrubCache[artifact.id]); return; }
-    if (_scrubGenerating[artifact.id]) { callback(null); return; }
-    _scrubGenerating[artifact.id] = true;
-
-    var done = false;
-    var perFrameTimer = null;
-    function finish(url) {
-      if (done) return;
-      done = true;
-      clearTimeout(timer);
-      clearTimeout(perFrameTimer);
-      video.onerror = null;
-      video.onloadedmetadata = null;
-      video.onseeked = null;
-      delete _scrubGenerating[artifact.id];
-      try { video.src = ""; video.load(); } catch (_) {}
-      callback(url || null);
-    }
-
-    var video = document.createElement("video");
-    video.preload = "metadata";
-    video.muted = true;
-    video.playsInline = true;
-    video.src = artifact.file;
-
-    var timer = setTimeout(function () { finish(null); }, 15000);
-
-    video.onerror = function () { finish(null); };
-
-    video.onloadedmetadata = function () {
-      var dur = video.duration;
-      if (!dur || !isFinite(dur)) { finish(null); return; }
-
-      var clipStart = artifact.start || 0;
-      var clipEnd = artifact.end || dur;
-      var clipDur = clipEnd - clipStart;
-      if (clipDur <= 0) clipDur = dur;
-
-      var canvas = document.createElement("canvas");
-      canvas.width = SCRUB_FRAME_WIDTH * SCRUB_FRAME_COUNT;
-      canvas.height = SCRUB_FRAME_HEIGHT;
-      var ctx = canvas.getContext("2d");
-
-      var seekTimes = [];
-      for (var i = 0; i < SCRUB_FRAME_COUNT; i++) {
-        var t = clipStart + (clipDur * (i + 0.5)) / SCRUB_FRAME_COUNT;
-        seekTimes.push(Math.min(Math.max(0, t), dur - 0.01));
-      }
-
-      var frameIndex = 0;
-      var seekGen = 0;
-
-      function captureAndAdvance() {
-        clearTimeout(perFrameTimer);
-        try { ctx.drawImage(video, frameIndex * SCRUB_FRAME_WIDTH, 0, SCRUB_FRAME_WIDTH, SCRUB_FRAME_HEIGHT); } catch (_) {}
-        frameIndex++;
-        if (frameIndex < seekTimes.length) {
-          seekToFrame(frameIndex);
-        } else {
-          video.onseeked = null;
-          canvas.toBlob(function (blob) {
-            if (!blob) { finish(null); return; }
-            var url = URL.createObjectURL(blob);
-            _scrubCache[artifact.id] = url;
-            finish(url);
-          }, "image/jpeg", 0.7);
-        }
-      }
-
-      function seekToFrame(idx) {
-        var gen = ++seekGen;
-        video.onseeked = function () {
-          if (gen !== seekGen) return;
-          captureAndAdvance();
-        };
-        perFrameTimer = setTimeout(function () {
-          if (gen !== seekGen) return;
-          captureAndAdvance();
-        }, 800);
-        video.currentTime = seekTimes[idx];
-      }
-
-      seekToFrame(0);
-    };
-  }
-
-  function activateScrubMode(mediaEl, artifact) {
-    var url = _scrubCache[artifact.id];
-    if (!url) return;
-    var img = mediaEl.querySelector("img");
-    if (img) img.style.display = "none";
-    mediaEl.style.backgroundImage = "url(" + url + ")";
-    mediaEl.style.backgroundSize = (SCRUB_FRAME_COUNT * 100) + "% 100%";
-    mediaEl.style.backgroundPosition = "0% 0%";
-    mediaEl.classList.add("scrub-active");
-
-    if (!mediaEl.querySelector(".scrub-progress")) {
-      var bar = el("div", "scrub-progress");
-      bar.appendChild(el("div", "scrub-progress-fill"));
-      mediaEl.appendChild(bar);
-    }
-  }
-
-  function scrubEnter(ev) {
+  function cardScrubEnter(ev) {
     var mediaEl = ev.currentTarget;
     var card = mediaEl.closest(".artifact-card");
     if (!card) return;
@@ -341,49 +232,80 @@
     var artifact = findArtifact(id);
     if (!artifact || artifact.type !== "clip") return;
 
-    if (_scrubCache[artifact.id]) {
-      activateScrubMode(mediaEl, artifact);
-      return;
+    cardScrubLeave();
+
+    var vid = document.createElement("video");
+    vid.preload = "auto";
+    vid.muted = true;
+    vid.playsInline = true;
+    vid.src = artifact.file;
+    vid.className = "card-scrub-video";
+
+    var img = mediaEl.querySelector("img");
+    if (img) img.style.display = "none";
+    mediaEl.appendChild(vid);
+    mediaEl.classList.add("scrub-active");
+
+    if (!mediaEl.querySelector(".scrub-progress")) {
+      var bar = el("div", "scrub-progress");
+      bar.appendChild(el("div", "scrub-progress-fill"));
+      mediaEl.appendChild(bar);
     }
 
-    generateScrubSprite(artifact, function (url) {
-      if (!url) return;
-      if (mediaEl.matches(":hover")) {
-        activateScrubMode(mediaEl, artifact);
-      }
-    });
+    _cardScrub = { mediaEl: mediaEl, videoEl: vid, raf: 0 };
+
+    var rect = mediaEl.getBoundingClientRect();
+    var frac = Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width));
+    vid.onloadedmetadata = function () {
+      if (!_cardScrub || _cardScrub.videoEl !== vid) return;
+      var dur = vid.duration;
+      if (!dur || !isFinite(dur)) return;
+      vid.currentTime = dur * frac;
+      var fill = mediaEl.querySelector(".scrub-progress-fill");
+      if (fill) fill.style.width = (frac * 100).toFixed(1) + "%";
+    };
   }
 
-  function scrubMove(ev) {
-    var target = ev.currentTarget;
-    if (!target.classList.contains("scrub-active")) return;
-    var clientX = ev.clientX;
-    if (_scrubRaf) return;
-    _scrubRaf = requestAnimationFrame(function () {
-      _scrubRaf = 0;
-      var rect = target.getBoundingClientRect();
-      var frac = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-      var frameIndex = Math.min(Math.floor(frac * SCRUB_FRAME_COUNT), SCRUB_FRAME_COUNT - 1);
-      var xPct = SCRUB_FRAME_COUNT > 1 ? (frameIndex / (SCRUB_FRAME_COUNT - 1)) * 100 : 0;
-      target.style.backgroundPosition = xPct + "% 0%";
+  function cardScrubMove(ev) {
+    if (!_cardScrub) return;
+    var mediaEl = ev.currentTarget;
+    if (mediaEl !== _cardScrub.mediaEl) return;
+    var vid = _cardScrub.videoEl;
+    if (!vid.duration || !isFinite(vid.duration)) return;
+    if (vid.readyState < 1) return;
 
-      var fill = target.querySelector(".scrub-progress-fill");
+    var clientX = ev.clientX;
+    if (_cardScrub.raf) return;
+    _cardScrub.raf = requestAnimationFrame(function () {
+      if (!_cardScrub) return;
+      _cardScrub.raf = 0;
+      var rect = mediaEl.getBoundingClientRect();
+      var frac = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+      vid.currentTime = vid.duration * frac;
+
+      var fill = mediaEl.querySelector(".scrub-progress-fill");
       if (fill) fill.style.width = (frac * 100).toFixed(1) + "%";
     });
   }
 
-  function scrubLeave(ev) {
-    var mediaEl = ev.currentTarget;
-    if (!mediaEl.classList.contains("scrub-active")) return;
+  function cardScrubLeave() {
+    if (!_cardScrub) return;
+    var mediaEl = _cardScrub.mediaEl;
+    var vid = _cardScrub.videoEl;
+
+    if (_cardScrub.raf) cancelAnimationFrame(_cardScrub.raf);
+
+    try { vid.src = ""; vid.load(); } catch (_) {}
+    if (vid.parentNode) vid.parentNode.removeChild(vid);
+
     mediaEl.classList.remove("scrub-active");
-    mediaEl.style.backgroundImage = "";
-    mediaEl.style.backgroundSize = "";
-    mediaEl.style.backgroundPosition = "";
     var img = mediaEl.querySelector("img");
     if (img) img.style.display = "";
 
     var fill = mediaEl.querySelector(".scrub-progress-fill");
     if (fill) fill.style.width = "0%";
+
+    _cardScrub = null;
   }
 
   function initClipThumbnails() {
@@ -1444,9 +1366,9 @@
         }
       }
       if (a.type === "clip") {
-        media.addEventListener("mouseenter", scrubEnter);
-        media.addEventListener("mousemove", scrubMove);
-        media.addEventListener("mouseleave", scrubLeave);
+        media.addEventListener("mouseenter", cardScrubEnter);
+        media.addEventListener("mousemove", cardScrubMove);
+        media.addEventListener("mouseleave", cardScrubLeave);
       }
       card.appendChild(media);
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.9.80"
+VERSIONNUM: str = "0.9.81"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Replaces the canvas-based sprite sheet scrubbing system on sidebar clip cards with a live `<video>` element that seeks directly via `currentTime` on hover
- Removes ~137 lines of sprite generation code (canvas capture, blob stitching, cache management) and replaces with ~70 lines using the same RAF-throttled seeking pattern as the timeline marker preview
- Static thumbnails are preserved for the initial card appearance; the video only appears on hover

## Test plan
- [ ] Open a viewer HTML with clip artifacts and verify hover-to-scrub works on clip cards
- [ ] Verify rapid movement between cards shows only one video at a time
- [ ] Verify non-clip cards (screen, gif) are unaffected
- [ ] Verify timeline marker hover preview still works independently