### PR TITLE
Update transcript plan with Screenspace architecture lessons

### DIFF
--- a/plans/TRANSCRIPT-PLAN.md
+++ b/plans/TRANSCRIPT-PLAN.md
@@ -14,15 +14,16 @@ Transcripts in clipgen are currently a "write to disk and forget" feature. This 
 
 - **Source-video transcripts are the primary model.** `--pre-transcribe [ID...]` transcribes full source videos upfront and stores results in the manifest. No IDs = all participants enqueued. This is the primary intended workflow: transcribe everything before analysis begins, then walk away for the duration. The Transcript workspace also supports queuing transcription jobs directly from the UI.
 - Per-clip transcripts are *derived* from source transcripts when available (filtering segments by time range). On-the-fly Whisper transcription is the fallback when no source transcript exists and transcription is requested.
-- Source transcripts are stored as a new top-level section in `clipgen_manifest.json`, keyed by participant ID.
+- Source transcripts are stored in a separate `transcripts_manifest.json` (following the Screenspace manifest separation pattern), keyed by participant ID. Per-clip transcript data (the derived `transcript` field on artifact records) stays on the artifact in `clipgen_manifest.json`.
 - Transcript segments are embedded on clip/reel artifact records as a `transcript` field (derived from source or generated on-the-fly).
 - Standalone transcript file output stays for researchers who just want text files (secondary, opt-in via `--transcribe`).
-- Two-tier corrections dictionary: study-local (default) + global (promoted).
+- Study-local corrections dictionary, stored inside `transcripts_manifest.json`. Global corrections deferred until multi-study need is proven.
 - Corrections feed back into Whisper as context keywords AND apply as post-processing.
-- Transcript segment schema is `{start, end, text}` — designed to accommodate a `speaker` field later (for diarization).
+- Transcript segment schema is `{id, start, end, text}` — `id` is index-based (e.g., `"P01:42"`) for provenance tracking on intake-generated artifacts. Designed to accommodate a `speaker` field later (for diarization).
 - Reel transcripts are merged from constituent clip transcripts, maintaining order.
 - **Dedicated workspace at `/transcripts/`** — a full-page curation environment (own Flask blueprint, own HTML/JS/CSS assets) following the Screenspace pattern. Works standalone with source media files; no spreadsheet required.
-- **Studio Transcript Intake tab** — a third tab in Studio's preview area (alongside Sheet Preview and Screenspace Intake) for browsing and searching transcript content without leaving Studio. Appears when source transcripts exist in the manifest.
+- **Transcript segments are NOT events.** Segments are dense continuous coverage (thousands per video); Screenspace events are sparse point detections (dozens per analysis). Clustering is nonsensical for continuous data. The useful interaction between transcripts and events is cross-referencing by timestamp, not unification into a single model.
+- **Studio Transcript Intake tab** — a third tab in Studio's preview area (alongside Sheet Preview and Screenspace Intake) for browsing and searching transcript content without leaving Studio. Appears when source transcripts exist in the manifest. Remains a separate tab from Screenspace Intake — different interaction model (search-based vs. detection-based).
 
 ---
 
@@ -34,27 +35,27 @@ Embed transcript data on artifacts and build the corrections system.
 
 - [ ] Add `--pre-transcribe [ID...]` CLI flag — accepts zero or more participant IDs; no IDs = enqueue all participants found in the spreadsheet
 - [ ] For each target participant, transcribe their source video (`{study}_{participant}.mp4`) using `transcribe_video()`
-- [ ] Store full-video transcript results in `clipgen_manifest.json` under a new top-level `source_transcripts` key, keyed by participant ID
-- [ ] Schema: `{"source_transcripts": {"P01": {"segments": [...], "language": str, "model": str, "source_file": str}}}`
-- [ ] Operation is idempotent: re-running `--pre-transcribe` skips participants already present in `source_transcripts`; force-retranscribe with an explicit flag if needed
+- [ ] Store full-video transcript results in a separate `transcripts_manifest.json` under a `source_transcripts` key, keyed by participant ID
+- [ ] Add `TRANSCRIPTS_MANIFEST_FILENAME` to `config.py` alongside `SCREENSPACE_MANIFEST_FILENAME`
+- [ ] Add `load_transcripts_manifest()` / `save_transcripts_manifest()` to `transcripts.py` following the `load_screenspace_manifest()` / `save_screenspace_manifest()` pattern
+- [ ] Schema: `{"source_transcripts": {"P01": {"segments": [...], "language": str, "model": str, "source_file": str, "transcribed_at": iso8601}}, "corrections": [...]}`
+- [ ] Operation is idempotent: re-running `--pre-transcribe` skips participants already present in `source_transcripts` within the transcripts manifest; force-retranscribe with an explicit flag if needed
 - [ ] Requires a spreadsheet (to resolve participant IDs and source video paths); can combine with `-s`, `-i/-o`, `-v`
 - [ ] Cannot combine with mode flags or `--studio`/`--insights`
 
 ### Transcript as artifact property
 
 - [ ] Add `transcript` field to clip artifact records in `process_clips()` — after `filter_segments()`, embed the segments list directly on the clip's artifact dict
-- [ ] Source priority: if a source transcript exists in the manifest for the clip's participant, derive via `filter_segments()`; otherwise fall back to on-the-fly Whisper transcription (if `--transcribe` or `TRANSCRIBE_ENABLED`)
-- [ ] Segment schema: `{"start": float, "end": float, "text": str}`
+- [ ] Source priority: if a source transcript exists in the transcripts manifest for the clip's participant, derive via `filter_segments()`; otherwise fall back to on-the-fly Whisper transcription (if `--transcribe` or `TRANSCRIBE_ENABLED`)
+- [ ] Segment schema: `{"id": str, "start": float, "end": float, "text": str}` — `id` is index-based (e.g., `"P01:42"` for participant + segment index) for provenance tracking
 - [ ] Add merged `transcript` field to reel artifact records — assembled from constituent clips' transcript segments during reel building, ordered to match the reel
 - [ ] Keep standalone transcript file output and transcript-type manifest entries as-is (opt-in via `--transcribe`, for researchers who just want text files)
 
 ### Corrections dictionary
 
-- [ ] Define corrections file format: `clipgen_corrections.json` (study-local, in output directory) and `~/.clipgen/corrections.json` (global)
-- [ ] Schema: `{"corrections": [{"from": str, "to": str, "created": iso8601}]}`
-- [ ] Study-local corrections take precedence over global when both match
-- [ ] Promotion mechanism: move a study-local correction to the global dictionary
-- [ ] Load global + study-local corrections at transcription time
+- [ ] Corrections stored inside `transcripts_manifest.json` under the `corrections` key (study-local only; global dictionary deferred until multi-study need is proven)
+- [ ] Schema: `{"corrections": [{"id": str, "from": str, "to": str, "created": iso8601}]}`
+- [ ] Load corrections from the transcripts manifest at transcription time
 
 ### Corrections integration with Whisper
 
@@ -71,7 +72,7 @@ Dedicated page at `/transcripts/` for transcript curation, editing, and transcri
 ### Server and routing
 
 - [ ] New `transcripts_server.py` — Flask blueprint registered at `/transcripts/`
-- [ ] `_init_transcripts_state()` — discovers source media files from input directory (like Screenspace's participant discovery), loads source transcripts from manifest
+- [ ] `_init_transcripts_state()` — reuse the shared participant video discovery utility (factored out of Screenspace's `_discover_participant_videos`), loads source transcripts from transcripts manifest
 - [ ] Register blueprint in `start_combined_server()` alongside Studio, Insights, and Screenspace
 - [ ] `--transcripts` CLI flag to launch the workspace; works standalone (no spreadsheet required) as long as source media files exist in the input directory
 - [ ] Can combine with `-i/-o`, `-v`; cannot combine with mode flags, format flags, or `--viewer`
@@ -89,31 +90,40 @@ The workspace is a full-page environment for deep transcript work:
 - [ ] **Main area — transcript view**: scrollable transcript for the selected participant, displayed as a segment list with timestamps on the left and text on the right
 - [ ] **Video player**: inline video playback for the selected participant's source video; clicking a transcript segment seeks to that position
 - [ ] **Playback-synced highlighting**: active segment highlighted as video plays, auto-scroll to keep current segment visible
-- [ ] **Corrections panel**: view and manage the corrections dictionary (study-local and global entries), with promote/demote/delete actions
+- [ ] **Corrections log**: accessible from header menu, shows study-local corrections with delete action; inline editing is the primary correction flow, the log is for review and cleanup
 
 ### Transcription queue
 
-The workspace can trigger and monitor transcription jobs, not just view results:
+The workspace can trigger and monitor transcription jobs, not just view results. Architecture follows the `ScreenspaceWorker` pattern (simplified):
 
+- [ ] **`TranscriptWorker`**: thread-based background worker modeled after `ScreenspaceWorker`
+  - `PriorityQueue` for task ordering
+  - Task lifecycle: QUEUED → RUNNING → COMPLETED / FAILED / CANCELLED (no PAUSE/RESUME — Whisper doesn't produce meaningful partial results)
+  - `on_task_complete` callback for manifest persistence (wired same as Screenspace)
+  - `restore_tasks()` for loading historical task state on server restart
+  - Task dict: `{id, participant, video_path, status, progress, result, created_at, completed_at}`
+  - Task ID format: `tr_<8hex>` (following Screenspace's `ss_<8hex>`)
+  - No task reordering (not needed for a simple "transcribe all participants" queue)
 - [ ] **Queue UI**: list of participants with transcription status (not started / queued / in progress / complete)
 - [ ] **Enqueue**: select one or more participants to transcribe; starts a background transcription job on the server
-- [ ] **Progress**: show progress for in-flight transcription (segment count or percentage if available from faster-whisper)
+- [ ] **Progress**: show progress for in-flight transcription (estimated from audio duration vs. last segment's timestamp); frontend polls via same fingerprint pattern as Screenspace
 - [ ] **Idempotent**: participants already transcribed show as complete; re-transcribe option available with confirmation
 - [ ] **API endpoints**:
   - `POST /transcripts/api/transcribe` — enqueue participant(s) for transcription
   - `GET /transcripts/api/transcribe/status` — poll transcription job status
-- [ ] Transcription results are stored to `source_transcripts` in the manifest, same as `--pre-transcribe`
+- [ ] Transcription results are stored to `source_transcripts` in the transcripts manifest, same as `--pre-transcribe`
 
 ### API endpoints
 
 - [ ] `GET /transcripts/api/participants` — list discovered source videos with transcription status
 - [ ] `GET /transcripts/api/transcript/<participant>` — return full source transcript segments for a participant
-- [ ] `PUT /transcripts/api/transcript/<participant>/segments/<index>` — edit a segment's text (creates a correction entry)
-- [ ] `GET /transcripts/api/corrections` — list all corrections (study-local + global, distinguished)
+- [ ] `PUT /transcripts/api/transcript/<participant>/segment` — edit a segment's text, identified by `{start, end}` timestamps (not array index — indices change on re-transcription); creates a correction entry
+- [ ] `GET /transcripts/api/vtt/<participant>` — serve transcript data as WebVTT for native `<track>` subtitle support (`transcripts.py` already has `_format_vtt()`)
+- [ ] `GET /transcripts/api/corrections` — list all study-local corrections
 - [ ] `POST /transcripts/api/corrections` — add a correction manually
-- [ ] `PUT /transcripts/api/corrections/<id>/promote` — promote study-local correction to global
 - [ ] `DELETE /transcripts/api/corrections/<id>` — remove a correction
-- [ ] `GET /transcripts/api/search?q=<query>` — keyword search across all transcribed participants; returns matching segments with participant ID and timestamps
+- [ ] `GET /transcripts/api/search?q=<query>` — keyword search across all transcribed participants; returns matching segments with participant ID and timestamps (Studio calls this directly via `../transcripts/api/search`, no duplicate endpoint needed)
+- [ ] Update `/api/status` in `server.py` to report `transcripts: true/false` alongside `studio`, `insights`, `screenspace`
 
 ### Editing
 
@@ -121,7 +131,6 @@ The workspace can trigger and monitor transcription jobs, not just view results:
 - [ ] On save, original and edited text are compared; if different, a correction entry is created automatically (`{"from": original, "to": edited}`)
 - [ ] Edited segments are visually marked (subtle indicator that the text was corrected)
 - [ ] Corrections apply immediately to all identical occurrences across all participants' transcripts (post-processing pass)
-- [ ] Option to promote a correction to the global dictionary via the corrections panel
 
 ### Search
 
@@ -139,21 +148,39 @@ Surface transcript data inside Studio as a lightweight intake tab for cross-refe
 ### Intake tab
 
 - [ ] Third tab in Studio's `#sheetPreview` area: **"Transcript Intake"** alongside "Sheet Preview" and "Screenspace Intake"
-- [ ] Tab only appears when source transcripts exist in the manifest (at least one participant transcribed); hidden otherwise
-- [ ] Loads transcript data from the manifest via a Studio API endpoint (not the Transcript workspace server — Studio serves its own data)
+- [ ] Tab only appears when source transcripts exist in the transcripts manifest (at least one participant transcribed); hidden otherwise
+- [ ] Loads transcript data via the Transcript workspace API (`../transcripts/api/...`), following the same cross-blueprint pattern Studio uses for Screenspace events (`../screenspace/api/events`)
 
 ### Intake tab contents
 
 - [ ] **Participant filter**: dropdown or chip bar to filter by participant
-- [ ] **Search**: keyword search across transcript content, scoped to selected participant(s) or all
+- [ ] **Search**: keyword search across transcript content, scoped to selected participant(s) or all; calls `../transcripts/api/search`
 - [ ] **Segment list**: matching transcript segments displayed as compact cards — timestamp, participant badge, text snippet
 - [ ] **"New only" toggle**: filter to segments not yet associated with any artifact (helps find uncaptured moments)
-- [ ] **Drag to artifact area**: segments can be dragged from the intake list to the artifact work area, creating a clip artifact card with pre-filled timestamp range from the segment
+- [ ] **Drag to artifact area**: segments dragged using the standardized drag data format:
+  ```javascript
+  {
+    participant: str,
+    desc: str,             // matched text snippet (truncated)
+    segStart: float,       // segment start in seconds
+    segDuration: float,    // segment end - start
+    source: "transcript",
+    search_query: str,     // provenance: the search term that found this
+    segment_ids: [str],    // provenance: segment IDs (e.g., ["P01:42", "P01:43"])
+  }
+  ```
+- [ ] Artifacts generated from transcript intake carry `source: "transcript"`, `segment_ids: [...]`, `intake_label: "search: <query>"` — matching the Screenspace pattern in `server.py`
+
+### Cross-referencing with Screenspace events
+
+- [ ] **On Screenspace intake cards**: when transcript data is available, show a "transcript context" line with the text at the card's time range (client-side join by participant + timestamp)
+- [ ] **On transcript search results**: when Screenspace events exist at the same timestamp, show a detector badge on the segment card (e.g., "change event detected here")
+- [ ] Cross-referencing is pure client-side — both data sources available in memory, joined by participant + timestamp at display time
 
 ### Studio API additions
 
-- [ ] `GET /studio/api/transcripts` — return source transcripts from manifest (participant list with segment counts, or full segments for a requested participant)
-- [ ] `GET /studio/api/transcripts/search?q=<query>` — search across transcript content, return matching segments
+- [ ] `GET /studio/api/transcripts` — return transcript summary from transcripts manifest (participant list with segment counts); full segment data fetched via `../transcripts/api/transcript/<participant>`
+- [ ] No duplicate search endpoint — Studio calls `../transcripts/api/search` directly
 
 ---
 
@@ -175,9 +202,20 @@ Surface transcripts in output-facing viewers and the Insights Builder.
 
 ### Timeline Viewer
 
-- [ ] Detail panel: scrollable transcript alongside video playback
-- [ ] Playback-synced transcript highlighting — active segment highlighted as video plays
+- [ ] **Transcript sidebar** (not a timeline track row): scrollable transcript panel alongside video playback. Transcript data is continuous — every second has text — so track markers would produce a solid unbroken bar that communicates nothing. Screenspace events work as track markers because they're sparse.
+- [ ] Playback-synced transcript highlighting — active segment highlighted as video plays, auto-scroll to keep current segment visible
+- [ ] Data contract: add optional `transcripts` key to `window.CLIPGEN_DATA`:
+  ```javascript
+  {
+    "transcripts": {
+      "P01": { "segments": [...], "language": "en" },
+      ...
+    }
+  }
+  ```
+- [ ] Add `transcripts` parameter to `finalize_timeline_data()` and a `load_transcripts_for_viewer()` helper following the `load_screenspace_events_for_viewer()` pattern in `viewer.py`
 - [ ] Type filter updated to include transcript-bearing artifacts
+- [ ] Show Screenspace event badges inline with transcript text at corresponding timestamps (cross-referencing in the viewer)
 
 ---
 
@@ -185,7 +223,7 @@ Surface transcripts in output-facing viewers and the Insights Builder.
 
 Not in scope for Phases 1–4, but the segment schema is designed to accommodate it.
 
-- Extend segment schema: `{start, end, text, speaker}`
+- Extend segment schema: `{id, start, end, text, speaker}`
 - Separate moderator speech from participant speech
 - Enable filtering/tagging by speaker role
 - Would require a diarization engine alongside or replacing Whisper (e.g., pyannote.audio)
@@ -195,8 +233,8 @@ Not in scope for Phases 1–4, but the segment schema is designed to accommodate
 ## Assumptions to monitor
 
 - **Whisper quality with context keywords** — test early with real session audio to confirm corrections-as-keywords measurably improves output
-- **Manifest size** — source transcripts stored in manifest may grow large for long sessions; worth checking at scale (e.g. 6+ participants with hour-long videos)
+- **Manifest size** — mitigated by using a separate `transcripts_manifest.json` so the clipgen manifest isn't bloated; still worth checking that the transcripts manifest loads quickly at scale (e.g. 6+ participants with hour-long videos = 10k+ segments)
 - **Auto-apply safety** — corrections applied without approval could introduce errors in edge cases (e.g., a legitimate use of the "from" text in a different context)
 - **Pre-transcribe runtime** — full-session transcription is slow; the idempotency guarantee (skip already-stored participants) means re-running is safe and partial runs can be completed incrementally
 - **Background transcription in workspace** — running Whisper in a background thread while serving the Flask app; need to ensure thread safety for manifest writes and that the GIL doesn't starve the server. Same single-threaded-by-nature constraint as Screenspace's task queue worker.
-- **Standalone discovery** — the workspace discovers source media from the input directory without a spreadsheet. Participant ID extraction from filenames (`{study}_{participant}.mp4`) must be robust to naming variations.
+- **Standalone discovery** — the workspace discovers source media from the input directory without a spreadsheet. Reuses the shared video discovery utility (factored from Screenspace's `_discover_participant_videos`). Participant ID extraction from filenames (`{study}_{participant}.mp4`) must be robust to naming variations.


### PR DESCRIPTION
## Summary

Updates TRANSCRIPT-PLAN.md to align with architectural patterns established by Screenspace, event markers, and Studio Intake — features that were built after the original transcript plan was written.

- **Separate manifest**: Use `transcripts_manifest.json` instead of embedding in `clipgen_manifest.json`, matching the Screenspace manifest separation pattern
- **Simplify corrections**: Study-local only (defer global dictionary and promotion/demotion), stored in the transcripts manifest
- **Add segment IDs**: Index-based IDs (`"P01:42"`) on segments for provenance tracking on intake-generated artifacts
- **Specify worker architecture**: `TranscriptWorker` modeled after `ScreenspaceWorker` (simplified — no pause/resume or reordering)
- **Share utilities**: Reuse video discovery from Screenspace instead of reimplementing
- **Standardize integration**: Drag-to-import data contract, artifact source attribution, cross-blueprint API calls, VTT endpoint, cross-referencing between Screenspace events and transcripts
- **Clarify design**: Transcript sidebar (not track markers) in Timeline Viewer; segments are NOT events; three separate Studio tabs

## Test plan

- [ ] Review plan document for internal consistency across all four phases
- [ ] Verify no references to old patterns remain (clipgen_manifest storage, global corrections, segment index editing)