### PR TITLE
Skip redundant CI checks on merged PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           REPO="${{ github.repository }}"
           SHA="${{ github.sha }}"
-          MERGED=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
-            --jq '[.[] | select(.state == "closed" and .merged_at != null)] | length')
+          MERGED=$(gh api "repos/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=5" \
+            --jq "[.[] | select(.merge_commit_sha == \"${SHA}\")] | length")
           if [[ "$MERGED" -gt 0 ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Commit $SHA is from a merged PR — skipping redundant checks"


### PR DESCRIPTION
## Summary

- Adds a `gate` job that checks whether a push to master came from a merged PR (by matching `merge_commit_sha` against recently closed PRs)
- If it did, the smoke-tests, lint, and typecheck jobs are skipped since they already passed on the PR
- Direct pushes to master still run all checks normally
- PR-triggered runs are unaffected — the gate is skipped on PR events and `always()` ensures downstream jobs proceed

## Test plan

- [ ] Merge a PR and verify the push-triggered workflow skips check jobs
- [ ] Push directly to master and verify all check jobs run
- [ ] Open a PR and verify all check jobs run