### PR TITLE
Compact Screenspace tool controls with hover tooltips

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -646,7 +646,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow: hidden;
 }
 
 #workflowTabs {
@@ -756,6 +755,8 @@ body {
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
+  padding-top: var(--space-3);
+  flex-shrink: 0;
 }
 
 #runBtn {
@@ -767,15 +768,41 @@ body {
 }
 
 #workflowIntervalSlot {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 2px;
   font-size: var(--text-xs);
   color: var(--color-text-dim);
 }
 
+.interval-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-right: none;
+  border-radius: calc(var(--radius) - 2px) 0 0 calc(var(--radius) - 2px);
+  flex-shrink: 0;
+}
+
+.interval-icon-mask {
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: var(--color-text-dim);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
 #workflowIntervalSlot .param-control input[type="number"] {
-  width: 3.5rem;
+  width: 3rem;
+  height: 28px;
+  border-radius: 0 calc(var(--radius) - 2px) calc(var(--radius) - 2px) 0;
+  text-align: center;
 }
 
 /* Run participant picker */
@@ -887,6 +914,44 @@ body {
   -webkit-mask-size: contain;
   -webkit-mask-repeat: no-repeat;
   flex-shrink: 0;
+}
+
+.scan-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.scan-toggle-btn:hover {
+  background: var(--color-surface-alt);
+}
+
+.scan-toggle-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+  background: var(--color-text-dim);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+.scan-toggle-btn.active {
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent);
+  border-color: var(--color-warning, #f59e0b);
+}
+
+.scan-toggle-btn.active .scan-toggle-icon {
+  background: var(--color-warning, #f59e0b);
 }
 
 .task-fast-badge {
@@ -1369,6 +1434,35 @@ body {
 }
 
 .btn[data-tooltip]:disabled:hover::after {
+  opacity: 1;
+}
+
+/* Generic hover tooltip (excludes .btn which has its own disabled tooltip) */
+
+[data-tooltip]:not(.btn) {
+  position: relative;
+}
+
+[data-tooltip]:not(.btn)::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-text);
+  color: var(--color-bg);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  white-space: nowrap;
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+  z-index: var(--z-float);
+}
+
+[data-tooltip]:not(.btn):hover::after {
   opacity: 1;
 }
 

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -123,20 +123,20 @@
           Scene
         </button>
       </div>
+      <div id="workflowActionRow">
+        <button id="toolInfoBtn" class="tool-info-btn"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1C11.866 1 15 4.13401 15 8ZM9 5C9 5.55228 8.55228 6 8 6C7.44772 6 7 5.55228 7 5C7 4.44772 7.44772 4 8 4C8.55228 4 9 4.44772 9 5ZM6.75 8C6.33579 8 6 8.33579 6 8.75C6 9.16421 6.33579 9.5 6.75 9.5H7.5V11.25C7.5 11.6642 7.83579 12 8.25 12C8.66421 12 9 11.6642 9 11.25V8.75C9 8.33579 8.66421 8 8.25 8H6.75Z"/></svg></button>
+        <div id="runParticipantPicker" class="run-picker-wrap"></div>
+        <div id="workflowIntervalSlot"></div>
+        <div id="runRegionPicker" class="run-picker-wrap"></div>
+        <div id="runScanModePicker"></div>
+        <button id="runBtn" class="btn btn-primary btn-icon" disabled data-tooltip="Select a region first">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M3 3.732a1 1 0 0 1 1.514-.857l8.07 4.268a1 1 0 0 1 0 1.714l-8.07 4.268A1 1 0 0 1 3 12.268V3.732Z"/>
+          </svg>
+          Run
+        </button>
+      </div>
       <div id="workflowBody">
-        <div id="workflowActionRow">
-          <button id="toolInfoBtn" class="tool-info-btn"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1C11.866 1 15 4.13401 15 8ZM9 5C9 5.55228 8.55228 6 8 6C7.44772 6 7 5.55228 7 5C7 4.44772 7.44772 4 8 4C8.55228 4 9 4.44772 9 5ZM6.75 8C6.33579 8 6 8.33579 6 8.75C6 9.16421 6.33579 9.5 6.75 9.5H7.5V11.25C7.5 11.6642 7.83579 12 8.25 12C8.66421 12 9 11.6642 9 11.25V8.75C9 8.33579 8.66421 8 8.25 8H6.75Z"/></svg></button>
-          <div id="runParticipantPicker" class="run-picker-wrap"></div>
-          <div id="workflowIntervalSlot"></div>
-          <div id="runRegionPicker" class="run-picker-wrap"></div>
-          <div id="runScanModePicker" class="run-picker-wrap"></div>
-          <button id="runBtn" class="btn btn-primary btn-icon" disabled data-tooltip="Select a region first">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M3 3.732a1 1 0 0 1 1.514-.857l8.07 4.268a1 1 0 0 1 0 1.714l-8.07 4.268A1 1 0 0 1 3 12.268V3.732Z"/>
-            </svg>
-            Run
-          </button>
-        </div>
         <div id="workflowParams"></div>
       </div>
     </section>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -573,53 +573,29 @@
     if (!wrap) return;
     wrap.innerHTML = "";
 
-    var btn = el("button", "run-picker-btn");
+    var btn = document.createElement("button");
     btn.type = "button";
+    btn.className = "scan-toggle-btn";
 
-    function updateBtn() {
-      btn.innerHTML = "";
+    var icon = el("span", "scan-toggle-icon");
+    var url = 'url("/screenspace/icons/chevron-double-right.svg")';
+    icon.style.maskImage = url;
+    icon.style.webkitMaskImage = url;
+    btn.appendChild(icon);
+
+    function updateState() {
       var isFast = state.scanMode === "fast";
-      if (isFast) {
-        var icon = el("span", "scan-mode-fast-icon");
-        var url = 'url("/screenspace/icons/chevron-double-right.svg")';
-        icon.style.maskImage = url;
-        icon.style.webkitMaskImage = url;
-        btn.appendChild(icon);
-      }
-      btn.appendChild(el("span", "run-picker-btn-text", isFast ? "Fast" : "Normal"));
-      var chev = el("span", "chevron");
-      chev.appendChild(svgChevronDownIcon());
-      btn.appendChild(chev);
+      btn.classList.toggle("active", isFast);
+      btn.setAttribute("data-tooltip", isFast ? "Fast scan enabled" : "Enable fast scan");
     }
-    updateBtn();
+    updateState();
 
-    var panel = el("div", "run-picker-panel hidden");
-    ["normal", "fast"].forEach(function (mode) {
-      var lbl = document.createElement("label");
-      var rb = document.createElement("input");
-      rb.type = "radio";
-      rb.name = "scanMode";
-      rb.value = mode;
-      rb.checked = state.scanMode === mode;
-      rb.addEventListener("change", function () {
-        state.scanMode = mode;
-        updateBtn();
-        closeRunPicker();
-      });
-      lbl.appendChild(rb);
-      lbl.appendChild(document.createTextNode(mode === "fast" ? "Fast" : "Normal"));
-      panel.appendChild(lbl);
-    });
-
-    btn.addEventListener("click", function (e) {
-      e.stopPropagation();
-      var open = !panel.classList.contains("hidden");
-      panel.classList.toggle("hidden", open);
-      btn.classList.toggle("open", !open);
+    btn.addEventListener("click", function () {
+      state.scanMode = state.scanMode === "fast" ? "normal" : "fast";
+      updateState();
     });
 
     wrap.appendChild(btn);
-    wrap.appendChild(panel);
   }
 
   function selectParticipant(pid, initialTimestamp) {
@@ -2115,7 +2091,14 @@
     var slot = qs("#workflowIntervalSlot");
     if (!slot) return;
     slot.innerHTML = "";
-    slot.appendChild(el("span", null, "Interval\u202f(s)"));
+    slot.setAttribute("data-tooltip", "Interval (seconds)");
+    var iconWrap = el("div", "interval-icon");
+    var iconMask = el("span", "interval-icon-mask");
+    var clockUrl = 'url("/screenspace/icons/clock.svg")';
+    iconMask.style.maskImage = clockUrl;
+    iconMask.style.webkitMaskImage = clockUrl;
+    iconWrap.appendChild(iconMask);
+    slot.appendChild(iconWrap);
     var ctrl = el("div", "param-control");
     ctrl.appendChild(numberInput(inputId, min, max, def, step));
     slot.appendChild(ctrl);

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.15"
+VERSIONNUM: str = "0.10.16"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Replace Fast Scan dropdown picker with a small icon toggle button (chevron-double-right icon, warning-colored active state)
- Replace Interval label+input with a compact clock-icon-prefixed number input (no text label)
- Add generic `[data-tooltip]` CSS hover tooltips for non-button elements, reusing existing tooltip styling tokens
- Move `#workflowActionRow` out of the `overflow: hidden` `#workflowBody` container so tooltips render unclipped above the tool selection bar

## Test plan

- [ ] Open Screenspace, verify Fast Scan appears as a small icon toggle (not a dropdown)
- [ ] Click toggle — confirm it flips between active/inactive states and updates `state.scanMode`
- [ ] Hover toggle and interval — confirm tooltips appear above, not clipped
- [ ] Switch to timelapse tool — fast scan toggle should be hidden
- [ ] Run a task with fast scan on — verify `scan_mode=fast` is sent
- [ ] Verify disabled Run button tooltip still works correctly (right-aligned)