### PR TITLE
Add participant filter to Screenspace Intake

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2207,6 +2207,38 @@ html[data-theme="dark"] .log-panel {
   color: #fff;
 }
 
+.intake-filter-participant-pills {
+  display: flex;
+  gap: 4px;
+}
+
+.intake-filter-participant {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  font-weight: 600;
+  text-transform: uppercase;
+  transition: background var(--duration-fast), color var(--duration-fast),
+              border-color var(--duration-fast);
+}
+
+.intake-filter-participant:hover {
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  border-color: var(--color-accent);
+}
+
+.intake-filter-participant.active {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+
 .intake-filter-new-label {
   font-size: var(--text-xs);
   color: var(--color-text-dim);

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -114,6 +114,7 @@
           <button class="intake-filter-det" data-detector="flow" style="--det-color:#6366f1"><span class="intake-det-icon" data-icon="arrows-right-left"></span>flow</button>
           <button class="intake-filter-det" data-detector="scene" style="--det-color:#14b8a6"><span class="intake-det-icon" data-icon="squares-2x2"></span>scene</button>
         </div>
+        <div id="intakeFilterParticipants" class="intake-filter-participant-pills"></div>
         <label class="intake-filter-new-label"><input id="intakeFilterNew" type="checkbox"> New only</label>
       </div>
       <canvas id="intakeTimeline"></canvas>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -34,6 +34,7 @@
     intakeFilterText: "",
     intakeFilterDetector: "",
     intakeFilterNew: false,
+    intakeFilterParticipants: [],
     intakeHoveredIdx: -1,
     activePreviewTab: "sheet",
   };
@@ -3424,11 +3425,48 @@
     }
   }
 
+  function buildParticipantPills() {
+    var container = qs("#intakeFilterParticipants");
+    if (!container) return;
+    var seen = {};
+    var participants = [];
+    for (var i = 0; i < state.intakeClusters.length; i++) {
+      var p = state.intakeClusters[i].participant;
+      if (p && !seen[p]) { seen[p] = true; participants.push(p); }
+    }
+    participants.sort();
+    var key = participants.join(",");
+    if (container.dataset.participants === key) {
+      syncParticipantPillStates();
+      return;
+    }
+    container.dataset.participants = key;
+    state.intakeFilterParticipants = state.intakeFilterParticipants.filter(function (p) { return seen[p]; });
+    container.innerHTML = "";
+    for (var j = 0; j < participants.length; j++) {
+      var btn = el("button", "intake-filter-participant", participants[j]);
+      btn.dataset.participant = participants[j];
+      if (state.intakeFilterParticipants.indexOf(participants[j]) !== -1) btn.classList.add("active");
+      container.appendChild(btn);
+    }
+  }
+
+  function syncParticipantPillStates() {
+    var btns = qsa(".intake-filter-participant");
+    for (var i = 0; i < btns.length; i++) {
+      var p = btns[i].dataset.participant;
+      if (state.intakeFilterParticipants.indexOf(p) !== -1) btns[i].classList.add("active");
+      else btns[i].classList.remove("active");
+    }
+  }
+
   function renderIntake(hasNew) {
     var container = qs("#intakeCards");
     var addAllBtn = qs("#intakeAddAllBtn");
     var reelAllBtn = qs("#intakeReelAllBtn");
     var tabBadge = qs("#intakeTabBadge");
+
+    buildParticipantPills();
 
     if (!state.intakeClusters.length) {
       if (tabBadge) tabBadge.classList.add("hidden");
@@ -3553,8 +3591,10 @@
     var text = state.intakeFilterText.toLowerCase();
     var det = state.intakeFilterDetector;
     var onlyNew = state.intakeFilterNew;
-    if (!text && !det && !onlyNew) return clusters;
+    var parts = state.intakeFilterParticipants;
+    if (!text && !det && !onlyNew && !parts.length) return clusters;
     return clusters.filter(function (c) {
+      if (parts.length && parts.indexOf(c.participant) === -1) return false;
       if (det && c.detector !== det) return false;
       if (text && (c.event_type || "").toLowerCase().indexOf(text) === -1
           && (c.region || "").toLowerCase().indexOf(text) === -1
@@ -3686,6 +3726,19 @@
         var all = qsa(".intake-filter-det");
         for (var j = 0; j < all.length; j++) all[j].classList.remove("active");
         if (state.intakeFilterDetector) this.classList.add("active");
+        renderIntake(false);
+      });
+    }
+    var partContainer = qs("#intakeFilterParticipants");
+    if (partContainer) {
+      partContainer.addEventListener("click", function (e) {
+        var btn = e.target.closest(".intake-filter-participant");
+        if (!btn) return;
+        var val = btn.dataset.participant;
+        var idx = state.intakeFilterParticipants.indexOf(val);
+        if (idx === -1) state.intakeFilterParticipants.push(val);
+        else state.intakeFilterParticipants.splice(idx, 1);
+        syncParticipantPillStates();
         renderIntake(false);
       });
     }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.14"
+VERSIONNUM: str = "0.10.15"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Adds multi-select participant filter pills to the Studio Screenspace Intake panel, dynamically populated from incoming events
- Pills use accent-colored active state (visually distinct from the per-detector-colored detector pills) and support toggling multiple participants simultaneously
- Integrates with existing filters (text search, detector type, "New only") as an AND condition via `filteredIntakeClusters()`
- Stale selections are automatically pruned when a participant's events are all dismissed

## Test plan

- [ ] Run Screenspace tasks across multiple participants and verify pills appear in the intake filter bar
- [ ] Click pills to filter: single select, multi-select, deselect all (shows everything)
- [ ] Combine participant filter with detector and text search filters
- [ ] Dismiss all events for a participant and verify its pill disappears
- [ ] Verify "Add All" buttons operate on the filtered subset