### PR TITLE
Filter out malformed artifacts to prevent empty cards in Viewer sidebar

### DIFF
--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -638,7 +638,9 @@
       return;
     }
 
-    state.artifacts = (data.artifacts || []).map(function (a, i) {
+    state.artifacts = (data.artifacts || []).filter(function (a) {
+      return a.id && a.file && (a.start != null || a.end != null);
+    }).map(function (a, i) {
       return Object.assign({}, a, { _idx: i });
     });
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.12"
+VERSIONNUM: str = "0.10.13"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -185,6 +185,40 @@ def test_load_manifest_reels_returns_empty_when_no_file(tmp_path, monkeypatch):
     assert viewer.load_manifest_reels() == []
 
 
+def test_load_manifest_filters_malformed_entries(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    good = _make_artifact("a4c2s0")
+    bad = {"id": "a1", "type": "clip"}  # missing file, start, end
+    raw_data = {
+        "meta": {},
+        "artifacts": [bad, good],
+        "timeline": {"duration": 0, "startOffset": 0},
+    }
+    (tmp_path / config.MANIFEST_FILENAME).write_text(json.dumps(raw_data))
+    loaded = viewer.load_manifest_artifacts()
+    assert len(loaded) == 1
+    assert loaded[0]["id"] == "a4c2s0"
+
+
+def test_save_manifest_does_not_preserve_preexisting_malformed(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    # Seed manifest with a malformed artifact
+    bad = {"id": "ghost", "type": "clip"}
+    raw_data = {
+        "meta": {},
+        "artifacts": [bad],
+        "timeline": {"duration": 0, "startOffset": 0},
+    }
+    (tmp_path / config.MANIFEST_FILENAME).write_text(json.dumps(raw_data))
+
+    # Save a valid artifact — malformed one should be cleaned up
+    viewer.save_manifest([_make_artifact("a4c2s0")])
+    loaded = viewer.load_manifest_artifacts()
+    ids = {a["id"] for a in loaded}
+    assert "ghost" not in ids
+    assert "a4c2s0" in ids
+
+
 def test_cli_manifest_flag_parsed(monkeypatch):
     import cli
 

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -73,6 +73,39 @@ def test_finalize_timeline_data_includes_reels():
     assert data["reels"] == reels
 
 
+# ---- finalize_timeline_data: artifact validation ----
+
+
+def test_finalize_timeline_data_drops_artifact_missing_file():
+    good = _make_artifact("a1c1s0")
+    bad = {"id": "a1", "type": "clip", "start": 0, "end": 10}
+    data = viewer.finalize_timeline_data([good, bad])
+    assert len(data["artifacts"]) == 1
+    assert data["artifacts"][0]["id"] == "a1c1s0"
+
+
+def test_finalize_timeline_data_drops_artifact_missing_start_and_end():
+    good = _make_artifact("a1c1s0")
+    bad = {"id": "a2", "type": "clip", "file": "clip.mp4", "start": None, "end": None}
+    data = viewer.finalize_timeline_data([good, bad])
+    assert len(data["artifacts"]) == 1
+    assert data["artifacts"][0]["id"] == "a1c1s0"
+
+
+def test_finalize_timeline_data_keeps_artifact_with_only_start():
+    art = _make_artifact("a1c1s0", end=None)
+    data = viewer.finalize_timeline_data([art])
+    assert len(data["artifacts"]) == 1
+
+
+def test_finalize_timeline_data_keeps_valid_artifacts_unmodified():
+    arts = [_make_artifact("a1c1s0"), _make_artifact("a2c1s0")]
+    data = viewer.finalize_timeline_data(arts)
+    assert len(data["artifacts"]) == 2
+    ids = {a["id"] for a in data["artifacts"]}
+    assert ids == {"a1c1s0", "a2c1s0"}
+
+
 # ---- finalize_gallery_data ----
 
 

--- a/viewer.py
+++ b/viewer.py
@@ -44,6 +44,17 @@ INTERACTIVE_ARTIFACTS: List[Dict[str, Any]] = []
 INTERACTIVE_REELS: List[Dict[str, Any]] = []
 
 
+def _is_valid_artifact(a: Dict[str, Any]) -> bool:
+    """Return True if artifact has minimum required fields for viewer rendering."""
+    if not a.get("id"):
+        return False
+    if not a.get("file"):
+        return False
+    if a.get("start") is None and a.get("end") is None:
+        return False
+    return True
+
+
 def build_artifact_records_for_clip(
     clip: utils.ClipRecord,
     base_video: str,
@@ -120,6 +131,18 @@ def finalize_timeline_data(
     screenspace_events: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Construct the full window.CLIPGEN_DATA structure for the timeline viewer."""
+    valid_artifacts = [a for a in artifacts if _is_valid_artifact(a)]
+    dropped = len(artifacts) - len(valid_artifacts)
+    if dropped:
+        dropped_ids = [
+            a.get("id", "<no-id>") for a in artifacts if not _is_valid_artifact(a)
+        ]
+        utils.warning_print(
+            f"Skipped {dropped} artifact(s) with missing required fields "
+            f"(ids: {', '.join(str(i) for i in dropped_ids[:5])})."
+        )
+    artifacts = valid_artifacts
+
     max_time = 0.0
     for a in artifacts:
         end = a.get("end") or a.get("start") or 0
@@ -383,7 +406,14 @@ def load_manifest_artifacts() -> List[Dict[str, Any]]:
         return []
     try:
         data = json.loads(manifest_path.read_text(encoding="utf-8"))
-        return data.get("artifacts", [])
+        raw = data.get("artifacts", [])
+        valid = [a for a in raw if _is_valid_artifact(a)]
+        if len(valid) < len(raw):
+            utils.warning_print(
+                f"Manifest contained {len(raw) - len(valid)} artifact(s) with "
+                "missing fields; skipped."
+            )
+        return valid
     except (OSError, json.JSONDecodeError, AttributeError):
         return []
 


### PR DESCRIPTION
## Summary
- Ghost artifacts with missing required fields (no file, no start/end) could persist in the manifest and render as empty cards with data-id "a1" in the Viewer sidebar
- No current code path generates a bare "a1" artifact ID — all production paths use `a{row}c{col}s{seg}` format — so the artifact likely entered the manifest from an older version or dev session
- Added `_is_valid_artifact()` validation (requires non-empty `id`, `file`, and at least one of `start`/`end`) at both Python boundaries (`finalize_timeline_data`, `load_manifest_artifacts`) and a JS-side filter in `viewer.js` initialization
- Manifests self-heal on next write since `save_manifest()` flows through `finalize_timeline_data()`

## Test plan
- [ ] Verify all existing tests still pass (`uv run pytest -c tests/pytest.ini`)
- [ ] Verify new validation tests pass in `test_viewer_data.py` and `test_manifest.py`
- [ ] Manually confirm a viewer generated from a manifest containing a ghost artifact no longer shows an empty card