### PR TITLE
Add perceptual performance: SSE streaming, preloading, skeletons, DOM batching

### DIFF
--- a/assets/web/insights-builder.css
+++ b/assets/web/insights-builder.css
@@ -620,6 +620,11 @@ body {
   font-size: var(--text-base);
 }
 
+.skeleton-card {
+  height: 120px;
+  margin-bottom: var(--space-3);
+}
+
 /* ---- Insight Cards ---- */
 
 .insight-card {

--- a/assets/web/insights-builder.html
+++ b/assets/web/insights-builder.html
@@ -71,9 +71,9 @@
         <button id="newInsightBtn" class="btn btn-primary">+ New Insight</button>
       </div>
       <div id="insightCards">
-        <div id="emptyState" class="empty-state">
-          <p>No insights yet. Click <strong>+ New Insight</strong> to start authoring.</p>
-        </div>
+        <div class="skeleton skeleton-card"></div>
+        <div class="skeleton skeleton-card"></div>
+        <div class="skeleton skeleton-card"></div>
       </div>
     </section>
   </main>

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -267,6 +267,12 @@ body {
   pointer-events: none;
 }
 
+.skeleton-frame {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-md);
+}
+
 /* Preview resize handle */
 
 .preview-resize-handle {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -32,7 +32,7 @@
       <div id="frameContainer">
         <canvas id="frameCanvas"></canvas>
         <canvas id="overlayCanvas"></canvas>
-        <div id="frameEmpty">Select a participant to view frames</div>
+        <div id="frameEmpty"><div class="skeleton skeleton-frame"></div></div>
         <div id="previewResizeHandle" class="preview-resize-handle"></div>
       </div>
       <div id="regionBar">

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -107,6 +107,7 @@
     hoveredTaskId: null,
     selectedTaskResults: null,
     pollTimer: null,
+    eventSource: null,
     queuePaused: false,
     timelineDragging: false,
     panelHeight: 340,
@@ -133,6 +134,7 @@
   var _overlayRaf = 0;
   var _cachedOverlayRect = null;
   var _lastPollFingerprint = "";
+  var _preloadedFrames = {};
 
   var _cachedThemeColors = null;
 
@@ -621,6 +623,10 @@
     _pendingFrameTs = null;
     _loadedFrameTs = timestamp;
 
+    // Use preloaded frame 0 if available
+    var preloaded = (timestamp === 0 && _preloadedFrames[state.selectedParticipant])
+      ? _preloadedFrames[state.selectedParticipant] : null;
+
     var img = new Image();
     img.onload = function () {
       state.frameImage = img;
@@ -648,7 +654,7 @@
         _fetchFrame(_pendingFrameTs);
       }
     };
-    img.src = frameUrl(state.selectedParticipant, timestamp);
+    img.src = preloaded || frameUrl(state.selectedParticipant, timestamp);
   }
 
   function initFrameControls() {
@@ -3311,7 +3317,7 @@
       var totalTasks = isMultitool ? participants.length : participants.length * regions.length;
       chain.then(function () {
         showToast(totalTasks + " task" + (totalTasks !== 1 ? "s" : "") + " queued: " + type);
-        startPolling();
+        startSSE();
       }).catch(function (err) { showToast("Error: " + err.message); });
     });
   }
@@ -4335,7 +4341,64 @@
     container.appendChild(frag);
   }
 
-  // ---- Polling ----
+  // ---- SSE (Server-Sent Events) with polling fallback ----
+
+  function handleTaskData(data) {
+    if (!data.ok) return;
+    var oldSelected = state.selectedTaskId;
+    var oldTask = oldSelected ? findTask(oldSelected) : null;
+    var wasRunning = oldTask && (oldTask.status === "queued" || oldTask.status === "running");
+    state.tasks = data.tasks;
+    if (data.paused !== undefined) {
+      state.queuePaused = data.paused;
+      updatePauseButton();
+    }
+    var fp = JSON.stringify(data.tasks.map(function (t) {
+      return t.id + ":" + t.status + ":" + t.progress;
+    }));
+    var changed = fp !== _lastPollFingerprint;
+    _lastPollFingerprint = fp;
+    if (changed) {
+      renderTaskList();
+      renderTimeline();
+    }
+    // Auto-update results for selected running task
+    if (oldSelected) {
+      var selTask = findTask(oldSelected);
+      if (selTask && selTask.status === "running" && selTask.result) {
+        state.selectedTaskResults = selTask.result;
+        renderResults();
+      }
+    }
+    // Auto-load results when selected task completes
+    if (wasRunning && oldSelected) {
+      var newTask = findTask(oldSelected);
+      if (newTask && newTask.status === "completed") {
+        loadAndShowResults(oldSelected);
+      }
+    }
+  }
+
+  function startSSE() {
+    if (state.eventSource) return;
+    var es = new EventSource("api/tasks/stream");
+    state.eventSource = es;
+
+    es.onmessage = function (e) {
+      var data;
+      try { data = JSON.parse(e.data); } catch (_) { return; }
+      handleTaskData(data);
+    };
+
+    es.onerror = function () {
+      // Connection lost — fall back to polling
+      es.close();
+      state.eventSource = null;
+      startPolling();
+    };
+  }
+
+  // ---- Polling (fallback) ----
 
   function startPolling() {
     if (state.pollTimer) return;
@@ -4353,41 +4416,7 @@
     }
 
     apiGet("api/tasks")
-      .then(function (data) {
-        if (!data.ok) return;
-        var oldSelected = state.selectedTaskId;
-        var oldTask = oldSelected ? findTask(oldSelected) : null;
-        var wasRunning = oldTask && (oldTask.status === "queued" || oldTask.status === "running");
-        state.tasks = data.tasks;
-        if (data.paused !== undefined) {
-          state.queuePaused = data.paused;
-          updatePauseButton();
-        }
-        var fp = JSON.stringify(data.tasks.map(function (t) {
-          return t.id + ":" + t.status + ":" + t.progress;
-        }));
-        var changed = fp !== _lastPollFingerprint;
-        _lastPollFingerprint = fp;
-        if (changed) {
-          renderTaskList();
-          renderTimeline();
-        }
-        // Auto-update results for selected running task
-        if (oldSelected) {
-          var selTask = findTask(oldSelected);
-          if (selTask && selTask.status === "running" && selTask.result) {
-            state.selectedTaskResults = selTask.result;
-            renderResults();
-          }
-        }
-        // Auto-load results when selected task completes
-        if (wasRunning && oldSelected) {
-          var newTask = findTask(oldSelected);
-          if (newTask && newTask.status === "completed") {
-            loadAndShowResults(oldSelected);
-          }
-        }
-      })
+      .then(function (data) { handleTaskData(data); })
       .catch(function () {});
   }
 
@@ -4586,6 +4615,7 @@
     if (showToggle) showToggle.classList.toggle("hidden", events.length === 0);
 
     var visibleCount = 0;
+    var frag = document.createDocumentFragment();
 
     countEl.textContent = "(" + results.length + ")";
     container.innerHTML = "";
@@ -4753,8 +4783,9 @@
         row.appendChild(btn);
       }
 
-      container.appendChild(row);
+      frag.appendChild(row);
     });
+    container.appendChild(frag);
   }
 
   // ---- Keyboard shortcuts ----
@@ -4962,6 +4993,14 @@
         if (!data.ok) return;
         state.participants = (data.participants || []).filter(function (p) { return p.has_video; });
         renderParticipantSelect();
+        // Preload frame 0 for all participants (instant first-frame display)
+        state.participants.forEach(function (p) {
+          var url = frameUrl(p.id, 0);
+          fetch(url)
+            .then(function (r) { return r.blob(); })
+            .then(function (blob) { _preloadedFrames[p.id] = URL.createObjectURL(blob); })
+            .catch(function () {});
+        });
         if (state.participants.length > 0) {
           var first = state.participants[0].id;
           selectParticipant(first);
@@ -4999,7 +5038,7 @@
           renderTaskList();
           renderTimeline();
           if (state.tasks.some(function (t) { return t.status === "queued" || t.status === "running"; })) {
-            startPolling();
+            startSSE();
           }
         }
       })

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -452,9 +452,12 @@ body {
 }
 
 #sheetLoading {
-  padding: var(--space-6);
-  text-align: center;
-  color: var(--color-text-dim);
+  padding: var(--space-5);
+}
+
+.skeleton-row {
+  height: 36px;
+  margin-bottom: var(--space-2);
 }
 
 #viewerArtifactCount {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -87,7 +87,11 @@
     <div id="filterBar" class="hidden"></div>
     <div id="sheetGrid">
       <div id="sheetLoading">
-        Loading sheet data...
+        <div class="skeleton skeleton-row"></div>
+        <div class="skeleton skeleton-row"></div>
+        <div class="skeleton skeleton-row"></div>
+        <div class="skeleton skeleton-row"></div>
+        <div class="skeleton skeleton-row" style="width: 60%"></div>
       </div>
     </div>
     <div id="intakePanel" class="hidden">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2332,9 +2332,6 @@
       setTitleSpinner("artifactsSpinner", false);
       state.generating = false;
       setGeneratingLock(false);
-      if (allArtifacts.length > 0) {
-        state.generatedArtifacts = state.generatedArtifacts.concat(allArtifacts);
-      }
       updateViewerButton();
       var msg = "Generated " + totalSuccess + " artifact(s)";
       if (totalFail > 0) msg += ", " + totalFail + " failed";
@@ -2367,7 +2364,11 @@
         if (data.ok) {
           for (var ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], true);
           totalSuccess += (data.generated || 1);
-          if (data.artifacts) allArtifacts = allArtifacts.concat(data.artifacts);
+          if (data.artifacts) {
+            allArtifacts = allArtifacts.concat(data.artifacts);
+            state.generatedArtifacts = state.generatedArtifacts.concat(data.artifacts);
+            updateViewerButton();
+          }
         } else {
           for (var ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], false);
           totalFail++;
@@ -2442,7 +2443,11 @@
               var res = data.results[ri];
               if (res.ok) {
                 totalSuccess++;
-                if (res.artifact) allArtifacts.push(res.artifact);
+                if (res.artifact) {
+                  allArtifacts.push(res.artifact);
+                  state.generatedArtifacts.push(res.artifact);
+                  updateViewerButton();
+                }
                 if (intakeCards[ri]) setCardResult(intakeCards[ri], true);
               } else {
                 totalFail++;

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -54,3 +54,18 @@
   --z-overlay: 2000;
   --z-toast: 3000;
 }
+
+/* Skeleton loading placeholder */
+.skeleton {
+  background: linear-gradient(90deg, var(--color-surface-alt, #e5e7eb) 25%, var(--color-surface, #f3f4f6) 50%, var(--color-surface-alt, #e5e7eb) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; }
+}

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -22,7 +22,7 @@
   var _filmstripObserver = null;
   var _filmstripThumbQueue = [];
   var _filmstripThumbActive = 0;
-  var FILMSTRIP_CONCURRENCY = 2;
+  var FILMSTRIP_CONCURRENCY = 4;
   var FILMSTRIP_STORAGE_KEY = "clipgen-viewer-filmstrip";
 
   var _cardScrub = null; // { mediaEl, videoEl, raf }
@@ -1342,6 +1342,7 @@
     if (!list) return;
     list.innerHTML = "";
 
+    var frag = document.createDocumentFragment();
     orderedArtifactsForList().forEach(function (a) {
       if (a.type === "transcript") return;
       var card = el("div", "artifact-card");
@@ -1395,8 +1396,9 @@
       card.addEventListener("mousemove", moveTooltip);
       card.addEventListener("mouseleave", hideTooltip);
 
-      list.appendChild(card);
+      frag.appendChild(card);
     });
+    list.appendChild(frag);
 
     updateListVisibility();
     if (state.selectedId) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.12"
+VERSIONNUM: str = "0.10.13"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/plans/PERFORMANCE-PLAN.md
+++ b/plans/PERFORMANCE-PLAN.md
@@ -62,7 +62,7 @@ The backend already streams results during analysis, but the frontend polls at 3
 
 How fast clipgen *feels* to the user, independent of actual processing time.
 
-### - [ ] 1A. Streaming progress for Screenspace analysis tasks
+### - [x] 1A. Streaming progress for Screenspace analysis tasks
 
 **Prior art:** Backend already streams results during analysis (`910df4a`). Frontend polls every 3s (increased from 2s in `89bd136`) with skip-if-unchanged fingerprinting and tab-hidden pause.
 
@@ -72,7 +72,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 **Trade-offs:** SSE adds a persistent connection per client. Flask's dev server handles this fine for single-user; production would need `gunicorn --worker-class gevent` or similar. Fallback: shorten poll interval to 500ms (cheap since `/api/tasks` is a dict read).
 
-### - [ ] 1B. Preload first frame when a video is selected in Screenspace
+### - [x] 1B. Preload first frame when a video is selected in Screenspace
 
 **Prior art:** Viewer already preloads clips as muted paused `<video>` elements (`8206470`). Same principle, different context.
 
@@ -82,7 +82,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 **Trade-offs:** Negligible. Tiny network cost, large perceptual win.
 
-### - [ ] 1C. Optimistic UI updates in Studio
+### - [x] 1C. Optimistic UI updates in Studio
 
 **Current:** Generate actions in Studio stream progress via ndjson (`/api/generate`), but the clip list only refreshes after the stream closes. The user waits for the full batch to finish before seeing new artifacts.
 
@@ -90,7 +90,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 **Trade-offs:** Requires handling partial state on cancel/error. Low risk since Studio already parses the ndjson stream line-by-line.
 
-### - [ ] 1D. Skeleton loading states for web UIs
+### - [x] 1D. Skeleton loading states for web UIs
 
 **Current:** Panels render empty, then fill. In Studio and Insights Builder, the clip/insight lists pop in after the initial API fetch completes.
 
@@ -98,7 +98,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 **Trade-offs:** Pure CSS/HTML, no backend change. Small effort.
 
-### - [ ] 1E. Frontend DOM batching for large artifact lists
+### - [x] 1E. Frontend DOM batching for large artifact lists
 
 **Prior art:** DocumentFragment batching already applied to Studio grid rendering (`89bd136`). Not yet applied to Viewer or Screenspace result lists.
 
@@ -108,7 +108,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 **Trade-offs:** None. Strictly better. Same pattern should be applied to Screenspace result lists and Viewer clip lists.
 
-### - [ ] 1F. Filmstrip thumbnail concurrency
+### - [x] 1F. Filmstrip thumbnail concurrency
 
 **Prior art:** Filmstrip concurrency was increased from 1→3 in `c5b604a`. Currently at 2 in viewer.js (may have been adjusted since).
 
@@ -394,15 +394,15 @@ Additional performance area: the raw speed of reading video frames and writing o
 | [ ] | 2 | 2C — Universal phash pre-filter (always-on candidate) | High — cheap filter, broad applicability, minimal quality loss |
 | [ ] | 3 | 5A — Cache uv in CI | High — near-instant CI installs |
 | [ ] | 4 | 3A — Parallel clip cutting | High — 3-4x faster batch generation |
-| [ ] | 5 | 1A — SSE for Screenspace progress | Medium — eliminates perceived stalls |
-| [ ] | 6 | 1B — Preload first frames | Medium — instant first interaction |
+| [x] | 5 | 1A — SSE for Screenspace progress | Medium — eliminates perceived stalls |
+| [x] | 6 | 1B — Preload first frames | Medium — instant first interaction |
 | [ ] | 7 | 3D — Transcript caching to disk | Medium — eliminates repeat transcription |
-| [ ] | 8 | 1E — DOM batching with fragments | Medium — smoother large lists |
+| [x] | 8 | 1E — DOM batching with fragments | Medium — smoother large lists |
 | [ ] | 9 | 5D — Parallel tests with xdist | Medium — faster CI feedback |
 | [ ] | 10 | 2F — Parallel region analysis | Medium — scales with CPU cores |
 | [ ] | 11 | 2E — Batch frame extraction via ffmpeg | Low-Medium — depends on video codec |
 | [ ] | 12 | 4A — Lazy-import heavy libs | Low-Medium — saves seconds on startup |
-| [ ] | 13 | 1C — Optimistic UI in Studio | Low-Medium — better feel during generation |
+| [x] | 13 | 1C — Optimistic UI in Studio | Low-Medium — better feel during generation |
 | [ ] | 14 | 5B — Skip torch for typecheck | Low — job already ~25s, marginal gain |
 | [ ] | 15 | 3B — Titlecard batching | Low — small per-clip overhead |
 | [ ] | 16 | 4C — Cache-busted static assets | Low — marginal for local tool |

--- a/screenspace.py
+++ b/screenspace.py
@@ -2106,6 +2106,8 @@ class ScreenspaceWorker:
         self._running = False
         self._paused = threading.Event()
         self.on_task_complete: Optional[Callable[[], None]] = None
+        self.on_progress_update: Optional[Callable[[], None]] = None
+        self._last_progress_notify: float = 0.0
 
     def start(self) -> None:
         """Start the worker thread."""
@@ -2356,6 +2358,11 @@ class ScreenspaceWorker:
                         self.on_task_complete()
                     except Exception as exc:
                         utils.warning_print(f"on_task_complete callback failed: {exc}")
+                if self.on_progress_update:
+                    try:
+                        self.on_progress_update()
+                    except Exception:
+                        pass
             except Exception as exc:
                 utils.warning_print(f"Worker loop error: {exc}")
 
@@ -2377,6 +2384,12 @@ class ScreenspaceWorker:
                     offset = t.get("_progress_offset", 0.0)
                     scale = t.get("_progress_scale", 1.0)
                     t["progress"] = min(offset + progress * scale, 1.0)
+            # Throttled SSE notification (~2 updates/sec)
+            now = time.monotonic()
+            if now - self._last_progress_notify >= 0.5:
+                self._last_progress_notify = now
+                if self.on_progress_update:
+                    self.on_progress_update()
 
         def _cancel_flag() -> bool:
             with self._lock:
@@ -2393,6 +2406,12 @@ class ScreenspaceWorker:
                         t["_raw_results"].append(result_dict)
                     if t.get("parameters", {}).get("detect_first"):
                         t["_cancelled"] = True
+            # Throttled SSE notification for new results
+            now = time.monotonic()
+            if now - self._last_progress_notify >= 0.5:
+                self._last_progress_notify = now
+                if self.on_progress_update:
+                    self.on_progress_update()
 
         try:
             result = self._dispatch(task, _on_progress, _cancel_flag, _on_result)

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -36,7 +36,9 @@ API endpoints (all under /screenspace/):
 from __future__ import annotations
 
 import copy
+import json
 import math
+import queue as queue_mod
 import threading
 import uuid
 from collections import OrderedDict
@@ -67,6 +69,34 @@ _video_cap_cache: OrderedDict[str, Any] = OrderedDict()
 _VIDEO_CAP_MAX = 3
 _video_cap_lock = threading.Lock()
 _video_metadata_cache: Dict[str, Dict[str, Any]] = {}
+
+# ---- SSE (Server-Sent Events) client registry ----
+
+_sse_clients: list[queue_mod.Queue[str]] = []
+_sse_clients_lock = threading.Lock()
+
+
+def _notify_sse_clients(event_type: str = "update") -> None:
+    """Push a notification to all connected SSE clients."""
+    with _sse_clients_lock:
+        for q in _sse_clients:
+            try:
+                q.put_nowait(event_type)
+            except queue_mod.Full:
+                pass
+
+
+def _sse_task_payload() -> str:
+    """Build an SSE data line with current task state."""
+    tasks = _worker.get_all_tasks() if _worker else []
+    clean = [_clean_task(t) for t in tasks]
+    paused = _worker.is_paused if _worker else False
+    alive = _worker.is_alive if _worker else False
+    data = json.dumps(
+        {"ok": True, "tasks": clean, "paused": paused, "worker_alive": alive}
+    )
+    return f"data: {data}\n\n"
+
 
 _assets_dir = utils.get_bundled_assets_root() / "assets" / "web"
 
@@ -440,6 +470,44 @@ def api_stashes_restore(stash_id: str) -> FlaskResponse:
 
 
 # ---- Tasks CRUD ----
+
+
+@screenspace_bp.route("/api/tasks/stream")
+def api_tasks_stream() -> FlaskResponse:
+    """SSE endpoint for live task updates (replaces polling)."""
+    client_q: queue_mod.Queue[str] = queue_mod.Queue(maxsize=64)
+    with _sse_clients_lock:
+        _sse_clients.append(client_q)
+
+    def generate():  # type: ignore[no-untyped-def]
+        try:
+            # Send current state immediately on connect
+            yield _sse_task_payload()
+            while True:
+                try:
+                    client_q.get(timeout=15)
+                    # Drain any queued notifications (coalesce rapid updates)
+                    while not client_q.empty():
+                        try:
+                            client_q.get_nowait()
+                        except queue_mod.Empty:
+                            break
+                    yield _sse_task_payload()
+                except queue_mod.Empty:
+                    # Keepalive comment to prevent connection timeout
+                    yield ": keepalive\n\n"
+        except GeneratorExit:
+            pass
+        finally:
+            with _sse_clients_lock:
+                if client_q in _sse_clients:
+                    _sse_clients.remove(client_q)
+
+    return Response(
+        generate(),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @screenspace_bp.route("/api/tasks")
@@ -860,6 +928,7 @@ def api_tasks_create() -> FlaskResponse:
 
     _worker.enqueue(task)
     _manifest.setdefault("tasks", []).append(task)
+    _notify_sse_clients("task_created")
 
     return jsonify({"ok": True, "task": _clean_task(task)})
 
@@ -876,8 +945,10 @@ def api_tasks_cancel(task_id: str) -> FlaskResponse:
             t for t in _manifest.get("tasks", []) if t["id"] != task_id
         ]
         _persist_manifest()
+        _notify_sse_clients("task_dismissed")
         return jsonify({"ok": True})
     if _worker.cancel(task_id):
+        _notify_sse_clients("task_cancelled")
         return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Task not found or already finished"}), 400
 
@@ -891,6 +962,7 @@ def api_tasks_reorder() -> FlaskResponse:
     if not data or "task_ids" not in data:
         return jsonify({"ok": False, "error": "task_ids list required"}), 400
     _worker.reorder(data["task_ids"])
+    _notify_sse_clients("reorder")
     return jsonify({"ok": True})
 
 
@@ -900,6 +972,7 @@ def api_tasks_pause() -> FlaskResponse:
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
     _worker.pause()
+    _notify_sse_clients("pause")
     return jsonify({"ok": True, "paused": True})
 
 
@@ -909,6 +982,7 @@ def api_tasks_resume() -> FlaskResponse:
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
     _worker.resume()
+    _notify_sse_clients("resume")
     return jsonify({"ok": True, "paused": False})
 
 
@@ -1075,6 +1149,7 @@ def _init_screenspace_state(
 
     _worker = screenspace.ScreenspaceWorker()
     _worker.on_task_complete = _persist_manifest
+    _worker.on_progress_update = lambda: _notify_sse_clients("progress")
     _worker.restore_tasks(_manifest.get("tasks", []))
     _worker.start()
 


### PR DESCRIPTION
## Summary

Implements all 6 perceptual performance experiments from PERFORMANCE-PLAN.md section 1:

- **1A** — SSE streaming for Screenspace task progress, replacing 3s polling with live Server-Sent Events (falls back to polling on disconnect)
- **1B** — Preload frame 0 for all participants on Screenspace init for instant first-frame display
- **1C** — Optimistic UI in Studio: artifact count and viewer button update incrementally during generation, not after stream closes
- **1D** — Skeleton loading states (shimmer placeholders) for Studio grid, Screenspace frame viewer, and Insights Builder cards
- **1E** — DocumentFragment batching for viewer artifact list and Screenspace result rows to eliminate per-element reflows
- **1F** — Filmstrip thumbnail concurrency increased from 2 to 4

## Test plan
- [ ] All 372 existing tests pass (`uv run pytest -c tests/pytest.ini`)
- [ ] Screenspace: run an analysis task, confirm results stream in live without 3s polling gaps; kill SSE in DevTools, confirm fallback to polling
- [ ] Screenspace: switch participants, confirm first frame appears instantly from preload cache
- [ ] Studio: generate multiple clips, confirm "Build Viewer" button enables as each clip finishes
- [ ] Studio/Screenspace/Insights: confirm skeleton shimmer shows briefly on initial load
- [ ] Viewer: open with many artifacts, confirm smooth list rendering