### PR TITLE
Implement transcript infrastructure (Phase 1)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,6 +10,7 @@ import argparse
 import io
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Tuple
 
@@ -47,8 +48,8 @@ def parse_arguments() -> argparse.Namespace:
 
     Returns:
         argparse.Namespace with mode flags/values, spreadsheet, yes, verbose, screen, gif,
-        transcribe, transcript_format, viewer, manifest, timeline_viewer, input, output,
-        titlecards, and related attributes.
+        transcribe, transcript_format, pre_transcribe, viewer, manifest, timeline_viewer,
+        input, output, titlecards, and related attributes.
     """
     parser = argparse.ArgumentParser(
         description=(
@@ -215,6 +216,13 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         choices=["md", "srt", "vtt"],
         metavar="FMT",
         help="Transcript format: md (default), srt, or vtt",
+    )
+    transcription.add_argument(
+        "--pre-transcribe",
+        nargs="*",
+        metavar="ID",
+        default=None,
+        help="Pre-transcribe source videos. No IDs = all participants. Specify IDs to transcribe specific participants (e.g., P01 P03).",
     )
 
     paths = parser.add_argument_group("spreadsheet & directories")
@@ -768,6 +776,97 @@ def _run_gallery_cli(args: argparse.Namespace) -> None:
         utils.info_print(f"Gallery viewer created: {gallery_path}")
 
 
+def _run_pre_transcribe(worksheet: Any, args: Any) -> None:
+    """Pre-transcribe source videos for specified participants."""
+    import transcripts
+
+    ctx = spreadsheet.build_sheet_context(worksheet)
+    if ctx is None:
+        utils.error_print("Cannot build sheet context.")
+        sys.exit(1)
+
+    available = spreadsheet.get_participant_list(
+        ctx.header_row, ctx.id_cell, ctx.num_participants
+    )
+
+    requested_ids = getattr(args, "pre_transcribe", [])
+    if not requested_ids:
+        target_ids = list(available)
+    else:
+        target_ids = []
+        for raw_id in requested_ids:
+            pid = utils.normalize_participant_id(raw_id).strip()
+            if pid in available:
+                target_ids.append(pid)
+            else:
+                utils.warning_print(
+                    f"Participant '{raw_id}' not found in spreadsheet. "
+                    f"Available: {', '.join(available)}"
+                )
+
+    if not target_ids:
+        utils.error_print("No valid participants to transcribe.")
+        return
+
+    manifest = transcripts.load_transcripts_manifest()
+    source_transcripts = manifest["source_transcripts"]
+    corrections = manifest["corrections"]
+    context_keywords = transcripts.get_corrections_keywords(corrections) or None
+
+    skipped = 0
+    transcribed = 0
+
+    for pid in target_ids:
+        if pid in source_transcripts:
+            utils.info_print(f"Skipping {pid}: already transcribed.")
+            skipped += 1
+            continue
+
+        col_idx = spreadsheet.find_participant_column(ctx.header_row, ctx.id_cell, pid)
+        override = None
+        if (
+            col_idx is not None
+            and ctx.filename_row_idx is not None
+            and ctx.filename_row_idx < len(ctx.sheet_data)
+            and col_idx < len(ctx.sheet_data[ctx.filename_row_idx])
+        ):
+            override = ctx.sheet_data[ctx.filename_row_idx][col_idx].strip() or None
+
+        video_filename = files.get_source_video_filename(ctx.study_name, pid, override)
+        video_path = utils.resolve_input_path(video_filename)
+        if not video_path.is_file():
+            utils.error_print(f"Source video not found for {pid}: {video_path}")
+            continue
+
+        utils.info_print(f"Transcribing {pid}: {video_path.name}...")
+        result = transcripts.transcribe_video(
+            str(video_path),
+            context_keywords=context_keywords,
+        )
+        if result is None:
+            utils.error_print(f"Transcription failed for {pid}.")
+            continue
+
+        source_transcripts[pid] = {
+            "segments": [
+                {"start": s["start"], "end": s["end"], "text": s["text"]}
+                for s in result["segments"]
+            ],
+            "language": result["language"],
+            "model": result["model"],
+            "source_file": result["source_file"],
+            "transcribed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        transcribed += 1
+
+        transcripts.save_transcripts_manifest(source_transcripts, corrections)
+        utils.info_print(f"  {pid}: {len(result['segments'])} segments stored.")
+
+    utils.info_print(
+        f"Pre-transcription complete: {transcribed} transcribed, {skipped} skipped."
+    )
+
+
 def _run_timeline_viewer_mode(worksheet: Any, args: Any) -> None:
     """Export all clips via batch mode and generate a per-participant timeline viewer."""
     clips_list = spreadsheet.generate_list(worksheet, "batch", skip_prompts=True)
@@ -1093,6 +1192,40 @@ def main() -> None:
             )
             sys.exit(1)
 
+    pre_transcribe_mode = getattr(args, "pre_transcribe", None) is not None
+    if pre_transcribe_mode:
+        conflicting = [
+            args.batch,
+            args.lines,
+            args.range,
+            args.category,
+            args.cell,
+            args.participant,
+            args.keyword,
+            args.severity,
+            mixed_selectors,
+            args.reel,
+            args.chronologic,
+            args.highlights,
+            args.screen,
+            args.gif,
+            args.viewer,
+            getattr(args, "regenerate", False),
+            timeline_viewer,
+            studio_mode,
+            insights_mode,
+            screenspace_mode,
+            gallery_arg is not None,
+        ]
+        if any(conflicting):
+            utils.error_print(
+                "--pre-transcribe cannot be combined with mode, format, or --studio/--insights/--screenspace flags.",
+                [
+                    "Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --pre-transcribe."
+                ],
+            )
+            sys.exit(1)
+
     cli_mode = (
         args.batch
         or args.lines
@@ -1257,6 +1390,10 @@ def main() -> None:
                 server.start_combined_server(
                     worksheet=worksheet, default_page="screenspace"
                 )
+                sys.exit(0)
+
+            if pre_transcribe_mode:
+                _run_pre_transcribe(worksheet, args)
                 sys.exit(0)
 
             # Execute based on mode

--- a/clipgen.py
+++ b/clipgen.py
@@ -719,26 +719,98 @@ def _run_clip_pipeline(
     return (results, missing_videos)
 
 
+def _embed_transcript_on_artifacts(
+    clip: Any,
+    base_video: str,
+    artifacts: List[Dict[str, Any]],
+    segment_details: List[Tuple[str, str, str]],
+    transcript_cache: Dict[str, Any],
+    transcripts_manifest: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Embed transcript segments on clip artifact records.
+
+    Source priority: transcripts manifest -> in-memory cache. Modifies artifacts in-place.
+    """
+    import transcripts
+
+    participant = clip.get("participant", "")
+    manifest = transcripts_manifest or transcripts.load_transcripts_manifest()
+    source_transcripts = manifest.get("source_transcripts", {})
+    corrections = manifest.get("corrections", [])
+
+    full_transcript = None
+    if participant and participant in source_transcripts:
+        entry = source_transcripts[participant]
+        raw_segments = entry.get("segments", [])
+        corrected = transcripts.apply_corrections(raw_segments, corrections)
+        full_transcript = transcripts.TranscriptResult(
+            segments=corrected,
+            language=entry.get("language", ""),
+            source_file=entry.get("source_file", str(base_video)),
+            model=entry.get("model", ""),
+        )
+    elif base_video in transcript_cache and transcript_cache[base_video]:
+        full_transcript = transcript_cache[base_video]
+
+    if not full_transcript:
+        return
+
+    for art_idx, (_out_path, start_str, end_str) in enumerate(segment_details):
+        if art_idx >= len(artifacts):
+            break
+        start_sec = utils.timestamp_to_seconds(start_str) or 0.0
+        end_sec = utils.timestamp_to_seconds(end_str) or 0.0
+        clipped = transcripts.filter_segments(
+            full_transcript, start_sec, end_sec, offset_to_zero=True
+        )
+        transcript_segments = []
+        for seg_idx, seg in enumerate(clipped["segments"]):
+            transcript_segments.append(
+                {
+                    "id": f"{participant}:{seg_idx}",
+                    "start": seg["start"],
+                    "end": seg["end"],
+                    "text": seg["text"],
+                }
+            )
+        if transcript_segments:
+            artifacts[art_idx]["transcript"] = transcript_segments
+
+
 def _transcribe_segments(
     clip: Any,
     base_video: str,
     segment_details: List[Tuple[str, str, str]],
     all_artifacts: List[Dict[str, Any]],
     transcript_cache: Dict[str, Any],
+    transcripts_manifest: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Transcribe segments of a clip and write transcript files."""
     import transcripts
 
     if base_video not in transcript_cache:
-        resolved = str(utils.resolve_input_path(base_video))
-        cached = transcripts.load_transcript_cache(resolved)
-        if cached is not None:
-            transcript_cache[base_video] = cached
+        participant = clip.get("participant", "")
+        manifest = transcripts_manifest or transcripts.load_transcripts_manifest()
+        source_transcripts = manifest.get("source_transcripts", {})
+        corrections = manifest.get("corrections", [])
+
+        if participant and participant in source_transcripts:
+            entry = source_transcripts[participant]
+            raw_segments = entry.get("segments", [])
+            corrected = transcripts.apply_corrections(raw_segments, corrections)
+            transcript_cache[base_video] = transcripts.TranscriptResult(
+                segments=corrected,
+                language=entry.get("language", ""),
+                source_file=entry.get("source_file", str(base_video)),
+                model=entry.get("model", ""),
+            )
         else:
-            result = transcripts.transcribe_video(resolved)
+            resolved = str(utils.resolve_input_path(base_video))
+            context_keywords = transcripts.get_corrections_keywords(corrections) or None
+            result = transcripts.transcribe_video(
+                resolved, context_keywords=context_keywords
+            )
             transcript_cache[base_video] = result
-            if result is not None:
-                transcripts.save_transcript_cache(result, resolved)
     full_transcript = transcript_cache[base_video]
     if not full_transcript:
         return
@@ -820,6 +892,7 @@ def process_clips(
     all_artifacts: List[Dict[str, Any]] = []
     fuzzy_matches: Dict[str, Optional[str]] = {}
     transcript_cache: Dict[str, Any] = {}
+    transcripts_manifest: Optional[Dict[str, Any]] = None  # lazy-loaded
     missing_videos: Set[str] = set()
 
     # -- Phase 1: Sequential preparation (handles user prompts) ---------------
@@ -985,17 +1058,29 @@ def process_clips(
     outputs_generated = 0
     outputs_skipped = skipped_no_times + skipped_no_video
 
+    # Lazy-load transcripts manifest once for embedding + transcription
+    import transcripts as _tr_mod
+
+    transcripts_manifest = _tr_mod.load_transcripts_manifest()
+
     for idx, (clip, base_video) in enumerate(prepared):
         generated_count, segment_details = results[idx]
         outputs_generated += generated_count
         if generated_count < len(clip["times"]):
             outputs_skipped += len(clip["times"]) - generated_count
         if segment_details:
-            all_artifacts.extend(
-                viewer.build_artifact_records_for_clip(
-                    clip, base_video, segment_details, output_format
-                )
+            clip_artifacts = viewer.build_artifact_records_for_clip(
+                clip, base_video, segment_details, output_format
             )
+            _embed_transcript_on_artifacts(
+                clip,
+                base_video,
+                clip_artifacts,
+                segment_details,
+                transcript_cache,
+                transcripts_manifest,
+            )
+            all_artifacts.extend(clip_artifacts)
 
     if config.TRANSCRIBE_ENABLED:
         transcribe_items = [
@@ -1025,6 +1110,7 @@ def process_clips(
                             segment_details,
                             all_artifacts,
                             transcript_cache,
+                            transcripts_manifest,
                         )
                         progress.update(t_task, advance=1)
             else:
@@ -1035,6 +1121,7 @@ def process_clips(
                         segment_details,
                         all_artifacts,
                         transcript_cache,
+                        transcripts_manifest,
                     )
 
     if missing_videos:
@@ -1063,6 +1150,65 @@ def compute_reel_id(components: List[Dict[str, Any]]) -> str:
         f"{c['cellRow']}:{c['cellCol']}:{c['start']}:{c['end']}" for c in components
     )
     return "reel_" + hashlib.sha256("|".join(parts).encode()).hexdigest()[:8]
+
+
+def _build_reel_transcript(
+    components: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Assemble merged transcript for a reel from its components.
+
+    Segments are derived from each component's source transcript,
+    with timestamps offset by cumulative component durations + titlecard durations.
+    """
+    import transcripts
+
+    manifest = transcripts.load_transcripts_manifest()
+    source_transcripts = manifest.get("source_transcripts", {})
+    corrections = manifest.get("corrections", [])
+
+    merged_segments: List[Dict[str, Any]] = []
+    cumulative_offset = 0.0
+    seg_counter = 0
+    titlecard_duration = (
+        config.TITLECARD_DURATION_SECONDS if config.TITLECARDS_ENABLED else 0
+    )
+
+    for comp in components:
+        participant = comp.get("participant", "")
+        comp_start = comp.get("start", 0.0)
+        comp_end = comp.get("end", 0.0)
+        comp_duration = comp_end - comp_start
+
+        full_transcript = None
+        if participant and participant in source_transcripts:
+            entry = source_transcripts[participant]
+            raw_segments = entry.get("segments", [])
+            corrected = transcripts.apply_corrections(raw_segments, corrections)
+            full_transcript = transcripts.TranscriptResult(
+                segments=corrected,
+                language=entry.get("language", ""),
+                source_file=entry.get("source_file", ""),
+                model=entry.get("model", ""),
+            )
+
+        if full_transcript:
+            clipped = transcripts.filter_segments(
+                full_transcript, comp_start, comp_end, offset_to_zero=True
+            )
+            for seg in clipped["segments"]:
+                merged_segments.append(
+                    {
+                        "id": f"reel:{seg_counter}",
+                        "start": seg["start"] + cumulative_offset + titlecard_duration,
+                        "end": seg["end"] + cumulative_offset + titlecard_duration,
+                        "text": seg["text"],
+                    }
+                )
+                seg_counter += 1
+
+        cumulative_offset += comp_duration + titlecard_duration
+
+    return merged_segments
 
 
 def process_reel(
@@ -1163,13 +1309,18 @@ def process_reel(
         return (0, [])
 
     reel_id = compute_reel_id(components)
-    reel_record = {
+    reel_record: Dict[str, Any] = {
         "id": reel_id,
         "file": Path(output_file).name,
         "study": study_name,
         "description": f"Reel: {len(components)} segments",
         "components": components,
     }
+
+    reel_transcript = _build_reel_transcript(components)
+    if reel_transcript:
+        reel_record["transcript"] = reel_transcript
+
     return (1, [reel_record])
 
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.19"
+VERSIONNUM: str = "0.10.20"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -125,6 +125,7 @@ STUDIO_THUMBNAIL_WIDTH: int = 200
 
 # Screenspace constants
 SCREENSPACE_MANIFEST_FILENAME: str = "screenspace_manifest.json"
+TRANSCRIPTS_MANIFEST_FILENAME: str = "transcripts_manifest.json"
 SCREENSPACE_DEFAULT_INTERVAL: float = (
     1.0  # default frame sampling interval (seconds) for analysis tasks
 )

--- a/plans/TRANSCRIPT-PLAN.md
+++ b/plans/TRANSCRIPT-PLAN.md
@@ -37,45 +37,45 @@ Embed transcript data on artifacts and build the corrections system.
 
 ### Pre-transcription CLI (`--pre-transcribe`)
 
-- [ ] Add `--pre-transcribe [ID...]` CLI flag — accepts zero or more participant IDs; no IDs = enqueue all participants found in the spreadsheet
-- [ ] For each target participant, transcribe their source video (`{study}_{participant}.mp4`) using `transcribe_video()`
-- [ ] Store full-video transcript results in a separate `transcripts_manifest.json` under a `source_transcripts` key, keyed by participant ID
-- [ ] Add `TRANSCRIPTS_MANIFEST_FILENAME` to `config.py` alongside `SCREENSPACE_MANIFEST_FILENAME`
-- [ ] Add `load_transcripts_manifest()` / `save_transcripts_manifest()` to `transcripts.py` following the `load_screenspace_manifest()` / `save_screenspace_manifest()` pattern
-- [ ] Schema: `{"source_transcripts": {"P01": {"segments": [{start, end, text}, ...], "language": str, "model": str, "source_file": str, "transcribed_at": iso8601}}, "corrections": [...]}` — segments store raw Whisper output; `id` field is added at manifest storage time (e.g. `"P01:42"`); corrections are applied as a read-time layer, not stored on segments
-- [ ] Operation is idempotent: re-running `--pre-transcribe` skips participants already present in `source_transcripts` within the transcripts manifest; force-retranscribe with an explicit flag if needed
-- [ ] Requires a spreadsheet (to resolve participant IDs and source video paths); can combine with `-s`, `-i/-o`, `-v`
-- [ ] Cannot combine with mode flags or `--studio`/`--insights`
+- [x] Add `--pre-transcribe [ID...]` CLI flag — accepts zero or more participant IDs; no IDs = enqueue all participants found in the spreadsheet
+- [x] For each target participant, transcribe their source video (`{study}_{participant}.mp4`) using `transcribe_video()`
+- [x] Store full-video transcript results in a separate `transcripts_manifest.json` under a `source_transcripts` key, keyed by participant ID
+- [x] Add `TRANSCRIPTS_MANIFEST_FILENAME` to `config.py` alongside `SCREENSPACE_MANIFEST_FILENAME`
+- [x] Add `load_transcripts_manifest()` / `save_transcripts_manifest()` to `transcripts.py` following the `load_screenspace_manifest()` / `save_screenspace_manifest()` pattern
+- [x] Schema: `{"source_transcripts": {"P01": {"segments": [{start, end, text}, ...], "language": str, "model": str, "source_file": str, "transcribed_at": iso8601}}, "corrections": [...]}` — segments store raw Whisper output; `id` field is added at manifest storage time (e.g. `"P01:42"`); corrections are applied as a read-time layer, not stored on segments
+- [x] Operation is idempotent: re-running `--pre-transcribe` skips participants already present in `source_transcripts` within the transcripts manifest; force-retranscribe with an explicit flag if needed
+- [x] Requires a spreadsheet (to resolve participant IDs and source video paths); can combine with `-s`, `-i/-o`, `-v`
+- [x] Cannot combine with mode flags or `--studio`/`--insights`
 
 ### Transcript as artifact property
 
-- [ ] Add `transcript` field to clip artifact records in `process_clips()` — after `filter_segments()`, embed the segments list directly on the clip's artifact dict
-- [ ] Source priority: if a source transcript exists in the transcripts manifest for the clip's participant, derive via `filter_segments()`; otherwise fall back to on-the-fly Whisper transcription (if `--transcribe` or `TRANSCRIBE_ENABLED`). The sidecar `.transcript.json` cache is removed.
-- [ ] Segment schema in manifest: `{"id": str, "start": float, "end": float, "text": str}` — `id` is index-based (e.g., `"P01:42"` for participant + segment index) for provenance tracking. Raw `TranscriptSegment` TypedDict stays `{start, end, text}` — `id` is assigned at manifest storage, not transcription.
-- [ ] Add merged `transcript` field to reel artifact records — assembled from constituent clips' transcript segments during reel building, ordered to match the reel. Segment timestamps in the merged reel transcript must be offset by cumulative titlecard/transition durations. Use the reel's `components` metadata (which stores per-component start/end in reel-relative time) to compute offsets.
-- [ ] Keep standalone transcript file output and transcript-type manifest entries as-is (opt-in via `--transcribe`, for researchers who just want text files)
+- [x] Add `transcript` field to clip artifact records in `process_clips()` — after `filter_segments()`, embed the segments list directly on the clip's artifact dict
+- [x] Source priority: if a source transcript exists in the transcripts manifest for the clip's participant, derive via `filter_segments()`; otherwise fall back to on-the-fly Whisper transcription (if `--transcribe` or `TRANSCRIBE_ENABLED`). The sidecar `.transcript.json` cache is removed.
+- [x] Segment schema in manifest: `{"id": str, "start": float, "end": float, "text": str}` — `id` is index-based (e.g., `"P01:42"` for participant + segment index) for provenance tracking. Raw `TranscriptSegment` TypedDict stays `{start, end, text}` — `id` is assigned at manifest storage, not transcription.
+- [x] Add merged `transcript` field to reel artifact records — assembled from constituent clips' transcript segments during reel building, ordered to match the reel. Segment timestamps in the merged reel transcript must be offset by cumulative titlecard/transition durations. Use the reel's `components` metadata (which stores per-component start/end in reel-relative time) to compute offsets.
+- [x] Keep standalone transcript file output and transcript-type manifest entries as-is (opt-in via `--transcribe`, for researchers who just want text files)
 
 ### Corrections dictionary
 
-- [ ] Corrections stored inside `transcripts_manifest.json` under the `corrections` key (study-local only; global dictionary deferred until multi-study need is proven)
-- [ ] Schema: `{"corrections": [{"id": str, "from": str, "to": str, "created": iso8601}]}`
-- [ ] Load corrections from the transcripts manifest at transcription time. Corrections are applied at read-time as post-processing on raw segments. Raw Whisper output in `source_transcripts` is never mutated. This enables clean re-transcription (replace raw segments, corrections auto-apply).
+- [x] Corrections stored inside `transcripts_manifest.json` under the `corrections` key (study-local only; global dictionary deferred until multi-study need is proven)
+- [x] Schema: `{"corrections": [{"id": str, "from": str, "to": str, "created": iso8601}]}`
+- [x] Load corrections from the transcripts manifest at transcription time. Corrections are applied at read-time as post-processing on raw segments. Raw Whisper output in `source_transcripts` is never mutated. This enables clean re-transcription (replace raw segments, corrections auto-apply).
 
 ### Corrections integration with Whisper
 
-- [ ] Feed correction targets (the `"to"` values) as `context_keywords` to `transcribe_video()` — these get appended to Whisper's `initial_prompt`
-- [ ] Post-processing pass after transcription: apply known `"from" → "to"` corrections to segment text
-- [ ] Auto-applied corrections should be flagged or logged so the researcher knows what was changed
+- [x] Feed correction targets (the `"to"` values) as `context_keywords` to `transcribe_video()` — these get appended to Whisper's `initial_prompt`
+- [x] Post-processing pass after transcription: apply known `"from" → "to"` corrections to segment text
+- [x] Auto-applied corrections should be flagged or logged so the researcher knows what was changed
 
 ### Sidecar cache removal
 
-- [ ] Remove sidecar cache: delete `save_transcript_cache()` and `load_transcript_cache()` from `transcripts.py`; remove cache call sites in `clipgen.py:_transcribe_segments()`
-- [ ] Update `_transcribe_segments()` in `clipgen.py` to check `transcripts_manifest.json` for pre-existing source transcripts. New read priority: in-memory cache -> transcripts manifest -> live Whisper.
+- [x] Remove sidecar cache: delete `save_transcript_cache()` and `load_transcript_cache()` from `transcripts.py`; remove cache call sites in `clipgen.py:_transcribe_segments()`
+- [x] Update `_transcribe_segments()` in `clipgen.py` to check `transcripts_manifest.json` for pre-existing source transcripts. New read priority: in-memory cache -> transcripts manifest -> live Whisper.
 
 ### Manifest-layer enrichment
 
-- [ ] Add `apply_corrections(segments, corrections)` function to `transcripts.py` — applies `from -> to` substitutions to segment text, returns corrected copy without mutating input
-- [ ] Assign segment IDs at manifest storage time: `"{participant}:{index}"` format, computed in `save_transcripts_manifest()`
+- [x] Add `apply_corrections(segments, corrections)` function to `transcripts.py` — applies `from -> to` substitutions to segment text, returns corrected copy without mutating input
+- [x] Assign segment IDs at manifest storage time: `"{participant}:{index}"` format, computed in `save_transcripts_manifest()`
 
 ---
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -30,6 +30,7 @@ def _base_args(**overrides):
         "titlecards": None,
         "filmstrip": None,
         "screenspace": False,
+        "pre_transcribe": None,
     }
     args.update(overrides)
     return Namespace(**args)
@@ -239,3 +240,24 @@ def test_run_cli_mode_reel_cli_dispatch(monkeypatch, make_clip):
 )
 def test_is_excel_spreadsheet_arg(value, expected):
     assert cli._is_excel_spreadsheet_arg(value) is expected
+
+
+# ---- --pre-transcribe flag parsing ----
+
+
+def test_pre_transcribe_absent(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py"])
+    args = cli.parse_arguments()
+    assert args.pre_transcribe is None
+
+
+def test_pre_transcribe_no_ids(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--pre-transcribe"])
+    args = cli.parse_arguments()
+    assert args.pre_transcribe == []
+
+
+def test_pre_transcribe_with_ids(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--pre-transcribe", "P01", "P03"])
+    args = cli.parse_arguments()
+    assert args.pre_transcribe == ["P01", "P03"]

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -282,3 +282,186 @@ class TestTranscribeVideoDebug:
         result = transcripts.transcribe_video("/fake/video.mp4", language="de")
         assert result is not None
         assert result["language"] == "de"
+
+
+# ---------------------------------------------------------------------------
+# apply_corrections
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCorrections:
+    def test_no_corrections_returns_copy(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="hello")]
+        result = transcripts.apply_corrections(segs, [])
+        assert result == segs
+        assert result is not segs
+
+    def test_single_correction(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="teh quick fox")]
+        corrections = [{"from": "teh", "to": "the"}]
+        result = transcripts.apply_corrections(segs, corrections)
+        assert result[0]["text"] == "the quick fox"
+
+    def test_multiple_corrections(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="teh quck fox")]
+        corrections = [
+            {"from": "teh", "to": "the"},
+            {"from": "quck", "to": "quick"},
+        ]
+        result = transcripts.apply_corrections(segs, corrections)
+        assert result[0]["text"] == "the quick fox"
+
+    def test_no_mutation_of_input(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="teh fox")]
+        original_text = segs[0]["text"]
+        transcripts.apply_corrections(segs, [{"from": "teh", "to": "the"}])
+        assert segs[0]["text"] == original_text
+
+    def test_case_insensitive(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="Teh quick TEH fox")]
+        corrections = [{"from": "teh", "to": "the"}]
+        result = transcripts.apply_corrections(segs, corrections)
+        assert result[0]["text"] == "the quick the fox"
+
+    def test_correction_not_found(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="hello world")]
+        corrections = [{"from": "xyz", "to": "abc"}]
+        result = transcripts.apply_corrections(segs, corrections)
+        assert result[0]["text"] == "hello world"
+
+    def test_skips_empty_from_or_to(self):
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="hello")]
+        corrections = [{"from": "", "to": "x"}, {"from": "y", "to": ""}]
+        result = transcripts.apply_corrections(segs, corrections)
+        assert result[0]["text"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# get_corrections_keywords
+# ---------------------------------------------------------------------------
+
+
+class TestGetCorrectionsKeywords:
+    def test_empty(self):
+        assert transcripts.get_corrections_keywords([]) == []
+
+    def test_extracts_unique_to_values(self):
+        corrections = [
+            {"from": "a", "to": "alpha"},
+            {"from": "b", "to": "beta"},
+            {"from": "c", "to": "alpha"},  # duplicate
+        ]
+        result = transcripts.get_corrections_keywords(corrections)
+        assert result == ["alpha", "beta"]
+
+    def test_strips_whitespace(self):
+        corrections = [{"from": "a", "to": "  alpha  "}]
+        result = transcripts.get_corrections_keywords(corrections)
+        assert result == ["alpha"]
+
+    def test_skips_empty_to(self):
+        corrections = [{"from": "a", "to": ""}, {"from": "b", "to": "  "}]
+        assert transcripts.get_corrections_keywords(corrections) == []
+
+
+# ---------------------------------------------------------------------------
+# Transcripts manifest I/O
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptsManifest:
+    def test_empty_manifest_default(self):
+        m = transcripts._empty_transcripts_manifest()
+        assert m == {"source_transcripts": {}, "corrections": []}
+
+    def test_load_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        m = transcripts.load_transcripts_manifest()
+        assert m == {"source_transcripts": {}, "corrections": []}
+
+    def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        source = {
+            "P01": {
+                "segments": [{"start": 0.0, "end": 1.0, "text": "hello"}],
+                "language": "en",
+                "model": "base",
+                "source_file": "video.mp4",
+                "transcribed_at": "2025-01-01T00:00:00+00:00",
+            }
+        }
+        corrections = [
+            {
+                "id": "c1",
+                "from": "helo",
+                "to": "hello",
+                "created": "2025-01-01T00:00:00+00:00",
+            }
+        ]
+        path = transcripts.save_transcripts_manifest(source, corrections)
+        assert path is not None
+
+        loaded = transcripts.load_transcripts_manifest()
+        assert loaded["corrections"] == corrections
+        assert "P01" in loaded["source_transcripts"]
+        assert len(loaded["source_transcripts"]["P01"]["segments"]) == 1
+
+    def test_segment_ids_assigned_on_save(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        source = {
+            "P01": {
+                "segments": [
+                    {"start": 0.0, "end": 1.0, "text": "first"},
+                    {"start": 1.0, "end": 2.0, "text": "second"},
+                ],
+                "language": "en",
+                "model": "base",
+                "source_file": "v.mp4",
+                "transcribed_at": "2025-01-01T00:00:00+00:00",
+            }
+        }
+        transcripts.save_transcripts_manifest(source, [])
+        loaded = transcripts.load_transcripts_manifest()
+        segs = loaded["source_transcripts"]["P01"]["segments"]
+        assert segs[0]["id"] == "P01:0"
+        assert segs[1]["id"] == "P01:1"
+
+    def test_corrections_preserved(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        corrections = [
+            {
+                "id": "c1",
+                "from": "teh",
+                "to": "the",
+                "created": "2025-01-01T00:00:00+00:00",
+            },
+            {
+                "id": "c2",
+                "from": "recieve",
+                "to": "receive",
+                "created": "2025-01-01T00:00:00+00:00",
+            },
+        ]
+        transcripts.save_transcripts_manifest({}, corrections)
+        loaded = transcripts.load_transcripts_manifest()
+        assert loaded["corrections"] == corrections
+
+    def test_load_corrupt_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        (tmp_path / config.TRANSCRIPTS_MANIFEST_FILENAME).write_text("not json")
+        m = transcripts.load_transcripts_manifest()
+        assert m == {"source_transcripts": {}, "corrections": []}
+
+
+# ---------------------------------------------------------------------------
+# ManifestSegment type
+# ---------------------------------------------------------------------------
+
+
+class TestManifestSegment:
+    def test_fields(self):
+        seg = transcripts.ManifestSegment(id="P01:0", start=0.0, end=1.0, text="hi")
+        assert seg["id"] == "P01:0"
+        assert seg["start"] == 0.0
+        assert seg["end"] == 1.0
+        assert seg["text"] == "hi"

--- a/transcripts.py
+++ b/transcripts.py
@@ -6,6 +6,7 @@ The Whisper model is lazy-loaded on first use and cached at module level for the
 Data types (defined below):
   TranscriptSegment – TypedDict: start (float), end (float), text (str)
   TranscriptResult  – TypedDict: segments, language, source_file, model
+  ManifestSegment   – TypedDict: id (str), start, end, text — enriched segment for manifest storage
 
 Key functions:
   transcribe_video(path, *, language, initial_prompt, context_keywords)
@@ -17,16 +18,23 @@ Key functions:
   read_transcript(filepath) → TranscriptResult (parses any supported format)
   get_transcript_extension(fmt) → file extension string for a format
 
-Pipeline integration: clipgen.process_clips() calls _transcribe_segments() which caches the
-full-video result per source video, then filters and writes per-clip transcripts. Transcript
-artifacts (type "transcript") are added to the artifact list for manifest tracking. Output
-filenames match the corresponding clip filename with the transcript extension.
+Manifest I/O:
+  load_transcripts_manifest() → dict with source_transcripts and corrections keys
+  save_transcripts_manifest(source_transcripts, corrections) → assigns segment IDs, writes JSON
+
+Corrections:
+  apply_corrections(segments, corrections) → new segment list with from→to substitutions applied
+  get_corrections_keywords(corrections) → unique "to" values for Whisper context_keywords
+
+Pipeline integration: clipgen.process_clips() calls _transcribe_segments() which checks the
+transcripts manifest for pre-existing source transcripts, then falls back to live Whisper.
+Transcript segments are embedded on clip/reel artifact records as a ``transcript`` field.
+Standalone transcript file output (type "transcript" artifacts) is opt-in via --transcribe.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -51,6 +59,15 @@ class TranscriptResult(TypedDict):
     language: str
     source_file: str
     model: str
+
+
+class ManifestSegment(TypedDict):
+    """Segment stored in transcripts_manifest.json — includes an ID for provenance tracking."""
+
+    id: str  # e.g. "P01:42"
+    start: float
+    end: float
+    text: str
 
 
 # ---------------------------------------------------------------------------
@@ -155,44 +172,118 @@ def transcribe_video(
 
 
 # ---------------------------------------------------------------------------
-# Disk cache (sidecar JSON next to source video)
+# Transcripts manifest (source-video transcripts + corrections dictionary)
 # ---------------------------------------------------------------------------
 
 
-def save_transcript_cache(result: TranscriptResult, video_path: str) -> bool:
-    """Save transcript to a sidecar JSON file next to the source video."""
-    cache_path = Path(video_path).with_suffix(".transcript.json")
-    try:
-        data = {
-            "segments": result["segments"],
-            "language": result["language"],
-            "source_file": result["source_file"],
-            "model": result["model"],
-            "video_mtime": os.path.getmtime(video_path),
-        }
-        cache_path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
-        return True
-    except OSError:
-        return False
+def _empty_transcripts_manifest() -> dict[str, Any]:
+    return {"source_transcripts": {}, "corrections": []}
 
 
-def load_transcript_cache(video_path: str) -> Optional[TranscriptResult]:
-    """Load cached transcript if sidecar exists and source video hasn't changed."""
-    cache_path = Path(video_path).with_suffix(".transcript.json")
-    if not cache_path.is_file():
-        return None
+def load_transcripts_manifest() -> dict[str, Any]:
+    """Load the transcripts manifest from the output directory.
+
+    Returns a dict with ``source_transcripts`` and ``corrections`` keys.
+    Missing or corrupt files return an empty manifest.
+    """
+    manifest_path = (
+        Path(utils.get_effective_output_dir()) / config.TRANSCRIPTS_MANIFEST_FILENAME
+    )
+    if not manifest_path.is_file():
+        return _empty_transcripts_manifest()
     try:
-        data = json.loads(cache_path.read_text(encoding="utf-8"))
-        if data.get("video_mtime") != os.path.getmtime(video_path):
-            return None
-        return TranscriptResult(
-            segments=[TranscriptSegment(**s) for s in data["segments"]],
-            language=data["language"],
-            source_file=data["source_file"],
-            model=data["model"],
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty_transcripts_manifest()
+    if not isinstance(data, dict):
+        return _empty_transcripts_manifest()
+    return {
+        "source_transcripts": data.get("source_transcripts") or {},
+        "corrections": data.get("corrections") or [],
+    }
+
+
+def save_transcripts_manifest(
+    source_transcripts: dict[str, Any],
+    corrections: list[dict[str, Any]],
+) -> Optional[Path]:
+    """Write the transcripts manifest to disk.
+
+    Assigns segment IDs (``"{participant}:{index}"``) at storage time.
+    Returns the manifest path on success, or ``None`` on failure.
+    """
+    for participant_id, entry in source_transcripts.items():
+        for idx, seg in enumerate(entry.get("segments", [])):
+            seg["id"] = f"{participant_id}:{idx}"
+
+    data = {"source_transcripts": source_transcripts, "corrections": corrections}
+    manifest_path = (
+        Path(utils.get_effective_output_dir()) / config.TRANSCRIPTS_MANIFEST_FILENAME
+    )
+    try:
+        manifest_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
         )
-    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return manifest_path
+    except OSError as exc:
+        utils.warning_print(f"Failed to save transcripts manifest: {exc}")
         return None
+
+
+# ---------------------------------------------------------------------------
+# Corrections
+# ---------------------------------------------------------------------------
+
+
+def apply_corrections(
+    segments: list[TranscriptSegment],
+    corrections: list[dict[str, Any]],
+) -> list[TranscriptSegment]:
+    """Apply corrections to transcript segments as post-processing.
+
+    Returns a new list of segments with ``from -> to`` substitutions applied.
+    Never mutates the input. Case-insensitive, word-boundary matching.
+    """
+    if not corrections:
+        return list(segments)
+
+    pairs = [(c["from"], c["to"]) for c in corrections if c.get("from") and c.get("to")]
+    if not pairs:
+        return list(segments)
+
+    corrected: list[TranscriptSegment] = []
+    total_applied = 0
+    for seg in segments:
+        text = seg["text"]
+        seg_applied = 0
+        for from_text, to_text in pairs:
+            pattern = re.compile(re.escape(from_text), re.IGNORECASE)
+            new_text, count = pattern.subn(to_text, text)
+            if count > 0:
+                text = new_text
+                seg_applied += count
+        total_applied += seg_applied
+        corrected.append(
+            TranscriptSegment(start=seg["start"], end=seg["end"], text=text)
+        )
+
+    if total_applied > 0:
+        utils.verbose_print(
+            f"  Auto-applied {total_applied} correction(s) across {len(segments)} segment(s)."
+        )
+    return corrected
+
+
+def get_corrections_keywords(corrections: list[dict[str, Any]]) -> list[str]:
+    """Extract unique ``to`` values from corrections for use as Whisper context keywords."""
+    seen: set[str] = set()
+    keywords: list[str] = []
+    for c in corrections:
+        to_val = c.get("to", "").strip()
+        if to_val and to_val not in seen:
+            seen.add(to_val)
+            keywords.append(to_val)
+    return keywords
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `--pre-transcribe [ID...]` CLI flag for upfront source video transcription, storing results in a separate `transcripts_manifest.json` with segment IDs and a corrections dictionary
- Embeds transcript segments directly on clip and reel artifact records as a `transcript` field, derived from source transcripts via `filter_segments()`
- Replaces the sidecar `.transcript.json` cache with the transcripts manifest as the single persistence layer
- Adds `apply_corrections()` for read-time post-processing and `get_corrections_keywords()` for biasing Whisper via `context_keywords`

## Test plan

- [x] 21 new tests for manifest I/O, corrections, keywords, segment IDs, and CLI flag parsing
- [x] Full test suite passes (450 tests)
- [ ] Manual smoke test: `--pre-transcribe` with debug mode creates `transcripts_manifest.json` with correct schema
- [ ] Verify clip artifacts gain `transcript` field when source transcripts exist
- [ ] Verify idempotency: re-running `--pre-transcribe` skips already-transcribed participants