### PR TITLE
Skip redundant CI checks on merged PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,32 @@ on:
       - ".github/workflows/tests.yml"
 
 jobs:
+  gate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Check if commit is from a merged PR
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPO="${{ github.repository }}"
+          SHA="${{ github.sha }}"
+          MERGED=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
+            --jq '[.[] | select(.state == "closed" and .merged_at != null)] | length')
+          if [[ "$MERGED" -gt 0 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Commit $SHA is from a merged PR — skipping redundant checks"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Commit $SHA is a direct push — running checks"
+          fi
+
   smoke-tests:
+    needs: [gate]
+    if: always() && (needs.gate.outputs.skip != 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -136,6 +161,8 @@ jobs:
           fi
 
   lint:
+    needs: [gate]
+    if: always() && (needs.gate.outputs.skip != 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -153,6 +180,8 @@ jobs:
         run: uvx ruff format --check
 
   typecheck:
+    needs: [gate]
+    if: always() && (needs.gate.outputs.skip != 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds a `gate` job that uses the GitHub API to detect whether a push to master came from a merged PR
- If it did, the smoke-tests, lint, and typecheck jobs are skipped (they already passed on the PR)
- Direct pushes to master still run all checks normally
- PR-triggered runs are unaffected — the gate job is skipped on PR events and `always()` ensures downstream jobs proceed

## Test plan

- [ ] Merge a PR and verify the push-triggered workflow shows gate as passing and check jobs as "Skipped"
- [ ] Push directly to master and verify all check jobs run
- [ ] Open a PR and verify all check jobs run (gate should show as "Skipped")