### PR TITLE
Add info tooltip to Screenspace tool action row

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1198,7 +1198,7 @@ body {
   box-shadow: var(--shadow-xl);
   padding: var(--space-3) var(--space-5) var(--space-5);
   display: grid;
-  grid-template-columns: 1.7fr 1fr 1fr;
+  grid-template-columns: 1.2fr 1fr 1fr;
   gap: var(--space-5);
   flex-shrink: 0;
   margin-bottom: var(--space-5);
@@ -1775,6 +1775,75 @@ body {
   margin-top: var(--space-1);
   font-size: var(--text-xs);
   color: var(--color-text-dim);
+}
+
+/* Tool info tooltip */
+
+.tool-info-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--color-text-dim);
+  opacity: 0.6;
+  transition: opacity var(--duration-fast);
+  line-height: 0;
+}
+
+.tool-info-btn:hover {
+  opacity: 1;
+  color: var(--color-accent);
+}
+
+.tool-info-tooltip {
+  position: fixed;
+  background: var(--color-panel-bg);
+  color: var(--color-text);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  font-size: var(--text-sm);
+  max-width: 320px;
+  z-index: var(--z-overlay);
+  box-shadow: var(--shadow-lg);
+  line-height: 1.5;
+  pointer-events: auto;
+  border: 1px solid var(--color-panel-border);
+}
+
+.tool-info-tooltip.hidden {
+  display: none;
+}
+
+.tool-info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-2);
+}
+
+.tool-info-close {
+  background: none;
+  border: none;
+  padding: var(--space-1);
+  cursor: pointer;
+  color: var(--color-text-dim);
+  line-height: 0;
+  border-radius: var(--radius-sm);
+}
+
+.tool-info-close:hover {
+  color: var(--color-text);
+  background: var(--color-surface-alt);
+}
+
+.tool-info-close.hidden {
+  display: none;
+}
+
+.tool-info-body {
+  margin: 0;
+  color: var(--color-text-dim);
+  font-size: var(--text-xs);
 }
 
 /* Dark mode — system preference */

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -121,6 +121,7 @@
       </div>
       <div id="workflowBody">
         <div id="workflowActionRow">
+          <button id="toolInfoBtn" class="tool-info-btn"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1C11.866 1 15 4.13401 15 8ZM9 5C9 5.55228 8.55228 6 8 6C7.44772 6 7 5.55228 7 5C7 4.44772 7.44772 4 8 4C8.55228 4 9 4.44772 9 5ZM6.75 8C6.33579 8 6 8.33579 6 8.75C6 9.16421 6.33579 9.5 6.75 9.5H7.5V11.25C7.5 11.6642 7.83579 12 8.25 12C8.66421 12 9 11.6642 9 11.25V8.75C9 8.33579 8.66421 8 8.25 8H6.75Z"/></svg></button>
           <div id="runParticipantPicker" class="run-picker-wrap"></div>
           <div id="workflowIntervalSlot"></div>
           <div id="runRegionPicker" class="run-picker-wrap"></div>
@@ -181,6 +182,7 @@
 
   <div id="toast" class="toast hidden"></div>
   <div id="ssTooltip" class="ss-tooltip hidden"></div>
+  <div id="toolInfoTooltip" class="tool-info-tooltip hidden"></div>
 
   <script src="screenspace.js"></script>
 </body>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1869,6 +1869,75 @@
     if (tip) tip.classList.add("hidden");
   }
 
+  // ---- Tool info tooltip ----
+
+  var TOOL_INFO = {
+    color: "[TODO_INFO] Color tool: finds frames where a region's average color matches your chosen target within the tolerance range. Useful for tracking UI state indicators, health bars, or any element identified by a specific color.",
+    change: "[TODO_INFO] Change tool: detects frames where pixel differences in the region exceed the threshold. Good for spotting sudden visual changes like screen transitions, pop-ups appearing, or loading states completing.",
+    similarity: "[TODO_INFO] Similarity tool: compares each frame against a captured reference using structural similarity (SSIM). Use it to find moments that look like a specific reference frame — e.g. a particular menu, dialog, or game state.",
+    text: "[TODO_INFO] Text tool: performs OCR on the region and fuzzy-matches against your search text. Useful for detecting when specific labels, error messages, or button text appear on screen.",
+    numbers: "[TODO_INFO] Numbers tool: reads numeric values from the region via OCR and compares them against your target using the selected operator. Great for monitoring scores, timers, counters, or any on-screen number.",
+    timelapse: "[TODO_INFO] Timelapse tool: generates a sped-up video or GIF of the region over the selected time range. Unlike other tools, this produces a single artifact rather than detecting individual frames.",
+    template: "[TODO_INFO] Template tool: searches the full video frame for a captured or uploaded reference image using template matching. Works across the entire frame, not just the selected region — ideal for finding icons, buttons, or UI elements wherever they appear.",
+    flow: "[TODO_INFO] Flow tool: detects motion in the region via dense optical flow. Higher magnitude thresholds filter out subtle movements. Useful for detecting player movement, animations starting, or activity in a specific area.",
+    scene: "[TODO_INFO] Scene tool: classifies each frame by comparing it to your captured reference scenes. Useful for building a timeline of when different screens, menus, or game levels are active."
+  };
+
+  var _toolInfoPinned = false;
+
+  function showToolInfoTooltip(anchorEl) {
+    var tip = qs("#toolInfoTooltip");
+    if (!tip) return;
+    var type = state.activeWorkflow;
+    var text = TOOL_INFO[type] || "";
+    tip.innerHTML = "";
+
+    var header = el("div", "tool-info-header");
+    header.appendChild(el("strong", null, type.charAt(0).toUpperCase() + type.slice(1)));
+    var closeBtn = el("button", "tool-info-close hidden");
+    closeBtn.appendChild(svgDismissIcon());
+    closeBtn.addEventListener("click", function () {
+      hideToolInfoTooltip(true);
+    });
+    header.appendChild(closeBtn);
+    tip.appendChild(header);
+
+    tip.appendChild(el("p", "tool-info-body", text));
+
+    tip.classList.remove("hidden");
+    positionToolInfoTooltip(tip, anchorEl);
+  }
+
+  function positionToolInfoTooltip(tip, anchorEl) {
+    var rect = anchorEl.getBoundingClientRect();
+    var x = rect.left;
+    var y = rect.bottom + 6;
+    tip.style.left = x + "px";
+    tip.style.top = y + "px";
+    var tipRect = tip.getBoundingClientRect();
+    if (tipRect.right > window.innerWidth - 8) {
+      tip.style.left = (window.innerWidth - tipRect.width - 8) + "px";
+    }
+    if (tipRect.bottom > window.innerHeight - 8) {
+      tip.style.top = (rect.top - tipRect.height - 6) + "px";
+    }
+  }
+
+  function pinToolInfoTooltip() {
+    _toolInfoPinned = true;
+    var tip = qs("#toolInfoTooltip");
+    if (!tip) return;
+    var closeBtn = tip.querySelector(".tool-info-close");
+    if (closeBtn) closeBtn.classList.remove("hidden");
+  }
+
+  function hideToolInfoTooltip(force) {
+    if (_toolInfoPinned && !force) return;
+    _toolInfoPinned = false;
+    var tip = qs("#toolInfoTooltip");
+    if (tip) tip.classList.add("hidden");
+  }
+
   function computeTickInterval(visibleSeconds) {
     var candidates = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
     for (var i = 0; i < candidates.length; i++) {
@@ -1906,12 +1975,32 @@
   function initWorkflowTabs() {
     qsa(".wf-tab").forEach(function (tab) {
       tab.addEventListener("click", function () {
+        hideToolInfoTooltip(true);
         state.activeWorkflow = tab.dataset.type;
         qsa(".wf-tab").forEach(function (t) { t.classList.remove("active"); });
         tab.classList.add("active");
         renderWorkflowParams();
       });
     });
+    // Tool info icon in action row
+    var infoBtn = qs("#toolInfoBtn");
+    if (infoBtn) {
+      infoBtn.addEventListener("mouseenter", function () {
+        if (!_toolInfoPinned) showToolInfoTooltip(infoBtn);
+      });
+      infoBtn.addEventListener("mouseleave", function () {
+        hideToolInfoTooltip(false);
+      });
+      infoBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        if (_toolInfoPinned) {
+          hideToolInfoTooltip(true);
+        } else {
+          showToolInfoTooltip(infoBtn);
+          pinToolInfoTooltip();
+        }
+      });
+    }
     renderWorkflowParams();
   }
 
@@ -1928,6 +2017,8 @@
   function renderWorkflowParams() {
     var container = qs("#workflowParams");
     container.innerHTML = "";
+    hideToolInfoTooltip(true);
+    _toolInfoPinned = false;
     var intervalSlot = qs("#workflowIntervalSlot");
     if (intervalSlot) intervalSlot.innerHTML = "";
     var type = state.activeWorkflow;


### PR DESCRIPTION
## Summary

- Adds a hoverable info icon (ⓘ) to the left of the participant picker in each Screenspace tool's action row
- Hovering shows a tooltip with usage advice for the active tool; clicking pins the tooltip so it stays visible with a dismiss button
- Switching tools or clicking dismiss closes any pinned tooltip
- Tooltip text is stubbed with `[TODO_INFO]` markers for all 9 tools, ready to be replaced with final copy

## Test plan

- [ ] Open Screenspace, verify info icon appears in the action row for each tool
- [ ] Hover icon → tooltip appears; move away → tooltip disappears
- [ ] Click icon → tooltip pins with close button; click close → dismissed
- [ ] Switch tool tab → pinned tooltip dismissed
- [ ] Click pinned info icon again → tooltip dismissed