### PR TITLE
Centralize color tokens into tokens.css

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,13 @@
 - Never write a class when a function will do.
 - Treat spreadsheet layout and timestamp semantics as domain rules; if tests conflict with these, reconsider or adjust the tests rather than changing core semantics to satisfy them.
 - All web UIs use vanilla JavaScript (ES5-style `.then()` chaining, not async/await), hand-written CSS with CSS variables for theming, and plain HTML. No React, TypeScript, CSS frameworks, or build tools.
-- **CSS design tokens**: Use tokens from `assets/web/tokens.css` for spacing (`--space-N`), font sizes (`--text-N`), border radius (`--radius-N`), shadows (`--shadow-N`), transitions (`--duration-N`), and z-index (`--z-N`). Never write raw `rem`/`px` values for these properties in new code. When editing existing CSS, convert touched values to tokens.
+- **CSS design tokens**: `assets/web/tokens.css` is the single source of truth for shared design values. Never redefine these in page CSS; page-specific variables (e.g. `--color-cell-text` in studio, `--color-overlay-bg` in gallery) stay in their own files.
+  - **Layout**: spacing (`--space-N`), font sizes (`--text-N`), border radius (`--radius-N`), shadows (`--shadow-N`), transitions (`--duration-N`), z-index (`--z-N`). Never write raw `rem`/`px` for these in new code; convert touched values to tokens when editing.
+  - **Core theme**: `--color-bg`, `--color-surface`, `--color-surface-alt`, `--color-text`, `--color-text-dim`, `--color-accent`, `--color-border`, `--color-selected`, `--color-panel-bg/border/shadow`, `--color-grid`, `--font-mono` — light/dark variants included.
+  - **Severity**: `--sev-critical`, `--sev-high`, `--sev-medium`, `--sev-low`, `--sev-na`, `--sev-positive`, `--sev-very-positive`, `--sev-unknown`.
+  - **Content types**: `--color-clip`, `--color-screen`, `--color-gif`.
+  - **Screenspace tasks**: `--color-task-{tool}` for multitool, color, change, similarity, text, numbers, timelapse, template, flow, scene. In JS, read via `getComputedStyle(document.documentElement).getPropertyValue("--color-task-" + type)` — do not hardcode hex values.
+  - **Insight categories**: `--color-causes`, `--color-behaviors`, `--color-impacts` (+ `-bg` variants).
 - Thin server, thick client: keep the Flask server focused on data/media endpoints; UI logic, state management, and rendering happen client-side.
 - Plan-driven development: detailed implementation plans with specific files, line numbers, code structure, and verification steps are written before coding begins. Follow attached plans closely.
 - Features are often built incrementally across multiple sessions. Check for existing groundwork before starting from scratch.

--- a/assets/web/gallery.css
+++ b/assets/web/gallery.css
@@ -8,20 +8,9 @@
   padding: 0;
 }
 
+/* Page-specific variables — shared tokens are in tokens.css */
 :root {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-border: #e0ddd7;
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --color-grid: rgba(0, 0, 0, 0.03);
   --color-overlay-bg: rgba(0, 0, 0, 0.85);
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
 }
 
 html {
@@ -314,34 +303,4 @@ body {
   opacity: 0.8;
 }
 
-/* Dark Mode */
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #020617;
-    --color-surface: #020617;
-    --color-surface-alt: #0b1120;
-    --color-text: #e5e7eb;
-    --color-text-dim: #9ca3af;
-    --color-accent: #38bdf8;
-    --color-border: #1f2933;
-    --color-panel-bg: rgba(15, 23, 42, 0.98);
-    --color-panel-border: rgba(148, 163, 184, 0.35);
-    --color-panel-shadow: rgba(0, 0, 0, 0.7);
-    --color-grid: rgba(255, 255, 255, 0.04);
-  }
-}
-
-html[data-theme="dark"] {
-  --color-bg: #020617;
-  --color-surface: #020617;
-  --color-surface-alt: #0b1120;
-  --color-text: #e5e7eb;
-  --color-text-dim: #9ca3af;
-  --color-accent: #38bdf8;
-  --color-border: #1f2933;
-  --color-panel-bg: rgba(15, 23, 42, 0.98);
-  --color-panel-border: rgba(148, 163, 184, 0.35);
-  --color-panel-shadow: rgba(0, 0, 0, 0.7);
-  --color-grid: rgba(255, 255, 255, 0.04);
-}
+/* Dark mode — shared tokens in tokens.css, no page-specific dark overrides */

--- a/assets/web/insights-builder.css
+++ b/assets/web/insights-builder.css
@@ -8,37 +8,8 @@
   padding: 0;
 }
 
+/* Page-specific variables — shared tokens are in tokens.css */
 :root {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-clip: #3659b3;
-  --color-screen: #0ea5e9;
-  --color-gif: #f97316;
-  --color-border: #e0ddd7;
-  --color-grid: rgba(0, 0, 0, 0.03);
-  --color-selected: rgba(29, 79, 114, 0.08);
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
-  --sev-critical: #b91c1c;
-  --sev-high: #dc2626;
-  --sev-medium: #ea580c;
-  --sev-low: #ca8a04;
-  --sev-na: #0891b2;
-  --sev-positive: #16a34a;
-  --sev-very-positive: #15803d;
-  --sev-unknown: #64748b;
-  --color-causes: #ea580c;
-  --color-behaviors: #2563eb;
-  --color-impacts: #dc2626;
-  --color-causes-bg: rgba(234, 88, 12, 0.06);
-  --color-behaviors-bg: rgba(37, 99, 235, 0.06);
-  --color-impacts-bg: rgba(220, 38, 38, 0.06);
   --sidebar-width: 420px;
 }
 
@@ -1076,73 +1047,7 @@ body {
   display: none !important;
 }
 
-/* ---- Dark theme ---- */
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #020617;
-    --color-surface: #020617;
-    --color-surface-alt: #0b1120;
-    --color-text: #e5e7eb;
-    --color-text-dim: #9ca3af;
-    --color-accent: #38bdf8;
-    --color-clip: #60a5fa;
-    --color-screen: #22d3ee;
-    --color-gif: #fb923c;
-    --color-border: #1f2933;
-    --color-grid: rgba(255, 255, 255, 0.04);
-    --color-selected: rgba(56, 189, 248, 0.2);
-    --color-panel-bg: rgba(15, 23, 42, 0.98);
-    --color-panel-border: rgba(148, 163, 184, 0.35);
-    --color-panel-shadow: rgba(0, 0, 0, 0.7);
-    --sev-critical: #f87171;
-    --sev-high: #fb7185;
-    --sev-medium: #fdba74;
-    --sev-low: #fde047;
-    --sev-na: #67e8f9;
-    --sev-positive: #86efac;
-    --sev-very-positive: #4ade80;
-    --sev-unknown: #94a3b8;
-    --color-causes: #fb923c;
-    --color-behaviors: #60a5fa;
-    --color-impacts: #f87171;
-    --color-causes-bg: rgba(251, 146, 60, 0.1);
-    --color-behaviors-bg: rgba(96, 165, 250, 0.1);
-    --color-impacts-bg: rgba(248, 113, 113, 0.1);
-  }
-}
-
-html[data-theme="dark"] {
-  --color-bg: #020617;
-  --color-surface: #020617;
-  --color-surface-alt: #0b1120;
-  --color-text: #e5e7eb;
-  --color-text-dim: #9ca3af;
-  --color-accent: #38bdf8;
-  --color-clip: #60a5fa;
-  --color-screen: #22d3ee;
-  --color-gif: #fb923c;
-  --color-border: #1f2933;
-  --color-grid: rgba(255, 255, 255, 0.04);
-  --color-selected: rgba(56, 189, 248, 0.2);
-  --color-panel-bg: rgba(15, 23, 42, 0.98);
-  --color-panel-border: rgba(148, 163, 184, 0.35);
-  --color-panel-shadow: rgba(0, 0, 0, 0.7);
-  --sev-critical: #f87171;
-  --sev-high: #fb7185;
-  --sev-medium: #fdba74;
-  --sev-low: #fde047;
-  --sev-na: #67e8f9;
-  --sev-positive: #86efac;
-  --sev-very-positive: #4ade80;
-  --sev-unknown: #94a3b8;
-  --color-causes: #fb923c;
-  --color-behaviors: #60a5fa;
-  --color-impacts: #f87171;
-  --color-causes-bg: rgba(251, 146, 60, 0.1);
-  --color-behaviors-bg: rgba(96, 165, 250, 0.1);
-  --color-impacts-bg: rgba(248, 113, 113, 0.1);
-}
+/* Dark mode — shared tokens in tokens.css, no page-specific dark overrides */
 
 /* ---- Responsive ---- */
 

--- a/assets/web/insights-viewer.css
+++ b/assets/web/insights-viewer.css
@@ -8,34 +8,7 @@
   padding: 0;
 }
 
-:root {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-border: #e0ddd7;
-  --color-grid: rgba(0, 0, 0, 0.03);
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
-  --sev-critical: #b91c1c;
-  --sev-high: #dc2626;
-  --sev-medium: #ea580c;
-  --sev-low: #ca8a04;
-  --sev-na: #0891b2;
-  --sev-positive: #16a34a;
-  --sev-very-positive: #15803d;
-  --sev-unknown: #64748b;
-  --color-causes: #ea580c;
-  --color-behaviors: #2563eb;
-  --color-impacts: #dc2626;
-  --color-causes-bg: rgba(234, 88, 12, 0.06);
-  --color-behaviors-bg: rgba(37, 99, 235, 0.06);
-  --color-impacts-bg: rgba(220, 38, 38, 0.06);
-}
+/* Page-specific variables — shared tokens are in tokens.css */
 
 html {
   font-size: 16px;
@@ -386,62 +359,4 @@ body {
   display: none !important;
 }
 
-/* ---- Dark theme ---- */
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #020617;
-    --color-surface: #020617;
-    --color-surface-alt: #0b1120;
-    --color-text: #e5e7eb;
-    --color-text-dim: #9ca3af;
-    --color-accent: #38bdf8;
-    --color-border: #1f2933;
-    --color-grid: rgba(255, 255, 255, 0.04);
-    --color-panel-bg: rgba(15, 23, 42, 0.98);
-    --color-panel-border: rgba(148, 163, 184, 0.35);
-    --color-panel-shadow: rgba(0, 0, 0, 0.7);
-    --sev-critical: #f87171;
-    --sev-high: #fb7185;
-    --sev-medium: #fdba74;
-    --sev-low: #fde047;
-    --sev-na: #67e8f9;
-    --sev-positive: #86efac;
-    --sev-very-positive: #4ade80;
-    --sev-unknown: #94a3b8;
-    --color-causes: #fb923c;
-    --color-behaviors: #60a5fa;
-    --color-impacts: #f87171;
-    --color-causes-bg: rgba(251, 146, 60, 0.1);
-    --color-behaviors-bg: rgba(96, 165, 250, 0.1);
-    --color-impacts-bg: rgba(248, 113, 113, 0.1);
-  }
-}
-
-html[data-theme="dark"] {
-  --color-bg: #020617;
-  --color-surface: #020617;
-  --color-surface-alt: #0b1120;
-  --color-text: #e5e7eb;
-  --color-text-dim: #9ca3af;
-  --color-accent: #38bdf8;
-  --color-border: #1f2933;
-  --color-grid: rgba(255, 255, 255, 0.04);
-  --color-panel-bg: rgba(15, 23, 42, 0.98);
-  --color-panel-border: rgba(148, 163, 184, 0.35);
-  --color-panel-shadow: rgba(0, 0, 0, 0.7);
-  --sev-critical: #f87171;
-  --sev-high: #fb7185;
-  --sev-medium: #fdba74;
-  --sev-low: #fde047;
-  --sev-na: #67e8f9;
-  --sev-positive: #86efac;
-  --sev-very-positive: #4ade80;
-  --sev-unknown: #94a3b8;
-  --color-causes: #fb923c;
-  --color-behaviors: #60a5fa;
-  --color-impacts: #f87171;
-  --color-causes-bg: rgba(251, 146, 60, 0.1);
-  --color-behaviors-bg: rgba(96, 165, 250, 0.1);
-  --color-impacts-bg: rgba(248, 113, 113, 0.1);
-}
+/* Dark mode — shared tokens in tokens.css, no page-specific dark overrides */

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -8,31 +8,7 @@
   padding: 0;
 }
 
-:root {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-border: #e0ddd7;
-  --color-selected: rgba(29, 79, 114, 0.08);
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --color-grid: rgba(0, 0, 0, 0.03);
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
-  --color-task-multitool: #2563eb;
-  --color-task-color: #8b5cf6;
-  --color-task-change: #f97316;
-  --color-task-similarity: #0ea5e9;
-  --color-task-text: #10b981;
-  --color-task-numbers: #eab308;
-  --color-task-timelapse: #ec4899;
-  --color-task-template: #f43f5e;
-  --color-task-flow: #6366f1;
-  --color-task-scene: #14b8a6;
-}
+/* Page-specific variables — shared tokens are in tokens.css */
 
 html {
   font-size: 16px;
@@ -2034,61 +2010,7 @@ body {
 
 /* Dark mode — system preference */
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --color-bg: #020617;
-    --color-surface: #020617;
-    --color-surface-alt: #0b1120;
-    --color-text: #e5e7eb;
-    --color-text-dim: #9ca3af;
-    --color-accent: #38bdf8;
-    --color-border: #1f2933;
-    --color-selected: rgba(56, 189, 248, 0.2);
-    --color-panel-bg: rgba(15, 23, 42, 0.98);
-    --color-panel-border: rgba(148, 163, 184, 0.35);
-    --color-panel-shadow: rgba(0, 0, 0, 0.7);
-    --color-grid: rgba(255, 255, 255, 0.04);
-    --color-task-multitool: #60a5fa;
-    --color-task-color: #a78bfa;
-    --color-task-change: #fb923c;
-    --color-task-similarity: #22d3ee;
-    --color-task-text: #34d399;
-    --color-task-numbers: #facc15;
-    --color-task-timelapse: #f472b6;
-    --color-task-template: #fb7185;
-    --color-task-flow: #818cf8;
-    --color-task-scene: #2dd4bf;
-  }
-}
-
-/* Dark mode — manual toggle */
-
-html[data-theme="dark"] {
-  --color-bg: #020617;
-  --color-surface: #020617;
-  --color-surface-alt: #0b1120;
-  --color-text: #e5e7eb;
-  --color-text-dim: #9ca3af;
-  --color-accent: #38bdf8;
-  --color-border: #1f2933;
-  --color-selected: rgba(56, 189, 248, 0.2);
-  --color-panel-bg: rgba(15, 23, 42, 0.98);
-  --color-panel-border: rgba(148, 163, 184, 0.35);
-  --color-panel-shadow: rgba(0, 0, 0, 0.7);
-  --color-grid: rgba(255, 255, 255, 0.04);
-  --color-task-multitool: #60a5fa;
-  --color-task-color: #a78bfa;
-  --color-task-change: #fb923c;
-  --color-task-similarity: #22d3ee;
-  --color-task-text: #34d399;
-  --color-task-numbers: #facc15;
-  --color-task-timelapse: #f472b6;
-  --color-task-template: #fb7185;
-  --color-task-flow: #818cf8;
-  --color-task-scene: #2dd4bf;
-}
-
-/* Dark element overrides */
+/* Dark element overrides — shared dark tokens are in tokens.css */
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) .modal-card {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -7,18 +7,15 @@
   var POLL_INTERVAL = 3000;
   var FRAME_STEP = 1.0;
 
-  var TASK_COLORS = {
-    multitool: "#2563eb",
-    color: "#8b5cf6",
-    change: "#f97316",
-    similarity: "#0ea5e9",
-    text: "#10b981",
-    numbers: "#eab308",
-    timelapse: "#ec4899",
-    template: "#f43f5e",
-    flow: "#6366f1",
-    scene: "#14b8a6",
-  };
+  var TASK_COLORS = (function () {
+    var types = ["multitool", "color", "change", "similarity", "text", "numbers", "timelapse", "template", "flow", "scene"];
+    var style = getComputedStyle(document.documentElement);
+    var map = {};
+    types.forEach(function (t) {
+      map[t] = style.getPropertyValue("--color-task-" + t).trim() || "#888";
+    });
+    return map;
+  })();
 
   var SS_TYPE_ICON_PATHS = {
     multitool: { viewBox: "0 0 16 16", paths: [

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -8,36 +8,13 @@
   padding: 0;
 }
 
+/* Page-specific variables — shared tokens are in tokens.css */
 :root {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-clip: #3659b3;
-  --color-screen: #0ea5e9;
-  --color-gif: #f97316;
-  --color-border: #e0ddd7;
-  --color-selected: rgba(29, 79, 114, 0.08);
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --color-grid: rgba(0, 0, 0, 0.03);
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
   --color-cell-text: #dbeafe;
   --color-cell-valid: #93c5fd;
   --color-cell-selected: #c4b5fd;
   --color-heatmap: 168, 130, 214;
   --color-cell-hover: rgba(29, 79, 114, 0.06);
-  --sev-critical: #b91c1c;
-  --sev-high: #dc2626;
-  --sev-medium: #ea580c;
-  --sev-low: #ca8a04;
-  --sev-na: #0891b2;
-  --sev-positive: #16a34a;
-  --sev-very-positive: #15803d;
-  --sev-unknown: #64748b;
 }
 
 html {
@@ -1679,70 +1656,24 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 /* ---- Dark mode ---- */
 
-/* OS preference (applies when user hasn't manually toggled) */
+/* OS preference — page-specific dark overrides (shared tokens in tokens.css) */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-    --color-bg: #020617;
-    --color-surface: #020617;
-    --color-surface-alt: #0b1120;
-    --color-text: #e5e7eb;
-    --color-text-dim: #9ca3af;
-    --color-accent: #38bdf8;
-    --color-clip: #60a5fa;
-    --color-screen: #22d3ee;
-    --color-gif: #fb923c;
-    --color-border: #1f2933;
-    --color-selected: rgba(56, 189, 248, 0.2);
-    --color-panel-bg: rgba(15, 23, 42, 0.98);
-    --color-panel-border: rgba(148, 163, 184, 0.35);
-    --color-panel-shadow: rgba(0, 0, 0, 0.7);
-    --color-grid: rgba(255, 255, 255, 0.04);
     --color-cell-text: #1e3a5f;
     --color-cell-valid: #1d4ed8;
     --color-cell-selected: #6d28d9;
     --color-cell-hover: rgba(56, 189, 248, 0.08);
     --color-heatmap: 192, 160, 235;
-    --sev-critical: #f87171;
-    --sev-high: #fb7185;
-    --sev-medium: #fdba74;
-    --sev-low: #fde047;
-    --sev-na: #67e8f9;
-    --sev-positive: #86efac;
-    --sev-very-positive: #4ade80;
-    --sev-unknown: #94a3b8;
   }
 }
 
-/* Manual toggle */
+/* Manual toggle — page-specific dark overrides */
 html[data-theme="dark"] {
-  --color-bg: #020617;
-  --color-surface: #020617;
-  --color-surface-alt: #0b1120;
-  --color-text: #e5e7eb;
-  --color-text-dim: #9ca3af;
-  --color-accent: #38bdf8;
-  --color-clip: #60a5fa;
-  --color-screen: #22d3ee;
-  --color-gif: #fb923c;
-  --color-border: #1f2933;
-  --color-selected: rgba(56, 189, 248, 0.2);
-  --color-panel-bg: rgba(15, 23, 42, 0.98);
-  --color-panel-border: rgba(148, 163, 184, 0.35);
-  --color-panel-shadow: rgba(0, 0, 0, 0.7);
-  --color-grid: rgba(255, 255, 255, 0.04);
   --color-cell-text: #1e3a5f;
   --color-cell-valid: #1d4ed8;
   --color-cell-selected: #6d28d9;
   --color-heatmap: 192, 160, 235;
   --color-cell-hover: rgba(56, 189, 248, 0.08);
-  --sev-critical: #f87171;
-  --sev-high: #fb7185;
-  --sev-medium: #fdba74;
-  --sev-low: #fde047;
-  --sev-na: #67e8f9;
-  --sev-positive: #86efac;
-  --sev-very-positive: #4ade80;
-  --sev-unknown: #94a3b8;
 }
 
 /* Dark element overrides (shared by both @media and data-theme via specificity) */

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -7,6 +7,18 @@
  * SHADOW:     --shadow-sm | --shadow-md | --shadow-lg | --shadow-xl | --shadow-focus
  * DURATION:   --duration-fast (150ms) | --duration-normal (250ms) | --duration-slow (350ms)
  * Z-INDEX:    --z-float (10) | --z-dropdown (100) | --z-modal (1000) | --z-overlay (2000) | --z-toast (3000)
+ *
+ * THEME:      --color-bg | --color-surface | --color-surface-alt | --color-text | --color-text-dim
+ *             --color-accent | --color-border | --color-selected
+ *             --color-panel-bg | --color-panel-border | --color-panel-shadow | --color-grid
+ *             --font-mono
+ * SEVERITY:   --sev-critical | --sev-high | --sev-medium | --sev-low | --sev-na
+ *             --sev-positive | --sev-very-positive | --sev-unknown
+ * CONTENT:    --color-clip | --color-screen | --color-gif
+ * TASK:       --color-task-multitool | --color-task-color | --color-task-change | --color-task-similarity
+ *             --color-task-text | --color-task-numbers | --color-task-timelapse | --color-task-template
+ *             --color-task-flow | --color-task-scene
+ * INSIGHTS:   --color-causes | --color-behaviors | --color-impacts (+ -bg variants)
  */
 
 :root {
@@ -27,6 +39,7 @@
   --text-lg: 1.125rem;
   --text-xl: 1.25rem;
   --text-2xl: 1.5rem;
+  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
 
   /* Border radius */
   --radius-sm: 4px;
@@ -35,12 +48,61 @@
   --radius-full: 999px;
   --radius: var(--radius-md);
 
-  /* Shadows */
-  --shadow-sm: 0 1px 3px var(--color-panel-shadow, rgba(15, 23, 42, 0.12));
-  --shadow-md: 0 4px 12px var(--color-panel-shadow, rgba(15, 23, 42, 0.12));
-  --shadow-lg: 0 8px 24px var(--color-panel-shadow, rgba(15, 23, 42, 0.12));
-  --shadow-xl: 0 24px 60px var(--color-panel-shadow, rgba(15, 23, 42, 0.12));
-  --shadow-focus: 0 0 0 2px var(--color-accent, #1d4f72);
+  /* Core theme colors */
+  --color-bg: #f4f2ee;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f1ece4;
+  --color-text: #111827;
+  --color-text-dim: #6b7280;
+  --color-accent: #1d4f72;
+  --color-border: #e0ddd7;
+  --color-selected: rgba(29, 79, 114, 0.08);
+  --color-panel-bg: rgba(255, 255, 255, 0.97);
+  --color-panel-border: rgba(148, 163, 184, 0.22);
+  --color-panel-shadow: rgba(15, 23, 42, 0.12);
+  --color-grid: rgba(0, 0, 0, 0.03);
+
+  /* Shadows (depend on theme colors above) */
+  --shadow-sm: 0 1px 3px var(--color-panel-shadow);
+  --shadow-md: 0 4px 12px var(--color-panel-shadow);
+  --shadow-lg: 0 8px 24px var(--color-panel-shadow);
+  --shadow-xl: 0 24px 60px var(--color-panel-shadow);
+  --shadow-focus: 0 0 0 2px var(--color-accent);
+
+  /* Severity colors */
+  --sev-critical: #b91c1c;
+  --sev-high: #dc2626;
+  --sev-medium: #ea580c;
+  --sev-low: #ca8a04;
+  --sev-na: #0891b2;
+  --sev-positive: #16a34a;
+  --sev-very-positive: #15803d;
+  --sev-unknown: #64748b;
+
+  /* Content-type colors */
+  --color-clip: #3659b3;
+  --color-screen: #0ea5e9;
+  --color-gif: #f97316;
+
+  /* Screenspace task colors */
+  --color-task-multitool: #2563eb;
+  --color-task-color: #8b5cf6;
+  --color-task-change: #f97316;
+  --color-task-similarity: #0ea5e9;
+  --color-task-text: #10b981;
+  --color-task-numbers: #eab308;
+  --color-task-timelapse: #ec4899;
+  --color-task-template: #f43f5e;
+  --color-task-flow: #6366f1;
+  --color-task-scene: #14b8a6;
+
+  /* Insight category colors */
+  --color-causes: #ea580c;
+  --color-behaviors: #2563eb;
+  --color-impacts: #dc2626;
+  --color-causes-bg: rgba(234, 88, 12, 0.06);
+  --color-behaviors-bg: rgba(37, 99, 235, 0.06);
+  --color-impacts-bg: rgba(220, 38, 38, 0.06);
 
   /* Transitions */
   --duration-fast: 150ms;
@@ -53,6 +115,94 @@
   --z-modal: 1000;
   --z-overlay: 2000;
   --z-toast: 3000;
+}
+
+/* Dark theme — OS preference (applies when user hasn't manually toggled) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-bg: #020617;
+    --color-surface: #020617;
+    --color-surface-alt: #0b1120;
+    --color-text: #e5e7eb;
+    --color-text-dim: #9ca3af;
+    --color-accent: #38bdf8;
+    --color-border: #1f2933;
+    --color-selected: rgba(56, 189, 248, 0.2);
+    --color-panel-bg: rgba(15, 23, 42, 0.98);
+    --color-panel-border: rgba(148, 163, 184, 0.35);
+    --color-panel-shadow: rgba(0, 0, 0, 0.7);
+    --color-grid: rgba(255, 255, 255, 0.04);
+    --sev-critical: #f87171;
+    --sev-high: #fb7185;
+    --sev-medium: #fdba74;
+    --sev-low: #fde047;
+    --sev-na: #67e8f9;
+    --sev-positive: #86efac;
+    --sev-very-positive: #4ade80;
+    --sev-unknown: #94a3b8;
+    --color-clip: #60a5fa;
+    --color-screen: #22d3ee;
+    --color-gif: #fb923c;
+    --color-task-multitool: #60a5fa;
+    --color-task-color: #a78bfa;
+    --color-task-change: #fb923c;
+    --color-task-similarity: #22d3ee;
+    --color-task-text: #34d399;
+    --color-task-numbers: #facc15;
+    --color-task-timelapse: #f472b6;
+    --color-task-template: #fb7185;
+    --color-task-flow: #818cf8;
+    --color-task-scene: #2dd4bf;
+    --color-causes: #fb923c;
+    --color-behaviors: #60a5fa;
+    --color-impacts: #f87171;
+    --color-causes-bg: rgba(251, 146, 60, 0.1);
+    --color-behaviors-bg: rgba(96, 165, 250, 0.1);
+    --color-impacts-bg: rgba(248, 113, 113, 0.1);
+  }
+}
+
+/* Dark theme — manual toggle */
+html[data-theme="dark"] {
+  --color-bg: #020617;
+  --color-surface: #020617;
+  --color-surface-alt: #0b1120;
+  --color-text: #e5e7eb;
+  --color-text-dim: #9ca3af;
+  --color-accent: #38bdf8;
+  --color-border: #1f2933;
+  --color-selected: rgba(56, 189, 248, 0.2);
+  --color-panel-bg: rgba(15, 23, 42, 0.98);
+  --color-panel-border: rgba(148, 163, 184, 0.35);
+  --color-panel-shadow: rgba(0, 0, 0, 0.7);
+  --color-grid: rgba(255, 255, 255, 0.04);
+  --sev-critical: #f87171;
+  --sev-high: #fb7185;
+  --sev-medium: #fdba74;
+  --sev-low: #fde047;
+  --sev-na: #67e8f9;
+  --sev-positive: #86efac;
+  --sev-very-positive: #4ade80;
+  --sev-unknown: #94a3b8;
+  --color-clip: #60a5fa;
+  --color-screen: #22d3ee;
+  --color-gif: #fb923c;
+  --color-task-multitool: #60a5fa;
+  --color-task-color: #a78bfa;
+  --color-task-change: #fb923c;
+  --color-task-similarity: #22d3ee;
+  --color-task-text: #34d399;
+  --color-task-numbers: #facc15;
+  --color-task-timelapse: #f472b6;
+  --color-task-template: #fb7185;
+  --color-task-flow: #818cf8;
+  --color-task-scene: #2dd4bf;
+  --color-causes: #fb923c;
+  --color-behaviors: #60a5fa;
+  --color-impacts: #f87171;
+  --color-causes-bg: rgba(251, 146, 60, 0.1);
+  --color-behaviors-bg: rgba(96, 165, 250, 0.1);
+  --color-impacts-bg: rgba(248, 113, 113, 0.1);
 }
 
 /* Skeleton loading placeholder */

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -8,33 +8,10 @@
   padding: 0;
 }
 
+/* Page-specific variables — shared tokens are in tokens.css */
 :root {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-clip: #3659b3;
-  --color-screen: #0ea5e9;
-  --color-gif: #f97316;
-  --color-border: #e0ddd7;
-  --color-selected: rgba(29, 79, 114, 0.08);
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --color-grid: rgba(0, 0, 0, 0.03);
   --color-selected-ring: #ffffff;
   --color-tooltip-shadow: rgba(0, 0, 0, 0.18);
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
-  --sev-critical-bg: #b91c1c;
-  --sev-high-bg: #dc2626;
-  --sev-medium-bg: #ea580c;
-  --sev-low-bg: #ca8a04;
-  --sev-na-bg: #0891b2;
-  --sev-positive-bg: #16a34a;
-  --sev-very-positive-bg: #15803d;
-  --sev-unknown-bg: #64748b;
 }
 
 html {
@@ -248,43 +225,43 @@ body {
 }
 
 .artifact-marker.sev-critical {
-  background-color: var(--sev-critical-bg);
-  border-color: var(--sev-critical-bg);
+  background-color: var(--sev-critical);
+  border-color: var(--sev-critical);
 }
 
 .artifact-marker.sev-high {
-  background-color: var(--sev-high-bg);
-  border-color: var(--sev-high-bg);
+  background-color: var(--sev-high);
+  border-color: var(--sev-high);
 }
 
 .artifact-marker.sev-medium {
-  background-color: var(--sev-medium-bg);
-  border-color: var(--sev-medium-bg);
+  background-color: var(--sev-medium);
+  border-color: var(--sev-medium);
 }
 
 .artifact-marker.sev-low {
-  background-color: var(--sev-low-bg);
-  border-color: var(--sev-low-bg);
+  background-color: var(--sev-low);
+  border-color: var(--sev-low);
 }
 
 .artifact-marker.sev-na {
-  background-color: var(--sev-na-bg);
-  border-color: var(--sev-na-bg);
+  background-color: var(--sev-na);
+  border-color: var(--sev-na);
 }
 
 .artifact-marker.sev-positive {
-  background-color: var(--sev-positive-bg);
-  border-color: var(--sev-positive-bg);
+  background-color: var(--sev-positive);
+  border-color: var(--sev-positive);
 }
 
 .artifact-marker.sev-very-positive {
-  background-color: var(--sev-very-positive-bg);
-  border-color: var(--sev-very-positive-bg);
+  background-color: var(--sev-very-positive);
+  border-color: var(--sev-very-positive);
 }
 
 .artifact-marker.sev-unknown {
-  background-color: var(--sev-unknown-bg);
-  border-color: var(--sev-unknown-bg);
+  background-color: var(--sev-unknown);
+  border-color: var(--sev-unknown);
 }
 
 .artifact-marker:hover {
@@ -441,14 +418,14 @@ body {
   flex-shrink: 0;
 }
 
-.legend-severity-swatch.sev-critical { background: var(--sev-critical-bg); }
-.legend-severity-swatch.sev-high { background: var(--sev-high-bg); }
-.legend-severity-swatch.sev-medium { background: var(--sev-medium-bg); }
-.legend-severity-swatch.sev-low { background: var(--sev-low-bg); }
-.legend-severity-swatch.sev-na { background: var(--sev-na-bg); }
-.legend-severity-swatch.sev-positive { background: var(--sev-positive-bg); }
-.legend-severity-swatch.sev-very-positive { background: var(--sev-very-positive-bg); }
-.legend-severity-swatch.sev-unknown { background: var(--sev-unknown-bg); }
+.legend-severity-swatch.sev-critical { background: var(--sev-critical); }
+.legend-severity-swatch.sev-high { background: var(--sev-high); }
+.legend-severity-swatch.sev-medium { background: var(--sev-medium); }
+.legend-severity-swatch.sev-low { background: var(--sev-low); }
+.legend-severity-swatch.sev-na { background: var(--sev-na); }
+.legend-severity-swatch.sev-positive { background: var(--sev-positive); }
+.legend-severity-swatch.sev-very-positive { background: var(--sev-very-positive); }
+.legend-severity-swatch.sev-unknown { background: var(--sev-unknown); }
 
 .legend-item {
   display: flex;
@@ -796,23 +773,23 @@ body {
   color: #fff;
 }
 
-.badge-severity.sev-critical { background: var(--sev-critical-bg); }
-.badge-severity.sev-high { background: var(--sev-high-bg); }
-.badge-severity.sev-medium { background: var(--sev-medium-bg); }
-.badge-severity.sev-low { background: var(--sev-low-bg); color: #1f2937; }
-.badge-severity.sev-na { background: var(--sev-na-bg); }
-.badge-severity.sev-positive { background: var(--sev-positive-bg); }
-.badge-severity.sev-very-positive { background: var(--sev-very-positive-bg); }
-.badge-severity.sev-unknown { background: var(--sev-unknown-bg); }
+.badge-severity.sev-critical { background: var(--sev-critical); }
+.badge-severity.sev-high { background: var(--sev-high); }
+.badge-severity.sev-medium { background: var(--sev-medium); }
+.badge-severity.sev-low { background: var(--sev-low); color: #1f2937; }
+.badge-severity.sev-na { background: var(--sev-na); }
+.badge-severity.sev-positive { background: var(--sev-positive); }
+.badge-severity.sev-very-positive { background: var(--sev-very-positive); }
+.badge-severity.sev-unknown { background: var(--sev-unknown); }
 
-.detail-badge.sev-critical { background: var(--sev-critical-bg); border-color: var(--sev-critical-bg); color: #fff; }
-.detail-badge.sev-high { background: var(--sev-high-bg); border-color: var(--sev-high-bg); color: #fff; }
-.detail-badge.sev-medium { background: var(--sev-medium-bg); border-color: var(--sev-medium-bg); color: #fff; }
-.detail-badge.sev-low { background: var(--sev-low-bg); border-color: var(--sev-low-bg); color: #1f2937; }
-.detail-badge.sev-na { background: var(--sev-na-bg); border-color: var(--sev-na-bg); color: #fff; }
-.detail-badge.sev-positive { background: var(--sev-positive-bg); border-color: var(--sev-positive-bg); color: #fff; }
-.detail-badge.sev-very-positive { background: var(--sev-very-positive-bg); border-color: var(--sev-very-positive-bg); color: #fff; }
-.detail-badge.sev-unknown { background: var(--sev-unknown-bg); border-color: var(--sev-unknown-bg); color: #fff; }
+.detail-badge.sev-critical { background: var(--sev-critical); border-color: var(--sev-critical); color: #fff; }
+.detail-badge.sev-high { background: var(--sev-high); border-color: var(--sev-high); color: #fff; }
+.detail-badge.sev-medium { background: var(--sev-medium); border-color: var(--sev-medium); color: #fff; }
+.detail-badge.sev-low { background: var(--sev-low); border-color: var(--sev-low); color: #1f2937; }
+.detail-badge.sev-na { background: var(--sev-na); border-color: var(--sev-na); color: #fff; }
+.detail-badge.sev-positive { background: var(--sev-positive); border-color: var(--sev-positive); color: #fff; }
+.detail-badge.sev-very-positive { background: var(--sev-very-positive); border-color: var(--sev-very-positive); color: #fff; }
+.detail-badge.sev-unknown { background: var(--sev-unknown); border-color: var(--sev-unknown); color: #fff; }
 
 .artifact-desc {
   font-size: var(--text-xs);
@@ -1088,31 +1065,8 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg: #020617;
-    --color-surface: #020617;
-    --color-surface-alt: #0b1120;
-    --color-text: #e5e7eb;
-    --color-text-dim: #9ca3af;
-    --color-accent: #38bdf8;
-    --color-clip: #60a5fa;
-    --color-screen: #22d3ee;
-    --color-gif: #fb923c;
-    --color-border: #1f2933;
-    --color-selected: rgba(56, 189, 248, 0.2);
-    --color-panel-bg: rgba(15, 23, 42, 0.98);
-    --color-panel-border: rgba(148, 163, 184, 0.35);
-    --color-panel-shadow: rgba(0, 0, 0, 0.7);
-    --color-grid: rgba(255, 255, 255, 0.04);
     --color-selected-ring: #0b1120;
     --color-tooltip-shadow: rgba(0, 0, 0, 0.7);
-    --sev-critical-bg: #f87171;
-    --sev-high-bg: #fb7185;
-    --sev-medium-bg: #fdba74;
-    --sev-low-bg: #fde047;
-    --sev-na-bg: #67e8f9;
-    --sev-positive-bg: #86efac;
-    --sev-very-positive-bg: #4ade80;
-    --sev-unknown-bg: #94a3b8;
   }
 
   #timelineTrack {
@@ -1136,31 +1090,8 @@ body {
 }
 
 html[data-theme="light"] {
-  --color-bg: #f4f2ee;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f1ece4;
-  --color-text: #111827;
-  --color-text-dim: #6b7280;
-  --color-accent: #1d4f72;
-  --color-clip: #3659b3;
-  --color-screen: #0ea5e9;
-  --color-gif: #f97316;
-  --color-border: #e0ddd7;
-  --color-selected: rgba(29, 79, 114, 0.08);
-  --color-panel-bg: rgba(255, 255, 255, 0.97);
-  --color-panel-border: rgba(148, 163, 184, 0.22);
-  --color-panel-shadow: rgba(15, 23, 42, 0.12);
-  --color-grid: rgba(0, 0, 0, 0.03);
   --color-selected-ring: #ffffff;
   --color-tooltip-shadow: rgba(0, 0, 0, 0.18);
-  --sev-critical-bg: #b91c1c;
-  --sev-high-bg: #dc2626;
-  --sev-medium-bg: #ea580c;
-  --sev-low-bg: #ca8a04;
-  --sev-na-bg: #0891b2;
-  --sev-positive-bg: #16a34a;
-  --sev-very-positive-bg: #15803d;
-  --sev-unknown-bg: #64748b;
 }
 
 html[data-theme="dark"] {
@@ -1181,14 +1112,14 @@ html[data-theme="dark"] {
   --color-grid: rgba(255, 255, 255, 0.04);
   --color-selected-ring: #0b1120;
   --color-tooltip-shadow: rgba(0, 0, 0, 0.7);
-  --sev-critical-bg: #f87171;
-  --sev-high-bg: #fb7185;
-  --sev-medium-bg: #fdba74;
-  --sev-low-bg: #fde047;
-  --sev-na-bg: #67e8f9;
-  --sev-positive-bg: #86efac;
-  --sev-very-positive-bg: #4ade80;
-  --sev-unknown-bg: #94a3b8;
+  --sev-critical: #f87171;
+  --sev-high: #fb7185;
+  --sev-medium: #fdba74;
+  --sev-low: #fde047;
+  --sev-na: #67e8f9;
+  --sev-positive: #86efac;
+  --sev-very-positive: #4ade80;
+  --sev-unknown: #94a3b8;
 }
 
 html[data-theme="dark"] .artifact-marker:hover {

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -2020,17 +2020,15 @@
 
   // ---- Screenspace track ----
 
-  var SS_DETECTOR_COLORS = {
-    multitool: "#2563eb",
-    color: "#8b5cf6",
-    change: "#f97316",
-    similarity: "#0ea5e9",
-    text: "#10b981",
-    numbers: "#eab308",
-    template: "#f43f5e",
-    flow: "#6366f1",
-    scene: "#14b8a6",
-  };
+  var SS_DETECTOR_COLORS = (function () {
+    var types = ["multitool", "color", "change", "similarity", "text", "numbers", "template", "flow", "scene"];
+    var style = getComputedStyle(document.documentElement);
+    var map = {};
+    types.forEach(function (t) {
+      map[t] = style.getPropertyValue("--color-task-" + t).trim() || "#888";
+    });
+    return map;
+  })();
 
   var SS_DETECTOR_ICON_PATHS = {
     multitool: { viewBox: "0 0 16 16", paths: [

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.13"
+VERSIONNUM: str = "0.10.14"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Moves all shared color variables (core theme, severity, content-type, Screenspace task, and insight category colors — both light and dark variants) from 6 individual CSS files into `tokens.css` as the single source of truth, eliminating ~530 lines of duplication
- Replaces hardcoded `TASK_COLORS` / `SS_DETECTOR_COLORS` JS objects in screenspace.js and viewer.js with `getComputedStyle` reads from CSS custom properties
- Standardizes viewer.css `--sev-*-bg` naming to `--sev-*` to match the convention in the other 3 files
- Updates AGENTS.md with a comprehensive token reference covering all categories so agents know what tokens exist and how to use them

## Test plan

- [x] `uv run pytest` — 229 passed (1 pre-existing failure unrelated to this change)
- [ ] Verify light/dark mode renders correctly in Studio, Screenspace, Viewer, Gallery, Insights Builder, Insights Viewer
- [ ] Verify Screenspace tool color badges render in both Screenspace and Viewer timeline