### PR TITLE
Disable browser autofill on all web UI text inputs (#131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Patterns distilled from recurring post-review and post-merge fixes across the pr
 - **Async race conditions**: For video seeking, image loading, or any async chain that can be re-triggered before completion, use a generation counter to reject stale callbacks. Coalesce rapid-fire requests with `requestAnimationFrame`.
 - **Canvas/rendering performance**: RAF-throttle canvas draws and mouse-tracking renders. Cache `getBoundingClientRect()` results instead of calling in loops. Pause polling when the tab is hidden (`document.hidden`).
 - **Flex layout**: Elements inside flex containers need explicit `flex: 1` or `min-width: 0` to avoid zero-width collapse. Verify new elements are visible after adding them to flex parents.
+- **Autocomplete off on text inputs**: Every `<input type="text">` (static or dynamic) must have `autocomplete="off"` to prevent browser autofill (e.g. contact names). For static HTML use the attribute directly; for JS-created inputs set `.autocomplete = "off"` after creation.
 
 ### Backend (Python / Flask)
 

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -1055,6 +1055,7 @@
       var fields = el("div", "insight-fields");
       var titleInput = document.createElement("input");
       titleInput.type = "text";
+      titleInput.autocomplete = "off";
       titleInput.value = insight.title || "";
       titleInput.placeholder = "Insight title";
       titleInput.addEventListener("input", function () {
@@ -1114,6 +1115,7 @@
       tcDiv.appendChild(el("label", "", "Timeline context"));
       var tcInput = document.createElement("input");
       tcInput.type = "text";
+      tcInput.autocomplete = "off";
       tcInput.value = insight.timelineContext || "";
       tcInput.placeholder = "e.g. During onboarding (first 5 minutes)";
       tcInput.addEventListener("input", function () {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -55,7 +55,7 @@
           <canvas id="playheadCanvas"></canvas>
         </div>
         <div id="timelineSeek">
-          <input id="timestampInput" type="text" placeholder="0:00" spellcheck="false">
+          <input id="timestampInput" type="text" placeholder="0:00" spellcheck="false" autocomplete="off">
           <div id="timelineStepBtns">
             <button id="framePrev" class="btn btn-small btn-icon" title="Step back 1s"></button>
             <button id="frameNext" class="btn btn-small btn-icon" title="Step forward 1s"></button>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2170,7 +2170,7 @@
       row1.appendChild(el("span", "param-label", "Hex color"));
       var ctrl1 = el("div", "param-control");
       var hexIn = document.createElement("input");
-      hexIn.type = "text"; hexIn.id = "paramColorHex" + sfx;
+      hexIn.type = "text"; hexIn.id = "paramColorHex" + sfx; hexIn.autocomplete = "off";
       hexIn.className = "color-hex-input"; hexIn.placeholder = "#000000"; hexIn.maxLength = 7;
       hexIn.style.width = "5.5rem";
       ctrl1.appendChild(hexIn);
@@ -2262,7 +2262,7 @@
       r1.appendChild(el("span", "param-label", "Search"));
       var c1 = el("div", "param-control");
       var searchIn = document.createElement("input");
-      searchIn.type = "text"; searchIn.id = "paramTextSearch" + sfx;
+      searchIn.type = "text"; searchIn.id = "paramTextSearch" + sfx; searchIn.autocomplete = "off";
       searchIn.placeholder = "Search text...";
       searchIn.style.flex = "1"; searchIn.style.fontSize = "var(--text-xs)";
       searchIn.style.padding = "var(--space-1)";
@@ -2657,6 +2657,7 @@
 
       var hexInput = document.createElement("input");
       hexInput.type = "text";
+      hexInput.autocomplete = "off";
       hexInput.id = "paramColorHex";
       hexInput.className = "color-hex-input";
       hexInput.placeholder = "#000000";
@@ -3046,6 +3047,7 @@
   function textInput(id, placeholder) {
     var inp = document.createElement("input");
     inp.type = "text";
+    inp.autocomplete = "off";
     inp.id = id;
     inp.placeholder = placeholder || "";
     return inp;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -101,7 +101,7 @@
         <button id="intakeReelAllBtn" class="btn btn-small" disabled>Add All to Reel</button>
       </div>
       <div class="intake-filters">
-        <input id="intakeFilterSearch" type="text" placeholder="Search events&#x2026;" class="intake-filter-search">
+        <input id="intakeFilterSearch" type="text" placeholder="Search events&#x2026;" class="intake-filter-search" autocomplete="off">
         <div class="intake-filter-pills">
           <button class="intake-filter-det" data-detector="multitool" style="--det-color:#2563eb"><span class="intake-det-icon" data-icon="link"></span>multitool</button>
           <button class="intake-filter-det" data-detector="color" style="--det-color:#8b5cf6"><span class="intake-det-icon" data-icon="eye-dropper"></span>color</button>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1949,6 +1949,7 @@
     var input = document.createElement("input");
     input.className = "stash-card-name-input";
     input.type = "text";
+    input.autocomplete = "off";
     input.value = stash.name;
 
     function commit() {


### PR DESCRIPTION
## Summary
- Adds `autocomplete="off"` to every `<input type="text">` across Studio, Screenspace, and Insights Builder — both static HTML and dynamically created inputs in JS
- Covers the shared `textInput()` helper in `screenspace.js` (6 callers) plus 5 individually created text inputs
- Adds a code review checklist entry to `AGENTS.md` so new text inputs follow the same pattern

Prevents browser autofill (e.g. macOS contact book names) from appearing in app-specific fields like search filters, region names, hex color inputs, and insight titles.