### PR TITLE
Keep Screenspace stash cards after restore

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1223,7 +1223,6 @@
       state.regions = data.regions || {};
       state.activeRegion = null;
       state.pendingRegion = null;
-      state.stashes = state.stashes.filter(function (s) { return s.id !== stashId; });
       renderRegionChips();
       renderOverlay();
       updateRegionButtons();

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -450,7 +450,7 @@ def api_stashes_delete(stash_id: str) -> FlaskResponse:
 
 @screenspace_bp.route("/api/stashes/<stash_id>/restore", methods=["POST"])
 def api_stashes_restore(stash_id: str) -> FlaskResponse:
-    """Restore a stash: replace active regions with stashed ones, remove stash."""
+    """Restore a stash: replace active regions with stashed ones (stash is kept)."""
     stashes = _manifest.get("stashes", [])
     idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
     if idx is None:
@@ -458,7 +458,7 @@ def api_stashes_restore(stash_id: str) -> FlaskResponse:
 
     import screenspace
 
-    stash = stashes.pop(idx)
+    stash = stashes[idx]
     _manifest["regions"] = copy.deepcopy(stash["regions"])
     screenspace.save_screenspace_manifest(
         _manifest["regions"],


### PR DESCRIPTION
Stash cards were previously consumed (removed) when restoring a stash. Now they persist after restore and require manual dismissal via the dismiss button. This lets users restore the same stash multiple times without re-creating it.

Backend: the restore endpoint reads the stash without popping it from the manifest list. Frontend: the client no longer filters the stash out of state after restore.