### PR TITLE
Add batch ffmpeg extraction, parallel workers, and timelapse improvements

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1153,6 +1153,13 @@ body {
   min-width: 0;
 }
 
+.param-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  margin-left: var(--space-1);
+  white-space: nowrap;
+}
+
 .param-value {
   font-size: var(--text-xs);
   font-family: var(--font-mono);

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2860,6 +2860,9 @@
       renderIntervalSlot("paramNumInterval", 0.5, 60, 2.0, 0.5);
     } else if (type === "timelapse") {
       addParamRow(container, "Speed", numberInput("paramTlSpeed", 2, 100, 10, 1));
+      addParamRow(container, "Sample every", numberInput("paramTlSampleInterval", 0, 60, 0, 0.5), "paramTlSampleIntervalVal");
+      var siHint = el("span", "param-hint", "seconds (0 = every frame)");
+      container.lastChild.querySelector(".param-control").appendChild(siHint);
       var fmtRow = el("div", "param-row");
       fmtRow.appendChild(el("span", "param-label", "Format"));
       var fmtControl = el("div", "param-control");
@@ -2996,6 +2999,10 @@
       dfCb.id = "paramDetectFirst";
       addParamRow(container, "Detect first", dfCb);
     }
+
+    // Hide scan mode picker for timelapse (fast scan doesn't apply)
+    var scanPicker = qs("#runScanModePicker");
+    if (scanPicker) scanPicker.style.display = type === "timelapse" ? "none" : "";
 
     updateRunButton();
   }
@@ -3318,7 +3325,7 @@
       if (participants.length === 0) return;
       var params = gatherWorkflowParams(type);
       if (params === null) return;
-      if (state.scanMode === "fast") params.scan_mode = "fast";
+      if (state.scanMode === "fast" && type !== "timelapse") params.scan_mode = "fast";
 
       if (state.inMarker !== null) params.start_seconds = state.inMarker;
       if (state.outMarker !== null) params.end_seconds = state.outMarker;
@@ -3522,6 +3529,8 @@
       params.interval = parseFloat((qs("#paramNumInterval") || {}).value) || 2.0;
     } else if (type === "timelapse") {
       params.speedup_factor = parseFloat((qs("#paramTlSpeed") || {}).value) || 10;
+      var si = parseFloat((qs("#paramTlSampleInterval") || {}).value);
+      if (si > 0) params.sample_interval = si;
       params.output_format = (qs("#paramTlFormat") || {}).value || "mp4";
     } else if (type === "template") {
       if (state.uploadedTemplate) {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.14"
+VERSIONNUM: str = "0.10.15"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -150,6 +150,15 @@ SCREENSPACE_FLOW_GRID_SIZE: int = 8
 SCREENSPACE_FLOW_GRID_MIN_MAG: float = 0.5
 SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER: float = 3.0
 SCREENSPACE_FAST_SCAN_PHASH_THRESHOLD: int = 12  # tighter than general 15
+SCREENSPACE_BATCH_EXTRACT: bool = (
+    True  # use ffmpeg pipe for frame extraction; falls back to cv2
+)
+SCREENSPACE_PARALLEL_WORKERS: int = (
+    2  # max concurrent analysis tasks in ScreenspaceWorker
+)
+SCREENSPACE_VIDEO_CAP_POOL_SIZE: int = (
+    6  # max cached VideoCapture objects for API frame endpoint
+)
 
 # Highlights reel constants
 HIGHLIGHTS_REEL_DURATION_SECONDS: int = 180  # 3-minute budget for highlights reel

--- a/plans/PERFORMANCE-PLAN.md
+++ b/plans/PERFORMANCE-PLAN.md
@@ -185,7 +185,7 @@ This could be always-on (not just fast scan), since phash is very cheap (~0.1ms 
 
 **Trade-offs:** 4x speedup for the most expensive per-frame operation. Slightly reduced precision for small template features (<20px). Could also be adopted as the default for the initial pass in normal mode, with full-res confirmation for frames that match.
 
-### - [ ] 2E. Batch frame extraction via ffmpeg instead of cv2
+### - [x] 2E. Batch frame extraction via ffmpeg instead of cv2
 
 **Current:** Frames are extracted one-at-a-time via `cv2.VideoCapture.grab()/retrieve()` or seek-based access (screenspace.py:457-496).
 
@@ -193,7 +193,7 @@ This could be always-on (not just fast scan), since phash is very cheap (~0.1ms 
 
 **Trade-offs:** Requires temp disk space for frames (or memory for pipe). Loses the ability to skip frames mid-scan (e.g. phash skip). Best combined with the coarse-to-fine approach: batch extract at coarse intervals, then targeted extraction for refinements. This optimization is independent of fast scan mode — it's a backend improvement that could apply always.
 
-### - [ ] 2F. Parallel analysis of independent regions
+### - [x] 2F. Parallel analysis of independent regions
 
 **Prior art:** Threading lock around VideoCapture seek+read was added in `370b3e4` to fix concurrent access crashes. This confirms that concurrent VideoCapture usage needs careful synchronization — each thread needs its own capture object.
 
@@ -277,7 +277,7 @@ Startup, mode-switching, and media loading.
 
 **Trade-offs:** Need to append version param to asset URLs. Small change.
 
-### - [ ] 4D. VideoCapture pool size for Screenspace
+### - [x] 4D. VideoCapture pool size for Screenspace
 
 **Prior art:** LRU VideoCapture cache was expanded from 1→3 in `89bd136`. Same direction, further increment.
 
@@ -403,8 +403,8 @@ Additional performance area: the raw speed of reading video frames and writing o
 | [ ] | 7 | 3D — Transcript caching to disk | Medium — eliminates repeat transcription |
 | [x] | 8 | 1E — DOM batching with fragments | Medium — smoother large lists |
 | [x] | 9 | 5D — Parallel tests with xdist — skipped (suite runs in 0.62s, xdist overhead would regress) | Medium — faster CI feedback |
-| [ ] | 10 | 2F — Parallel region analysis | Medium — scales with CPU cores |
-| [ ] | 11 | 2E — Batch frame extraction via ffmpeg | Low-Medium — depends on video codec |
+| [x] | 10 | 2F — Parallel region analysis | Medium — scales with CPU cores |
+| [x] | 11 | 2E — Batch frame extraction via ffmpeg | Low-Medium — depends on video codec |
 | [ ] | 12 | 4A — Lazy-import heavy libs | Low-Medium — saves seconds on startup |
 | [x] | 13 | 1C — Optimistic UI in Studio | Low-Medium — better feel during generation |
 | [x] | 14 | 5B — Skip torch for typecheck — skipped (ty needs installed deps) | Low — job already ~25s, marginal gain |

--- a/screenspace.py
+++ b/screenspace.py
@@ -27,12 +27,15 @@ import json
 import math
 import queue
 import re
+import shutil
+import subprocess
 import threading
 import time
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 import cv2
 import imagehash
@@ -50,6 +53,7 @@ import video
 # ---------------------------------------------------------------------------
 
 _ocr_readers: Dict[tuple, Any] = {}
+_ocr_lock = threading.Lock()
 
 
 def _get_ocr_reader(languages: List[str]) -> Any:
@@ -57,9 +61,10 @@ def _get_ocr_reader(languages: List[str]) -> Any:
     import easyocr
 
     key = tuple(sorted(languages))
-    if key not in _ocr_readers:
-        _ocr_readers[key] = easyocr.Reader(list(key), verbose=False)
-    return _ocr_readers[key]
+    with _ocr_lock:
+        if key not in _ocr_readers:
+            _ocr_readers[key] = easyocr.Reader(list(key), verbose=False)
+        return _ocr_readers[key]
 
 
 # ---------------------------------------------------------------------------
@@ -447,6 +452,23 @@ def scan_video_frames(
     - ``phash_skip``: skip frames whose perceptual hash is unchanged
     - ``max_region_dim``: downscale extracted region to this max dimension
     """
+    # Try ffmpeg pipe extraction first (faster H.264 decoding)
+    if config.SCREENSPACE_BATCH_EXTRACT:
+        if _scan_via_ffmpeg_pipe(
+            video_path,
+            region,
+            interval_seconds,
+            callback,
+            start_seconds=start_seconds,
+            end_seconds=end_seconds if end_seconds is not None else 0.0,
+            fps=fps,
+            duration=duration,
+            fast_opts=fast_opts,
+            full_frame=False,
+        ):
+            return
+
+    # Fallback: cv2.VideoCapture-based extraction
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return
@@ -561,6 +583,23 @@ def scan_video_full_frames(
     ``max_region_dim`` downscales the full frame; ``phash_skip`` skips
     perceptually identical frames.
     """
+    # Try ffmpeg pipe extraction first (faster H.264 decoding)
+    if config.SCREENSPACE_BATCH_EXTRACT:
+        if _scan_via_ffmpeg_pipe(
+            video_path,
+            None,
+            interval_seconds,
+            callback,
+            start_seconds=start_seconds,
+            end_seconds=end_seconds if end_seconds is not None else 0.0,
+            fps=fps,
+            duration=duration,
+            fast_opts=fast_opts,
+            full_frame=True,
+        ):
+            return
+
+    # Fallback: cv2.VideoCapture-based extraction
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return
@@ -654,28 +693,226 @@ def scan_video_full_frames(
     cap.release()
 
 
+# ---------------------------------------------------------------------------
+# Batch frame extraction via ffmpeg pipe (experiment 2E)
+# ---------------------------------------------------------------------------
+
+
+def _ffmpeg_pipe_frames(
+    video_path: str,
+    interval_seconds: float,
+    *,
+    start_seconds: float = 0.0,
+    end_seconds: float = 0.0,
+    region: Optional[Dict[str, int]] = None,
+    frame_width: int = 0,
+    frame_height: int = 0,
+    max_dim: int = 0,
+) -> Iterator[Tuple[float, np.ndarray]]:
+    """Yield ``(timestamp, frame)`` tuples extracted via an ffmpeg pipe.
+
+    Uses a single ffmpeg process with ``-f rawvideo`` piped to stdout,
+    which is typically faster than per-frame ``cv2.VideoCapture`` seeking
+    for H.264 content.
+
+    *region* applies an ffmpeg ``crop`` filter so only the ROI pixels are
+    decoded and transferred.  *max_dim* adds a ``scale`` filter to cap the
+    largest output dimension (useful for fast-scan downscaling).
+
+    The caller can stop iteration at any time (e.g. on cancel); the
+    ``finally`` block ensures the subprocess is cleaned up.
+    """
+    if not shutil.which("ffmpeg"):
+        return
+
+    # Determine output dimensions
+    filters = [f"fps=1/{interval_seconds}"]
+
+    if region:
+        filters.append(f"crop={region['w']}:{region['h']}:{region['x']}:{region['y']}")
+        out_w, out_h = region["w"], region["h"]
+    else:
+        out_w, out_h = frame_width, frame_height
+
+    if out_w <= 0 or out_h <= 0:
+        return
+
+    if max_dim > 0 and (out_w > max_dim or out_h > max_dim):
+        scale = max_dim / max(out_w, out_h)
+        out_w = int(out_w * scale)
+        out_h = int(out_h * scale)
+        # Ensure even dimensions for rawvideo
+        out_w += out_w % 2
+        out_h += out_h % 2
+        filters.append(f"scale={out_w}:{out_h}")
+
+    cmd: List[str] = ["ffmpeg"]
+    if start_seconds > 0:
+        cmd += ["-ss", str(start_seconds)]
+    cmd += ["-i", video_path]
+    if end_seconds > start_seconds:
+        cmd += ["-t", str(end_seconds - start_seconds)]
+    cmd += [
+        "-vf",
+        ",".join(filters),
+        "-pix_fmt",
+        "bgr24",
+        "-f",
+        "rawvideo",
+        "-loglevel",
+        "error",
+        "pipe:1",
+    ]
+
+    frame_size = out_w * out_h * 3
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    frame_idx = 0
+    try:
+        while True:
+            raw = proc.stdout.read(frame_size)
+            if len(raw) < frame_size:
+                break
+            frame = np.frombuffer(raw, dtype=np.uint8).reshape((out_h, out_w, 3)).copy()
+            ts = start_seconds + frame_idx * interval_seconds
+            if end_seconds > 0 and ts > end_seconds:
+                break
+            yield (ts, frame)
+            frame_idx += 1
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+def _scan_via_ffmpeg_pipe(
+    video_path: str,
+    region: Optional[Dict[str, int]],
+    interval_seconds: float,
+    callback: Callable[[float, np.ndarray], Optional[bool]],
+    *,
+    start_seconds: float = 0.0,
+    end_seconds: float = 0.0,
+    fps: float = 0.0,
+    duration: float = 0.0,
+    fast_opts: Optional[Dict[str, Any]] = None,
+    full_frame: bool = False,
+) -> bool:
+    """Try to scan frames via ffmpeg pipe, calling *callback* for each.
+
+    Returns ``True`` if the ffmpeg path succeeded (caller should skip the
+    cv2 fallback), ``False`` if it failed and the caller should fall back
+    to cv2-based extraction.
+    """
+    if not shutil.which("ffmpeg"):
+        return False
+
+    props = video.probe_video_properties(video_path)
+    if not props:
+        return False
+    frame_width = props.get("width", 0)
+    frame_height = props.get("height", 0)
+    if frame_width <= 0 or frame_height <= 0:
+        return False
+
+    if end_seconds <= 0:
+        end_seconds = duration
+
+    # Fast-scan state
+    _phash_skip = bool(fast_opts and fast_opts.get("phash_skip"))
+    _max_dim = (fast_opts or {}).get("max_region_dim", 0)
+    _phash_thresh = (fast_opts or {}).get(
+        "phash_threshold", config.SCREENSPACE_FAST_SCAN_PHASH_THRESHOLD
+    )
+    _prev_phash: List[Optional[imagehash.ImageHash]] = [None]
+
+    pipe_region = None if full_frame else region
+    # For the pipe, push max_dim downscaling into ffmpeg when phash_skip is off.
+    # When phash_skip is on, we need the un-downscaled frame for hashing, so
+    # we downscale in Python after the hash check.
+    pipe_max_dim = _max_dim if (not _phash_skip and _max_dim > 0) else 0
+
+    try:
+        for ts, frame in _ffmpeg_pipe_frames(
+            video_path,
+            interval_seconds,
+            start_seconds=start_seconds,
+            end_seconds=end_seconds,
+            region=pipe_region,
+            frame_width=frame_width,
+            frame_height=frame_height,
+            max_dim=pipe_max_dim,
+        ):
+            if _phash_skip:
+                fh = compute_phash(frame)
+                if _prev_phash[0] is not None and fh - _prev_phash[0] <= _phash_thresh:
+                    continue
+                _prev_phash[0] = fh
+                # Downscale after phash if needed
+                if _max_dim > 0:
+                    rh, rw = frame.shape[:2]
+                    if rh > _max_dim or rw > _max_dim:
+                        sc = _max_dim / max(rh, rw)
+                        frame = cv2.resize(
+                            frame,
+                            (int(rw * sc), int(rh * sc)),
+                            interpolation=cv2.INTER_AREA,
+                        )
+
+            result = callback(ts, frame)
+            if result is False:
+                break
+
+        return True  # ffmpeg pipe succeeded (even if video had 0 frames)
+    except Exception:
+        return False
+
+
 def build_timelapse_command(
     video_path: str,
     region: Dict[str, int],
     speedup_factor: float,
     output_path: str,
     output_format: str = "mp4",
+    *,
+    start_seconds: float = 0.0,
+    end_seconds: Optional[float] = None,
+    sample_interval: float = 0.0,
 ) -> List[str]:
-    """Construct ffmpeg argv for a cropped timelapse."""
+    """Construct ffmpeg argv for a cropped timelapse.
+
+    *sample_interval* (seconds) controls frame sampling: when > 0, only one
+    frame per interval is kept before cropping and speed-up.  0 means every
+    frame is used (default).
+    """
     x, y, w, h = region["x"], region["y"], region["w"], region["h"]
-    vf = f"crop={w}:{h}:{x}:{y},setpts=PTS/{speedup_factor}"
+    filters: List[str] = []
+    if sample_interval > 0:
+        filters.append(f"fps=1/{sample_interval}")
+    filters.append(f"crop={w}:{h}:{x}:{y}")
+    filters.append(f"setpts=PTS/{speedup_factor}")
+    vf = ",".join(filters)
 
     cmd = [
         "ffmpeg",
         "-y",
         "-loglevel",
         config.FFMPEG_LOGLEVEL,
-        "-i",
-        video_path,
-        "-vf",
-        vf,
-        "-an",
     ]
+
+    if start_seconds > 0:
+        cmd += ["-ss", str(start_seconds)]
+
+    cmd += ["-i", video_path]
+
+    if end_seconds is not None and end_seconds > start_seconds:
+        cmd += ["-t", str(end_seconds - start_seconds)]
+
+    cmd += ["-vf", vf, "-an"]
 
     if output_format == "gif":
         cmd.extend(["-loop", "0"])
@@ -684,6 +921,22 @@ def build_timelapse_command(
 
     cmd.append(output_path)
     return cmd
+
+
+def _probe_video_meta(video_path: str) -> Tuple[float, float]:
+    """Return ``(fps, duration)`` via ffprobe, falling back to cv2."""
+    props = video.probe_video_properties(video_path)
+    if props and props.get("fps", 0) > 0 and props.get("duration", 0) > 0:
+        return (props["fps"], props["duration"])
+    # Fallback for containers where ffprobe can't report duration/fps
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        return (0.0, 0.0)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    total = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    dur = total / fps if fps > 0 else 0.0
+    cap.release()
+    return (fps, dur)
 
 
 # ---------------------------------------------------------------------------
@@ -713,13 +966,9 @@ def scan_color(
     if interval_seconds <= 0:
         interval_seconds = config.SCREENSPACE_DEFAULT_INTERVAL
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -798,13 +1047,9 @@ def scan_changes(
     if noise_threshold <= 0:
         noise_threshold = config.SCREENSPACE_NOISE_THRESHOLD
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -878,13 +1123,9 @@ def scan_similarity(
     if interval_seconds <= 0:
         interval_seconds = config.SCREENSPACE_DEFAULT_INTERVAL
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -999,13 +1240,9 @@ def scan_text(
 
     reader = _get_ocr_reader(languages)
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -1103,13 +1340,9 @@ def scan_numbers(
 
     reader = _get_ocr_reader(languages)
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -1186,21 +1419,83 @@ def generate_timelapse(
     speedup_factor: float,
     output_path: str,
     output_format: str = "mp4",
+    *,
+    start_seconds: float = 0.0,
+    end_seconds: Optional[float] = None,
+    sample_interval: float = 0.0,
+    on_progress: Optional[Callable[[float], None]] = None,
+    cancel_flag: Optional[Callable[[], bool]] = None,
 ) -> Optional[str]:
     """Generate a cropped timelapse via ffmpeg.
+
+    *sample_interval* controls frame sampling (seconds between captured
+    frames).  0 means every frame is used.
+
+    Reports encoding progress through *on_progress* by parsing ffmpeg's
+    ``-progress`` output.  Checks *cancel_flag* periodically to allow
+    early termination.
 
     Returns output file path on success, ``None`` on failure.
     """
     cmd = build_timelapse_command(
-        video_path, region, speedup_factor, output_path, output_format
+        video_path,
+        region,
+        speedup_factor,
+        output_path,
+        output_format,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+        sample_interval=sample_interval,
     )
-    result = video.run_ffmpeg_process(
-        cmd,
-        input_file=video_path,
-        output_file=output_path,
-        os_error_message="Failed to generate timelapse",
+
+    # Estimate output duration for progress calculation.
+    input_duration = 0.0
+    if end_seconds is not None and end_seconds > start_seconds:
+        input_duration = end_seconds - start_seconds
+    else:
+        _, vid_dur = _probe_video_meta(video_path)
+        if vid_dur > 0:
+            input_duration = max(vid_dur - start_seconds, 0.0)
+
+    expected_out_us = (
+        (input_duration / speedup_factor * 1_000_000) if input_duration > 0 else 0
     )
-    if result is None or result.returncode != 0:
+
+    # Use Popen with -progress to get real-time encoding updates
+    cmd += ["-progress", "pipe:1"]
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except (FileNotFoundError, OSError):
+        return None
+
+    if on_progress:
+        on_progress(0.0)
+
+    try:
+        for line in proc.stdout:
+            text = line.decode("utf-8", errors="replace").strip()
+            if text.startswith("out_time_us=") and expected_out_us > 0 and on_progress:
+                try:
+                    us = int(text.split("=", 1)[1])
+                    on_progress(min(us / expected_out_us, 0.99))
+                except (ValueError, ZeroDivisionError):
+                    pass
+            if cancel_flag and cancel_flag():
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                return None
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+        proc.wait()
+
+    if on_progress:
+        on_progress(1.0)
+    if proc.returncode != 0:
         return None
     return output_path
 
@@ -1234,13 +1529,9 @@ def scan_template(
     if interval_seconds <= 0:
         interval_seconds = config.SCREENSPACE_DEFAULT_INTERVAL
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -1330,13 +1621,9 @@ def scan_flow(
     if interval_seconds <= 0:
         interval_seconds = config.SCREENSPACE_DEFAULT_INTERVAL
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -1431,13 +1718,9 @@ def scan_scene(
     if not ref_fps:
         return []
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if end_seconds is None or end_seconds > vid_duration:
         end_seconds = vid_duration
@@ -1762,13 +2045,9 @@ def scan_multitool(
         if s_end is not None:
             scan_end = min(scan_end, s_end) if scan_end is not None else s_end
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    vid_fps, vid_duration = _probe_video_meta(video_path)
+    if vid_fps <= 0:
         return []
-    vid_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    vid_duration = total_frames / vid_fps if vid_fps > 0 else 0.0
-    cap.release()
 
     if scan_end is None or scan_end > vid_duration:
         scan_end = vid_duration
@@ -2109,7 +2388,7 @@ class ScreenspaceWorker:
         self._running = False
         self._queue.put((0, "", _SENTINEL))
         if self._thread is not None:
-            self._thread.join(timeout=5)
+            self._thread.join(timeout=15)
 
     def enqueue(self, task: Dict[str, Any]) -> str:
         """Add a task to the queue. Returns the task ID."""
@@ -2192,11 +2471,7 @@ class ScreenspaceWorker:
             start = params.get("start_seconds", 0.0)
             end = params.get("end_seconds")
             if end is None:
-                cap = cv2.VideoCapture(task["video_path"])
-                fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
-                total = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-                end = total / fps if fps > 0 else 0.0
-                cap.release()
+                _, end = _probe_video_meta(task["video_path"])
             resume_at = start + progress * (end - start)
 
             with self._lock:
@@ -2306,43 +2581,82 @@ class ScreenspaceWorker:
                 task["heatmap_gif"] = Path(gp).name
 
     def _run(self) -> None:
-        """Worker loop."""
-        while self._running:
-            try:
-                item = self._queue.get(timeout=1)
-            except queue.Empty:
-                continue
+        """Worker loop with concurrent task execution via ThreadPoolExecutor."""
+        max_workers = config.SCREENSPACE_PARALLEL_WORKERS
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            active: Dict[str, Future[None]] = {}
 
-            try:
-                priority, created_at, task_id = item
-                if task_id is _SENTINEL:
-                    break
+            while self._running:
+                try:
+                    # 1. Collect completed futures
+                    done_ids = [tid for tid, f in active.items() if f.done()]
+                    for tid in done_ids:
+                        future = active.pop(tid)
+                        try:
+                            future.result()
+                        except Exception as exc:
+                            utils.warning_print(f"Worker task {tid} raised: {exc}")
 
-                if self._paused.is_set():
-                    self._queue.put(item)
-                    time.sleep(0.25)
-                    continue
+                    if done_ids:
+                        if self.on_task_complete:
+                            try:
+                                self.on_task_complete()
+                            except Exception as exc:
+                                utils.warning_print(
+                                    f"on_task_complete callback failed: {exc}"
+                                )
+                        if self.on_progress_update:
+                            try:
+                                self.on_progress_update()
+                            except Exception:
+                                pass
 
-                with self._lock:
-                    task = self._tasks.get(task_id)
-                    if task is None or task["status"] != TASK_STATUS_QUEUED:
+                    # 2. If paused, wait
+                    if self._paused.is_set():
+                        time.sleep(0.25)
                         continue
-                    task["status"] = TASK_STATUS_RUNNING
 
-                self._execute_task(task)
+                    # 3. Submit new tasks if capacity available
+                    if len(active) >= max_workers:
+                        time.sleep(0.1)
+                        continue
 
-                if self.on_task_complete:
                     try:
-                        self.on_task_complete()
-                    except Exception as exc:
-                        utils.warning_print(f"on_task_complete callback failed: {exc}")
-                if self.on_progress_update:
-                    try:
-                        self.on_progress_update()
-                    except Exception:
-                        pass
-            except Exception as exc:
-                utils.warning_print(f"Worker loop error: {exc}")
+                        item = self._queue.get(timeout=0.25)
+                    except queue.Empty:
+                        continue
+
+                    priority, created_at, task_id = item
+                    if task_id is _SENTINEL:
+                        # Wait for active tasks to finish
+                        for f in active.values():
+                            try:
+                                f.result(timeout=10)
+                            except Exception:
+                                pass
+                        if self.on_task_complete:
+                            try:
+                                self.on_task_complete()
+                            except Exception:
+                                pass
+                        break
+
+                    if self._paused.is_set():
+                        self._queue.put(item)
+                        time.sleep(0.25)
+                        continue
+
+                    with self._lock:
+                        task = self._tasks.get(task_id)
+                        if task is None or task["status"] != TASK_STATUS_QUEUED:
+                            continue
+                        task["status"] = TASK_STATUS_RUNNING
+
+                    future = pool.submit(self._execute_task, task)
+                    active[task_id] = future
+
+                except Exception as exc:
+                    utils.warning_print(f"Worker loop error: {exc}")
 
     def _execute_task(self, task: Dict[str, Any]) -> None:
         """Dispatch task to the appropriate workflow function."""
@@ -2454,9 +2768,10 @@ class ScreenspaceWorker:
         task_type = task["type"]
 
         # Fast scan: apply interval multiplier and build optimization dict
+        # (timelapse has its own sample_interval and does not use fast scan)
         scan_mode = params.get("scan_mode", "normal")
         fast_opts: Optional[Dict[str, Any]] = None
-        if scan_mode == "fast":
+        if scan_mode == "fast" and task_type != "timelapse":
             multiplier = config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
             if params.get("interval", 0) > 0:
                 params["interval"] = params["interval"] * multiplier
@@ -2565,6 +2880,11 @@ class ScreenspaceWorker:
                 speedup_factor=params.get("speedup_factor", 10.0),
                 output_path=output_path,
                 output_format=params.get("output_format", "mp4"),
+                start_seconds=params.get("start_seconds", 0.0),
+                end_seconds=params.get("end_seconds"),
+                sample_interval=params.get("sample_interval", 0.0),
+                on_progress=on_progress,
+                cancel_flag=cancel_flag,
             )
         elif task_type == "template":
             template_img = params.get("template_image")

--- a/screenspace.py
+++ b/screenspace.py
@@ -766,6 +766,7 @@ def _ffmpeg_pipe_frames(
 
     frame_size = out_w * out_h * 3
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert proc.stdout is not None  # guaranteed by stdout=PIPE
     frame_idx = 0
     try:
         while True:
@@ -1465,6 +1466,7 @@ def generate_timelapse(
     cmd += ["-progress", "pipe:1"]
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        assert proc.stdout is not None  # guaranteed by stdout=PIPE
     except (FileNotFoundError, OSError):
         return None
 
@@ -2596,8 +2598,6 @@ class ScreenspaceWorker:
                             future.result()
                         except Exception as exc:
                             utils.warning_print(f"Worker task {tid} raised: {exc}")
-
-                    if done_ids:
                         if self.on_task_complete:
                             try:
                                 self.on_task_complete()

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -66,7 +66,6 @@ _worker: Optional["screenspace.ScreenspaceWorker"] = None
 _output_dir: str = ""
 _participants: List[Dict[str, Any]] = []
 _video_cap_cache: OrderedDict[str, Any] = OrderedDict()
-_VIDEO_CAP_MAX = 3
 _video_cap_lock = threading.Lock()
 _video_metadata_cache: Dict[str, Dict[str, Any]] = {}
 
@@ -74,6 +73,7 @@ _video_metadata_cache: Dict[str, Dict[str, Any]] = {}
 
 _sse_clients: list[queue_mod.Queue[str]] = []
 _sse_clients_lock = threading.Lock()
+_persist_lock = threading.Lock()
 
 
 def _notify_sse_clients(event_type: str = "update") -> None:
@@ -169,7 +169,7 @@ def _get_video_cap(video_path: str) -> Optional["cv2.VideoCapture"]:
     if not cap.isOpened():
         return None
     _video_cap_cache[video_path] = cap
-    if len(_video_cap_cache) > _VIDEO_CAP_MAX:
+    if len(_video_cap_cache) > config.SCREENSPACE_VIDEO_CAP_POOL_SIZE:
         _, old_cap = _video_cap_cache.popitem(last=False)
         old_cap.release()
     return cap
@@ -1179,14 +1179,15 @@ def _persist_manifest() -> None:
     """Save manifest after a task completes."""
     import screenspace
 
-    if _worker:
-        new_events = _worker.drain_new_events()
-        if new_events:
-            _manifest.setdefault("events", []).extend(new_events)
-        tasks = _worker.get_all_tasks()
-        screenspace.save_screenspace_manifest(
-            _manifest.get("regions", {}),
-            tasks,
-            _manifest.get("events", []),
-            stashes=_manifest.get("stashes", []),
-        )
+    with _persist_lock:
+        if _worker:
+            new_events = _worker.drain_new_events()
+            if new_events:
+                _manifest.setdefault("events", []).extend(new_events)
+            tasks = _worker.get_all_tasks()
+            screenspace.save_screenspace_manifest(
+                _manifest.get("regions", {}),
+                tasks,
+                _manifest.get("events", []),
+                stashes=_manifest.get("stashes", []),
+            )

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1,7 +1,10 @@
 """Tests for Screenspace analysis primitives, manifest I/O, and worker."""
 
+import io
 import json
+import threading
 import time
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -1168,3 +1171,563 @@ class TestFastScanDispatchIntervalMultiplier:
         assert captured["fast_opts"]["template_downscale"] is True
         # Template should be downscaled by 2x in _dispatch
         assert captured["template_shape"] == (50, 100, 3)
+
+
+# ---------------------------------------------------------------------------
+# 2E: ffmpeg pipe extraction
+# ---------------------------------------------------------------------------
+
+
+class TestFfmpegPipeFrames:
+    def test_yields_frames_from_raw_bytes(self, monkeypatch):
+        """Generator yields correct (ts, frame) tuples from raw BGR pipe."""
+        w, h = 4, 2
+        # Two solid-color frames
+        frame1 = np.full((h, w, 3), 100, dtype=np.uint8)
+        frame2 = np.full((h, w, 3), 200, dtype=np.uint8)
+        raw = frame1.tobytes() + frame2.tobytes()
+
+        fake_proc = mock.MagicMock()
+        fake_proc.stdout = io.BytesIO(raw)
+        fake_proc.terminate = mock.MagicMock()
+        fake_proc.wait = mock.MagicMock()
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: fake_proc)
+
+        frames = list(
+            screenspace._ffmpeg_pipe_frames(
+                "/fake.mp4",
+                1.0,
+                start_seconds=5.0,
+                end_seconds=10.0,
+                frame_width=w,
+                frame_height=h,
+            )
+        )
+        assert len(frames) == 2
+        assert frames[0][0] == 5.0
+        assert frames[1][0] == 6.0
+        assert frames[0][1].shape == (h, w, 3)
+        assert np.all(frames[0][1] == 100)
+        assert np.all(frames[1][1] == 200)
+
+    def test_empty_when_no_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _: None)
+        frames = list(
+            screenspace._ffmpeg_pipe_frames(
+                "/fake.mp4", 1.0, frame_width=10, frame_height=10
+            )
+        )
+        assert frames == []
+
+
+class TestScanViaFfmpegPipe:
+    def test_returns_false_when_no_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _: None)
+        result = screenspace._scan_via_ffmpeg_pipe(
+            "/fake.mp4", None, 1.0, lambda ts, f: None, duration=10.0
+        )
+        assert result is False
+
+    def test_returns_false_when_probe_fails(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("video.probe_video_properties", lambda _: None)
+        result = screenspace._scan_via_ffmpeg_pipe(
+            "/fake.mp4", None, 1.0, lambda ts, f: None, duration=10.0
+        )
+        assert result is False
+
+    def test_calls_callback_with_frames(self, monkeypatch):
+        w, h = 4, 2
+        frame_data = np.full((h, w, 3), 42, dtype=np.uint8)
+        raw = frame_data.tobytes()
+
+        fake_proc = mock.MagicMock()
+        fake_proc.stdout = io.BytesIO(raw)
+        fake_proc.terminate = mock.MagicMock()
+        fake_proc.wait = mock.MagicMock()
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: fake_proc)
+        monkeypatch.setattr(
+            "video.probe_video_properties",
+            lambda _: {"width": w, "height": h, "video_codec": "h264"},
+        )
+
+        received = []
+
+        def cb(ts, frame):
+            received.append((ts, frame.copy()))
+
+        result = screenspace._scan_via_ffmpeg_pipe(
+            "/fake.mp4", None, 1.0, cb, duration=10.0, full_frame=True
+        )
+        assert result is True
+        assert len(received) == 1
+        assert received[0][0] == 0.0
+        assert np.all(received[0][1] == 42)
+
+    def test_builds_crop_filter_for_region(self, monkeypatch):
+        w, h = 8, 6
+        region = {"x": 1, "y": 2, "w": 4, "h": 3}
+
+        captured_cmd = {}
+
+        def fake_popen(cmd, **kw):
+            captured_cmd["args"] = cmd
+            proc = mock.MagicMock()
+            # Return empty bytes so the generator exits immediately
+            proc.stdout = io.BytesIO(b"")
+            proc.terminate = mock.MagicMock()
+            proc.wait = mock.MagicMock()
+            return proc
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+        monkeypatch.setattr(
+            "video.probe_video_properties",
+            lambda _: {"width": w, "height": h, "video_codec": "h264"},
+        )
+
+        screenspace._scan_via_ffmpeg_pipe(
+            "/fake.mp4", region, 1.0, lambda ts, f: None, duration=10.0
+        )
+
+        cmd_str = " ".join(captured_cmd["args"])
+        assert "crop=4:3:1:2" in cmd_str
+
+    def test_stops_on_callback_false(self, monkeypatch):
+        w, h = 4, 2
+        frame = np.full((h, w, 3), 1, dtype=np.uint8)
+        raw = frame.tobytes() * 5  # 5 frames
+
+        fake_proc = mock.MagicMock()
+        fake_proc.stdout = io.BytesIO(raw)
+        fake_proc.terminate = mock.MagicMock()
+        fake_proc.wait = mock.MagicMock()
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: fake_proc)
+        monkeypatch.setattr(
+            "video.probe_video_properties",
+            lambda _: {"width": w, "height": h, "video_codec": "h264"},
+        )
+
+        call_count = [0]
+
+        def cb(ts, frame):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                return False
+
+        result = screenspace._scan_via_ffmpeg_pipe(
+            "/fake.mp4", None, 1.0, cb, duration=10.0, full_frame=True
+        )
+        assert result is True
+        assert call_count[0] == 2
+
+
+class TestScanVideoFramesFfmpegIntegration:
+    def test_tries_ffmpeg_first_when_enabled(self, monkeypatch):
+        """With BATCH_EXTRACT=True and ffmpeg succeeding, cv2 is not used."""
+        monkeypatch.setattr(config, "SCREENSPACE_BATCH_EXTRACT", True)
+        monkeypatch.setattr(
+            screenspace,
+            "_scan_via_ffmpeg_pipe",
+            lambda *a, **kw: True,
+        )
+        cv2_called = [False]
+
+        def fake_cap(path):
+            cv2_called[0] = True
+            cap = mock.MagicMock()
+            cap.isOpened.return_value = False
+            return cap
+
+        monkeypatch.setattr(screenspace.cv2, "VideoCapture", fake_cap)
+
+        screenspace.scan_video_frames(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            1.0,
+            lambda ts, f: None,
+        )
+        assert cv2_called[0] is False
+
+    def test_falls_back_to_cv2_when_ffmpeg_fails(self, monkeypatch):
+        """With BATCH_EXTRACT=True but ffmpeg failing, cv2 path is entered."""
+        monkeypatch.setattr(config, "SCREENSPACE_BATCH_EXTRACT", True)
+        monkeypatch.setattr(
+            screenspace,
+            "_scan_via_ffmpeg_pipe",
+            lambda *a, **kw: False,
+        )
+        cv2_called = [False]
+
+        def fake_cap2(path):
+            cv2_called[0] = True
+            cap = mock.MagicMock()
+            cap.isOpened.return_value = False
+            return cap
+
+        monkeypatch.setattr(screenspace.cv2, "VideoCapture", fake_cap2)
+
+        screenspace.scan_video_frames(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            1.0,
+            lambda ts, f: None,
+        )
+        assert cv2_called[0] is True
+
+    def test_skipped_when_batch_extract_disabled(self, monkeypatch):
+        """With BATCH_EXTRACT=False, ffmpeg pipe is never attempted."""
+        monkeypatch.setattr(config, "SCREENSPACE_BATCH_EXTRACT", False)
+        pipe_called = [False]
+
+        def fake_pipe(*a, **kw):
+            pipe_called[0] = True
+            return True
+
+        monkeypatch.setattr(screenspace, "_scan_via_ffmpeg_pipe", fake_pipe)
+
+        # cv2 fallback — won't actually process since file doesn't exist
+        cap_mock = mock.MagicMock()
+        cap_mock.isOpened.return_value = False
+        monkeypatch.setattr(screenspace.cv2, "VideoCapture", lambda _: cap_mock)
+
+        screenspace.scan_video_frames(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            1.0,
+            lambda ts, f: None,
+        )
+        assert pipe_called[0] is False
+
+
+# ---------------------------------------------------------------------------
+# 2F: Parallel worker
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerParallel:
+    def test_two_tasks_run_concurrently(self, monkeypatch):
+        """With PARALLEL_WORKERS=2, two tasks reach RUNNING simultaneously."""
+        monkeypatch.setattr(config, "SCREENSPACE_PARALLEL_WORKERS", 2)
+
+        barrier = threading.Barrier(2, timeout=5)
+        reached_running = {"count": 0}
+
+        def slow_dispatch(self, task, on_progress, cancel_flag, on_result=None):
+            reached_running["count"] += 1
+            barrier.wait()  # both tasks must reach here
+            time.sleep(0.05)
+            return []
+
+        monkeypatch.setattr(screenspace.ScreenspaceWorker, "_dispatch", slow_dispatch)
+
+        worker = screenspace.ScreenspaceWorker()
+        worker.start()
+
+        t1 = screenspace.create_task(
+            "color",
+            "P01",
+            "s.mp4",
+            "/v.mp4",
+            "r1",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+        )
+        t2 = screenspace.create_task(
+            "color",
+            "P02",
+            "s.mp4",
+            "/v2.mp4",
+            "r2",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+        )
+        worker.enqueue(t1)
+        worker.enqueue(t2)
+
+        # Wait for both tasks to complete
+        for _ in range(100):
+            tasks = worker.get_all_tasks()
+            statuses = [t["status"] for t in tasks]
+            if all(s in ("completed", "failed") for s in statuses):
+                break
+            time.sleep(0.05)
+
+        worker.stop()
+        # Both tasks reached the barrier (ran concurrently)
+        assert reached_running["count"] == 2
+
+    def test_sequential_when_workers_1(self, monkeypatch):
+        """With PARALLEL_WORKERS=1, tasks execute one at a time."""
+        monkeypatch.setattr(config, "SCREENSPACE_PARALLEL_WORKERS", 1)
+
+        max_concurrent = {"value": 0, "current": 0}
+        lock = threading.Lock()
+
+        def counting_dispatch(self, task, on_progress, cancel_flag, on_result=None):
+            with lock:
+                max_concurrent["current"] += 1
+                max_concurrent["value"] = max(
+                    max_concurrent["value"], max_concurrent["current"]
+                )
+            time.sleep(0.1)
+            with lock:
+                max_concurrent["current"] -= 1
+            return []
+
+        monkeypatch.setattr(
+            screenspace.ScreenspaceWorker, "_dispatch", counting_dispatch
+        )
+
+        worker = screenspace.ScreenspaceWorker()
+        worker.start()
+
+        for i in range(3):
+            t = screenspace.create_task(
+                "color",
+                f"P0{i}",
+                "s.mp4",
+                f"/v{i}.mp4",
+                f"r{i}",
+                {"x": 0, "y": 0, "w": 1, "h": 1},
+            )
+            worker.enqueue(t)
+
+        for _ in range(100):
+            tasks = worker.get_all_tasks()
+            if all(t["status"] in ("completed", "failed") for t in tasks):
+                break
+            time.sleep(0.05)
+
+        worker.stop()
+        assert max_concurrent["value"] == 1
+
+    def test_parallel_pause_flags_all_running(self, monkeypatch):
+        """Pausing flags all running tasks."""
+        monkeypatch.setattr(config, "SCREENSPACE_PARALLEL_WORKERS", 2)
+
+        gate = threading.Event()
+
+        def blocking_dispatch(self, task, on_progress, cancel_flag, on_result=None):
+            gate.wait(timeout=5)
+            return []
+
+        monkeypatch.setattr(
+            screenspace.ScreenspaceWorker, "_dispatch", blocking_dispatch
+        )
+
+        worker = screenspace.ScreenspaceWorker()
+        worker.start()
+
+        t1 = screenspace.create_task(
+            "color",
+            "P01",
+            "s.mp4",
+            "/v.mp4",
+            "r1",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+        )
+        t2 = screenspace.create_task(
+            "color",
+            "P02",
+            "s.mp4",
+            "/v2.mp4",
+            "r2",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+        )
+        worker.enqueue(t1)
+        worker.enqueue(t2)
+
+        # Wait for both to be RUNNING
+        for _ in range(50):
+            tasks = worker.get_all_tasks()
+            running = [t for t in tasks if t["status"] == "running"]
+            if len(running) == 2:
+                break
+            time.sleep(0.05)
+
+        worker.pause()
+        # Check both have _paused_flag
+        with worker._lock:
+            for tid in [t1["id"], t2["id"]]:
+                assert worker._tasks[tid].get("_paused_flag") is True
+
+        gate.set()
+        worker.stop()
+
+
+class TestOcrReaderLock:
+    def test_ocr_lock_prevents_duplicate_creation(self, monkeypatch):
+        """Only one EasyOCR Reader is created even with concurrent calls."""
+        call_count = {"n": 0}
+        fake_reader = mock.MagicMock()
+
+        def fake_reader_init(languages, verbose=False):
+            call_count["n"] += 1
+            time.sleep(0.05)  # simulate slow init
+            return fake_reader
+
+        # Clear cache
+        screenspace._ocr_readers.clear()
+
+        mock_easyocr = mock.MagicMock()
+        mock_easyocr.Reader = fake_reader_init
+        monkeypatch.setitem(__import__("sys").modules, "easyocr", mock_easyocr)
+
+        threads = []
+        for _ in range(4):
+            t = threading.Thread(target=screenspace._get_ocr_reader, args=(["en"],))
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert call_count["n"] == 1
+        screenspace._ocr_readers.clear()
+
+
+# ---------------------------------------------------------------------------
+# Timelapse bug fixes
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTimelapseCommandMarkers:
+    def test_start_seconds_adds_ss_flag(self):
+        cmd = screenspace.build_timelapse_command(
+            "/video.mp4",
+            {"x": 0, "y": 0, "w": 100, "h": 100},
+            10.0,
+            "/out.mp4",
+            start_seconds=30.0,
+        )
+        ss_idx = cmd.index("-ss")
+        assert cmd[ss_idx + 1] == "30.0"
+        # -ss must appear before -i for fast seeking
+        i_idx = cmd.index("-i")
+        assert ss_idx < i_idx
+
+    def test_end_seconds_adds_t_flag(self):
+        cmd = screenspace.build_timelapse_command(
+            "/video.mp4",
+            {"x": 0, "y": 0, "w": 100, "h": 100},
+            10.0,
+            "/out.mp4",
+            start_seconds=10.0,
+            end_seconds=40.0,
+        )
+        t_idx = cmd.index("-t")
+        assert cmd[t_idx + 1] == "30.0"  # 40 - 10
+
+    def test_no_markers_omits_flags(self):
+        cmd = screenspace.build_timelapse_command(
+            "/video.mp4",
+            {"x": 0, "y": 0, "w": 100, "h": 100},
+            10.0,
+            "/out.mp4",
+        )
+        assert "-ss" not in cmd
+        assert "-t" not in cmd
+
+
+class TestGenerateTimelapseProgress:
+    def test_reports_progress_from_ffmpeg_output(self, monkeypatch):
+        """on_progress is called with values parsed from ffmpeg -progress."""
+        # Simulate ffmpeg -progress output with out_time_us lines
+        progress_output = (
+            b"out_time_us=0\n"
+            b"progress=continue\n"
+            b"out_time_us=5000000\n"
+            b"progress=continue\n"
+            b"out_time_us=10000000\n"
+            b"progress=end\n"
+        )
+
+        fake_proc = mock.MagicMock()
+        fake_proc.stdout = io.BytesIO(progress_output)
+        fake_proc.returncode = 0
+        fake_proc.wait = mock.MagicMock()
+
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: fake_proc)
+
+        progress_values = []
+
+        result = screenspace.generate_timelapse(
+            "/video.mp4",
+            {"x": 0, "y": 0, "w": 100, "h": 100},
+            10.0,
+            "/out.mp4",
+            start_seconds=0.0,
+            end_seconds=100.0,  # 100s input / 10x speedup = 10s output = 10_000_000 us
+            on_progress=lambda p: progress_values.append(round(p, 2)),
+        )
+
+        assert result == "/out.mp4"
+        # Should have: 0.0 (initial), 0.0 (out_time_us=0), 0.5 (5M/10M), 0.99 (capped)
+        assert 0.0 in progress_values
+        assert any(0.4 <= v <= 0.6 for v in progress_values)  # ~0.5 from 5M/10M
+        assert 1.0 in progress_values  # final
+
+    def test_cancel_flag_terminates_process(self, monkeypatch):
+        """cancel_flag=True stops ffmpeg and returns None."""
+        # Output enough lines so the loop iterates
+        progress_output = b"out_time_us=0\nprogress=continue\n" * 5
+
+        fake_proc = mock.MagicMock()
+        fake_proc.stdout = io.BytesIO(progress_output)
+        fake_proc.returncode = -15  # SIGTERM
+        fake_proc.wait = mock.MagicMock()
+        fake_proc.terminate = mock.MagicMock()
+
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: fake_proc)
+
+        result = screenspace.generate_timelapse(
+            "/video.mp4",
+            {"x": 0, "y": 0, "w": 100, "h": 100},
+            10.0,
+            "/out.mp4",
+            start_seconds=0.0,
+            end_seconds=100.0,
+            cancel_flag=lambda: True,
+        )
+
+        assert result is None
+        fake_proc.terminate.assert_called_once()
+
+
+class TestTimelapseDispatchPassesMarkers:
+    def test_dispatch_forwards_start_end_to_timelapse(self, monkeypatch):
+        """_dispatch passes start_seconds and end_seconds to generate_timelapse."""
+        captured = {}
+
+        def fake_generate(
+            video_path, region, speedup_factor, output_path, output_format="mp4", **kw
+        ):
+            captured.update(kw)
+            return output_path
+
+        monkeypatch.setattr(screenspace, "generate_timelapse", fake_generate)
+
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "timelapse",
+            "P01",
+            "s_P01.mp4",
+            "/fake.mp4",
+            "region1",
+            {"x": 0, "y": 0, "w": 100, "h": 100},
+            parameters={
+                "speedup_factor": 5.0,
+                "start_seconds": 15.0,
+                "end_seconds": 45.0,
+            },
+        )
+        worker._dispatch(task, lambda p: None, lambda: False, None)
+
+        assert captured["start_seconds"] == 15.0
+        assert captured["end_seconds"] == 45.0
+        assert captured["on_progress"] is not None
+        assert captured["cancel_flag"] is not None

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -652,6 +652,13 @@ class TestScreenspaceWorker:
             t = worker.get_task(t2["id"])
             assert t is not None
             assert t["status"] in ("completed", "failed")
+            # on_task_complete fires in the _run loop after the future is
+            # collected, which may lag behind the task status change.
+            # Wait for the callback to actually fire for task 2.
+            for _ in range(20):
+                if call_count["n"] >= 2:
+                    break
+                time.sleep(0.1)
             assert call_count["n"] >= 2
         finally:
             worker.stop()

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -741,3 +741,43 @@ def _create_region(client, name, x=100, y=20, w=300, h=30):
             "canvas_height": 1080,
         },
     )
+
+
+# ---- VideoCapture pool size (4D) ----
+
+
+def test_video_cap_pool_uses_config(monkeypatch):
+    """Eviction respects config.SCREENSPACE_VIDEO_CAP_POOL_SIZE."""
+    from collections import OrderedDict
+    from unittest import mock
+
+    monkeypatch.setattr(config, "SCREENSPACE_VIDEO_CAP_POOL_SIZE", 2)
+
+    # Replace module-level cache with a fresh one
+    original_cache = screenspace_server._video_cap_cache
+    screenspace_server._video_cap_cache = OrderedDict()
+
+    try:
+        fake_caps = {}
+
+        def fake_videocapture(path):
+            cap = mock.MagicMock()
+            cap.isOpened.return_value = True
+            fake_caps[path] = cap
+            return cap
+
+        monkeypatch.setattr("cv2.VideoCapture", fake_videocapture)
+
+        # Open 3 captures with pool size of 2
+        screenspace_server._get_video_cap("/a.mp4")
+        screenspace_server._get_video_cap("/b.mp4")
+        screenspace_server._get_video_cap("/c.mp4")
+
+        # Pool should have evicted the oldest (/a.mp4)
+        assert len(screenspace_server._video_cap_cache) == 2
+        assert "/a.mp4" not in screenspace_server._video_cap_cache
+        assert "/b.mp4" in screenspace_server._video_cap_cache
+        assert "/c.mp4" in screenspace_server._video_cap_cache
+        fake_caps["/a.mp4"].release.assert_called_once()
+    finally:
+        screenspace_server._video_cap_cache = original_cache

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -94,6 +94,9 @@ def test_probe_video_properties_parses_output(monkeypatch):
         "height": 1080,
         "video_codec": "h264",
         "audio_codec": "aac",
+        "fps": 0.0,
+        "duration": 0.0,
+        "nb_frames": 0,
     }
 
 
@@ -238,7 +241,7 @@ def test_concatenate_clips_warns_on_mismatch(monkeypatch):
     warnings = []
     original_warning = video.utils.warning_print
 
-    def capture_warning(msg: str, details: list[str] | None = None):
+    def capture_warning(msg, details=None):
         warnings.append(msg)
         original_warning(msg, details)
 

--- a/video.py
+++ b/video.py
@@ -599,11 +599,14 @@ def get_file_duration(filepath: str) -> Optional[int]:
 
 
 def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
-    """Probe video file for stream properties (resolution, codecs).
+    """Probe video file for stream properties (resolution, codecs, timing).
 
     Returns:
         Dict with 'width' (int), 'height' (int), 'video_codec' (str),
-        'audio_codec' (str or None if no audio stream), or None if probe fails.
+        'audio_codec' (str or None if no audio stream),
+        'fps' (float, 0.0 if unknown), 'duration' (float seconds, 0.0 if unknown),
+        'nb_frames' (int, 0 if unknown),
+        or None if probe fails.
     """
     if config.DEBUGGING:
         return {
@@ -611,6 +614,9 @@ def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
             "height": 1080,
             "video_codec": "h264",
             "audio_codec": "aac",
+            "fps": 30.0,
+            "duration": 300.0,
+            "nb_frames": 9000,
         }
 
     resolved = str(Path(filepath).resolve())
@@ -625,7 +631,9 @@ def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
         "-v",
         "error",
         "-show_entries",
-        "stream=width,height,codec_name,codec_type",
+        "stream=width,height,codec_name,codec_type,r_frame_rate,nb_frames",
+        "-show_entries",
+        "format=duration",
         "-of",
         "json",
         filepath,
@@ -644,23 +652,49 @@ def probe_video_properties(filepath: str) -> Optional[Dict[str, Any]]:
     width = height = 0
     video_codec: Optional[str] = None
     audio_codec: Optional[str] = None
+    fps = 0.0
+    nb_frames = 0
     for stream in streams:
         codec_type = stream.get("codec_type", "")
         if codec_type == "video" and video_codec is None:
             width = int(stream.get("width", 0))
             height = int(stream.get("height", 0))
             video_codec = stream.get("codec_name")
+            # Parse r_frame_rate (e.g. "30/1", "30000/1001")
+            rfr = stream.get("r_frame_rate", "")
+            if "/" in rfr:
+                parts = rfr.split("/")
+                try:
+                    num, den = float(parts[0]), float(parts[1])
+                    fps = num / den if den > 0 else 0.0
+                except (ValueError, IndexError):
+                    pass
+            nb_frames = int(stream.get("nb_frames", 0) or 0)
         elif codec_type == "audio" and audio_codec is None:
             audio_codec = stream.get("codec_name")
 
     if not video_codec or width <= 0 or height <= 0:
         return None
 
+    # Duration from format-level metadata (more reliable than stream-level)
+    fmt_duration = 0.0
+    fmt = data.get("format", {})
+    try:
+        fmt_duration = float(fmt.get("duration", 0))
+    except (ValueError, TypeError):
+        pass
+    # Fallback: compute from frame count and fps
+    if fmt_duration <= 0 and nb_frames > 0 and fps > 0:
+        fmt_duration = nb_frames / fps
+
     result = {
         "width": width,
         "height": height,
         "video_codec": video_codec,
         "audio_codec": audio_codec,
+        "fps": fps,
+        "duration": fmt_duration,
+        "nb_frames": nb_frames,
     }
     _video_properties_cache[resolved] = result
     return result


### PR DESCRIPTION
## Summary

- **Batch frame extraction (2E):** Screenspace analysis now extracts frames via an ffmpeg pipe (`-f rawvideo -pix_fmt bgr24 pipe:1`) instead of per-frame cv2 seeking, with automatic cv2 fallback when ffmpeg is unavailable. Replaced 9 cv2 metadata-only opens with a shared `_probe_video_meta()` helper backed by ffprobe.
- **Parallel task execution (2F):** `ScreenspaceWorker._run()` rewritten to use `ThreadPoolExecutor` (configurable via `SCREENSPACE_PARALLEL_WORKERS`, default 2), enabling concurrent analysis of independent regions. Added thread-safety locks for OCR reader cache and manifest persistence.
- **VideoCapture pool size (4D):** Pool increased from hardcoded 3 to configurable 6 via `SCREENSPACE_VIDEO_CAP_POOL_SIZE` in config.
- **Timelapse improvements:** Real-time progress reporting via ffmpeg `-progress pipe:1`, in/out timeline marker support, configurable `sample_interval` parameter (UI + backend), and fast scan exclusion (hidden toggle, skipped in dispatch).
- **Expanded `probe_video_properties()`** to return `fps`, `duration`, and `nb_frames` from ffprobe.

## Test plan

- [ ] Verify `uv run pytest -c tests/pytest.ini` passes (excluding cv2-dependent tests on CI)
- [ ] Run a Screenspace analysis and confirm faster frame extraction via ffmpeg pipe
- [ ] Queue 2+ tasks simultaneously and verify parallel execution in Task Queue
- [ ] Run a timelapse with in/out markers and sample_interval > 0, confirm progress updates and correct output
- [ ] Confirm fast scan toggle is hidden when timelapse is selected