### PR TITLE
Fix Flask server 404s in PyInstaller binaries

### DIFF
--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -13,6 +13,7 @@ datas = []
 datas += collect_data_files("gspread")
 datas += collect_data_files("openpyxl")
 datas += collect_data_files("rich")
+datas += [("../assets", "assets")]
 
 
 a = Analysis(

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.5"
+VERSIONNUM: str = "0.10.6"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/insights_server.py
+++ b/insights_server.py
@@ -40,7 +40,7 @@ _insights_data: Dict[str, Any] = {}
 _output_dir: Union[str, Path] = ""
 _sprite_cache: Dict[str, bytes] = {}
 
-_assets_dir = Path(__file__).resolve().parent / "assets" / "web"
+_assets_dir = utils.get_bundled_assets_root() / "assets" / "web"
 
 # ---- Blueprint ----
 

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -68,7 +68,7 @@ _VIDEO_CAP_MAX = 3
 _video_cap_lock = threading.Lock()
 _video_metadata_cache: Dict[str, Dict[str, Any]] = {}
 
-_assets_dir = Path(__file__).resolve().parent / "assets" / "web"
+_assets_dir = utils.get_bundled_assets_root() / "assets" / "web"
 
 # ---- Blueprint ----
 
@@ -90,7 +90,7 @@ def serve_static(filename: str) -> FlaskResponse:
 
 @screenspace_bp.route("/icons/<path:filename>")
 def serve_icons(filename: str) -> FlaskResponse:
-    icons_dir = Path(__file__).resolve().parent / "assets" / "icons"
+    icons_dir = utils.get_bundled_assets_root() / "assets" / "icons"
     return send_from_directory(icons_dir, filename)
 
 

--- a/server.py
+++ b/server.py
@@ -67,7 +67,7 @@ _settings_defaults: Dict[str, Any] = {
     name: getattr(config, name) for name in getattr(config, "STUDIO_SETTINGS", {})
 }
 
-_assets_dir = Path(__file__).resolve().parent / "assets" / "web"
+_assets_dir = utils.get_bundled_assets_root() / "assets" / "web"
 
 # ---- Blueprint ----
 

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import difflib
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, TypedDict, TypeVar
@@ -491,6 +492,19 @@ def resolve_output_path(name: str) -> Path:
     if path.is_absolute():
         return path
     return base / path
+
+
+def get_bundled_assets_root() -> Path:
+    """Return the base directory for bundled project assets.
+
+    In a PyInstaller one-file build, bundled data is extracted to sys._MEIPASS.
+    In source runs, assets are relative to the source directory.
+    """
+    if getattr(sys, "frozen", False):
+        return Path(
+            getattr(sys, "_MEIPASS", str(Path(sys.executable).resolve().parent))
+        )
+    return Path(__file__).resolve().parent
 
 
 # ---- Filename and study name helpers ----

--- a/viewer.py
+++ b/viewer.py
@@ -28,7 +28,6 @@ Artifact manifest (save_manifest / load_manifest_*):
 """
 
 import json
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -191,10 +190,7 @@ def _generate_viewer_html(
     Shared implementation for timeline and gallery viewer generation.
     Returns the path to the generated HTML, or None on failure.
     """
-    if getattr(sys, "frozen", False):
-        assets_base = Path(sys.executable).resolve().parent
-    else:
-        assets_base = Path(__file__).resolve().parent
+    assets_base = utils.get_bundled_assets_root()
     assets_dir = assets_base / "assets" / "web"
     template_path = assets_dir / template_name
     js_path = assets_dir / js_name


### PR DESCRIPTION
## Summary
- Bundle the `assets/` directory in the PyInstaller spec so HTML/CSS/JS and icon files are included in built binaries
- Add `utils.get_bundled_assets_root()` helper that resolves to `sys._MEIPASS` in frozen builds (where PyInstaller extracts bundled data), with fallback to `sys.executable` parent for one-folder builds
- Update `server.py`, `insights_server.py`, `screenspace_server.py`, and `viewer.py` to use the shared helper instead of `Path(__file__).resolve().parent`, which pointed to the wrong location in packaged binaries

## Test plan
- [x] All 342 existing tests pass
- [ ] Build binary with `pyinstaller --clean --noconfirm build/clipgen.spec` and verify `/studio/`, `/insights/`, `/screenspace/` load without 404s