### PR TITLE
Fix CI cache: use enable-cache for setup-uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
-          cache: true
+          enable-cache: true
 
       - name: Install dependencies (CPU-only torch)
         run: |
@@ -162,7 +162,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
-          cache: true
+          enable-cache: true
 
       - name: Install dependencies (CPU-only torch)
         run: |


### PR DESCRIPTION
## Summary

- Fix `cache: true` → `enable-cache: true` for `astral-sh/setup-uv@v7`. The action uses `enable-cache`, not `cache`, which caused GitHub to log warnings and skip caching entirely.

## Test plan

- [ ] CI run shows no "Unexpected input" warnings on the Setup uv step
- [ ] Second CI run shows "Cache restored from key: ..." in Setup uv logs