### PR TITLE
Fix Studio drag ghost showing overlays from sibling cards

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -251,6 +251,19 @@
     return 3600;
   }
 
+  function setCardDragImage(ev, card) {
+    var clone = card.cloneNode(true);
+    clone.style.position = "absolute";
+    clone.style.top = "-9999px";
+    clone.style.left = "-9999px";
+    clone.style.width = card.offsetWidth + "px";
+    clone.style.zIndex = "-1";
+    document.body.appendChild(clone);
+    var rect = card.getBoundingClientRect();
+    ev.dataTransfer.setDragImage(clone, ev.clientX - rect.left, ev.clientY - rect.top);
+    setTimeout(function () { document.body.removeChild(clone); }, 0);
+  }
+
   // ---- Filtering ----
 
   function severityRank(label) {
@@ -1629,6 +1642,7 @@
           }
           ev.dataTransfer.setData("application/json", JSON.stringify(data));
           ev.dataTransfer.effectAllowed = "copyMove";
+          setCardDragImage(ev, this);
         });
       })(item, isIntake);
 
@@ -3549,6 +3563,7 @@
             event_ids: cluster.events.map(function (e) { return e.id; }),
           }));
           ev.dataTransfer.effectAllowed = "copyMove";
+          setCardDragImage(ev, this);
         });
       })(c);
 


### PR DESCRIPTION
## Summary
- Dragging Screen Intake cards in Studio produced a drag ghost containing overlay information (names, badges, duration pills) from every other card on the page
- Added a `setCardDragImage` helper that deep-clones just the dragged card and uses `setDragImage()` to produce a clean ghost
- Applied to both the intake panel cards and artifact queue cards, which share the same `.queue-card` structure with absolute-positioned overlays

## Test plan
- [ ] Open Studio with Screenspace intake data, drag an intake card — ghost should show only that single card
- [ ] Drag an intake-sourced card from the Artifacts field — same clean ghost
- [ ] Verify other drags (grid cells, reel cards, stashes) still work normally