### PR TITLE
Fix crash when using local Excel files without Google credentials

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -458,6 +458,14 @@ def authenticate_google() -> Any:
 # ---- Worksheet selection ----
 
 
+def _is_excel_spreadsheet_arg(spreadsheet_arg: Optional[str]) -> bool:
+    """Return True if the -s argument points to a local Excel file."""
+    if not spreadsheet_arg:
+        return False
+    raw = spreadsheet_arg.strip().lower()
+    return raw == config.COMMAND_EXCEL or raw.endswith(".xlsx")
+
+
 def select_worksheet(
     gspread_client: Any, doc_list: List[str], args: Any, cli_mode: bool
 ) -> Any:
@@ -1221,11 +1229,14 @@ def main() -> None:
         utils.info_print(f"Regenerated {regenerated} of {total} item(s).")
         sys.exit(0)
 
-    # Authenticate with Google (once per run)
-    import google_api
+    # Authenticate with Google (once per run) – skip for local Excel files
+    gspread_client = None
+    doc_list: List[str] = []
+    if not _is_excel_spreadsheet_arg(getattr(args, "spreadsheet", None)):
+        import google_api
 
-    gspread_client = authenticate_google()
-    doc_list = google_api.get_all_spreadsheets(gspread_client)
+        gspread_client = authenticate_google()
+        doc_list = google_api.get_all_spreadsheets(gspread_client)
 
     # Outer loop so 'top' can return to spreadsheet selection
     while True:

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.6"
+VERSIONNUM: str = "0.10.7"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -217,3 +217,25 @@ def test_run_cli_mode_reel_cli_dispatch(monkeypatch, make_clip):
     # First positional argument should be the clips list returned from generate_list.
     assert process_reel.call_args[0][0] is clips
     completion.assert_called_once()
+
+
+# ---- Excel auth-skipping ----
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("excel", True),
+        ("EXCEL", True),
+        ("  excel  ", True),
+        ("notes.xlsx", True),
+        ("path/to/file.XLSX", True),
+        (None, False),
+        ("", False),
+        ("my-spreadsheet", False),
+        ("https://docs.google.com/spreadsheets/d/abc", False),
+        ("42", False),
+    ],
+)
+def test_is_excel_spreadsheet_arg(value, expected):
+    assert cli._is_excel_spreadsheet_arg(value) is expected


### PR DESCRIPTION
## Summary
- Skip Google authentication (`authenticate_google()` and `get_all_spreadsheets()`) when `-s excel` or `-s *.xlsx` is passed, so users without `credentials.json` can work with local Excel files
- Add `_is_excel_spreadsheet_arg()` helper that detects Excel-targeting `-s` values before the auth call in `main()`
- Add parametrized tests covering 10 cases for the new helper

## Test plan
- [x] All 352 existing tests pass
- [ ] Verify on Windows: `./clipgen.exe -s excel -o ./output` no longer crashes without `credentials.json`
- [ ] Verify Google Sheets flow still works normally when `-s excel` is not used