### PR TITLE
Word-level transcript editing with correction chaining

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -393,7 +393,7 @@ body {
   gap: var(--space-3);
   padding: var(--space-2) var(--space-5);
   border-left: 3px solid transparent;
-  cursor: pointer;
+  cursor: default;
   transition: background var(--duration-fast), border-color var(--duration-fast);
 }
 
@@ -434,18 +434,23 @@ body {
   vertical-align: middle;
 }
 
-.segment-text-input {
-  width: 100%;
-  font-size: var(--text-base);
-  font-family: inherit;
-  line-height: 1.6;
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--color-accent);
+/* Word-level inline editing */
+
+.segment-word {
+  cursor: pointer;
   border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  color: var(--color-text);
+  transition: background var(--duration-fast), box-shadow var(--duration-fast);
+}
+
+.segment-word:hover {
+  background: var(--color-selected);
+}
+
+.segment-word-editing {
   outline: none;
-  resize: vertical;
+  background: var(--color-selected);
+  box-shadow: 0 1px 0 var(--color-accent);
+  cursor: text;
 }
 
 /* Queue panel */

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -393,7 +393,7 @@ body {
   gap: var(--space-3);
   padding: var(--space-2) var(--space-5);
   border-left: 3px solid transparent;
-  cursor: default;
+  cursor: pointer;
   transition: background var(--duration-fast), border-color var(--duration-fast);
 }
 
@@ -446,11 +446,18 @@ body {
   background: var(--color-selected);
 }
 
-.segment-word-editing {
+.segment-text-editing {
   outline: none;
-  background: var(--color-selected);
   box-shadow: 0 1px 0 var(--color-accent);
   cursor: text;
+}
+
+.segment-text-editing .segment-word {
+  cursor: text;
+}
+
+.segment-text-editing .segment-word:hover {
+  background: none;
 }
 
 /* Queue panel */

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -16,7 +16,7 @@
     searchQuery: "",
     searchResults: null,
     activeSegmentIndex: -1,
-    editingSegmentId: null,
+    editingWordEl: null,
     pollTimer: null,
   };
 
@@ -243,6 +243,7 @@
   function renderSegments() {
     var container = qs("#segmentList");
     var empty = qs("#transcriptEmpty");
+    state.editingWordEl = null;
 
     if (state.segments.length === 0) {
       container.innerHTML = "";
@@ -258,7 +259,17 @@
       var correctedClass = seg.corrected ? " segment-corrected" : "";
       html += '<div class="segment-row' + activeClass + correctedClass + '" data-index="' + i + '" data-start="' + seg.start + '">';
       html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
-      html += '<span class="segment-text" data-id="' + escapeHtml(seg.id) + '">' + escapeHtml(seg.text) + '</span>';
+      // Split text into word spans
+      var tokens = seg.text.split(/(\s+)/);
+      var wordHtml = "";
+      for (var w = 0; w < tokens.length; w++) {
+        if (/^\s+$/.test(tokens[w])) {
+          wordHtml += tokens[w];
+        } else if (tokens[w]) {
+          wordHtml += '<span class="segment-word" data-original="' + escapeHtml(tokens[w]) + '">' + escapeHtml(tokens[w]) + '</span>';
+        }
+      }
+      html += '<span class="segment-text" data-id="' + escapeHtml(seg.id) + '">' + wordHtml + '</span>';
       html += '</div>';
     }
     container.innerHTML = html;
@@ -272,16 +283,13 @@
           var start = parseFloat(row.getAttribute("data-start"));
           seekVideo(start);
         });
-        row.querySelector(".segment-text").addEventListener("click", function (e) {
-          e.stopPropagation();
-          var start = parseFloat(row.getAttribute("data-start"));
-          seekVideo(start);
-        });
-        row.querySelector(".segment-text").addEventListener("dblclick", function (e) {
-          e.stopPropagation();
-          var segId = this.getAttribute("data-id");
-          startEditing(segId, this);
-        });
+        var wordSpans = row.querySelectorAll(".segment-word");
+        for (var k = 0; k < wordSpans.length; k++) {
+          wordSpans[k].addEventListener("click", function (e) {
+            e.stopPropagation();
+            startWordEditing(this);
+          });
+        }
       })(rows[j]);
     }
   }
@@ -356,63 +364,95 @@
     }
   }
 
-  // ---- Inline editing ----
+  // ---- Inline word editing ----
 
-  function startEditing(segmentId, textEl) {
-    if (state.editingSegmentId === segmentId) return;
-    state.editingSegmentId = segmentId;
+  function startWordEditing(wordEl) {
+    if (state.editingWordEl === wordEl) return;
+    if (state.editingWordEl) finishWordEditing(state.editingWordEl);
 
-    var currentText = textEl.textContent;
-    var input = document.createElement("textarea");
-    input.className = "segment-text-input";
-    input.value = currentText;
-    input.autocomplete = "off";
-    input.rows = 2;
-    textEl.innerHTML = "";
-    textEl.appendChild(input);
-    input.focus();
-    input.select();
+    state.editingWordEl = wordEl;
+    var original = wordEl.getAttribute("data-original");
 
-    function save() {
-      var newText = input.value.trim();
-      state.editingSegmentId = null;
-      if (!newText || newText === currentText) {
-        textEl.textContent = currentText;
-        return;
-      }
-      textEl.textContent = newText;
-      saveSegmentEdit(segmentId, newText);
+    wordEl.setAttribute("contenteditable", "true");
+    wordEl.setAttribute("spellcheck", "false");
+    wordEl.classList.add("segment-word-editing");
+
+    var range = document.createRange();
+    range.selectNodeContents(wordEl);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    wordEl.focus();
+
+    function onBlur() {
+      wordEl.removeEventListener("blur", onBlur);
+      wordEl.removeEventListener("keydown", onKeydown);
+      wordEl.removeEventListener("paste", onPaste);
+      finishWordEditing(wordEl);
     }
 
-    input.addEventListener("blur", save);
-    input.addEventListener("keydown", function (e) {
-      if (e.key === "Enter" && !e.shiftKey) {
+    function onKeydown(e) {
+      if (e.key === "Enter") {
         e.preventDefault();
-        input.blur();
+        wordEl.blur();
       }
       if (e.key === "Escape") {
-        state.editingSegmentId = null;
-        textEl.textContent = currentText;
+        wordEl.textContent = original;
+        wordEl.blur();
       }
-    });
+      if (e.key === "Tab") {
+        e.preventDefault();
+        wordEl.blur();
+      }
+    }
+
+    function onPaste(e) {
+      e.preventDefault();
+      var text = (e.clipboardData || window.clipboardData).getData("text/plain");
+      text = text.replace(/\s+/g, " ").trim();
+      document.execCommand("insertText", false, text);
+    }
+
+    wordEl.addEventListener("blur", onBlur);
+    wordEl.addEventListener("keydown", onKeydown);
+    wordEl.addEventListener("paste", onPaste);
   }
 
-  function saveSegmentEdit(segmentId, newText) {
-    var pid = state.selectedParticipant;
-    if (!pid) return;
+  function finishWordEditing(wordEl) {
+    var original = wordEl.getAttribute("data-original");
+    var newText = wordEl.textContent.trim();
 
-    apiPut("api/transcript/" + pid + "/segment", {
-      segment_id: segmentId,
-      text: newText,
+    wordEl.removeAttribute("contenteditable");
+    wordEl.classList.remove("segment-word-editing");
+
+    if (state.editingWordEl === wordEl) state.editingWordEl = null;
+
+    if (!newText) {
+      wordEl.textContent = original;
+      return;
+    }
+    if (newText === original) return;
+
+    wordEl.textContent = newText;
+    wordEl.setAttribute("data-original", newText);
+    saveWordCorrection(original, newText);
+  }
+
+  function saveWordCorrection(fromText, toText) {
+    apiPost("api/corrections", {
+      from: fromText,
+      to: toText,
     }).then(function (data) {
       if (data.ok && data.correction) {
         showToast("Correction created");
-        // Reload transcript to show updated corrections
-        loadTranscript(pid);
-        loadCorrections();
+        var pid = state.selectedParticipant;
+        if (pid) {
+          loadTranscript(pid);
+          loadCorrections();
+        }
       }
     }).catch(function () {
-      showToast("Failed to save edit");
+      showToast("Failed to save correction");
     });
   }
 

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -16,7 +16,7 @@
     searchQuery: "",
     searchResults: null,
     activeSegmentIndex: -1,
-    editingWordEl: null,
+    editingTextEl: null,
     pollTimer: null,
   };
 
@@ -243,7 +243,7 @@
   function renderSegments() {
     var container = qs("#segmentList");
     var empty = qs("#transcriptEmpty");
-    state.editingWordEl = null;
+    state.editingTextEl = null;
 
     if (state.segments.length === 0) {
       container.innerHTML = "";
@@ -278,18 +278,22 @@
     var rows = container.querySelectorAll(".segment-row");
     for (var j = 0; j < rows.length; j++) {
       (function (row) {
+        var textEl = row.querySelector(".segment-text");
         row.querySelector(".segment-timestamp").addEventListener("click", function (e) {
           e.stopPropagation();
           var start = parseFloat(row.getAttribute("data-start"));
           seekVideo(start);
         });
-        var wordSpans = row.querySelectorAll(".segment-word");
-        for (var k = 0; k < wordSpans.length; k++) {
-          wordSpans[k].addEventListener("click", function (e) {
-            e.stopPropagation();
-            startWordEditing(this);
-          });
-        }
+        textEl.addEventListener("click", function (e) {
+          e.stopPropagation();
+          if (state.editingTextEl === textEl) return;
+          var start = parseFloat(row.getAttribute("data-start"));
+          seekVideo(start);
+        });
+        textEl.addEventListener("dblclick", function (e) {
+          e.stopPropagation();
+          startSegmentEditing(textEl);
+        });
       })(rows[j]);
     }
   }
@@ -364,92 +368,144 @@
     }
   }
 
-  // ---- Inline word editing ----
+  // ---- Inline segment editing ----
 
-  function startWordEditing(wordEl) {
-    if (state.editingWordEl === wordEl) return;
-    if (state.editingWordEl) finishWordEditing(state.editingWordEl);
+  function startSegmentEditing(textEl) {
+    if (state.editingTextEl === textEl) return;
+    if (state.editingTextEl) finishSegmentEditing(state.editingTextEl, false);
 
-    state.editingWordEl = wordEl;
-    var original = wordEl.getAttribute("data-original");
-
-    wordEl.setAttribute("contenteditable", "true");
-    wordEl.setAttribute("spellcheck", "false");
-    wordEl.classList.add("segment-word-editing");
-
-    var range = document.createRange();
-    range.selectNodeContents(wordEl);
-    var sel = window.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
-    wordEl.focus();
+    state.editingTextEl = textEl;
+    textEl.setAttribute("data-original-text", textEl.textContent);
+    textEl.setAttribute("contenteditable", "true");
+    textEl.setAttribute("spellcheck", "false");
+    textEl.classList.add("segment-text-editing");
 
     function onBlur() {
-      wordEl.removeEventListener("blur", onBlur);
-      wordEl.removeEventListener("keydown", onKeydown);
-      wordEl.removeEventListener("paste", onPaste);
-      finishWordEditing(wordEl);
+      textEl.removeEventListener("blur", onBlur);
+      textEl.removeEventListener("keydown", onKeydown);
+      textEl.removeEventListener("paste", onPaste);
+      finishSegmentEditing(textEl, false);
     }
 
     function onKeydown(e) {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
-        wordEl.blur();
+        textEl.blur();
       }
       if (e.key === "Escape") {
-        wordEl.textContent = original;
-        wordEl.blur();
-      }
-      if (e.key === "Tab") {
         e.preventDefault();
-        wordEl.blur();
+        textEl.removeEventListener("blur", onBlur);
+        textEl.removeEventListener("keydown", onKeydown);
+        textEl.removeEventListener("paste", onPaste);
+        finishSegmentEditing(textEl, true);
       }
     }
 
     function onPaste(e) {
       e.preventDefault();
       var text = (e.clipboardData || window.clipboardData).getData("text/plain");
-      text = text.replace(/\s+/g, " ").trim();
+      text = text.replace(/[\r\n]+/g, " ").trim();
       document.execCommand("insertText", false, text);
     }
 
-    wordEl.addEventListener("blur", onBlur);
-    wordEl.addEventListener("keydown", onKeydown);
-    wordEl.addEventListener("paste", onPaste);
+    textEl.addEventListener("blur", onBlur);
+    textEl.addEventListener("keydown", onKeydown);
+    textEl.addEventListener("paste", onPaste);
   }
 
-  function finishWordEditing(wordEl) {
-    var original = wordEl.getAttribute("data-original");
-    var newText = wordEl.textContent.trim();
+  function finishSegmentEditing(textEl, cancel) {
+    var originalText = textEl.getAttribute("data-original-text") || "";
+    var newText = textEl.textContent.trim();
 
-    wordEl.removeAttribute("contenteditable");
-    wordEl.classList.remove("segment-word-editing");
+    textEl.removeAttribute("contenteditable");
+    textEl.removeAttribute("data-original-text");
+    textEl.classList.remove("segment-text-editing");
+    if (state.editingTextEl === textEl) state.editingTextEl = null;
 
-    if (state.editingWordEl === wordEl) state.editingWordEl = null;
-
-    if (!newText) {
-      wordEl.textContent = original;
+    if (cancel || !newText || newText === originalText) {
+      // Reload to restore clean word spans
+      var pid = state.selectedParticipant;
+      if (pid) loadTranscript(pid);
       return;
     }
-    if (newText === original) return;
 
-    wordEl.textContent = newText;
-    wordEl.setAttribute("data-original", newText);
-    saveWordCorrection(original, newText);
+    var corrections = extractCorrections(originalText, newText);
+    if (corrections.length === 0) return;
+
+    saveCorrections(corrections);
   }
 
-  function saveWordCorrection(fromText, toText) {
-    apiPost("api/corrections", {
-      from: fromText,
-      to: toText,
-    }).then(function (data) {
-      if (data.ok && data.correction) {
-        showToast("Correction created");
-        var pid = state.selectedParticipant;
-        if (pid) {
-          loadTranscript(pid);
-          loadCorrections();
+  function extractCorrections(oldText, newText) {
+    var oldWords = oldText.trim().split(/\s+/).filter(Boolean);
+    var newWords = newText.trim().split(/\s+/).filter(Boolean);
+    if (oldWords.join(" ") === newWords.join(" ")) return [];
+
+    // LCS table for word-level alignment
+    var m = oldWords.length, n = newWords.length;
+    var dp = [];
+    for (var i = 0; i <= m; i++) {
+      dp[i] = [];
+      for (var j = 0; j <= n; j++) {
+        if (i === 0 || j === 0) dp[i][j] = 0;
+        else if (oldWords[i - 1] === newWords[j - 1]) dp[i][j] = dp[i - 1][j - 1] + 1;
+        else dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+
+    // Backtrack to get edit operations
+    var ops = [];
+    var i = m, j = n;
+    while (i > 0 || j > 0) {
+      if (i > 0 && j > 0 && oldWords[i - 1] === newWords[j - 1]) {
+        ops.unshift({ type: "eq" });
+        i--; j--;
+      } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+        ops.unshift({ type: "ins", word: newWords[j - 1] });
+        j--;
+      } else {
+        ops.unshift({ type: "del", word: oldWords[i - 1] });
+        i--;
+      }
+    }
+
+    // Group consecutive non-equal ops into from→to correction pairs
+    var corrections = [];
+    var k = 0;
+    while (k < ops.length) {
+      if (ops[k].type !== "eq") {
+        var fromParts = [];
+        var toParts = [];
+        while (k < ops.length && ops[k].type !== "eq") {
+          if (ops[k].type === "del") fromParts.push(ops[k].word);
+          else toParts.push(ops[k].word);
+          k++;
         }
+        if (fromParts.length > 0 && toParts.length > 0) {
+          corrections.push({ from: fromParts.join(" "), to: toParts.join(" ") });
+        }
+      } else {
+        k++;
+      }
+    }
+    return corrections;
+  }
+
+  function saveCorrections(corrections) {
+    var chain = Promise.resolve();
+    corrections.forEach(function (c) {
+      chain = chain.then(function () {
+        return apiPost("api/corrections", { from: c.from, to: c.to });
+      });
+    });
+    chain.then(function () {
+      var msg = corrections.length === 1
+        ? "Correction created"
+        : corrections.length + " corrections created";
+      showToast(msg);
+      var pid = state.selectedParticipant;
+      if (pid) {
+        loadTranscript(pid);
+        loadCorrections();
       }
     }).catch(function () {
       showToast("Failed to save correction");

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -491,17 +491,23 @@
   }
 
   function saveCorrections(corrections) {
+    var created = 0, updated = 0, removed = 0;
     var chain = Promise.resolve();
     corrections.forEach(function (c) {
       chain = chain.then(function () {
-        return apiPost("api/corrections", { from: c.from, to: c.to });
+        return apiPost("api/corrections", { from: c.from, to: c.to }).then(function (data) {
+          if (data.ok) {
+            if (data.removed) removed++;
+            else if (data.correction) updated++;  // covers both new and updated
+          }
+        });
       });
     });
     chain.then(function () {
-      var msg = corrections.length === 1
-        ? "Correction created"
-        : corrections.length + " corrections created";
-      showToast(msg);
+      var parts = [];
+      if (updated) parts.push(updated === 1 ? "1 correction saved" : updated + " corrections saved");
+      if (removed) parts.push(removed === 1 ? "1 reverted" : removed + " reverted");
+      showToast(parts.join(", ") || "No changes");
       var pid = state.selectedParticipant;
       if (pid) {
         loadTranscript(pid);

--- a/clipgen.py
+++ b/clipgen.py
@@ -84,6 +84,8 @@ MODE_ALIASES = {
     "studio": "studio",
     "ss": "screenspace",
     "screenspace": "screenspace",
+    "tr": "transcripts",
+    "transcripts": "transcripts",
     "se": "settings",
     "settings": "settings",
 }
@@ -2069,6 +2071,11 @@ def _dispatch_interactive_mode(
 
         server.start_combined_server(worksheet=worksheet, default_page="screenspace")
         return None
+    if mode == "transcripts":
+        import server
+
+        server.start_combined_server(worksheet=worksheet, default_page="transcripts")
+        return None
     if mode == "timeline-viewer":
         clips_list = spreadsheet.generate_list(worksheet, "batch", skip_prompts=True)
         outputs_generated, artifacts = process_clips(clips_list, output_format="clip")
@@ -2153,7 +2160,7 @@ def run_interactive_mode(worksheet: Any) -> None:
             input_mode = utils.read_user_input(
                 "\nEnter mode or input directly:\n"
                 "  Tools: (s)creen, (g)if, (re)el, (rl) reel-late, (rg) regenerate, (se)ttings \n"
-                "  Front: (st) studio, (in) insights, (ss) screenspace, (br)owse \n"
+                "  Front: (st) studio, (in) insights, (ss) screenspace, (tr)anscripts, (br)owse \n"
                 "  Packs: (v)iewer, (tv) timeline-viewer, (gv) gallery \n"
                 "  Modes: (b)atch, (r)ange, (c)ategory, (l)ine, (ce)ll, (p)articipant, (k)eyword, (sv) severity \n"
                 '  Or enter mixed selectors directly: e.g. 5, P01.11, 13-16, "Observations"\n>> '

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.22"
+VERSIONNUM: str = "0.10.23"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -256,7 +256,9 @@ def api_corrections_add() -> FlaskResponse:
             if chained["from"].lower() == to_text.lower():
                 corrections.remove(chained)
                 _persist_manifest()
-                return jsonify({"ok": True, "correction": None, "removed": chained["id"]})
+                return jsonify(
+                    {"ok": True, "correction": None, "removed": chained["id"]}
+                )
             chained["to"] = to_text
             correction = chained
         else:

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -240,14 +240,33 @@ def api_corrections_add() -> FlaskResponse:
     if not from_text or not to_text:
         return jsonify({"ok": False, "error": "'from' and 'to' required"}), 400
 
-    correction = {
-        "id": f"c_{uuid.uuid4().hex[:8]}",
-        "from": from_text,
-        "to": to_text,
-        "created": datetime.now(timezone.utc).isoformat(),
-    }
     with _manifest_lock:
-        _manifest.setdefault("corrections", []).append(correction)
+        corrections = _manifest.setdefault("corrections", [])
+
+        # Check for an existing correction whose `to` chains into this `from`.
+        # e.g. existing "teh"→"the" + new "the"→"they" → update to "teh"→"they".
+        # If the update would make from == to, delete the correction instead.
+        chained = None
+        for c in corrections:
+            if c.get("to", "").lower() == from_text.lower():
+                chained = c
+                break
+
+        if chained:
+            if chained["from"].lower() == to_text.lower():
+                corrections.remove(chained)
+                _persist_manifest()
+                return jsonify({"ok": True, "correction": None, "removed": chained["id"]})
+            chained["to"] = to_text
+            correction = chained
+        else:
+            correction = {
+                "id": f"c_{uuid.uuid4().hex[:8]}",
+                "from": from_text,
+                "to": to_text,
+                "created": datetime.now(timezone.utc).isoformat(),
+            }
+            corrections.append(correction)
 
     _persist_manifest()
     return jsonify({"ok": True, "correction": correction})


### PR DESCRIPTION
## Summary
- Replaces line-level transcript editing (textarea on double-click) with word-level inline editing. Each word renders as a clickable span; single-click seeks the video, double-click enters edit mode via `contentEditable` on the segment.
- Arrow keys and shift-selection work natively across words. On save, an LCS-based word diff extracts only changed phrases as corrections instead of storing the entire line.
- Chained corrections are collapsed: re-editing a previously corrected word updates the existing correction rather than appending a duplicate. Reverting to the original deletes the correction entirely.
- Adds `(tr)anscripts` to the interactive mode menu under "Front" for launching the Transcripts workspace from the terminal.

## Test plan
- [ ] Double-click a word → segment enters edit mode, word is selected
- [ ] Arrow keys / shift-select work across words within the segment
- [ ] Edit one word, press Enter → single word-level correction created
- [ ] Edit multiple words → each changed phrase becomes a separate correction
- [ ] Re-edit a corrected word → existing correction updated, not duplicated
- [ ] Revert a word to its original → correction deleted
- [ ] Single-click on text → seeks video
- [ ] Escape cancels editing without saving
- [ ] Type `tr` in interactive mode → Transcripts frontend launches
- [ ] Run `uv run --extra dev pytest -c tests/pytest.ini` → all tests pass