### PR TITLE
Prevent text selection in Studio Sheet Preview grid

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -447,6 +447,7 @@ body {
   overflow: auto;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
+  user-select: none;
 }
 
 #sheetGrid table {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1273,6 +1273,10 @@
   function bindGridEvents() {
     var grid = qs("#sheetGrid");
 
+    grid.addEventListener("selectstart", function (ev) {
+      ev.preventDefault();
+    });
+
     grid.addEventListener("click", function (ev) {
       // Batch select: click # header
       var batchTh = ev.target.closest(".col-row-num-header");


### PR DESCRIPTION
Shift-clicking cells in the Sheet Preview to add clips to the Reels queue triggered unwanted browser text selection on observation, category, and severity columns. This adds `user-select: none` on `#sheetGrid` and a `selectstart` event listener to fully suppress selection from shift-clicks, double-clicks, and multi-clicks within the grid. Text selection elsewhere on the page is unaffected.