### PR TITLE
Optimize CI build: exclude unused modules, CPU-only torch, pin PyInstaller

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     strategy:
@@ -32,8 +36,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync
-          uv pip install pyinstaller
+          uv sync --torch-backend cpu
+          uv pip install pyinstaller==6.19.0
 
       - name: Build executable
         run: uv run pyinstaller --clean --noconfirm build/clipgen.spec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies (CPU-only torch)
         run: |
           uv venv
-          uv pip install . --torch-backend cpu
+          uv pip install ".[dev]" --torch-backend cpu
 
       - name: Run smoke tests
         run: uv run --no-sync pytest -c tests/pytest.ini
@@ -69,7 +69,7 @@ jobs:
       - name: Install dependencies (CPU-only torch)
         run: |
           uv venv
-          uv pip install . --torch-backend cpu
+          uv pip install ".[dev]" --torch-backend cpu
 
       - name: Type check
         run: uvx ty check

--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -16,6 +16,17 @@ datas += collect_data_files("rich")
 datas += [("../assets", "assets")]
 
 
+excludes = [
+    # Test frameworks — not needed in production binary
+    "pytest", "_pytest", "py", "pluggy", "iniconfig",
+    # Torch submodules clipgen never uses
+    "tensorboard", "torch.distributed",
+    # GUI toolkit pulled in transitively — clipgen is CLI-only
+    "tkinter", "_tkinter",
+    # Other unused transitive dependencies
+    "matplotlib", "IPython", "notebook", "jupyter",
+]
+
 a = Analysis(
     ["../clipgen.py"],
     pathex=[".."],
@@ -25,7 +36,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=excludes,
     noarchive=False,
 )
 pyz = PYZ(a.pure)
@@ -39,7 +50,7 @@ exe = EXE(
     name="clipgen",
     debug=False,
     bootloader_ignore_signals=False,
-    strip=False,
+    strip=True,
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,10 @@ dependencies = [
     "imagehash>=4.3.0",
     "scikit-image>=0.22.0",
     "easyocr>=1.7.0",
-    "pytest",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [tool.setuptools]
 packages = []

--- a/uv.lock
+++ b/uv.lock
@@ -230,9 +230,13 @@ dependencies = [
     { name = "imagehash" },
     { name = "opencv-python-headless" },
     { name = "openpyxl" },
-    { name = "pytest" },
     { name = "rich" },
     { name = "scikit-image" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -245,10 +249,11 @@ requires-dist = [
     { name = "imagehash", specifier = ">=4.3.0" },
     { name = "opencv-python-headless", specifier = ">=4.8.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
-    { name = "pytest" },
+    { name = "pytest", marker = "extra == 'dev'" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "scikit-image", specifier = ">=0.22.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## Summary
- Add `excludes` list to `build/clipgen.spec` to skip bundling unused modules (pytest, torch.distributed, tensorboard, tkinter, matplotlib, IPython, jupyter), reducing binary size and eliminating build warnings
- Move `pytest` from production dependencies to `[project.optional-dependencies] dev` in `pyproject.toml` so the test framework isn't bundled into release binaries
- Use `--torch-backend cpu` in the build workflow to avoid downloading CUDA stubs, and pin `pyinstaller==6.19.0` for reproducibility
- Enable `strip=True` in the spec file to strip debug symbols from bundled libraries
- Add minimal `permissions` block to the build workflow for better security hygiene

## Test plan
- [ ] Trigger `build-binaries` workflow manually and verify both macOS and Windows builds succeed
- [ ] Verify the `checks` workflow still passes (pytest installed via `.[dev]` extra)
- [ ] Compare artifact sizes against previous build to confirm reduction