### PR TITLE
Fix Screenspace template tasks stuck at queued

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2553,8 +2553,10 @@
     var btn = qs("#runBtn");
     var hasRegion = state.runRegions.length > 0 || !!state.activeRegion;
     var hasParticipants = state.runParticipants.length > 0 || !!state.selectedParticipant;
-    btn.disabled = !hasRegion || !hasParticipants;
-    if (!hasRegion) {
+    // Template with uploaded image can run without a region (full-frame scan)
+    var templateNoRegion = state.activeWorkflow === "template" && !!state.uploadedTemplate;
+    btn.disabled = (!hasRegion && !templateNoRegion) || !hasParticipants;
+    if (!hasRegion && !templateNoRegion) {
       btn.setAttribute("data-tooltip", "Select a region first");
     } else if (!hasParticipants) {
       btn.setAttribute("data-tooltip", "Select participants to run");
@@ -2567,16 +2569,17 @@
 
   function initRunButton() {
     qs("#runBtn").addEventListener("click", function () {
+      var type = state.activeWorkflow;
       var regions = state.runRegions.length > 0
         ? state.runRegions
         : (state.activeRegion ? [state.activeRegion] : []);
-      if (regions.length === 0) return;
+      // Template with uploaded image can run without a region (full-frame scan)
+      if (regions.length === 0 && !(type === "template" && state.uploadedTemplate)) return;
+      if (regions.length === 0) regions = [""];
       var participants = state.runParticipants.length > 0
         ? state.runParticipants
         : (state.selectedParticipant ? [state.selectedParticipant] : []);
       if (participants.length === 0) return;
-
-      var type = state.activeWorkflow;
       var params = gatherWorkflowParams(type);
       if (params === null) return;
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.3"
+VERSIONNUM: str = "0.10.5"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace.py
+++ b/screenspace.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import copy
 import difflib
 import json
+import math
 import queue
 import re
 import threading
@@ -230,10 +231,14 @@ def match_template(
     if len(locs[0]) == 0:
         return []
 
-    # Collect raw detections sorted by score descending
+    # Collect raw detections sorted by score descending.
+    # TM_CCOEFF_NORMED can produce inf/nan when a frame patch has zero
+    # variance (constant colour) — skip those positions.
     detections: List[Dict[str, Any]] = []
     for pt_y, pt_x in zip(locs[0], locs[1]):
         score = float(result[pt_y, pt_x])
+        if not math.isfinite(score):
+            continue
         detections.append(
             {"x": int(pt_x), "y": int(pt_y), "w": tw, "h": th, "score": score}
         )
@@ -1595,6 +1600,11 @@ class ScreenspaceWorker:
         return True
 
     @property
+    def is_alive(self) -> bool:
+        """Return whether the worker thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
     def is_paused(self) -> bool:
         """Return whether the queue is paused."""
         return self._paused.is_set()
@@ -1735,25 +1745,32 @@ class ScreenspaceWorker:
                 item = self._queue.get(timeout=1)
             except queue.Empty:
                 continue
-            priority, created_at, task_id = item
-            if task_id is _SENTINEL:
-                break
 
-            if self._paused.is_set():
-                self._queue.put(item)
-                time.sleep(0.25)
-                continue
+            try:
+                priority, created_at, task_id = item
+                if task_id is _SENTINEL:
+                    break
 
-            with self._lock:
-                task = self._tasks.get(task_id)
-                if task is None or task["status"] != TASK_STATUS_QUEUED:
+                if self._paused.is_set():
+                    self._queue.put(item)
+                    time.sleep(0.25)
                     continue
-                task["status"] = TASK_STATUS_RUNNING
 
-            self._execute_task(task)
+                with self._lock:
+                    task = self._tasks.get(task_id)
+                    if task is None or task["status"] != TASK_STATUS_QUEUED:
+                        continue
+                    task["status"] = TASK_STATUS_RUNNING
 
-            if self.on_task_complete:
-                self.on_task_complete()
+                self._execute_task(task)
+
+                if self.on_task_complete:
+                    try:
+                        self.on_task_complete()
+                    except Exception as exc:
+                        utils.warning_print(f"on_task_complete callback failed: {exc}")
+            except Exception as exc:
+                utils.warning_print(f"Worker loop error: {exc}")
 
     def _execute_task(self, task: Dict[str, Any]) -> None:
         """Dispatch task to the appropriate workflow function."""

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -36,6 +36,7 @@ API endpoints (all under /screenspace/):
 from __future__ import annotations
 
 import copy
+import math
 import threading
 import uuid
 from collections import OrderedDict
@@ -447,7 +448,10 @@ def api_tasks_list() -> FlaskResponse:
     tasks = _worker.get_all_tasks() if _worker else []
     clean = [_clean_task(t) for t in tasks]
     paused = _worker.is_paused if _worker else False
-    return jsonify({"ok": True, "tasks": clean, "paused": paused})
+    alive = _worker.is_alive if _worker else False
+    return jsonify(
+        {"ok": True, "tasks": clean, "paused": paused, "worker_alive": alive}
+    )
 
 
 @screenspace_bp.route("/api/tasks/<task_id>")
@@ -493,17 +497,27 @@ def api_tasks_create() -> FlaskResponse:
         return jsonify({"ok": False, "error": "participant is required"}), 400
 
     region_name = data.get("region", "").strip()
-    if not region_name:
+
+    # Template tasks with an uploaded image scan the full frame; no region needed
+    has_uploaded_template = task_type == "template" and data.get("parameters", {}).get(
+        "template_image_data"
+    )
+
+    if not region_name and not has_uploaded_template:
         return jsonify({"ok": False, "error": "region is required"}), 400
 
-    regions = _manifest.get("regions", {})
-    if region_name not in regions:
-        for stash in _manifest.get("stashes", []):
-            if region_name in stash.get("regions", {}):
-                regions = stash["regions"]
-                break
-    if region_name not in regions:
-        return jsonify({"ok": False, "error": f"Region '{region_name}' not found"}), 400
+    regions: Dict[str, Any] = {}
+    if region_name:
+        regions = _manifest.get("regions", {})
+        if region_name not in regions:
+            for stash in _manifest.get("stashes", []):
+                if region_name in stash.get("regions", {}):
+                    regions = stash["regions"]
+                    break
+        if region_name not in regions:
+            return jsonify(
+                {"ok": False, "error": f"Region '{region_name}' not found"}
+            ), 400
 
     video_path = _find_participant_video(participant)
     if video_path is None:
@@ -517,16 +531,21 @@ def api_tasks_create() -> FlaskResponse:
             source_video = Path(p["video_path"]).name
             break
 
-    region_data = regions[region_name]
-    props = video.probe_video_properties(video_path)
-    if props and props.get("width") and props.get("height"):
-        region_coords = _denormalize_region(
-            region_data, props["width"], props["height"]
-        )
+    if region_name:
+        region_data = regions[region_name]
+        props = video.probe_video_properties(video_path)
+        if props and props.get("width") and props.get("height"):
+            region_coords = _denormalize_region(
+                region_data, props["width"], props["height"]
+            )
+        else:
+            region_coords = {
+                k: region_data[k] for k in ("x", "y", "w", "h") if k in region_data
+            }
     else:
-        region_coords = {
-            k: region_data[k] for k in ("x", "y", "w", "h") if k in region_data
-        }
+        # Full-frame template scan -- sentinel region
+        region_name = "full_frame"
+        region_coords = {"x": 0, "y": 0, "w": 0, "h": 0}
     parameters = data.get("parameters", {})
 
     import screenspace
@@ -793,6 +812,17 @@ def api_events_bulk_include() -> FlaskResponse:
 # ---- Helpers ----
 
 
+def _sanitize_floats(obj: Any) -> Any:
+    """Replace non-finite floats (inf, nan) with None for JSON safety."""
+    if isinstance(obj, float) and not math.isfinite(obj):
+        return None
+    if isinstance(obj, dict):
+        return {k: _sanitize_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_floats(v) for v in obj]
+    return obj
+
+
 def _clean_task(task: Dict[str, Any]) -> Dict[str, Any]:
     """Remove internal fields from a task dict for API responses."""
     cleaned = {k: v for k, v in task.items() if not k.startswith("_")}
@@ -808,7 +838,7 @@ def _clean_task(task: Dict[str, Any]) -> Dict[str, Any]:
                 "reference_scenes",
             )
         }
-    return cleaned
+    return _sanitize_floats(cleaned)
 
 
 # ---- State initialization ----

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -595,6 +595,64 @@ class TestScreenspaceWorker:
         finally:
             worker.stop()
 
+    def test_worker_survives_on_task_complete_exception(self):
+        """Worker continues processing tasks after on_task_complete raises."""
+        worker = screenspace.ScreenspaceWorker()
+        call_count = {"n": 0}
+
+        def bad_callback():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise TypeError("simulated persistence failure")
+
+        worker.on_task_complete = bad_callback
+        worker.start()
+        try:
+            t1 = screenspace.create_task(
+                "color",
+                "P01",
+                "s.mp4",
+                "/nonexistent/v.mp4",
+                "r",
+                {"x": 0, "y": 0, "w": 10, "h": 10},
+                parameters={
+                    "target_color": {"h": 0, "s": 0, "v": 0},
+                    "tolerance": {"h": 10, "s": 10, "v": 10},
+                },
+            )
+            worker.enqueue(t1)
+            for _ in range(50):
+                t = worker.get_task(t1["id"])
+                if t and t["status"] in ("completed", "failed"):
+                    break
+                time.sleep(0.1)
+
+            # Second task should still process even though first callback raised
+            t2 = screenspace.create_task(
+                "color",
+                "P02",
+                "s.mp4",
+                "/nonexistent/v.mp4",
+                "r",
+                {"x": 0, "y": 0, "w": 10, "h": 10},
+                parameters={
+                    "target_color": {"h": 0, "s": 0, "v": 0},
+                    "tolerance": {"h": 10, "s": 10, "v": 10},
+                },
+            )
+            worker.enqueue(t2)
+            for _ in range(50):
+                t = worker.get_task(t2["id"])
+                if t and t["status"] in ("completed", "failed"):
+                    break
+                time.sleep(0.1)
+            t = worker.get_task(t2["id"])
+            assert t is not None
+            assert t["status"] in ("completed", "failed")
+            assert call_count["n"] >= 2
+        finally:
+            worker.stop()
+
     def test_text_task_easyocr_importable(self):
         import easyocr  # noqa: F401
 

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -295,6 +295,42 @@ def test_create_task_new_types_accepted(client, task_type):
     assert "video" in data["error"].lower()
 
 
+def test_create_template_task_no_region_with_upload(client):
+    """Template task with uploaded image skips region validation."""
+    import base64
+
+    # Minimal 1x1 red PNG
+    png_b64 = base64.b64encode(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
+        b"\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00"
+        b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    ).decode()
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "template",
+            "participant": "P01",
+            "parameters": {"template_image_data": png_b64},
+        },
+    )
+    data = resp.get_json()
+    # Should fail at video check, NOT at "region is required"
+    assert resp.status_code == 400
+    assert "region" not in data["error"].lower()
+    assert "video" in data["error"].lower()
+
+
+def test_create_non_template_task_still_requires_region(client):
+    """Non-template tasks still require a region."""
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={"type": "change", "participant": "P01"},
+    )
+    assert resp.status_code == 400
+    assert "region" in resp.get_json()["error"].lower()
+
+
 def test_get_task_not_found(client):
     resp = client.get("/screenspace/api/tasks/ss_nonexist")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- **Root cause:** `cv2.matchTemplate` with `TM_CCOEFF_NORMED` produces `Infinity` scores when frame patches have zero variance (constant-color areas). Python serializes these as `Infinity` in JSON responses, which is not valid JSON — `JSON.parse` in the browser silently fails, so the frontend never receives poll updates and tasks appear permanently stuck at "queued."
- Filter non-finite scores (`inf`/`nan`) in `match_template()` at the source, and add a `_sanitize_floats()` safety net in `_clean_task()` for all API responses
- Allow template tasks with uploaded PNG images to run without selecting a region (full-frame scan), on both frontend and server
- Wrap the worker loop body in try/except to prevent the background thread from dying on unexpected errors (e.g. manifest persistence failures)
- Expose `worker_alive` in the task list API for diagnostics

## Test plan
- [x] Existing screenspace tests pass (342/342)
- [ ] Upload a PNG template, run without selecting a region — task should be created and complete
- [ ] Verify task progress updates in the UI (no longer stuck at "queued")
- [ ] Run a non-template task to confirm region validation still applies