### PR TITLE
Comply with LGPL terms for bundled FFmpeg in cv2

### DIFF
--- a/build/THIRD-PARTY-LICENSES
+++ b/build/THIRD-PARTY-LICENSES
@@ -15,7 +15,8 @@ icecream                    2.1.10     MIT
 rich                        14.3.3     MIT
 faster-whisper              1.2.1      MIT
 CTranslate2                 4.7.1      MIT
-opencv-python-headless      4.13.0     MIT (bindings) + Apache 2.0 (OpenCV)*
+opencv-python-headless      4.13.0     MIT (bindings) + Apache 2.0 (OpenCV)
+  FFmpeg (bundled in cv2)     7.1        LGPL-2.1-or-later
 Flask                       3.1.3      BSD-3-Clause
 Werkzeug                    3.1.6      BSD-3-Clause
 Jinja2                      3.1.6      BSD-3-Clause
@@ -29,13 +30,6 @@ Pillow                      12.1.1     HPND (MIT-CMU)
 EasyOCR                     1.7.2      Apache-2.0
 google-auth                 2.49.1     Apache-2.0
 google-auth-oauthlib        1.3.0      Apache-2.0
-
-* The opencv-python-headless pip package bundles FFmpeg shared libraries
-  (LGPL 2.1) and GPL-licensed codecs (libx264, libx265).  clipgen's
-  PyInstaller build EXCLUDES these libraries from the binary — only OpenCV's
-  image-processing core (Apache 2.0) and its Python bindings (MIT) are
-  shipped.  Video decoding uses the system-installed ffmpeg, which is not
-  bundled.
 
 
 ===============================================================================
@@ -772,6 +766,37 @@ Copyright notices:
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+
+===============================================================================
+LGPL-2.1-OR-LATER (FFmpeg and related libraries)
+===============================================================================
+
+The opencv-python-headless package bundles FFmpeg shared libraries and several
+codec/protocol libraries as dynamic libraries inside cv2/.dylibs/.  These are
+built by the opencv-python project as LGPL (without --enable-gpl), so the
+FFmpeg libraries remain LGPL-2.1-or-later.
+
+The bundled FFmpeg libraries are:
+  libavcodec, libavformat, libavfilter, libavutil, libavdevice,
+  libswresample, libswscale, libpostproc
+
+Additional codec and protocol libraries bundled under LGPL-2.1-or-later:
+  libmp3lame, libbluray, libgnutls, libnettle, libhogweed,
+  libsoxr, libtasn1, libopencore-amrnb, libopencore-amrwb
+
+clipgen does not call cv2.VideoCapture or any other FFmpeg-backed cv2 function.
+Video decoding uses the system-installed ffmpeg binary via subprocess.  The
+FFmpeg shared libraries above are bundled solely because cv2.abi3.so links
+against them at load time.
+
+Source code for FFmpeg is available at: https://ffmpeg.org/download.html
+Source code for the opencv-python build (including FFmpeg build configuration)
+is available at: https://github.com/opencv/opencv-python
+
+The full text of the GNU Lesser General Public License version 2.1 is
+reproduced in the opencv-python-headless LICENSE-3RD-PARTY.txt file,
+which is included in this distribution at cv2/LICENSE-3RD-PARTY.txt.
 
 
 ===============================================================================

--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -39,36 +39,6 @@ a = Analysis(
     excludes=excludes,
     noarchive=False,
 )
-
-# Exclude FFmpeg libraries bundled inside opencv-python-headless.
-# These include GPL-licensed codecs (libx264, libx265) that would make the
-# entire binary GPL if distributed.  clipgen uses system ffmpeg for video
-# operations; only OpenCV's image-processing functions (no VideoCapture) are
-# needed at runtime.
-_FFMPEG_LIB_PREFIXES = (
-    # FFmpeg core libraries (LGPL 2.1, but tainted GPL by bundled codecs)
-    "libavcodec",
-    "libavdevice",
-    "libavfilter",
-    "libavformat",
-    "libavutil",
-    "libswresample",
-    "libswscale",
-    "libpostproc",
-    # GPL 2.0 codec libraries
-    "libx264",
-    "libx265",
-    # NOTE: libavif (AVIF image codec, BSD) is NOT excluded — it is not part
-    # of FFmpeg and is needed by OpenCV for image I/O.
-)
-
-def _is_ffmpeg_lib(name):
-    """True for FFmpeg shared libraries bundled inside the cv2 package."""
-    base = name.rsplit("/", 1)[-1] if "/" in name else name
-    return any(base.startswith(p) for p in _FFMPEG_LIB_PREFIXES)
-
-a.binaries = [b for b in a.binaries if not _is_ffmpeg_lib(b[0])]
-
 pyz = PYZ(a.pure)
 
 exe = EXE(

--- a/plans/LICENSE-PLAN.md
+++ b/plans/LICENSE-PLAN.md
@@ -2,7 +2,21 @@
 
 ## Context
 
-clipgen bundles 20+ third-party libraries into a PyInstaller binary. All licenses (MIT, BSD, Apache 2.0, HPND) require attribution. The `build/THIRD-PARTY-LICENSES` file contains the full notices. This plan covers how to get that file to end users.
+clipgen bundles 20+ third-party libraries into a PyInstaller binary. All licenses (MIT, BSD, Apache 2.0, HPND, LGPL) require attribution. The `build/THIRD-PARTY-LICENSES` file contains the full notices. This plan covers how to get that file to end users.
+
+## Architectural decisions
+
+### OpenCV and FFmpeg (decided 2026-04-04)
+
+`opencv-python-headless` bundles FFmpeg shared libraries (libavcodec, libavformat, etc.) inside `cv2/.dylibs/`. The `cv2.abi3.so` binary hard-links against these at load time — they **cannot** be excluded from a PyInstaller build without breaking `import cv2`.
+
+The opencv-python project builds FFmpeg as **LGPL 2.1** (without `--enable-gpl`). The `libx264`/`libx265` dylibs are present as transitive dynamic dependencies but are not compiled into FFmpeg, so they do not taint the FFmpeg license.
+
+**Decision:** Keep FFmpeg libraries bundled. Comply with LGPL 2.1 terms by:
+1. Including the LGPL license text (via `cv2/LICENSE-3RD-PARTY.txt` in the bundle)
+2. Attributing FFmpeg and listing the bundled libraries in `build/THIRD-PARTY-LICENSES`
+3. Providing source code pointers (ffmpeg.org, github.com/opencv/opencv-python)
+4. Not calling `cv2.VideoCapture` or any FFmpeg-backed cv2 API — video decoding uses system ffmpeg via subprocess
 
 ## Steps
 


### PR DESCRIPTION
## Summary

Follow-up to #149. The PyInstaller spec's FFmpeg dylib exclusion broke `import cv2` at runtime because `cv2.abi3.so` hard-links against FFmpeg libraries at load time. Rather than building OpenCV from source without FFmpeg, we keep the libraries bundled and comply with LGPL 2.1 terms: attributing FFmpeg, including the LGPL license text (via `cv2/LICENSE-3RD-PARTY.txt`), and pointing to source code. The LICENSE-PLAN.md is updated with the architectural decision.

## Test plan

- [ ] PyInstaller `--onefile` build launches without `dlopen` errors
- [ ] Screenspace frame preview works with real video files