### PR TITLE
Add transcript caching, lazy imports, and endcard batching (#3B, #3D, #4A)

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -624,14 +624,22 @@ def _process_single_clip_segments(
                 end_pos=end_time,
                 reencode=config.REENCODING,
             )
+            clip_resolution = None
             if ok and config.TITLECARDS_ENABLED:
                 import titlecards
 
-                ok = titlecards.prepend_titlecard_to_clip(clip, out_name)
+                props = video.probe_video_properties(out_name)
+                if props:
+                    clip_resolution = f"{props['width']}x{props['height']}"
+                ok = titlecards.prepend_titlecard_to_clip(
+                    clip, out_name, resolution=clip_resolution
+                )
             if ok:
                 import titlecards
 
-                ok = titlecards.append_endcard_to_clip(out_name)
+                ok = titlecards.append_endcard_to_clip(
+                    out_name, resolution=clip_resolution
+                )
         elif output_format == "screen":
             ok = video.extract_screenshot(
                 input_file=base_video,
@@ -722,9 +730,15 @@ def _transcribe_segments(
     import transcripts
 
     if base_video not in transcript_cache:
-        transcript_cache[base_video] = transcripts.transcribe_video(
-            str(utils.resolve_input_path(base_video))
-        )
+        resolved = str(utils.resolve_input_path(base_video))
+        cached = transcripts.load_transcript_cache(resolved)
+        if cached is not None:
+            transcript_cache[base_video] = cached
+        else:
+            result = transcripts.transcribe_video(resolved)
+            transcript_cache[base_video] = result
+            if result is not None:
+                transcripts.save_transcript_cache(result, resolved)
     full_transcript = transcript_cache[base_video]
     if not full_transcript:
         return
@@ -1031,6 +1045,11 @@ def process_clips(
         "screen": "screenshot(s)",
         "gif": "GIF(s)",
     }.get(output_format, "file(s)")
+    if config.TITLECARDS_ENABLED:
+        import titlecards
+
+        titlecards.clear_endcard_cache()
+
     if outputs_skipped > 0:
         utils.standard_print(
             f"* Summary: {outputs_generated} {item_name} generated, {outputs_skipped} skipped due to errors."

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.16"
+VERSIONNUM: str = "0.10.17"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/plans/PERFORMANCE-PLAN.md
+++ b/plans/PERFORMANCE-PLAN.md
@@ -219,7 +219,7 @@ Speed of generating clips, screenshots, GIFs, and reels.
 
 **Trade-offs:** Disk I/O may become the bottleneck on HDDs. On SSDs, 3-4x speedup is realistic. Source video reads are sequential (same file), but ffmpeg handles concurrent reads from the same input well since it seeks independently.
 
-### - [ ] 3B. Titlecard batching
+### - [x] 3B. Titlecard batching
 
 **Current:** Each clip gets its own titlecard via a separate ffmpeg subprocess (titlecards.py:53-101). For 20 clips, that's 20 extra ffmpeg invocations.
 
@@ -235,7 +235,7 @@ Speed of generating clips, screenshots, GIFs, and reels.
 
 **Trade-offs:** Diagnostic-only. No risk, helps users help themselves.
 
-### - [ ] 3D. Transcript caching across sessions
+### - [x] 3D. Transcript caching across sessions
 
 **Prior art:** Skip-if-exists pattern already proven for artifact regeneration in Studio (`cbee9eb`). Same principle: check for cached output before doing expensive work.
 
@@ -251,7 +251,7 @@ Speed of generating clips, screenshots, GIFs, and reels.
 
 Startup, mode-switching, and media loading.
 
-### - [ ] 4A. Lazy-import EasyOCR and scikit-image in Screenspace
+### - [x] 4A. Lazy-import EasyOCR and scikit-image in Screenspace
 
 **Prior art:** Deferred imports for cv2, screenspace, gspread, and openpyxl already done in `8e85ac0`, saving 3-6s on startup. Same pattern to extend.
 
@@ -400,14 +400,14 @@ Additional performance area: the raw speed of reading video frames and writing o
 | [x] | 4 | 3A — Parallel clip cutting | High — 3-4x faster batch generation |
 | [x] | 5 | 1A — SSE for Screenspace progress | Medium — eliminates perceived stalls |
 | [x] | 6 | 1B — Preload first frames | Medium — instant first interaction |
-| [ ] | 7 | 3D — Transcript caching to disk | Medium — eliminates repeat transcription |
+| [x] | 7 | 3D — Transcript caching to disk | Medium — eliminates repeat transcription |
 | [x] | 8 | 1E — DOM batching with fragments | Medium — smoother large lists |
 | [x] | 9 | 5D — Parallel tests with xdist — skipped (suite runs in 0.62s, xdist overhead would regress) | Medium — faster CI feedback |
 | [x] | 10 | 2F — Parallel region analysis | Medium — scales with CPU cores |
 | [x] | 11 | 2E — Batch frame extraction via ffmpeg | Low-Medium — depends on video codec |
-| [ ] | 12 | 4A — Lazy-import heavy libs | Low-Medium — saves seconds on startup |
+| [x] | 12 | 4A — Lazy-import heavy libs | Low-Medium — saves seconds on startup |
 | [x] | 13 | 1C — Optimistic UI in Studio | Low-Medium — better feel during generation |
 | [x] | 14 | 5B — Skip torch for typecheck — skipped (ty needs installed deps) | Low — job already ~25s, marginal gain |
-| [ ] | 15 | 3B — Titlecard batching | Low — small per-clip overhead |
+| [x] | 15 | 3B — Titlecard batching | Low — small per-clip overhead |
 | [ ] | 16 | 4C — Cache-busted static assets | Low — marginal for local tool |
 | [ ] | 17 | 7A — Hardware decode | Low — platform-specific, complex |

--- a/screenspace.py
+++ b/screenspace.py
@@ -35,13 +35,13 @@ import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 import cv2
-import imagehash
 import numpy as np
-from PIL import Image
-from skimage.metrics import structural_similarity as ssim
+
+if TYPE_CHECKING:
+    import imagehash
 
 import config
 import utils
@@ -179,12 +179,17 @@ def regions_are_similar(
     b_blur = cv2.GaussianBlur(region_b, (k, k), 0)
     a_gray = cv2.cvtColor(a_blur, cv2.COLOR_BGR2GRAY)
     b_gray = cv2.cvtColor(b_blur, cv2.COLOR_BGR2GRAY)
+    from skimage.metrics import structural_similarity as ssim
+
     score = float(ssim(a_gray, b_gray))
     return score >= threshold, score
 
 
 def compute_phash(region_pixels: np.ndarray) -> imagehash.ImageHash:
     """Compute perceptual hash of a region for fast similarity scanning."""
+    import imagehash
+    from PIL import Image
+
     rgb = cv2.cvtColor(region_pixels, cv2.COLOR_BGR2RGB)
     pil_img = Image.fromarray(rgb)
     return imagehash.phash(pil_img)
@@ -1119,6 +1124,8 @@ def scan_similarity(
     Returns list of ``{timestamp, score}`` dicts, sorted by score
     descending.
     """
+    from skimage.metrics import structural_similarity as ssim
+
     if threshold <= 0:
         threshold = config.SCREENSPACE_SSIM_THRESHOLD
     if interval_seconds <= 0:
@@ -2295,6 +2302,8 @@ def generate_heatmap_gif(
     Divides *results* into *num_frames* temporal buckets, progressively
     accumulates heatmap data, and writes frames as an animated GIF.
     """
+    from PIL import Image
+
     if not results:
         return None
 

--- a/titlecards.py
+++ b/titlecards.py
@@ -16,13 +16,21 @@ Key functions:
 
 import os
 import tempfile
+import threading
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import config
 import utils
 import video
 from utils import ClipRecord
+
+# ---------------------------------------------------------------------------
+# Endcard cache — keyed by resolution, shared across threads
+# ---------------------------------------------------------------------------
+
+_endcard_cache: Dict[str, str] = {}
+_endcard_lock = threading.Lock()
 
 
 def _get_video_resolution(filepath: str) -> Optional[str]:
@@ -195,7 +203,40 @@ def build_endcard_frame(resolution: str) -> Optional[str]:
     )
 
 
-def prepend_titlecard_to_clip(clip: ClipRecord, clip_path: str) -> bool:
+def get_or_build_endcard(resolution: str) -> Optional[str]:
+    """Return a cached endcard path for the given resolution, building if needed."""
+    with _endcard_lock:
+        cached = _endcard_cache.get(resolution)
+        if cached and Path(cached).is_file():
+            return cached
+    path = build_endcard_frame(resolution)
+    if path:
+        with _endcard_lock:
+            existing = _endcard_cache.get(resolution)
+            if existing and Path(existing).is_file():
+                try:
+                    Path(path).unlink()
+                except OSError:
+                    pass
+                return existing
+            _endcard_cache[resolution] = path
+    return path
+
+
+def clear_endcard_cache() -> None:
+    """Remove all cached endcard temp files."""
+    with _endcard_lock:
+        for path in _endcard_cache.values():
+            try:
+                Path(path).unlink(missing_ok=True)
+            except (OSError, TypeError):
+                pass
+        _endcard_cache.clear()
+
+
+def prepend_titlecard_to_clip(
+    clip: ClipRecord, clip_path: str, resolution: Optional[str] = None
+) -> bool:
     """Prepend a generated titlecard to an existing clip file in-place.
 
     Returns True when the clip is usable (with or without titlecard), False on hard failure.
@@ -216,7 +257,8 @@ def prepend_titlecard_to_clip(clip: ClipRecord, clip_path: str) -> bool:
         )
         return False
 
-    resolution = _get_video_resolution(clip_path)
+    if not resolution:
+        resolution = _get_video_resolution(clip_path)
     if not resolution:
         utils.warning_print(
             f"Could not determine video resolution for '{clip_path}'. "
@@ -290,7 +332,7 @@ def prepend_titlecard_to_clip(clip: ClipRecord, clip_path: str) -> bool:
                 pass
 
 
-def append_endcard_to_clip(clip_path: str) -> bool:
+def append_endcard_to_clip(clip_path: str, resolution: Optional[str] = None) -> bool:
     """Append an endcard segment to an existing clip file in-place."""
     if not config.TITLECARDS_ENABLED:
         return True
@@ -308,7 +350,8 @@ def append_endcard_to_clip(clip_path: str) -> bool:
         )
         return False
 
-    resolution = _get_video_resolution(clip_path)
+    if not resolution:
+        resolution = _get_video_resolution(clip_path)
     if not resolution:
         utils.warning_print(
             f"Could not determine video resolution for '{clip_path}'. "
@@ -316,7 +359,7 @@ def append_endcard_to_clip(clip_path: str) -> bool:
         )
         return True
 
-    endcard_path = build_endcard_frame(resolution)
+    endcard_path = get_or_build_endcard(resolution)
     if not endcard_path:
         return True
 
@@ -372,10 +415,9 @@ def append_endcard_to_clip(clip_path: str) -> bool:
         os.replace(output_temp_path, clip_path)
         return True
     finally:
-        for temp in (endcard_path, output_temp_path):
-            if not temp:
-                continue
+        # Only clean up the concat output temp — endcard is managed by the cache
+        if output_temp_path:
             try:
-                Path(temp).unlink()
+                Path(output_temp_path).unlink()
             except OSError:
                 pass

--- a/transcripts.py
+++ b/transcripts.py
@@ -25,6 +25,8 @@ filenames match the corresponding clip filename with the transcript extension.
 
 from __future__ import annotations
 
+import json
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -149,6 +151,47 @@ def transcribe_video(
         )
     except Exception as exc:
         utils.warning_print(f"Transcription failed for {Path(video_path).name}: {exc}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Disk cache (sidecar JSON next to source video)
+# ---------------------------------------------------------------------------
+
+
+def save_transcript_cache(result: TranscriptResult, video_path: str) -> bool:
+    """Save transcript to a sidecar JSON file next to the source video."""
+    cache_path = Path(video_path).with_suffix(".transcript.json")
+    try:
+        data = {
+            "segments": result["segments"],
+            "language": result["language"],
+            "source_file": result["source_file"],
+            "model": result["model"],
+            "video_mtime": os.path.getmtime(video_path),
+        }
+        cache_path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
+        return True
+    except OSError:
+        return False
+
+
+def load_transcript_cache(video_path: str) -> Optional[TranscriptResult]:
+    """Load cached transcript if sidecar exists and source video hasn't changed."""
+    cache_path = Path(video_path).with_suffix(".transcript.json")
+    if not cache_path.is_file():
+        return None
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        if data.get("video_mtime") != os.path.getmtime(video_path):
+            return None
+        return TranscriptResult(
+            segments=[TranscriptSegment(**s) for s in data["segments"]],
+            language=data["language"],
+            source_file=data["source_file"],
+            model=data["model"],
+        )
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
         return None
 
 


### PR DESCRIPTION
## Summary

Three performance improvements from PERFORMANCE-PLAN.md:

- **3D — Transcript caching**: Caches full-video transcripts as sidecar `.transcript.json` files next to source videos with mtime-based invalidation. Three-tier lookup: in-memory → disk → live transcription with save-back.
- **4A — Lazy imports**: Defers `skimage`, `imagehash`, and `PIL.Image` imports in `screenspace.py` from module level to point of use, avoiding heavy package loads when screenspace analysis isn't active.
- **3B — Endcard batching**: Thread-safe endcard cache keyed by resolution so identical endcards are built once per batch instead of once per clip. Shares a single ffprobe resolution probe between titlecard and endcard operations.

## Test plan
- [x] 406 tests pass (`uv run pytest -c tests/pytest.ini`)
- [ ] Verify `.transcript.json` sidecar is created on first transcription run and loaded on subsequent runs
- [ ] Verify screenspace import no longer pulls in skimage/imagehash/PIL at module level
- [ ] Verify endcard temp file is reused across clips at the same resolution