### PR TITLE
Add Fast Scan mode for Screenspace analysis

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -779,6 +779,11 @@ body {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+#runBtn {
+  flex-shrink: 0;
 }
 
 #runBtn {
@@ -894,6 +899,69 @@ body {
 
 .run-picker-toggle-all:hover {
   text-decoration: underline;
+}
+
+.scan-mode-fast-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background: var(--color-warning, #f59e0b);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  flex-shrink: 0;
+}
+
+.task-fast-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-warning, #f59e0b);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.task-fast-badge-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background: currentColor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+.fast-scan-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-warning, #f59e0b);
+  padding: var(--space-1) var(--space-2);
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 8%, transparent);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-2);
+}
+
+.fast-scan-label.hidden { display: none; }
+
+.fast-scan-label-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background: currentColor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  flex-shrink: 0;
+}
+
+.fast-scan-rerun-btn {
+  margin-left: auto;
 }
 
 #workflowParams {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -129,6 +129,7 @@
           <div id="runParticipantPicker" class="run-picker-wrap"></div>
           <div id="workflowIntervalSlot"></div>
           <div id="runRegionPicker" class="run-picker-wrap"></div>
+          <div id="runScanModePicker" class="run-picker-wrap"></div>
           <button id="runBtn" class="btn btn-primary btn-icon" disabled data-tooltip="Select a region first">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
               <path d="M3 3.732a1 1 0 0 1 1.514-.857l8.07 4.268a1 1 0 0 1 0 1.714l-8.07 4.268A1 1 0 0 1 3 12.268V3.732Z"/>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -116,6 +116,7 @@
     pipetteActive: false,
     runParticipants: [],
     runRegions: [],
+    scanMode: "normal",
     taskEvents: {},
     showExcluded: true,
     certaintyCutoff: 0,
@@ -568,6 +569,60 @@
     var chevron = el("span", "chevron");
     chevron.appendChild(svgChevronDownIcon());
     btn.appendChild(chevron);
+  }
+
+  function renderScanModePicker() {
+    var wrap = qs("#runScanModePicker");
+    if (!wrap) return;
+    wrap.innerHTML = "";
+
+    var btn = el("button", "run-picker-btn");
+    btn.type = "button";
+
+    function updateBtn() {
+      btn.innerHTML = "";
+      var isFast = state.scanMode === "fast";
+      if (isFast) {
+        var icon = el("span", "scan-mode-fast-icon");
+        var url = 'url("/screenspace/icons/chevron-double-right.svg")';
+        icon.style.maskImage = url;
+        icon.style.webkitMaskImage = url;
+        btn.appendChild(icon);
+      }
+      btn.appendChild(el("span", "run-picker-btn-text", isFast ? "Fast" : "Normal"));
+      var chev = el("span", "chevron");
+      chev.appendChild(svgChevronDownIcon());
+      btn.appendChild(chev);
+    }
+    updateBtn();
+
+    var panel = el("div", "run-picker-panel hidden");
+    ["normal", "fast"].forEach(function (mode) {
+      var lbl = document.createElement("label");
+      var rb = document.createElement("input");
+      rb.type = "radio";
+      rb.name = "scanMode";
+      rb.value = mode;
+      rb.checked = state.scanMode === mode;
+      rb.addEventListener("change", function () {
+        state.scanMode = mode;
+        updateBtn();
+        closeRunPicker();
+      });
+      lbl.appendChild(rb);
+      lbl.appendChild(document.createTextNode(mode === "fast" ? "Fast" : "Normal"));
+      panel.appendChild(lbl);
+    });
+
+    btn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      var open = !panel.classList.contains("hidden");
+      panel.classList.toggle("hidden", open);
+      btn.classList.toggle("open", !open);
+    });
+
+    wrap.appendChild(btn);
+    wrap.appendChild(panel);
   }
 
   function selectParticipant(pid, initialTimestamp) {
@@ -3266,6 +3321,7 @@
       if (participants.length === 0) return;
       var params = gatherWorkflowParams(type);
       if (params === null) return;
+      if (state.scanMode === "fast") params.scan_mode = "fast";
 
       if (state.inMarker !== null) params.start_seconds = state.inMarker;
       if (state.outMarker !== null) params.end_seconds = state.outMarker;
@@ -3284,7 +3340,9 @@
             };
             return apiPost("api/tasks", body).then(function (data) {
               if (data.ok) {
-                state.tasks.push(data.task);
+                if (!state.tasks.some(function (t) { return t.id === data.task.id; })) {
+                  state.tasks.push(data.task);
+                }
                 renderTaskList();
               } else {
                 showToast(data.error || "Failed to create task for " + pid);
@@ -3304,7 +3362,9 @@
               };
               return apiPost("api/tasks", body).then(function (data) {
                 if (data.ok) {
-                  state.tasks.push(data.task);
+                  if (!state.tasks.some(function (t) { return t.id === data.task.id; })) {
+                    state.tasks.push(data.task);
+                  }
                   renderTaskList();
                 } else {
                   showToast(data.error || "Failed to create task for " + pid + " / " + regionName);
@@ -4281,6 +4341,18 @@
       badge.appendChild(iconSpan);
       card.appendChild(badge);
 
+      // Fast scan badge
+      if ((task.parameters || {}).scan_mode === "fast") {
+        var fb = el("span", "task-fast-badge");
+        var bi = el("span", "task-fast-badge-icon");
+        var burl = 'url("/screenspace/icons/chevron-double-right.svg")';
+        bi.style.maskImage = burl;
+        bi.style.webkitMaskImage = burl;
+        fb.appendChild(bi);
+        fb.appendChild(document.createTextNode("Fast"));
+        card.appendChild(fb);
+      }
+
       // Info
       var info = el("div", "task-card-info");
       var meta = el("span", "task-card-meta");
@@ -4555,14 +4627,60 @@
     var results = state.selectedTaskResults;
     var task = state.selectedTaskId ? findTask(state.selectedTaskId) : null;
 
+    // Manage fast scan label — between panel-header and resultsList
+    var fastLabel = qs("#fastScanLabel");
+    if (!fastLabel) {
+      fastLabel = el("div", "fast-scan-label hidden");
+      fastLabel.id = "fastScanLabel";
+      container.parentNode.insertBefore(fastLabel, container);
+    }
+
     if (!results || !task) {
       container.innerHTML = '<div class="panel-empty">Click a task to view results.</div>';
       countEl.textContent = "";
       actionsEl.classList.add("hidden");
+      fastLabel.classList.add("hidden");
       return;
     }
 
     actionsEl.classList.remove("hidden");
+
+    if ((task.parameters || {}).scan_mode === "fast") {
+      fastLabel.classList.remove("hidden");
+      fastLabel.innerHTML = "";
+      var fIcon = el("span", "fast-scan-label-icon");
+      var fUrl = 'url("/screenspace/icons/chevron-double-right.svg")';
+      fIcon.style.maskImage = fUrl;
+      fIcon.style.webkitMaskImage = fUrl;
+      fastLabel.appendChild(fIcon);
+      fastLabel.appendChild(document.createTextNode("Fast scan results"));
+      var rerunBtn = el("button", "ss-btn ss-btn-sm fast-scan-rerun-btn", "Re-Run Normal");
+      (function (t) {
+        rerunBtn.addEventListener("click", function () {
+          var params = {};
+          Object.keys(t.parameters || {}).forEach(function (k) { params[k] = t.parameters[k]; });
+          delete params.scan_mode;
+          apiPost("api/tasks", {
+            type: t.type,
+            participant: t.participant,
+            region: t.region || "",
+            parameters: params,
+          }).then(function (data) {
+            if (data.ok) {
+              state.tasks.push(data.task);
+              renderTaskList();
+              startSSE();
+              showToast("Re-queued in Normal mode");
+            } else {
+              showToast(data.error || "Failed to re-queue task");
+            }
+          });
+        });
+      })(task);
+      fastLabel.appendChild(rerunBtn);
+    } else {
+      fastLabel.classList.add("hidden");
+    }
 
     // Show/hide certainty controls based on whether the tool has confidence scores
     var hasConf = task && { change: 1, similarity: 1, text: 1, template: 1, scene: 1, flow: 1, multitool: 1 }[task.type];
@@ -5007,6 +5125,7 @@
           state.runParticipants = [first];
         }
         renderRunParticipantPicker();
+        renderScanModePicker();
       })
       .catch(function () { showToast("Failed to load participants"); });
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.13"
+VERSIONNUM: str = "0.10.14"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -148,6 +148,8 @@ SCREENSPACE_SCENE_SIMILARITY_THRESHOLD: float = 0.75
 SCREENSPACE_SCENE_HISTOGRAM_BINS: int = 64
 SCREENSPACE_FLOW_GRID_SIZE: int = 8
 SCREENSPACE_FLOW_GRID_MIN_MAG: float = 0.5
+SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER: float = 3.0
+SCREENSPACE_FAST_SCAN_PHASH_THRESHOLD: int = 12  # tighter than general 15
 
 # Highlights reel constants
 HIGHLIGHTS_REEL_DURATION_SECONDS: int = 180  # 3-minute budget for highlights reel

--- a/plans/PERFORMANCE-PLAN.md
+++ b/plans/PERFORMANCE-PLAN.md
@@ -124,7 +124,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 The heaviest computation in clipgen. Several of the experiments below trade result precision for speed — these are best offered as an explicit **"Fast Scan" mode** that the user opts into, rather than silently degrading quality. The UX contract: fast scan gives you quick, approximate results to orient yourself; if something looks interesting, re-run at full fidelity.
 
-### - [ ] 2.0. Fast Scan mode — design concept
+### - [x] 2.0. Fast Scan mode — design concept
 
 A toggle (button or dropdown next to the Run button, or a config flag `SCREENSPACE_FAST_SCAN`) that bundles several of the strategies below into a single user-facing choice:
 
@@ -139,7 +139,7 @@ When fast scan completes, the results panel could show a subtle label ("Fast sca
 
 The individual levers are described below. Any of them could also be adopted independently (always-on) if testing shows the quality trade-off is negligible.
 
-### - [ ] 2A. Adaptive resolution: low-res scan, high-res confirm
+### - [x] 2A. Adaptive resolution: low-res scan, high-res confirm
 
 **Prior art:** Downsampling already exists per-tool (`253d592`): color→64px, SSIM→256px, optical flow→256px, scene fingerprint→128px. These were introduced as fixed targets.
 
@@ -153,7 +153,7 @@ Concrete example for change detection:
 
 **Trade-offs:** Adds ~10% overhead for frames that trigger (double read + re-evaluate). Net win depends on what fraction of frames are uneventful — for most videos, >90%. In fast scan mode without re-confirmation, some borderline events may be missed, but the user has opted into that trade-off.
 
-### - [ ] 2B. Variable frame intervals (coarse-to-fine)
+### - [x] 2B. Variable frame intervals (coarse-to-fine)
 
 **Current:** Fixed interval (default 1.0s, config.py:127). Every frame is sampled uniformly regardless of content.
 
@@ -165,7 +165,7 @@ This is particularly valuable for long videos (30+ minutes) where large stretche
 
 **Trade-offs:** More complex scan logic. The two-phase UX needs thoughtful design. In normal mode, the current uniform interval is kept unchanged.
 
-### - [ ] 2C. Universal phash pre-filter for static frames
+### - [x] 2C. Universal phash pre-filter for static frames
 
 **Prior art:** pHash pre-filter introduced for similarity scans in `253d592`. Static-frame skipping added for similarity in `910df4a`. OCR skip-on-unchanged also uses a fast mean pixel diff (~0.1ms vs ~500-1000ms OCR). Infrastructure exists — threshold constant `SCREENSPACE_PHASH_THRESHOLD`, phash computation, hamming distance check.
 
@@ -177,7 +177,7 @@ This could be always-on (not just fast scan), since phash is very cheap (~0.1ms 
 
 **Trade-offs:** Risk: aggressive skipping could miss subtle changes that specific tools are designed to detect (e.g. a small counter incrementing in one corner while the rest of the frame is static). Mitigate by computing phash only over the analysis region, not the full frame. Use tool-specific thresholds if needed (tighter for change detection, looser for color analysis).
 
-### - [ ] 2D. Template matching at reduced resolution
+### - [x] 2D. Template matching at reduced resolution
 
 **Current:** Template matching runs at full frame resolution with a blur kernel of 3. `cv2.matchTemplate()` is O(W*H) per template — expensive for full-HD frames.
 
@@ -394,8 +394,8 @@ Additional performance area: the raw speed of reading video frames and writing o
 
 | Status | # | Experiment | Expected Impact |
 |--------|---|-----------|----------------|
-| [ ] | 1 | 2.0 — **Fast Scan mode** (bundles 2A-2D) | High — 3-5x faster Screenspace with explicit quality trade-off |
-| [ ] | 2 | 2C — Universal phash pre-filter (always-on candidate) | High — cheap filter, broad applicability, minimal quality loss |
+| [x] | 1 | 2.0 — **Fast Scan mode** (bundles 2A-2D) | High — 3-5x faster Screenspace with explicit quality trade-off |
+| [x] | 2 | 2C — Universal phash pre-filter (always-on candidate) | High — cheap filter, broad applicability, minimal quality loss |
 | [x] | 3 | 5A — Cache uv in CI | High — near-instant CI installs |
 | [ ] | 4 | 3A — Parallel clip cutting | High — 3-4x faster batch generation |
 | [x] | 5 | 1A — SSE for Screenspace progress | Medium — eliminates perceived stalls |

--- a/screenspace.py
+++ b/screenspace.py
@@ -432,6 +432,7 @@ def scan_video_frames(
     end_seconds: Optional[float] = None,
     fps: float = 0.0,
     duration: float = 0.0,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Iterate through video at interval, extract region, call callback.
 
@@ -441,6 +442,10 @@ def scan_video_frames(
     When *fps* and *duration* are provided, skips internal metadata reads.
     Uses sequential frame reading (grab/retrieve) for small intervals
     to avoid expensive H.264 seeking.
+
+    *fast_opts* enables fast-scan optimizations when provided:
+    - ``phash_skip``: skip frames whose perceptual hash is unchanged
+    - ``max_region_dim``: downscale extracted region to this max dimension
     """
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
@@ -453,6 +458,14 @@ def scan_video_frames(
         duration = total_frames / fps if fps > 0 else 0.0
     if end_seconds is None or end_seconds > duration:
         end_seconds = duration
+
+    # Fast-scan state
+    _phash_skip = bool(fast_opts and fast_opts.get("phash_skip"))
+    _max_dim = (fast_opts or {}).get("max_region_dim", 0)
+    _phash_thresh = (fast_opts or {}).get(
+        "phash_threshold", config.SCREENSPACE_FAST_SCAN_PHASH_THRESHOLD
+    )
+    _prev_phash: List[Optional[imagehash.ImageHash]] = [None]
 
     use_sequential = interval_seconds <= config.SCREENSPACE_SEQUENTIAL_READ_MAX_INTERVAL
 
@@ -476,6 +489,24 @@ def scan_video_frames(
                     break
                 ts = start_seconds + frame_idx / fps
                 cropped = extract_region(frame, region)
+                if _max_dim > 0:
+                    rh, rw = cropped.shape[:2]
+                    if rh > _max_dim or rw > _max_dim:
+                        sc = _max_dim / max(rh, rw)
+                        cropped = cv2.resize(
+                            cropped,
+                            (int(rw * sc), int(rh * sc)),
+                            interpolation=cv2.INTER_AREA,
+                        )
+                if _phash_skip:
+                    fh = compute_phash(cropped)
+                    if (
+                        _prev_phash[0] is not None
+                        and fh - _prev_phash[0] <= _phash_thresh
+                    ):
+                        frame_idx += 1
+                        continue
+                    _prev_phash[0] = fh
                 result = callback(ts, cropped)
                 if result is False:
                     break
@@ -488,6 +519,21 @@ def scan_video_frames(
             if not ret:
                 break
             cropped = extract_region(frame, region)
+            if _max_dim > 0:
+                rh, rw = cropped.shape[:2]
+                if rh > _max_dim or rw > _max_dim:
+                    sc = _max_dim / max(rh, rw)
+                    cropped = cv2.resize(
+                        cropped,
+                        (int(rw * sc), int(rh * sc)),
+                        interpolation=cv2.INTER_AREA,
+                    )
+            if _phash_skip:
+                fh = compute_phash(cropped)
+                if _prev_phash[0] is not None and fh - _prev_phash[0] <= _phash_thresh:
+                    ts += interval_seconds
+                    continue
+                _prev_phash[0] = fh
             result = callback(ts, cropped)
             if result is False:
                 break
@@ -505,10 +551,15 @@ def scan_video_full_frames(
     end_seconds: Optional[float] = None,
     fps: float = 0.0,
     duration: float = 0.0,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Like :func:`scan_video_frames` but passes the full frame (no region crop).
 
     Used by template detection which searches the entire frame.
+
+    *fast_opts* enables fast-scan optimizations (see :func:`scan_video_frames`).
+    ``max_region_dim`` downscales the full frame; ``phash_skip`` skips
+    perceptually identical frames.
     """
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
@@ -521,6 +572,14 @@ def scan_video_full_frames(
         duration = total_frames / fps if fps > 0 else 0.0
     if end_seconds is None or end_seconds > duration:
         end_seconds = duration
+
+    # Fast-scan state
+    _phash_skip = bool(fast_opts and fast_opts.get("phash_skip"))
+    _max_dim = (fast_opts or {}).get("max_region_dim", 0)
+    _phash_thresh = (fast_opts or {}).get(
+        "phash_threshold", config.SCREENSPACE_FAST_SCAN_PHASH_THRESHOLD
+    )
+    _prev_phash: List[Optional[imagehash.ImageHash]] = [None]
 
     use_sequential = interval_seconds <= config.SCREENSPACE_SEQUENTIAL_READ_MAX_INTERVAL
 
@@ -543,6 +602,24 @@ def scan_video_full_frames(
                 if not ret:
                     break
                 ts = start_seconds + frame_idx / fps
+                if _max_dim > 0:
+                    fh, fw = frame.shape[:2]
+                    if fh > _max_dim or fw > _max_dim:
+                        sc = _max_dim / max(fh, fw)
+                        frame = cv2.resize(
+                            frame,
+                            (int(fw * sc), int(fh * sc)),
+                            interpolation=cv2.INTER_AREA,
+                        )
+                if _phash_skip:
+                    ph = compute_phash(frame)
+                    if (
+                        _prev_phash[0] is not None
+                        and ph - _prev_phash[0] <= _phash_thresh
+                    ):
+                        frame_idx += 1
+                        continue
+                    _prev_phash[0] = ph
                 result = callback(ts, frame)
                 if result is False:
                     break
@@ -554,6 +631,21 @@ def scan_video_full_frames(
             ret, frame = cap.read()
             if not ret:
                 break
+            if _max_dim > 0:
+                fh, fw = frame.shape[:2]
+                if fh > _max_dim or fw > _max_dim:
+                    sc = _max_dim / max(fh, fw)
+                    frame = cv2.resize(
+                        frame,
+                        (int(fw * sc), int(fh * sc)),
+                        interpolation=cv2.INTER_AREA,
+                    )
+            if _phash_skip:
+                ph = compute_phash(frame)
+                if _prev_phash[0] is not None and ph - _prev_phash[0] <= _phash_thresh:
+                    ts += interval_seconds
+                    continue
+                _prev_phash[0] = ph
             result = callback(ts, frame)
             if result is False:
                 break
@@ -611,6 +703,7 @@ def scan_color(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan video for frames where region color matches target.
 
@@ -672,6 +765,7 @@ def scan_color(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -691,6 +785,7 @@ def scan_changes(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan video for change points in a region.
 
@@ -751,6 +846,7 @@ def scan_changes(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -770,6 +866,7 @@ def scan_similarity(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Find frames where region is similar to a reference.
 
@@ -859,6 +956,7 @@ def scan_similarity(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -880,6 +978,7 @@ def scan_text(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan for text appearances in a region using EasyOCR.
 
@@ -953,6 +1052,7 @@ def scan_text(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -979,6 +1079,7 @@ def scan_numbers(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan for numeric values in a region and apply a comparison.
 
@@ -1071,6 +1172,7 @@ def scan_numbers(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -1116,6 +1218,7 @@ def scan_template(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan video for frames containing the template image.
 
@@ -1145,13 +1248,29 @@ def scan_template(
 
     results: List[Dict[str, Any]] = []
 
+    _tmpl_downscale = bool(fast_opts and fast_opts.get("template_downscale"))
+
     def _cb(ts: float, frame: np.ndarray) -> Optional[bool]:
         if cancel_flag and cancel_flag():
             return False
+        work_frame = frame
+        scale_back = 1
+        if _tmpl_downscale:
+            fh, fw = frame.shape[:2]
+            nw, nh = fw // 2, fh // 2
+            if nw > 0 and nh > 0:
+                work_frame = cv2.resize(frame, (nw, nh), interpolation=cv2.INTER_AREA)
+                scale_back = 2
         matches = match_template(
-            frame, template_image, threshold=threshold, mask=template_mask
+            work_frame, template_image, threshold=threshold, mask=template_mask
         )
         if matches:
+            if scale_back > 1:
+                for m in matches:
+                    m["x"] *= scale_back
+                    m["y"] *= scale_back
+                    m["w"] *= scale_back
+                    m["h"] *= scale_back
             best = max(m["score"] for m in matches)
             rd = {
                 "timestamp": ts,
@@ -1180,6 +1299,7 @@ def scan_template(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -1198,6 +1318,7 @@ def scan_flow(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan video for motion in a region using dense optical flow.
 
@@ -1263,6 +1384,7 @@ def scan_flow(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -1282,6 +1404,7 @@ def scan_scene(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Classify frames by similarity to reference scene fingerprints.
 
@@ -1369,6 +1492,7 @@ def scan_scene(
         end_seconds=end_seconds,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -1607,6 +1731,7 @@ def scan_multitool(
     on_progress: Optional[Callable[[float], None]] = None,
     cancel_flag: Optional[Callable[[], bool]] = None,
     on_result: Optional[Callable[[Dict[str, Any]], None]] = None,
+    fast_opts: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Run a multi-factor scan chaining several tool types.
 
@@ -1699,6 +1824,7 @@ def scan_multitool(
         end_seconds=scan_end,
         fps=vid_fps,
         duration=vid_duration,
+        fast_opts=fast_opts,
     )
 
     if on_progress:
@@ -2327,6 +2453,27 @@ class ScreenspaceWorker:
         params = task.get("parameters", {})
         task_type = task["type"]
 
+        # Fast scan: apply interval multiplier and build optimization dict
+        scan_mode = params.get("scan_mode", "normal")
+        fast_opts: Optional[Dict[str, Any]] = None
+        if scan_mode == "fast":
+            multiplier = config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
+            if params.get("interval", 0) > 0:
+                params["interval"] = params["interval"] * multiplier
+            _fast_dims = {
+                "color": 32,
+                "change": 128,
+                "similarity": 128,
+                "flow": 128,
+                "scene": 64,
+            }
+            fast_opts = {
+                "phash_skip": True,
+                "max_region_dim": _fast_dims.get(task_type, 0),
+            }
+            if task_type == "template":
+                fast_opts["template_downscale"] = True
+
         if task_type == "color":
             return scan_color(
                 video_path,
@@ -2339,6 +2486,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "change":
             return scan_changes(
@@ -2352,6 +2500,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "similarity":
             ref_frame = params.get("reference_frame")
@@ -2368,6 +2517,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "text":
             return scan_text(
@@ -2382,6 +2532,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "numbers":
             return scan_numbers(
@@ -2398,6 +2549,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "timelapse":
             output_path = params.get("output_path", "")
@@ -2418,18 +2570,32 @@ class ScreenspaceWorker:
             template_img = params.get("template_image")
             if template_img is None:
                 raise ValueError("Template scan requires a template_image parameter")
+            tmpl_mask = params.get("template_mask")
+            # Fast scan: downscale template + mask by 2x
+            if scan_mode == "fast" and template_img is not None:
+                th, tw = template_img.shape[:2]
+                ntw, nth = tw // 2, th // 2
+                if ntw > 0 and nth > 0:
+                    template_img = cv2.resize(
+                        template_img, (ntw, nth), interpolation=cv2.INTER_AREA
+                    )
+                    if tmpl_mask is not None:
+                        tmpl_mask = cv2.resize(
+                            tmpl_mask, (ntw, nth), interpolation=cv2.INTER_AREA
+                        )
             return scan_template(
                 video_path,
                 region,
                 template_image=template_img,
                 threshold=params.get("threshold", 0),
                 interval_seconds=params.get("interval", 0),
-                template_mask=params.get("template_mask"),
+                template_mask=tmpl_mask,
                 start_seconds=params.get("start_seconds", 0.0),
                 end_seconds=params.get("end_seconds"),
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "flow":
             return scan_flow(
@@ -2442,6 +2608,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "scene":
             ref_scenes = params.get("reference_scenes")
@@ -2458,11 +2625,21 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         elif task_type == "multitool":
             steps = params.get("steps", [])
             if not steps or len(steps) < 2:
                 raise ValueError("Multitool requires at least 2 steps")
+            # Fast scan: multiply the interval used by scan_multitool
+            # (reads from steps[0]["interval"] with fallback to default)
+            if scan_mode == "fast" and steps:
+                mt_interval = steps[0].get(
+                    "interval", config.SCREENSPACE_DEFAULT_INTERVAL
+                )
+                steps[0]["interval"] = (
+                    mt_interval * config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
+                )
             return scan_multitool(
                 video_path,
                 region,
@@ -2472,6 +2649,7 @@ class ScreenspaceWorker:
                 on_progress=on_progress,
                 cancel_flag=cancel_flag,
                 on_result=on_result,
+                fast_opts=fast_opts,
             )
         else:
             raise ValueError(f"Unknown task type: {task_type}")

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1032,3 +1032,139 @@ class TestScanMultitool:
                 {"x": 0, "y": 0, "w": 100, "h": 100},
                 steps=[{"type": "color"}],
             )
+
+
+# ---------------------------------------------------------------------------
+# Fast Scan mode
+# ---------------------------------------------------------------------------
+
+
+class TestFastScanDispatchIntervalMultiplier:
+    """Verify _dispatch() applies interval multiplier in fast scan mode."""
+
+    def test_interval_multiplied_for_fast_scan(self, monkeypatch):
+        captured = {}
+
+        def fake_scan_color(
+            video_path,
+            region,
+            *,
+            target_color,
+            tolerance,
+            interval_seconds=0,
+            start_seconds=0.0,
+            end_seconds=None,
+            on_progress=None,
+            cancel_flag=None,
+            on_result=None,
+            fast_opts=None,
+        ):
+            captured["interval"] = interval_seconds
+            captured["fast_opts"] = fast_opts
+            return []
+
+        monkeypatch.setattr(screenspace, "scan_color", fake_scan_color)
+
+        worker = screenspace.ScreenspaceWorker()
+        task = {
+            "id": "ss_test1",
+            "type": "color",
+            "video_path": "/fake.mp4",
+            "region_coords": {"x": 0, "y": 0, "w": 100, "h": 100},
+            "parameters": {
+                "scan_mode": "fast",
+                "interval": 1.0,
+                "target_color": {"h": 0, "s": 0, "v": 0},
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+            },
+        }
+        worker._dispatch(task, lambda p: None, lambda: False, None)
+
+        expected = 1.0 * config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
+        assert captured["interval"] == expected
+        assert captured["fast_opts"] is not None
+        assert captured["fast_opts"]["phash_skip"] is True
+        assert captured["fast_opts"]["max_region_dim"] == 32
+
+    def test_normal_scan_no_fast_opts(self, monkeypatch):
+        captured = {}
+
+        def fake_scan_color(
+            video_path,
+            region,
+            *,
+            target_color,
+            tolerance,
+            interval_seconds=0,
+            start_seconds=0.0,
+            end_seconds=None,
+            on_progress=None,
+            cancel_flag=None,
+            on_result=None,
+            fast_opts=None,
+        ):
+            captured["interval"] = interval_seconds
+            captured["fast_opts"] = fast_opts
+            return []
+
+        monkeypatch.setattr(screenspace, "scan_color", fake_scan_color)
+
+        worker = screenspace.ScreenspaceWorker()
+        task = {
+            "id": "ss_test2",
+            "type": "color",
+            "video_path": "/fake.mp4",
+            "region_coords": {"x": 0, "y": 0, "w": 100, "h": 100},
+            "parameters": {
+                "interval": 1.0,
+                "target_color": {"h": 0, "s": 0, "v": 0},
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+            },
+        }
+        worker._dispatch(task, lambda p: None, lambda: False, None)
+
+        assert captured["interval"] == 1.0
+        assert captured["fast_opts"] is None
+
+    def test_template_dispatch_gets_downscale_flag(self, monkeypatch):
+        captured = {}
+
+        def fake_scan_template(
+            video_path,
+            region,
+            *,
+            template_image,
+            threshold=0,
+            interval_seconds=0,
+            template_mask=None,
+            start_seconds=0.0,
+            end_seconds=None,
+            on_progress=None,
+            cancel_flag=None,
+            on_result=None,
+            fast_opts=None,
+        ):
+            captured["fast_opts"] = fast_opts
+            captured["template_shape"] = template_image.shape
+            return []
+
+        monkeypatch.setattr(screenspace, "scan_template", fake_scan_template)
+
+        worker = screenspace.ScreenspaceWorker()
+        tmpl = np.zeros((100, 200, 3), dtype=np.uint8)
+        task = {
+            "id": "ss_test3",
+            "type": "template",
+            "video_path": "/fake.mp4",
+            "region_coords": {"x": 0, "y": 0, "w": 100, "h": 100},
+            "parameters": {
+                "scan_mode": "fast",
+                "interval": 1.0,
+                "template_image": tmpl,
+            },
+        }
+        worker._dispatch(task, lambda p: None, lambda: False, None)
+
+        assert captured["fast_opts"]["template_downscale"] is True
+        # Template should be downscaled by 2x in _dispatch
+        assert captured["template_shape"] == (50, 100, 3)

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -680,6 +680,54 @@ def test_create_multitool_task_no_global_region_ok(client):
     assert "No video" in data["error"]
 
 
+def test_fast_scan_mode_passes_validation(client):
+    """scan_mode in parameters should not cause a validation error.
+
+    P01 has no video, so task creation fails at the video-existence check
+    (not at parameter validation).  This confirms scan_mode is accepted
+    and passes through to the task parameters.
+    """
+    screenspace_server._manifest["regions"]["fstest"] = {
+        "x": 0,
+        "y": 0,
+        "w": 10,
+        "h": 10,
+    }
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "color",
+            "participant": "P01",
+            "region": "fstest",
+            "parameters": {
+                "scan_mode": "fast",
+                "target_color": {"h": 0, "s": 0, "v": 0},
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+                "interval": 1.0,
+            },
+        },
+    )
+    data = resp.get_json()
+    # Should fail at video check, not at parameter validation
+    assert resp.status_code == 400
+    assert "video" in data["error"].lower()
+
+
+def test_clean_task_preserves_scan_mode():
+    """_clean_task should keep scan_mode in parameters (not stripped)."""
+    task = {
+        "id": "ss_test",
+        "type": "color",
+        "parameters": {
+            "scan_mode": "fast",
+            "target_color": {"h": 0, "s": 0, "v": 0},
+            "interval": 1.0,
+        },
+    }
+    cleaned = screenspace_server._clean_task(task)
+    assert cleaned["parameters"]["scan_mode"] == "fast"
+
+
 def _create_region(client, name, x=100, y=20, w=300, h=30):
     client.post(
         "/screenspace/api/regions",


### PR DESCRIPTION
## Summary

- Adds a **Fast Scan** dropdown (Normal/Fast) next to the Run button in Screenspace, bundling four performance optimizations from the performance plan (2.0, 2A–2D): 3× frame interval multiplier, halved analysis resolution per tool, universal perceptual-hash pre-filter to skip static frames, and 2× template matching downscale
- Fast scan tasks show a chevron-double-right badge in the task queue and a "Fast scan results" label with a **Re-Run Normal** button in the results panel for easy upgrade to full fidelity
- Fixes a pre-existing race condition where SSE task updates could cause duplicate task cards when clicking Run while SSE is active
- Adds `flex-wrap` to the workflow action row so the Run button is never pushed off-screen
- Includes 5 new tests covering dispatch interval multiplication, normal mode passthrough, template downscale, API validation, and `_clean_task` preservation

## Test plan
- [x] All 383 tests pass (`uv run pytest -c tests/pytest.ini`)
- [ ] Manual: select Fast mode, run a color/change/similarity/template scan, verify results appear with fast badge and re-run button
- [ ] Manual: click Re-Run Normal on a fast scan result, verify new task queues without `scan_mode`
- [ ] Manual: verify action row wraps cleanly at narrow widths without hiding Run button