### PR TITLE
Add per-tool Fast mode descriptions to Screenspace tooltip

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -954,6 +954,26 @@ body {
   background: var(--color-warning, #f59e0b);
 }
 
+.scan-toggle-tooltip {
+  position: fixed;
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-text);
+  color: var(--color-bg);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  white-space: pre-line;
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  z-index: var(--z-float);
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+
+.scan-toggle-tooltip.visible {
+  opacity: 1;
+}
+
 .task-fast-badge {
   display: inline-flex;
   align-items: center;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -575,6 +575,19 @@
     btn.appendChild(chevron);
   }
 
+  var FAST_SCAN_DESCRIPTIONS = {
+    color: "Lower resolution, skips unchanged frames",
+    change: "Lower resolution, skips unchanged frames",
+    similarity: "Lower resolution, skips unchanged frames",
+    text: "Skips unchanged frames",
+    numbers: "Skips unchanged frames",
+    template: "Downscales template 2\u00D7, skips unchanged frames",
+    flow: "Lower resolution, skips unchanged frames",
+    scene: "Lower resolution, skips unchanged frames",
+    inactivity: "Lower resolution, skips unchanged frames",
+    multitool: "Skips unchanged frames, widens interval"
+  };
+
   function renderScanModePicker() {
     var wrap = qs("#runScanModePicker");
     if (!wrap) return;
@@ -590,12 +603,29 @@
     icon.style.webkitMaskImage = url;
     btn.appendChild(icon);
 
+    var tip = el("div", "scan-toggle-tooltip");
+    document.body.appendChild(tip);
+
     function updateState() {
       var isFast = state.scanMode === "fast";
       btn.classList.toggle("active", isFast);
-      btn.setAttribute("data-tooltip", isFast ? "Fast scan enabled" : "Enable fast scan");
+      var label = isFast ? "Fast scan enabled" : "Enable fast scan";
+      var desc = FAST_SCAN_DESCRIPTIONS[state.activeWorkflow];
+      if (desc) label += "\n" + desc;
+      tip.textContent = label;
     }
     updateState();
+    btn._updateScanState = updateState;
+
+    btn.addEventListener("mouseenter", function () {
+      var r = btn.getBoundingClientRect();
+      tip.style.left = (r.left + r.width / 2) + "px";
+      tip.style.top = (r.top - tip.offsetHeight - 6) + "px";
+      tip.classList.add("visible");
+    });
+    btn.addEventListener("mouseleave", function () {
+      tip.classList.remove("visible");
+    });
 
     btn.addEventListener("click", function () {
       state.scanMode = state.scanMode === "fast" ? "normal" : "fast";
@@ -3026,6 +3056,8 @@
     // Hide scan mode picker for timelapse (fast scan doesn't apply)
     var scanPicker = qs("#runScanModePicker");
     if (scanPicker) scanPicker.style.display = type === "timelapse" ? "none" : "";
+    var scanBtn = scanPicker && scanPicker.querySelector(".scan-toggle-btn");
+    if (scanBtn && scanBtn._updateScanState) scanBtn._updateScanState();
 
     updateRunButton();
   }


### PR DESCRIPTION
## Summary

- The Fast mode toggle tooltip now describes what Fast mode does for the currently selected tool (e.g. "Lower resolution, skips unchanged frames" for color, "Skips unchanged frames" for text/numbers, "Downscales template 2×" for template).
- The tooltip updates automatically when switching between tools.
- Uses a fixed-position DOM tooltip appended to `document.body` to avoid clipping by `overflow: hidden` on `#bottomPanel`.

## Test plan

- [ ] Open Screenspace, hover the Fast toggle — tooltip shows "Enable fast scan" plus a per-tool description on the second line
- [ ] Switch between tools (color, text, template, etc.) — description updates
- [ ] Toggle Fast mode on — first line changes to "Fast scan enabled"
- [ ] Switch to timelapse — Fast toggle is hidden (unchanged behavior)