### PR TITLE
Comply with LGPL terms for bundled FFmpeg in cv2

### DIFF
--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -46,11 +46,20 @@ a = Analysis(
 # operations; only OpenCV's image-processing functions (no VideoCapture) are
 # needed at runtime.
 _FFMPEG_LIB_PREFIXES = (
-    "libav",        # libavcodec, libavformat, libavfilter, libavutil, libavdevice
-    "libsw",        # libswresample, libswscale
-    "libpostproc",  # FFmpeg post-processing
-    "libx264",      # GPL 2.0 — H.264 encoder
-    "libx265",      # GPL 2.0 — H.265 encoder
+    # FFmpeg core libraries (LGPL 2.1, but tainted GPL by bundled codecs)
+    "libavcodec",
+    "libavdevice",
+    "libavfilter",
+    "libavformat",
+    "libavutil",
+    "libswresample",
+    "libswscale",
+    "libpostproc",
+    # GPL 2.0 codec libraries
+    "libx264",
+    "libx265",
+    # NOTE: libavif (AVIF image codec, BSD) is NOT excluded — it is not part
+    # of FFmpeg and is needed by OpenCV for image I/O.
 )
 
 def _is_ffmpeg_lib(name):


### PR DESCRIPTION
## Summary

Follow-up to #149. The PyInstaller spec's FFmpeg dylib exclusion broke `import cv2` at runtime because `cv2.abi3.so` hard-links against FFmpeg libraries at load time. Rather than building OpenCV from source without FFmpeg, we keep the libraries bundled and comply with LGPL 2.1 terms: attributing FFmpeg, including the LGPL license text (via `cv2/LICENSE-3RD-PARTY.txt`), and pointing to source code. The LICENSE-PLAN.md is updated with the architectural decision.

## Test plan

- [ ] PyInstaller `--onefile` build launches without `dlopen` errors
- [ ] Screenspace frame preview works with real video files