### PR TITLE
Fix binary working directory resolving to PyInstaller temp dir

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -426,9 +426,7 @@ def get_runtime_working_dir() -> str:
     executable directory so local assets resolve from where the binary lives.
     """
     if getattr(sys, "frozen", False):
-        return str(
-            Path(getattr(sys, "_MEIPASS", str(Path(sys.executable).resolve().parent)))
-        )
+        return str(Path(sys.executable).resolve().parent)
     return str(Path(__file__).resolve().parent)
 
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.20"
+VERSIONNUM: str = "0.10.21"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- `get_runtime_working_dir()` was returning `sys._MEIPASS` (PyInstaller's temporary extraction directory) for frozen builds, causing the working directory to resolve to e.g. `/private/var/folders/.../T/_MEIMT4J7d` instead of the directory containing the binary
- Changed to use `sys.executable`'s parent directory instead; `_MEIPASS` is only relevant for bundled asset resolution, which is already handled by `get_bundled_assets_root()`
- Bumps version to 0.10.21

## Test plan
- [x] Existing test suite passes (480 tests)
- [ ] Run PyInstaller binary and verify working directory points to the binary's location