### PR TITLE
Fix Screenspace task validation and persistence

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.17"
+VERSIONNUM: str = "0.10.18"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -333,15 +333,8 @@ def api_regions_create() -> FlaskResponse:
     if "description" in data:
         region["description"] = str(data["description"])
 
-    import screenspace
-
     _manifest.setdefault("regions", {})[name] = region
-    screenspace.save_screenspace_manifest(
-        _manifest.get("regions", {}),
-        _manifest.get("tasks", []),
-        _manifest.get("events", []),
-        stashes=_manifest.get("stashes", []),
-    )
+    _persist_manifest(drain_events=False)
 
     return jsonify({"ok": True, "region": region})
 
@@ -353,15 +346,8 @@ def api_regions_delete(name: str) -> FlaskResponse:
     if name not in regions:
         return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 404
 
-    import screenspace
-
     del regions[name]
-    screenspace.save_screenspace_manifest(
-        regions,
-        _manifest.get("tasks", []),
-        _manifest.get("events", []),
-        stashes=_manifest.get("stashes", []),
-    )
+    _persist_manifest(drain_events=False)
 
     return jsonify({"ok": True})
 
@@ -388,16 +374,9 @@ def api_stashes_create() -> FlaskResponse:
         "createdAt": datetime.now(timezone.utc).isoformat(),
         "regions": copy.deepcopy(regions),
     }
-    import screenspace
-
     _manifest.setdefault("stashes", []).append(stash)
     _manifest["regions"] = {}
-    screenspace.save_screenspace_manifest(
-        _manifest.get("regions", {}),
-        _manifest.get("tasks", []),
-        _manifest.get("events", []),
-        stashes=_manifest.get("stashes", []),
-    )
+    _persist_manifest(drain_events=False)
     return jsonify({"ok": True, "stash": stash})
 
 
@@ -413,18 +392,11 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
     if stash is None:
         return jsonify({"ok": False, "error": "Stash not found"}), 404
 
-    import screenspace
-
     name = data.get("name", "").strip()
     if name:
         stash["name"] = name
 
-    screenspace.save_screenspace_manifest(
-        _manifest.get("regions", {}),
-        _manifest.get("tasks", []),
-        _manifest.get("events", []),
-        stashes=stashes,
-    )
+    _persist_manifest(drain_events=False)
     return jsonify({"ok": True, "stash": stash})
 
 
@@ -436,15 +408,8 @@ def api_stashes_delete(stash_id: str) -> FlaskResponse:
     if idx is None:
         return jsonify({"ok": False, "error": "Stash not found"}), 404
 
-    import screenspace
-
     stashes.pop(idx)
-    screenspace.save_screenspace_manifest(
-        _manifest.get("regions", {}),
-        _manifest.get("tasks", []),
-        _manifest.get("events", []),
-        stashes=stashes,
-    )
+    _persist_manifest(drain_events=False)
     return jsonify({"ok": True})
 
 
@@ -456,16 +421,9 @@ def api_stashes_restore(stash_id: str) -> FlaskResponse:
     if idx is None:
         return jsonify({"ok": False, "error": "Stash not found"}), 404
 
-    import screenspace
-
     stash = stashes[idx]
     _manifest["regions"] = copy.deepcopy(stash["regions"])
-    screenspace.save_screenspace_manifest(
-        _manifest["regions"],
-        _manifest.get("tasks", []),
-        _manifest.get("events", []),
-        stashes=stashes,
-    )
+    _persist_manifest(drain_events=False)
     return jsonify({"ok": True, "regions": _manifest["regions"]})
 
 
@@ -567,9 +525,16 @@ def api_tasks_create() -> FlaskResponse:
         return jsonify({"ok": False, "error": "participant is required"}), 400
 
     region_name = data.get("region", "").strip()
+    raw_parameters = data.get("parameters")
+    if raw_parameters is None:
+        parameters: Dict[str, Any] = {}
+    elif isinstance(raw_parameters, dict):
+        parameters = raw_parameters
+    else:
+        return jsonify({"ok": False, "error": "parameters must be an object"}), 400
 
     # Template tasks with an uploaded image scan the full frame; no region needed
-    has_uploaded_template = task_type == "template" and data.get("parameters", {}).get(
+    has_uploaded_template = task_type == "template" and parameters.get(
         "template_image_data"
     )
 
@@ -579,8 +544,7 @@ def api_tasks_create() -> FlaskResponse:
 
     # Early validation for multitool steps (before video path lookup)
     if task_type == "multitool":
-        parameters_early = data.get("parameters", {})
-        mt_steps = parameters_early.get("steps")
+        mt_steps = parameters.get("steps")
         if not mt_steps or not isinstance(mt_steps, list) or len(mt_steps) < 2:
             return jsonify(
                 {"ok": False, "error": "Multitool requires at least 2 steps"}
@@ -614,9 +578,7 @@ def api_tasks_create() -> FlaskResponse:
 
     # Multitool validates per-step regions; non-multitool validates global region
     if task_type == "multitool":
-        mt_steps_early: list[dict[str, Any]] = data.get("parameters", {}).get(
-            "steps", []
-        )
+        mt_steps_early: list[dict[str, Any]] = parameters.get("steps", [])
         for i, step in enumerate(mt_steps_early):
             step_region = (step.get("region") or "").strip()
             if not step_region:
@@ -661,9 +623,7 @@ def api_tasks_create() -> FlaskResponse:
         region_coords = _resolve_region_coords(region_name)
     elif task_type == "multitool":
         # Multitool uses per-step regions; use first step's region for top-level metadata
-        first_step_region = (
-            data.get("parameters", {}).get("steps", [{}])[0].get("region", "")
-        )
+        first_step_region = parameters.get("steps", [{}])[0].get("region", "")
         if first_step_region and first_step_region in all_known_regions:
             region_name = first_step_region
             region_coords = _resolve_region_coords(first_step_region)
@@ -674,19 +634,56 @@ def api_tasks_create() -> FlaskResponse:
         # Full-frame template scan -- sentinel region
         region_name = "full_frame"
         region_coords = {"x": 0, "y": 0, "w": 0, "h": 0}
-    parameters = data.get("parameters", {})
 
     import screenspace
+
+    try:
+        if task_type == "similarity":
+            parameters["reference_timestamp"] = _coerce_float(
+                parameters.get("reference_timestamp"),
+                "reference_timestamp",
+                required=True,
+            )
+        elif task_type == "template" and not parameters.get("template_image_data"):
+            parameters["reference_timestamp"] = _coerce_float(
+                parameters.get("reference_timestamp"),
+                "reference_timestamp",
+                required=True,
+            )
+        elif task_type == "scene":
+            parameters["scene_references"] = _validate_scene_references(
+                parameters.get("scene_references")
+            )
+        elif task_type == "multitool":
+            for i, step in enumerate(parameters.get("steps", [])):
+                step_context = f"Step {i}: "
+                if step["type"] == "similarity":
+                    step["reference_timestamp"] = _coerce_float(
+                        step.get("reference_timestamp"),
+                        "reference_timestamp",
+                        required=True,
+                        context=step_context,
+                    )
+                elif step["type"] == "template" and not step.get("template_image_data"):
+                    step["reference_timestamp"] = _coerce_float(
+                        step.get("reference_timestamp"),
+                        "reference_timestamp",
+                        required=True,
+                        context=step_context,
+                    )
+                elif step["type"] == "scene":
+                    step["scene_references"] = _validate_scene_references(
+                        step.get("scene_references"),
+                        context=step_context,
+                    )
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
 
     # Similarity tasks: extract reference frame from video at given timestamp
     if task_type == "similarity":
         import cv2
 
-        ref_ts = parameters.get("reference_timestamp")
-        if ref_ts is None:
-            return jsonify(
-                {"ok": False, "error": "Similarity scan requires reference_timestamp"}
-            ), 400
+        ref_ts = cast(float, parameters["reference_timestamp"])
         cap = cv2.VideoCapture(video_path)
         if not cap.isOpened():
             return jsonify(
@@ -732,14 +729,7 @@ def api_tasks_create() -> FlaskResponse:
             else:
                 parameters["template_image"] = img
         else:
-            ref_ts = parameters.get("reference_timestamp")
-            if ref_ts is None:
-                return jsonify(
-                    {
-                        "ok": False,
-                        "error": "Template scan requires reference_timestamp or uploaded image",
-                    }
-                ), 400
+            ref_ts = cast(float, parameters["reference_timestamp"])
             cap = cv2.VideoCapture(video_path)
             if not cap.isOpened():
                 return jsonify(
@@ -760,11 +750,7 @@ def api_tasks_create() -> FlaskResponse:
     if task_type == "scene":
         import cv2
 
-        scene_refs = parameters.get("scene_references")
-        if not scene_refs or not isinstance(scene_refs, list):
-            return jsonify(
-                {"ok": False, "error": "Scene scan requires scene_references list"}
-            ), 400
+        scene_refs = cast(List[Dict[str, Any]], parameters["scene_references"])
         cap = cv2.VideoCapture(video_path)
         if not cap.isOpened():
             return jsonify(
@@ -811,14 +797,7 @@ def api_tasks_create() -> FlaskResponse:
             step_rc = step["region_coords"]
 
             if stype == "similarity":
-                ref_ts = step.get("reference_timestamp")
-                if ref_ts is None:
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Step {i}: similarity requires reference_timestamp",
-                        }
-                    ), 400
+                ref_ts = cast(float, step["reference_timestamp"])
                 cap = cv2.VideoCapture(video_path)
                 if not cap.isOpened():
                     return jsonify({"ok": False, "error": "Could not open video"}), 500
@@ -860,14 +839,7 @@ def api_tasks_create() -> FlaskResponse:
                     else:
                         step["template_image"] = img
                 else:
-                    ref_ts = step.get("reference_timestamp")
-                    if ref_ts is None:
-                        return jsonify(
-                            {
-                                "ok": False,
-                                "error": f"Step {i}: template requires reference_timestamp or uploaded image",
-                            }
-                        ), 400
+                    ref_ts = cast(float, step["reference_timestamp"])
                     cap = cv2.VideoCapture(video_path)
                     if not cap.isOpened():
                         return jsonify(
@@ -886,14 +858,7 @@ def api_tasks_create() -> FlaskResponse:
                     step["template_image"] = screenspace.extract_region(frame, step_rc)
 
             elif stype == "scene":
-                scene_refs = step.get("scene_references")
-                if not scene_refs or not isinstance(scene_refs, list):
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Step {i}: scene requires scene_references list",
-                        }
-                    ), 400
+                scene_refs = cast(List[Dict[str, Any]], step["scene_references"])
                 cap = cv2.VideoCapture(video_path)
                 if not cap.isOpened():
                     return jsonify({"ok": False, "error": "Could not open video"}), 500
@@ -928,7 +893,7 @@ def api_tasks_create() -> FlaskResponse:
     )
 
     _worker.enqueue(task)
-    _manifest.setdefault("tasks", []).append(task)
+    _persist_manifest(drain_events=False)
     _notify_sse_clients("task_created")
 
     return jsonify({"ok": True, "task": _clean_task(task)})
@@ -942,13 +907,11 @@ def api_tasks_cancel(task_id: str) -> FlaskResponse:
     if request.args.get("dismiss") == "true":
         if not _worker.remove_task(task_id):
             return jsonify({"ok": False, "error": "Task not found"}), 404
-        _manifest["tasks"] = [
-            t for t in _manifest.get("tasks", []) if t["id"] != task_id
-        ]
-        _persist_manifest()
+        _persist_manifest(drain_events=False)
         _notify_sse_clients("task_dismissed")
         return jsonify({"ok": True})
     if _worker.cancel(task_id):
+        _persist_manifest(drain_events=False)
         _notify_sse_clients("task_cancelled")
         return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Task not found or already finished"}), 400
@@ -963,6 +926,7 @@ def api_tasks_reorder() -> FlaskResponse:
     if not data or "task_ids" not in data:
         return jsonify({"ok": False, "error": "task_ids list required"}), 400
     _worker.reorder(data["task_ids"])
+    _persist_manifest(drain_events=False)
     _notify_sse_clients("reorder")
     return jsonify({"ok": True})
 
@@ -973,6 +937,7 @@ def api_tasks_pause() -> FlaskResponse:
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
     _worker.pause()
+    _persist_manifest(drain_events=False)
     _notify_sse_clients("pause")
     return jsonify({"ok": True, "paused": True})
 
@@ -983,6 +948,7 @@ def api_tasks_resume() -> FlaskResponse:
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
     _worker.resume()
+    _persist_manifest(drain_events=False)
     _notify_sse_clients("resume")
     return jsonify({"ok": True, "paused": False})
 
@@ -1025,7 +991,7 @@ def api_event_exclude(event_id: str) -> FlaskResponse:
     for e in _manifest.get("events", []):
         if e["id"] == event_id:
             e["excluded"] = True
-            _persist_manifest()
+            _persist_manifest(drain_events=False)
             return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Event not found"}), 404
 
@@ -1036,7 +1002,7 @@ def api_event_include(event_id: str) -> FlaskResponse:
     for e in _manifest.get("events", []):
         if e["id"] == event_id:
             e["excluded"] = False
-            _persist_manifest()
+            _persist_manifest(drain_events=False)
             return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Event not found"}), 404
 
@@ -1053,7 +1019,7 @@ def api_events_bulk_exclude() -> FlaskResponse:
         if e["id"] in ids:
             e["excluded"] = True
             count += 1
-    _persist_manifest()
+    _persist_manifest(drain_events=False)
     return jsonify({"ok": True, "updated": count})
 
 
@@ -1069,11 +1035,64 @@ def api_events_bulk_include() -> FlaskResponse:
         if e["id"] in ids:
             e["excluded"] = False
             count += 1
-    _persist_manifest()
+    _persist_manifest(drain_events=False)
     return jsonify({"ok": True, "updated": count})
 
 
 # ---- Helpers ----
+
+
+def _coerce_float(
+    value: Any,
+    field_name: str,
+    *,
+    required: bool = False,
+    context: str = "",
+) -> float:
+    """Validate and coerce a request field to a finite float."""
+    if value is None:
+        if required:
+            raise ValueError(f"{context}{field_name} is required")
+        raise ValueError(f"{context}{field_name} must be a number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{context}{field_name} must be a number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{context}{field_name} must be a finite number")
+    return number
+
+
+def _validate_scene_references(
+    scene_refs: Any, *, context: str = ""
+) -> List[Dict[str, Any]]:
+    """Validate scene reference payloads and normalize numeric fields."""
+    if not scene_refs or not isinstance(scene_refs, list):
+        raise ValueError(f"{context}scene_references must be a non-empty list")
+    validated_refs = []
+    for i, ref_raw in enumerate(scene_refs):
+        if not isinstance(ref_raw, dict):
+            raise ValueError(f"{context}scene_references[{i}] must be an object")
+        name = str(ref_raw.get("name", "")).strip()
+        if not name:
+            raise ValueError(f"{context}scene_references[{i}].name is required")
+        ref: Dict[str, Any] = {
+            "name": name,
+            "timestamp": _coerce_float(
+                ref_raw.get("timestamp"),
+                f"scene_references[{i}].timestamp",
+                required=True,
+                context=context,
+            ),
+        }
+        if "threshold" in ref_raw and ref_raw.get("threshold") is not None:
+            ref["threshold"] = _coerce_float(
+                ref_raw.get("threshold"),
+                f"scene_references[{i}].threshold",
+                context=context,
+            )
+        validated_refs.append(ref)
+    return validated_refs
 
 
 def _sanitize_floats(obj: Any) -> Any:
@@ -1176,19 +1195,20 @@ def _discover_participant_videos(study_name: str) -> None:
                 )
 
 
-def _persist_manifest() -> None:
-    """Save manifest after a task completes."""
+def _persist_manifest(*, drain_events: bool = True) -> None:
+    """Persist the current manifest state through a single synchronized path."""
     import screenspace
 
     with _persist_lock:
-        if _worker:
+        if _worker and drain_events:
             new_events = _worker.drain_new_events()
             if new_events:
                 _manifest.setdefault("events", []).extend(new_events)
-            tasks = _worker.get_all_tasks()
-            screenspace.save_screenspace_manifest(
-                _manifest.get("regions", {}),
-                tasks,
-                _manifest.get("events", []),
-                stashes=_manifest.get("stashes", []),
-            )
+        tasks = _worker.get_all_tasks() if _worker else _manifest.get("tasks", [])
+        _manifest["tasks"] = tasks
+        screenspace.save_screenspace_manifest(
+            _manifest.get("regions", {}),
+            tasks,
+            _manifest.get("events", []),
+            stashes=_manifest.get("stashes", []),
+        )

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -1073,21 +1073,22 @@ def _validate_scene_references(
     for i, ref_raw in enumerate(scene_refs):
         if not isinstance(ref_raw, dict):
             raise ValueError(f"{context}scene_references[{i}] must be an object")
-        name = str(ref_raw.get("name", "")).strip()
+        ref_data = cast(Dict[str, Any], ref_raw)
+        name = str(ref_data.get("name", "")).strip()
         if not name:
             raise ValueError(f"{context}scene_references[{i}].name is required")
         ref: Dict[str, Any] = {
             "name": name,
             "timestamp": _coerce_float(
-                ref_raw.get("timestamp"),
+                ref_data.get("timestamp"),
                 f"scene_references[{i}].timestamp",
                 required=True,
                 context=context,
             ),
         }
-        if "threshold" in ref_raw and ref_raw.get("threshold") is not None:
+        if "threshold" in ref_data and ref_data.get("threshold") is not None:
             ref["threshold"] = _coerce_float(
-                ref_raw.get("threshold"),
+                ref_data.get("threshold"),
                 f"scene_references[{i}].threshold",
                 context=context,
             )

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -331,6 +331,94 @@ def test_create_non_template_task_still_requires_region(client):
     assert "region" in resp.get_json()["error"].lower()
 
 
+def test_create_similarity_task_invalid_reference_timestamp(client, monkeypatch):
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "similarity",
+            "participant": "P01",
+            "region": "r",
+            "parameters": {"reference_timestamp": "not-a-number"},
+        },
+    )
+    assert resp.status_code == 400
+    assert "reference_timestamp" in resp.get_json()["error"]
+
+
+def test_create_template_task_invalid_reference_timestamp(client, monkeypatch):
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "template",
+            "participant": "P01",
+            "region": "r",
+            "parameters": {"reference_timestamp": "not-a-number"},
+        },
+    )
+    assert resp.status_code == 400
+    assert "reference_timestamp" in resp.get_json()["error"]
+
+
+def test_create_scene_task_invalid_scene_references(client, monkeypatch):
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "scene",
+            "participant": "P01",
+            "region": "r",
+            "parameters": {
+                "scene_references": [{"name": "Main menu", "timestamp": "x"}]
+            },
+        },
+    )
+    assert resp.status_code == 400
+    assert "scene_references[0].timestamp" in resp.get_json()["error"]
+
+
+def test_create_multitool_task_invalid_step_reference_timestamp(client, monkeypatch):
+    _create_region(client, "healthbar")
+    _create_region(client, "statusbar", x=0, y=0, w=100, h=20)
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "multitool",
+            "participant": "P01",
+            "region": "healthbar",
+            "parameters": {
+                "steps": [
+                    {
+                        "type": "similarity",
+                        "region": "healthbar",
+                        "reference_timestamp": "bad",
+                    },
+                    {"type": "change", "region": "statusbar"},
+                ]
+            },
+        },
+    )
+    assert resp.status_code == 400
+    assert "Step 0: reference_timestamp" in resp.get_json()["error"]
+
+
+def test_create_task_persists_manifest(client, monkeypatch):
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={"type": "color", "participant": "P01", "region": "r"},
+    )
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
+
+
 def test_get_task_not_found(client):
     resp = client.get("/screenspace/api/tasks/ss_nonexist")
     assert resp.status_code == 404
@@ -339,6 +427,19 @@ def test_get_task_not_found(client):
 def test_cancel_task_not_found(client):
     resp = client.delete("/screenspace/api/tasks/ss_nonexist")
     assert resp.status_code == 400
+
+
+def test_cancel_task_persists_manifest(client, monkeypatch):
+    worker = screenspace_server._worker
+    assert worker is not None
+    task = screenspace.create_task(
+        "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.delete(f"/screenspace/api/tasks/{task['id']}")
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
 
 
 def test_dismiss_queued_task(client):
@@ -391,11 +492,61 @@ def test_reorder_missing_body(client):
 
 
 def test_reorder_valid(client):
+    worker = screenspace_server._worker
+    assert worker is not None
+    task = screenspace.create_task(
+        "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
     resp = client.put(
         "/screenspace/api/tasks/reorder",
-        json={"task_ids": ["ss_a", "ss_b"]},
+        json={"task_ids": [task["id"]]},
     )
     assert resp.status_code == 200
+
+
+def test_reorder_persists_manifest(client, monkeypatch):
+    worker = screenspace_server._worker
+    assert worker is not None
+    task = screenspace.create_task(
+        "color", "P01", "s.mp4", "/v.mp4", "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.put(
+        "/screenspace/api/tasks/reorder",
+        json={"task_ids": [task["id"]]},
+    )
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
+
+
+def test_pause_persists_manifest(client, monkeypatch):
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.post("/screenspace/api/tasks/pause")
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
+
+
+def test_resume_persists_manifest(client, monkeypatch):
+    worker = screenspace_server._worker
+    assert worker is not None
+    task = screenspace.create_task(
+        "color",
+        "P01",
+        "s.mp4",
+        "/v.mp4",
+        "r",
+        {"x": 0, "y": 0, "w": 1, "h": 1},
+        parameters={"start_seconds": 0.0, "end_seconds": 10.0},
+    )
+    worker.enqueue(task)
+    with worker._lock:
+        worker._tasks[task["id"]]["status"] = screenspace.TASK_STATUS_PAUSED
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.post("/screenspace/api/tasks/resume")
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
 
 
 # ---- Video ----
@@ -503,6 +654,14 @@ def test_event_exclude(client):
     data = resp.get_json()
     assert data["ok"] is True
     assert screenspace_server._manifest["events"][0]["excluded"] is True
+
+
+def test_event_exclude_uses_persist_manifest_helper(client, monkeypatch):
+    screenspace_server._manifest["events"] = [_sample_event("ev_1")]
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.put("/screenspace/api/events/ev_1/exclude")
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
 
 
 def test_event_include(client):
@@ -728,6 +887,32 @@ def test_clean_task_preserves_scan_mode():
     assert cleaned["parameters"]["scan_mode"] == "fast"
 
 
+def test_create_region_uses_persist_manifest_helper(client, monkeypatch):
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.post(
+        "/screenspace/api/regions",
+        json={
+            "name": "healthbar",
+            "x": 100,
+            "y": 20,
+            "w": 300,
+            "h": 30,
+            "canvas_width": 1920,
+            "canvas_height": 1080,
+        },
+    )
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
+
+
+def test_create_stash_uses_persist_manifest_helper(client, monkeypatch):
+    _create_region(client, "stashme")
+    calls = _install_persist_spy(monkeypatch)
+    resp = client.post("/screenspace/api/stashes")
+    assert resp.status_code == 200
+    assert calls == [{"drain_events": False}]
+
+
 def _create_region(client, name, x=100, y=20, w=300, h=30):
     client.post(
         "/screenspace/api/regions",
@@ -741,6 +926,27 @@ def _create_region(client, name, x=100, y=20, w=300, h=30):
             "canvas_height": 1080,
         },
     )
+
+
+def _enable_video_task_setup(monkeypatch, participant_id):
+    for participant in screenspace_server._participants:
+        if participant["id"] == participant_id:
+            participant["has_video"] = True
+    monkeypatch.setattr(
+        screenspace_server.video,
+        "probe_video_properties",
+        lambda _path: {"width": 1920, "height": 1080},
+    )
+
+
+def _install_persist_spy(monkeypatch):
+    calls = []
+
+    def spy(*, drain_events=True):
+        calls.append({"drain_events": drain_events})
+
+    monkeypatch.setattr(screenspace_server, "_persist_manifest", spy)
+    return calls
 
 
 # ---- VideoCapture pool size (4D) ----


### PR DESCRIPTION
## Summary
- harden `screenspace_server.py` task creation so malformed Screenspace payloads return `400` errors instead of triggering server exceptions
- route Screenspace region, stash, task, and event mutations through one synchronized manifest persistence path and persist queue state changes immediately
- add focused API regression tests for malformed task payloads and persistence behavior, and bump the patch version to `0.10.18`

## Test plan
- [x] `uv run ruff check --fix config.py screenspace_server.py tests/test_screenspace_api.py`
- [x] `uv run ruff format config.py screenspace_server.py tests/test_screenspace_api.py`
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace_api.py`