### PR TITLE
Add parallel clip cutting via ThreadPoolExecutor (#3A)

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -854,8 +854,9 @@ def process_clips(
     # -- Phase 2: Execute ffmpeg work ------------------------------------------
     workers = _resolve_clip_workers()
     use_parallel = workers >= 2 and len(prepared) >= 2
+    _EMPTY_RESULT: Tuple[int, List[Tuple[str, str, str]]] = (0, [])
     # Pre-allocate results in original order for deterministic artifact output
-    results: List[Optional[Tuple[int, List[Tuple[str, str, str]]]]] = [None] * len(
+    results: List[Tuple[int, List[Tuple[str, str, str]]]] = [_EMPTY_RESULT] * len(
         prepared
     )
 
@@ -971,7 +972,7 @@ def process_clips(
     outputs_skipped = skipped_no_times + skipped_no_video
 
     for idx, (clip, base_video) in enumerate(prepared):
-        generated_count, segment_details = results[idx]  # type: ignore[misc]
+        generated_count, segment_details = results[idx]
         outputs_generated += generated_count
         if generated_count < len(clip["times"]):
             outputs_skipped += len(clip["times"]) - generated_count
@@ -984,9 +985,9 @@ def process_clips(
 
     if config.TRANSCRIBE_ENABLED:
         transcribe_items = [
-            (clip, base_video, results[idx][1])  # type: ignore[index]
+            (clip, base_video, results[idx][1])
             for idx, (clip, base_video) in enumerate(prepared)
-            if results[idx] and results[idx][1]  # type: ignore[index]
+            if results[idx][1]
         ]
         if transcribe_items:
             progress = utils.create_progress_bar()

--- a/clipgen.py
+++ b/clipgen.py
@@ -14,8 +14,10 @@ This script supports full unicode/UTF-8 for international characters in:
 - File paths
 """
 
+import concurrent.futures
 import difflib
 import hashlib
+import os
 import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -445,6 +447,14 @@ def _is_excel_worksheet(worksheet: Any) -> bool:
 # ---- Clip processing pipeline ----
 
 
+def _resolve_clip_workers() -> int:
+    """Return the effective parallel worker count for clip generation."""
+    workers = config.CLIP_PARALLEL_WORKERS
+    if workers <= 0:
+        workers = min(4, os.cpu_count() or 1)
+    return workers
+
+
 def _check_source_video(
     clip: ClipRecord,
     missing_videos: Set[str],
@@ -771,76 +781,249 @@ def process_clips(
 ) -> Tuple[int, List[Dict[str, Any]]]:
     """Process and generate outputs from the clips list.
 
+    Uses a three-phase approach:
+    1. Sequential preparation (user prompts, fuzzy video matching)
+    2. Parallel ffmpeg execution via ThreadPoolExecutor (when workers >= 2)
+    3. Sequential post-processing (artifact records, transcription)
+
     Returns:
         Tuple of (count of files generated, list of artifact records).
     """
     if config.DEBUGGING:
         ic(len(clips_list))
 
+    if not clips_list:
+        utils.warning_print(
+            "No clips to process. No timestamps were found or selected."
+        )
+        return (0, [])
+
+    utils.standard_print(
+        "\n* ffmpeg is set to never prompt for input and will always overwrite.\n"
+        "  Only warns if close to crashing.\n"
+    )
+
     all_artifacts: List[Dict[str, Any]] = []
     fuzzy_matches: Dict[str, Optional[str]] = {}
     transcript_cache: Dict[str, Any] = {}
+    missing_videos: Set[str] = set()
 
-    def _update_secondary(description: str) -> None:
-        if _active_progress is not None and _active_secondary_task is not None:
-            _active_progress.update(_active_secondary_task, description=description)
+    # -- Phase 1: Sequential preparation (handles user prompts) ---------------
+    prepared: List[Tuple[ClipRecord, str]] = []
+    skipped_no_times = 0
+    skipped_no_video = 0
 
-    def _advance_secondary() -> None:
-        if _active_progress is not None and _active_secondary_task is not None:
-            _active_progress.update(_active_secondary_task, advance=1)
+    global _active_progress, _active_secondary_task
+    progress = utils.create_progress_bar()
+    if progress:
+        _active_progress = progress
+        with progress:
+            prep_task = progress.add_task("Preparing clips", total=len(clips_list))
+            for clip in clips_list:
+                clip, base_video = _prepare_and_check_clip(
+                    clip, missing_videos, fuzzy_matches
+                )
+                if not clip["times"]:
+                    skipped_no_times += 1
+                elif base_video is None:
+                    skipped_no_video += len(clip["times"])
+                else:
+                    prepared.append((clip, base_video))
+                progress.update(prep_task, advance=1)
+        _active_progress = None
+    else:
+        for clip in clips_list:
+            clip, base_video = _prepare_and_check_clip(
+                clip, missing_videos, fuzzy_matches
+            )
+            if not clip["times"]:
+                skipped_no_times += 1
+            elif base_video is None:
+                skipped_no_video += len(clip["times"])
+            else:
+                prepared.append((clip, base_video))
 
-    def process_single_clip(clip: Any, missing_videos: Set[str]) -> Tuple[int, int]:
-        """Process a single clip and return (generated, skipped)."""
-        clip, base_video = _prepare_and_check_clip(clip, missing_videos, fuzzy_matches)
-        if not clip["times"]:
-            _advance_secondary()
-            return (0, 1)
-        if base_video is None:
-            _advance_secondary()
-            return (0, len(clip["times"]))
-
-        generated_count, segment_details = _process_single_clip_segments(
-            clip,
-            base_video,
-            missing_videos,
-            output_format=output_format,
-            collect_paths=True,
-            include_severity=include_severity,
+    if not prepared:
+        utils.warning_print(
+            "No clips to process. No timestamps were found or selected."
         )
+        if missing_videos:
+            utils.standard_print(f"* Missing source video files: {len(missing_videos)}")
+        return (0, [])
+
+    # -- Phase 2: Execute ffmpeg work ------------------------------------------
+    workers = _resolve_clip_workers()
+    use_parallel = workers >= 2 and len(prepared) >= 2
+    # Pre-allocate results in original order for deterministic artifact output
+    results: List[Optional[Tuple[int, List[Tuple[str, str, str]]]]] = [None] * len(
+        prepared
+    )
+
+    if use_parallel:
+        progress = utils.create_progress_bar()
+        if progress:
+            with progress:
+                cut_task = progress.add_task("Processing clips", total=len(prepared))
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=workers,
+                ) as pool:
+                    future_to_idx = {
+                        pool.submit(
+                            _process_single_clip_segments,
+                            clip,
+                            base_video,
+                            missing_videos,
+                            output_format=output_format,
+                            collect_paths=True,
+                            include_severity=include_severity,
+                        ): idx
+                        for idx, (clip, base_video) in enumerate(prepared)
+                    }
+                    for future in concurrent.futures.as_completed(future_to_idx):
+                        idx = future_to_idx[future]
+                        try:
+                            results[idx] = future.result()
+                        except Exception as exc:
+                            clip, _ = prepared[idx]
+                            desc = (clip.get("desc") or "")[
+                                : config.PROGRESS_DESCRIPTION_LENGTH
+                            ]
+                            utils.error_print(
+                                f"Clip failed: [{clip.get('participant', '')}] {desc}",
+                                [str(exc)],
+                            )
+                            results[idx] = (0, [])
+                        progress.update(cut_task, advance=1)
+        else:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=workers,
+            ) as pool:
+                future_to_idx = {
+                    pool.submit(
+                        _process_single_clip_segments,
+                        clip,
+                        base_video,
+                        missing_videos,
+                        output_format=output_format,
+                        collect_paths=True,
+                        include_severity=include_severity,
+                    ): idx
+                    for idx, (clip, base_video) in enumerate(prepared)
+                }
+                for future in concurrent.futures.as_completed(future_to_idx):
+                    idx = future_to_idx[future]
+                    try:
+                        results[idx] = future.result()
+                    except Exception as exc:
+                        clip, _ = prepared[idx]
+                        desc = (clip.get("desc") or "")[
+                            : config.PROGRESS_DESCRIPTION_LENGTH
+                        ]
+                        utils.error_print(
+                            f"Clip failed: [{clip.get('participant', '')}] {desc}",
+                            [str(exc)],
+                        )
+                        results[idx] = (0, [])
+    else:
+        # Sequential execution (workers=1 or single clip)
+        progress = utils.create_progress_bar()
+        if progress:
+            with progress:
+                cut_task = progress.add_task("Processing clips", total=len(prepared))
+                for idx, (clip, base_video) in enumerate(prepared):
+                    desc_preview = (clip.get("desc") or "")[
+                        : config.PROGRESS_DESCRIPTION_LENGTH
+                    ]
+                    participant = clip.get("participant", "")
+                    progress.update(
+                        cut_task,
+                        description=f"[{participant}] {desc_preview}...",
+                    )
+                    results[idx] = _process_single_clip_segments(
+                        clip,
+                        base_video,
+                        missing_videos,
+                        output_format=output_format,
+                        collect_paths=True,
+                        include_severity=include_severity,
+                    )
+                    progress.update(cut_task, advance=1)
+        else:
+            for idx, (clip, base_video) in enumerate(prepared):
+                if (
+                    getattr(config, "VERBOSITY", config.STANDARD) >= config.VERBOSE
+                    and len(prepared) > 1
+                ):
+                    utils.verbose_print(
+                        f"Processing clip {idx + 1} of {len(prepared)}..."
+                    )
+                results[idx] = _process_single_clip_segments(
+                    clip,
+                    base_video,
+                    missing_videos,
+                    output_format=output_format,
+                    collect_paths=True,
+                    include_severity=include_severity,
+                )
+
+    # -- Phase 3: Build artifacts and transcribe (sequential) ------------------
+    outputs_generated = 0
+    outputs_skipped = skipped_no_times + skipped_no_video
+
+    for idx, (clip, base_video) in enumerate(prepared):
+        generated_count, segment_details = results[idx]  # type: ignore[misc]
+        outputs_generated += generated_count
+        if generated_count < len(clip["times"]):
+            outputs_skipped += len(clip["times"]) - generated_count
         if segment_details:
             all_artifacts.extend(
                 viewer.build_artifact_records_for_clip(
                     clip, base_video, segment_details, output_format
                 )
             )
-            if config.TRANSCRIBE_ENABLED:
-                participant = clip.get("participant", "")
-                desc_preview = (clip.get("desc") or "")[
-                    : config.PROGRESS_DESCRIPTION_LENGTH
-                ]
-                _update_secondary(f"[{participant}] {desc_preview}...")
-                _transcribe_segments(
-                    clip, base_video, segment_details, all_artifacts, transcript_cache
-                )
-        _advance_secondary()
-        skipped_count = (
-            len(clip["times"]) - generated_count
-            if generated_count < len(clip["times"])
-            else 0
-        )
-        return (generated_count, skipped_count)
 
-    results, _ = _run_clip_pipeline(
-        clips_list,
-        empty_warning="No clips to process. No timestamps were found or selected.",
-        intro_message="\n* ffmpeg is set to never prompt for input and will always overwrite.\n  Only warns if close to crashing.\n",
-        task_label="Processing clips",
-        per_clip_fn=process_single_clip,
-        show_fallback_counter=True,
-        secondary_task_label="Transcribing" if config.TRANSCRIBE_ENABLED else None,
-    )
-    outputs_generated = sum(generated_count for generated_count, _ in results)
-    outputs_skipped = sum(skipped_count for _, skipped_count in results)
+    if config.TRANSCRIBE_ENABLED:
+        transcribe_items = [
+            (clip, base_video, results[idx][1])  # type: ignore[index]
+            for idx, (clip, base_video) in enumerate(prepared)
+            if results[idx] and results[idx][1]  # type: ignore[index]
+        ]
+        if transcribe_items:
+            progress = utils.create_progress_bar()
+            if progress:
+                with progress:
+                    t_task = progress.add_task(
+                        "Transcribing", total=len(transcribe_items)
+                    )
+                    for clip, base_video, segment_details in transcribe_items:
+                        desc_preview = (clip.get("desc") or "")[
+                            : config.PROGRESS_DESCRIPTION_LENGTH
+                        ]
+                        participant = clip.get("participant", "")
+                        progress.update(
+                            t_task,
+                            description=f"[{participant}] {desc_preview}...",
+                        )
+                        _transcribe_segments(
+                            clip,
+                            base_video,
+                            segment_details,
+                            all_artifacts,
+                            transcript_cache,
+                        )
+                        progress.update(t_task, advance=1)
+            else:
+                for clip, base_video, segment_details in transcribe_items:
+                    _transcribe_segments(
+                        clip,
+                        base_video,
+                        segment_details,
+                        all_artifacts,
+                        transcript_cache,
+                    )
+
+    if missing_videos:
+        utils.standard_print(f"* Missing source video files: {len(missing_videos)}")
 
     item_name = {
         "clip": "video(s)",

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.15"
+VERSIONNUM: str = "0.10.16"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -98,6 +98,7 @@ GALLERY_GIF_DURATION_SECONDS: int = 3  # Default per-GIF duration in gallery mod
 GALLERY_PARALLEL_WORKERS: int = (
     4  # Max concurrent ffmpeg processes for gallery GIF extraction
 )
+CLIP_PARALLEL_WORKERS: int = 0  # Max concurrent ffmpeg processes for clip/screenshot/GIF generation; 0 = auto (min(4, cpu_count))
 MAX_FILESIZE_MB: int = 0  # Maximum output file size in MB (0 = disabled)
 MIN_SOURCE_VIDEO_SIZE_MB: int = 100  # Minimum file size (MB) to consider as a source video candidate during fuzzy matching
 MANIFEST_FILENAME: str = "clipgen_manifest.json"  # cumulative artifact manifest; consumed by Insights Builder and --regenerate
@@ -246,6 +247,7 @@ SETTINGS_DESCRIPTIONS: Dict[str, str] = {
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
     "FILMSTRIP_ENABLED": "Show thumbnail images on timeline markers instead of solid colors (in the HTML viewer).",
+    "CLIP_PARALLEL_WORKERS": "Number of concurrent ffmpeg processes for clip generation. 0 = auto, 1 = sequential.",
 }
 
 # Studio-exposed settings with UI metadata (group, type, constraints).
@@ -285,5 +287,11 @@ STUDIO_SETTINGS: Dict[str, Dict[str, Any]] = {
         "step": 10,
     },
     "MANIFEST_ENABLED": {"group": "Generation", "type": "bool"},
+    "CLIP_PARALLEL_WORKERS": {
+        "group": "Generation",
+        "type": "int",
+        "min": 0,
+        "step": 1,
+    },
     "STUDIO_CELL_EXPAND_HOVER": {"group": "Sheet Preview", "type": "bool"},
 }

--- a/plans/PERFORMANCE-PLAN.md
+++ b/plans/PERFORMANCE-PLAN.md
@@ -209,7 +209,7 @@ This could be always-on (not just fast scan), since phash is very cheap (~0.1ms 
 
 Speed of generating clips, screenshots, GIFs, and reels.
 
-### - [ ] 3A. Parallel clip cutting
+### - [x] 3A. Parallel clip cutting
 
 **Prior art:** ThreadPoolExecutor with 4 workers already used for gallery GIF extraction (`c5b604a`), achieving 3-4x speedup. Same pattern, same module (video.py), different function.
 
@@ -397,7 +397,7 @@ Additional performance area: the raw speed of reading video frames and writing o
 | [x] | 1 | 2.0 — **Fast Scan mode** (bundles 2A-2D) | High — 3-5x faster Screenspace with explicit quality trade-off |
 | [x] | 2 | 2C — Universal phash pre-filter (always-on candidate) | High — cheap filter, broad applicability, minimal quality loss |
 | [x] | 3 | 5A — Cache uv in CI | High — near-instant CI installs |
-| [ ] | 4 | 3A — Parallel clip cutting | High — 3-4x faster batch generation |
+| [x] | 4 | 3A — Parallel clip cutting | High — 3-4x faster batch generation |
 | [x] | 5 | 1A — SSE for Screenspace progress | Medium — eliminates perceived stalls |
 | [x] | 6 | 1B — Preload first frames | Medium — instant first interaction |
 | [ ] | 7 | 3D — Transcript caching to disk | Medium — eliminates repeat transcription |

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import clipgen
+import config
 
 
 def _prepared_clip(raw_clip, times):
@@ -19,6 +20,7 @@ def test_process_clips_counts_generated_segments_for_all_formats(
     )
     monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
     monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
 
     call_counter = {"n": 0}
 
@@ -77,6 +79,7 @@ def test_process_clips_skips_when_source_video_missing(monkeypatch, make_clip):
     )
     monkeypatch.setattr(clipgen.Path, "is_file", lambda self: False)
     monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
     run_ffmpeg = Mock(return_value=True)
     monkeypatch.setattr(clipgen.video, "run_ffmpeg", run_ffmpeg)
 
@@ -150,3 +153,49 @@ def test_process_reel_returns_zero_when_no_segments_generated(monkeypatch, make_
     result, _artifacts = clipgen.process_reel(raw_clips, output_file="reel.mp4")
     assert result == 0
     concat.assert_not_called()
+
+
+def test_process_clips_parallel_generates_all(monkeypatch, make_clip):
+    """Multiple clips processed in parallel should all generate successfully."""
+    clips = [make_clip(row=i, col=2) for i in range(3, 7)]
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 4)
+
+    call_counter = {"n": 0}
+
+    def unique_name(_template, file_format=None):
+        call_counter["n"] += 1
+        return f"out_{call_counter['n']}{file_format or '.mp4'}"
+
+    monkeypatch.setattr(clipgen.files, "get_unique_filename", unique_name)
+    run_ffmpeg = Mock(return_value=True)
+    monkeypatch.setattr(clipgen.video, "run_ffmpeg", run_ffmpeg)
+
+    count, _artifacts = clipgen.process_clips(clips, output_format="clip")
+    assert count == 4
+    assert run_ffmpeg.call_count == 4
+
+
+def test_resolve_clip_workers(monkeypatch):
+    """Auto-detect returns min(4, cpu_count); explicit values pass through."""
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 0)
+    monkeypatch.setattr(clipgen.os, "cpu_count", lambda: 8)
+    assert clipgen._resolve_clip_workers() == 4
+
+    monkeypatch.setattr(clipgen.os, "cpu_count", lambda: 2)
+    assert clipgen._resolve_clip_workers() == 2
+
+    monkeypatch.setattr(clipgen.os, "cpu_count", lambda: None)
+    assert clipgen._resolve_clip_workers() == 1
+
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 6)
+    assert clipgen._resolve_clip_workers() == 6
+
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+    assert clipgen._resolve_clip_workers() == 1


### PR DESCRIPTION
## Summary

- Rewrites `process_clips()` into a three-phase pipeline: sequential clip preparation (preserving fuzzy-match prompts), parallel ffmpeg execution via `ThreadPoolExecutor`, and sequential post-processing (artifact records, transcription)
- Adds `CLIP_PARALLEL_WORKERS` config constant (default `0` = auto-detect `min(4, cpu_count)`; set to `1` for sequential fallback), exposed in Studio settings
- Results are collected in original clip order for deterministic artifact output
- Marks experiment 3A as complete in the performance plan

## Test plan
- [x] Existing `test_process_clips_*` tests pinned to sequential mode and passing
- [x] New `test_process_clips_parallel_generates_all` verifies 4 clips with 4 workers
- [x] New `test_resolve_clip_workers` covers auto-detect and explicit values
- [x] All 406 tests pass, no new type errors