### PR TITLE
Segment marking and Transcript Intake tab for Studio (#158)

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2271,3 +2271,43 @@ html[data-theme="dark"] .log-panel {
 .queue-card-intake .queue-card-ref {
   font-size: var(--text-xs);
 }
+
+/* Transcript Intake */
+
+.tr-intake-toggle {
+  font-size: var(--text-xs);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  color: var(--color-text-dim);
+}
+
+.tr-intake-queue-card .queue-card-thumb {
+  background: var(--color-surface-alt);
+  min-height: 36px;
+}
+
+.tr-intake-card-category-dot {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+.tr-intake-card-text {
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  line-height: 1.3;
+  max-height: 2.6em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.tr-intake-filter-cat {
+  font-size: var(--text-xs);
+}

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -71,6 +71,7 @@
       <div class="preview-tabs">
         <button class="preview-tab active" data-tab="sheet">Sheet Preview</button>
         <button class="preview-tab hidden" data-tab="intake">Screenspace Intake <span id="intakeTabBadge" class="intake-tab-badge hidden">0</span></button>
+        <button class="preview-tab hidden" data-tab="transcript-intake">Transcript Intake <span id="trIntakeTabBadge" class="intake-tab-badge hidden">0</span></button>
       </div>
       <button id="filterToggle" class="btn btn-small btn-icon" title="Filter rows">
         <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
@@ -121,6 +122,22 @@
       <canvas id="intakeTimeline"></canvas>
       <div id="intakeCards" class="intake-cards-grid">
         <div class="drop-target-empty">Screenspace events will appear here</div>
+      </div>
+    </div>
+    <div id="trIntakePanel" class="hidden">
+      <div class="area-controls" id="trIntakeControls">
+        <label class="intake-cluster-label">Merge gap <input id="trIntakeClusterThreshold" type="number" min="1" max="60" value="5" class="intake-cluster-input">s</label>
+        <label class="tr-intake-toggle"><input id="trIntakeShowAll" type="checkbox"> Show all</label>
+        <button id="trIntakeAddAllBtn" class="btn btn-small" disabled>Add All to Artifacts</button>
+        <button id="trIntakeReelAllBtn" class="btn btn-small" disabled>Add All to Reel</button>
+      </div>
+      <div class="intake-filters">
+        <div id="trIntakeCategoryPills" class="intake-filter-pills"></div>
+        <div id="trIntakeFilterParticipants" class="intake-filter-participant-pills"></div>
+      </div>
+      <canvas id="trIntakeTimeline"></canvas>
+      <div id="trIntakeCards" class="intake-cards-grid">
+        <div class="drop-target-empty">Transcript marks will appear here</div>
       </div>
     </div>
   </section>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -37,6 +37,13 @@
     intakeFilterParticipants: [],
     intakeHoveredIdx: -1,
     activePreviewTab: "sheet",
+    trIntakeMarks: [],
+    trIntakeClusters: [],
+    trIntakePollTimer: null,
+    trIntakeFilterCategory: "",
+    trIntakeFilterParticipants: [],
+    trIntakeShowAll: false,
+    trIntakeHoveredIdx: -1,
   };
 
   var SEVERITY_ORDER = [
@@ -576,27 +583,39 @@
     var filterToggle = qs("#filterToggle");
     var refreshBtn = qs("#refreshSheet");
     var intakePanel = qs("#intakePanel");
+    var trIntakePanel = qs("#trIntakePanel");
+
+    // Hide everything first
+    grid.classList.add("hidden");
+    intakePanel.classList.add("hidden");
+    if (trIntakePanel) trIntakePanel.classList.add("hidden");
+    if (filterBar) filterBar.classList.add("hidden");
+    if (filterToggle) filterToggle.classList.add("hidden");
+    if (refreshBtn) refreshBtn.classList.add("hidden");
+
+    // Stop both intake poll timers
+    if (state.intakePollTimer) { clearInterval(state.intakePollTimer); state.intakePollTimer = null; }
+    if (state.trIntakePollTimer) { clearInterval(state.trIntakePollTimer); state.trIntakePollTimer = null; }
 
     if (state.activePreviewTab === "sheet") {
       grid.classList.remove("hidden");
-      intakePanel.classList.add("hidden");
       if (filterToggle) filterToggle.classList.remove("hidden");
       if (refreshBtn) refreshBtn.classList.remove("hidden");
       if (state.filtersVisible && filterBar) filterBar.classList.remove("hidden");
-      // Pause intake polling when leaving intake tab
-      if (state.intakePollTimer) { clearInterval(state.intakePollTimer); state.intakePollTimer = null; }
-    } else {
-      grid.classList.add("hidden");
-      if (filterBar) filterBar.classList.add("hidden");
-      if (filterToggle) filterToggle.classList.add("hidden");
-      if (refreshBtn) refreshBtn.classList.add("hidden");
+    } else if (state.activePreviewTab === "intake") {
       intakePanel.classList.remove("hidden");
-      // Resume intake polling when entering intake tab
-      if (!state.intakePollTimer && !document.hidden) {
+      if (!document.hidden) {
         pollIntakeEvents();
         state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
       }
       setTimeout(sizeIntakeCanvas, 0);
+    } else if (state.activePreviewTab === "transcript-intake") {
+      if (trIntakePanel) trIntakePanel.classList.remove("hidden");
+      if (!document.hidden) {
+        pollTranscriptIntakeMarks();
+        state.trIntakePollTimer = setInterval(pollTranscriptIntakeMarks, 10000);
+      }
+      setTimeout(sizeTrIntakeCanvas, 0);
     }
     computeGridMaxHeight();
   }
@@ -1434,7 +1453,7 @@
           addToQueue(state.artifactQueue, info.items[i], renderArtifactQueue);
         return;
       }
-      if (info.source === "screenspace") {
+      if (info.source === "screenspace" || info.source === "transcript") {
         state.artifactQueue.push(info);
         renderArtifactQueue();
         return;
@@ -1451,7 +1470,7 @@
           addToQueue(state.reelQueue, info.items[i], renderReelQueue);
         return;
       }
-      if (info.source === "screenspace") {
+      if (info.source === "screenspace" || info.source === "transcript") {
         state.reelQueue.push(info);
         renderReelQueue();
         return;
@@ -3223,6 +3242,8 @@
         if (data.transcripts) {
           var link = qs("#transcriptsLink");
           if (link) link.classList.remove("hidden");
+          var trIntakeTab = qs('.preview-tab[data-tab="transcript-intake"]');
+          if (trIntakeTab) trIntakeTab.classList.remove("hidden");
         }
       })
       .catch(function () {});
@@ -3791,6 +3812,436 @@
     });
   }
 
+  // ---- Transcript Intake ----
+
+  var TR_INTAKE_CATEGORIES = {
+    pain_point: { label: "Pain Point", color: "#dc2626" },
+    delight:    { label: "Delight",    color: "#16a34a" },
+    quote:      { label: "Quote",      color: "#2563eb" },
+    insight:    { label: "Insight",    color: "#f97316" },
+    task:       { label: "Task Issue", color: "#8b5cf6" },
+    bookmark:   { label: "Bookmark",   color: "#0891b2" },
+  };
+
+  function pollTranscriptIntakeMarks() {
+    fetch("../transcripts/api/marks")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.ok) return;
+        state.trIntakeMarks = data.marks.filter(function (m) { return m.valid; });
+        var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value) || 5;
+        state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, threshold);
+
+        // If "Show all" is enabled, also fetch all segments as unmark items
+        if (state.trIntakeShowAll) {
+          fetch("../transcripts/api/participants")
+            .then(function (r2) { return r2.json(); })
+            .then(function (pData) {
+              if (!pData.ok) return;
+              var transcribed = pData.participants.filter(function (p) { return p.has_transcript; });
+              var promises = transcribed.map(function (p) {
+                return fetch("../transcripts/api/transcript/" + p.id).then(function (r3) { return r3.json(); });
+              });
+              Promise.all(promises).then(function (results) {
+                var markedIds = {};
+                for (var i = 0; i < state.trIntakeMarks.length; i++) markedIds[state.trIntakeMarks[i].segment_id] = true;
+                var allItems = state.trIntakeMarks.slice();
+                for (var j = 0; j < results.length; j++) {
+                  if (!results[j].ok) continue;
+                  var pid = results[j].participant;
+                  var segs = results[j].segments;
+                  for (var k = 0; k < segs.length; k++) {
+                    if (!markedIds[segs[k].id]) {
+                      allItems.push({
+                        id: null,
+                        segment_id: segs[k].id,
+                        category: null,
+                        label: null,
+                        valid: true,
+                        participant: pid,
+                        start: segs[k].start,
+                        end: segs[k].end,
+                        text: segs[k].text,
+                      });
+                    }
+                  }
+                }
+                state.trIntakeClusters = clusterTranscriptMarks(allItems, threshold);
+                renderTranscriptIntake();
+              });
+            });
+        } else {
+          renderTranscriptIntake();
+        }
+      })
+      .catch(function () {});
+  }
+
+  function clusterTranscriptMarks(marks, thresholdSec) {
+    if (!marks.length) return [];
+    var sorted = marks.slice().sort(function (a, b) {
+      if (a.participant !== b.participant) return a.participant < b.participant ? -1 : 1;
+      return a.start - b.start;
+    });
+    var clusters = [];
+    var cur = null;
+    for (var i = 0; i < sorted.length; i++) {
+      var m = sorted[i];
+      if (!cur || m.participant !== cur.participant || m.start - cur.end > thresholdSec) {
+        if (cur) clusters.push(cur);
+        cur = {
+          participant: m.participant,
+          start: m.start,
+          end: m.end,
+          marks: [m],
+          category: m.category || "bookmark",
+          label: m.label || "",
+          text: m.text || "",
+        };
+      } else {
+        cur.end = Math.max(cur.end, m.end);
+        cur.marks.push(m);
+        if (m.text) cur.text += " " + m.text;
+        if (m.label && !cur.label) cur.label = m.label;
+      }
+    }
+    if (cur) clusters.push(cur);
+    return clusters;
+  }
+
+  function filteredTranscriptIntakeClusters() {
+    var clusters = state.trIntakeClusters;
+    var cat = state.trIntakeFilterCategory;
+    var parts = state.trIntakeFilterParticipants;
+    if (!cat && !parts.length) return clusters;
+    return clusters.filter(function (c) {
+      if (parts.length && parts.indexOf(c.participant) === -1) return false;
+      if (cat && c.category !== cat) return false;
+      return true;
+    });
+  }
+
+  function renderTranscriptIntake() {
+    var filtered = filteredTranscriptIntakeClusters();
+    var container = qs("#trIntakeCards");
+    var addAllBtn = qs("#trIntakeAddAllBtn");
+    var reelAllBtn = qs("#trIntakeReelAllBtn");
+    var badge = qs("#trIntakeTabBadge");
+
+    if (badge) {
+      if (state.trIntakeMarks.length > 0) {
+        badge.textContent = state.trIntakeMarks.length;
+        badge.classList.remove("hidden");
+      } else {
+        badge.classList.add("hidden");
+      }
+    }
+
+    if (addAllBtn) addAllBtn.disabled = filtered.length === 0;
+    if (reelAllBtn) reelAllBtn.disabled = filtered.length === 0;
+
+    buildTrIntakeParticipantPills();
+
+    if (filtered.length === 0) {
+      container.innerHTML = '<div class="drop-target-empty">Transcript marks will appear here</div>';
+      renderTrIntakeTimeline();
+      return;
+    }
+
+    container.innerHTML = "";
+    for (var i = 0; i < filtered.length; i++) {
+      var c = filtered[i];
+      var card = document.createElement("div");
+      card.className = "queue-card intake-queue-card tr-intake-queue-card";
+      card.draggable = true;
+      card.dataset.trIntakeIdx = i;
+
+      // Thumbnail area with category dot and duration
+      var thumb = document.createElement("div");
+      thumb.className = "queue-card-thumb";
+
+      var catColor = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
+      var dot = document.createElement("span");
+      dot.className = "tr-intake-card-category-dot";
+      dot.style.background = catColor;
+      thumb.appendChild(dot);
+
+      var dur = document.createElement("span");
+      dur.className = "queue-card-duration";
+      dur.textContent = formatDuration(Math.max(0, c.end - c.start));
+      thumb.appendChild(dur);
+      card.appendChild(thumb);
+
+      // Metadata
+      var meta = document.createElement("div");
+      meta.className = "queue-card-meta";
+      var ref = document.createElement("span");
+      ref.className = "queue-card-ref";
+      ref.textContent = c.participant + " \u00b7 " + formatDuration(c.start) + "\u2013" + formatDuration(c.end);
+      meta.appendChild(ref);
+
+      // Text snippet
+      var textSnippet = document.createElement("span");
+      textSnippet.className = "tr-intake-card-text";
+      var txt = c.label || c.text || "";
+      textSnippet.textContent = txt.length > 80 ? txt.substring(0, 80) + "\u2026" : txt;
+      meta.appendChild(textSnippet);
+      card.appendChild(meta);
+
+      // Drag support
+      (function (cluster) {
+        card.addEventListener("dragstart", function (ev) {
+          ev.dataTransfer.setData("application/json", JSON.stringify({
+            participant: cluster.participant,
+            desc: cluster.category || "transcript",
+            segStart: cluster.start,
+            segDuration: cluster.end - cluster.start,
+            source: "transcript",
+            mark_ids: cluster.marks.map(function (m) { return m.id; }),
+          }));
+          ev.dataTransfer.effectAllowed = "copyMove";
+          setCardDragImage(ev, this);
+        });
+      })(c);
+
+      container.appendChild(card);
+    }
+
+    renderTrIntakeTimeline();
+  }
+
+  function trIntakeAddToArtifacts(cluster) {
+    state.artifactQueue.push({
+      participant: cluster.participant,
+      segStart: cluster.start,
+      segDuration: cluster.end - cluster.start,
+      desc: cluster.category || "transcript",
+      source: "transcript",
+      mark_ids: cluster.marks.map(function (m) { return m.id; }),
+    });
+    renderArtifactQueue();
+  }
+
+  function trIntakeAddToReel(cluster) {
+    state.reelQueue.push({
+      participant: cluster.participant,
+      segStart: cluster.start,
+      segDuration: cluster.end - cluster.start,
+      desc: cluster.category || "transcript",
+      source: "transcript",
+      mark_ids: cluster.marks.map(function (m) { return m.id; }),
+    });
+    renderReelQueue();
+  }
+
+  function buildTrIntakeParticipantPills() {
+    var container = qs("#trIntakeFilterParticipants");
+    if (!container) return;
+    var pids = {};
+    for (var i = 0; i < state.trIntakeClusters.length; i++) {
+      pids[state.trIntakeClusters[i].participant] = true;
+    }
+    var sorted = Object.keys(pids).sort();
+    container.innerHTML = "";
+    for (var j = 0; j < sorted.length; j++) {
+      var btn = document.createElement("button");
+      btn.className = "intake-filter-participant" + (state.trIntakeFilterParticipants.indexOf(sorted[j]) >= 0 ? " active" : "");
+      btn.textContent = sorted[j];
+      btn.dataset.participant = sorted[j];
+      container.appendChild(btn);
+    }
+  }
+
+  function sizeTrIntakeCanvas() {
+    var canvas = qs("#trIntakeTimeline");
+    if (!canvas) return;
+    var w = canvas.clientWidth;
+    if (w <= 0) return;
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = w * dpr;
+    canvas.height = 48 * dpr;
+    var ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    renderTrIntakeTimeline();
+  }
+
+  function renderTrIntakeTimeline() {
+    var canvas = qs("#trIntakeTimeline");
+    if (!canvas) return;
+    var ctx = canvas.getContext("2d");
+    var w = canvas.clientWidth;
+    var h = 48;
+    ctx.clearRect(0, 0, w, h);
+
+    var filtered = filteredTranscriptIntakeClusters();
+    if (filtered.length === 0) return;
+
+    // Find time range
+    var minT = Infinity, maxT = 0;
+    for (var i = 0; i < filtered.length; i++) {
+      if (filtered[i].start < minT) minT = filtered[i].start;
+      if (filtered[i].end > maxT) maxT = filtered[i].end;
+    }
+    if (maxT <= minT) maxT = minT + 1;
+    var range = maxT - minT;
+    var pad = 8;
+    var usableW = w - pad * 2;
+
+    // Draw time ruler
+    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-text-dim") || "#888";
+    ctx.font = "10px monospace";
+    ctx.textAlign = "center";
+    var tickCount = Math.min(Math.floor(usableW / 60), 10);
+    for (var t = 0; t <= tickCount; t++) {
+      var frac = t / tickCount;
+      var sec = minT + frac * range;
+      var x = pad + frac * usableW;
+      ctx.fillText(formatDuration(sec), x, 10);
+      ctx.fillRect(x, 12, 1, 4);
+    }
+
+    // Draw cluster markers
+    for (var j = 0; j < filtered.length; j++) {
+      var c = filtered[j];
+      var x1 = pad + ((c.start - minT) / range) * usableW;
+      var x2 = pad + ((c.end - minT) / range) * usableW;
+      var mw = Math.max(x2 - x1, 4);
+      var color = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
+      ctx.fillStyle = color;
+      ctx.globalAlpha = j === state.trIntakeHoveredIdx ? 1.0 : 0.6;
+      ctx.fillRect(x1, 20, mw, 24);
+    }
+    ctx.globalAlpha = 1.0;
+  }
+
+  function initTranscriptIntake() {
+    var trIntakeCards = qs("#trIntakeCards");
+    if (!trIntakeCards) return;
+
+    // Click: normal = Artifacts, shift = Reel
+    trIntakeCards.addEventListener("click", function (e) {
+      var card = e.target.closest(".tr-intake-queue-card");
+      if (!card) return;
+      var idx = parseInt(card.dataset.trIntakeIdx);
+      var cluster = filteredTranscriptIntakeClusters()[idx];
+      if (!cluster) return;
+      if (e.shiftKey) trIntakeAddToReel(cluster);
+      else trIntakeAddToArtifacts(cluster);
+    });
+
+    // Right-click: dismiss — remove marks
+    trIntakeCards.addEventListener("contextmenu", function (e) {
+      var card = e.target.closest(".tr-intake-queue-card");
+      if (!card) return;
+      e.preventDefault();
+      var idx = parseInt(card.dataset.trIntakeIdx);
+      var cluster = filteredTranscriptIntakeClusters()[idx];
+      if (!cluster) return;
+      var ids = cluster.marks.map(function (m) { return m.id; }).filter(Boolean);
+      if (!ids.length) return;
+      fetch("../transcripts/api/marks/" + ids[0], {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: ids }),
+      })
+        .then(function () { pollTranscriptIntakeMarks(); })
+        .catch(function () {});
+    });
+
+    // Cluster threshold change
+    var thresholdInput = qs("#trIntakeClusterThreshold");
+    if (thresholdInput) {
+      thresholdInput.addEventListener("change", function () {
+        var val = parseInt(this.value) || 5;
+        state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, val);
+        renderTranscriptIntake();
+      });
+    }
+
+    // "Show all" toggle
+    var showAllToggle = qs("#trIntakeShowAll");
+    if (showAllToggle) {
+      showAllToggle.addEventListener("change", function () {
+        state.trIntakeShowAll = this.checked;
+        pollTranscriptIntakeMarks();
+      });
+    }
+
+    // Category pills
+    var catPills = qs("#trIntakeCategoryPills");
+    if (catPills) {
+      var cats = Object.keys(TR_INTAKE_CATEGORIES);
+      for (var i = 0; i < cats.length; i++) {
+        (function (key) {
+          var cat = TR_INTAKE_CATEGORIES[key];
+          var btn = document.createElement("button");
+          btn.className = "intake-filter-det tr-intake-filter-cat";
+          btn.style.setProperty("--det-color", cat.color);
+          btn.textContent = cat.label;
+          btn.dataset.category = key;
+          btn.addEventListener("click", function () {
+            if (state.trIntakeFilterCategory === key) {
+              state.trIntakeFilterCategory = "";
+              btn.classList.remove("active");
+            } else {
+              state.trIntakeFilterCategory = key;
+              var all = catPills.querySelectorAll(".tr-intake-filter-cat");
+              for (var j = 0; j < all.length; j++) all[j].classList.remove("active");
+              btn.classList.add("active");
+            }
+            renderTranscriptIntake();
+          });
+          catPills.appendChild(btn);
+        })(cats[i]);
+      }
+    }
+
+    // Participant pills (delegated)
+    var partPills = qs("#trIntakeFilterParticipants");
+    if (partPills) {
+      partPills.addEventListener("click", function (e) {
+        var btn = e.target.closest(".intake-filter-participant");
+        if (!btn) return;
+        var pid = btn.dataset.participant;
+        var idx = state.trIntakeFilterParticipants.indexOf(pid);
+        if (idx >= 0) {
+          state.trIntakeFilterParticipants.splice(idx, 1);
+          btn.classList.remove("active");
+        } else {
+          state.trIntakeFilterParticipants.push(pid);
+          btn.classList.add("active");
+        }
+        renderTranscriptIntake();
+      });
+    }
+
+    // Add All buttons
+    var addAllBtn = qs("#trIntakeAddAllBtn");
+    if (addAllBtn) {
+      addAllBtn.addEventListener("click", function () {
+        var filtered = filteredTranscriptIntakeClusters();
+        for (var i = 0; i < filtered.length; i++) trIntakeAddToArtifacts(filtered[i]);
+      });
+    }
+    var reelAllBtn = qs("#trIntakeReelAllBtn");
+    if (reelAllBtn) {
+      reelAllBtn.addEventListener("click", function () {
+        var filtered = filteredTranscriptIntakeClusters();
+        for (var i = 0; i < filtered.length; i++) trIntakeAddToReel(filtered[i]);
+      });
+    }
+
+    // Visibility change — pause/resume polling
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) {
+        if (state.trIntakePollTimer) { clearInterval(state.trIntakePollTimer); state.trIntakePollTimer = null; }
+      } else if (state.activePreviewTab === "transcript-intake") {
+        pollTranscriptIntakeMarks();
+        if (!state.trIntakePollTimer) state.trIntakePollTimer = setInterval(pollTranscriptIntakeMarks, 10000);
+      }
+    });
+  }
+
   document.addEventListener("click", function (ev) {
     var wrap = qs(".filter-cat-wrap");
     if (wrap && !wrap.contains(ev.target)) {
@@ -3816,9 +4267,11 @@
     updateViewerButton();
     checkNavLinks();
     initIntake();
+    initTranscriptIntake();
     window.addEventListener("resize", function () {
       computeGridMaxHeight();
       sizeIntakeCanvas();
+      sizeTrIntakeCanvas();
     });
 
     document.addEventListener("dragstart", function (ev) {

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -257,6 +257,10 @@ body {
   white-space: nowrap;
 }
 
+#searchMarkAllBtn {
+  flex-shrink: 0;
+}
+
 #searchResults {
   position: absolute;
   top: 100%;
@@ -388,10 +392,103 @@ body {
   opacity: 0.7;
 }
 
+/* Segment mark gutter */
+
+.segment-mark {
+  flex: 0 0 14px;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--color-border);
+  cursor: pointer;
+  margin-top: 5px;
+  transition: border-color var(--duration-fast), background var(--duration-fast), box-shadow var(--duration-fast);
+}
+
+.segment-mark:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(29, 79, 114, 0.15);
+}
+
+.segment-mark.marked {
+  border-color: transparent;
+}
+
+.segment-mark.marked:hover {
+  box-shadow: 0 0 0 2px rgba(29, 79, 114, 0.25);
+}
+
+/* Mark popover */
+
+.mark-popover {
+  position: fixed;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-3);
+  z-index: var(--z-dropdown);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 200px;
+}
+
+.mark-popover.hidden {
+  display: none;
+}
+
+.mark-popover-categories {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.mark-cat-pill {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform var(--duration-fast), box-shadow var(--duration-fast);
+  padding: 0;
+}
+
+.mark-cat-pill:hover {
+  transform: scale(1.2);
+}
+
+.mark-cat-pill.active {
+  box-shadow: 0 0 0 2px var(--color-panel-bg), 0 0 0 4px currentColor;
+}
+
+.mark-popover-label {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-xs);
+  outline: none;
+}
+
+.mark-popover-label:focus {
+  border-color: var(--color-accent);
+}
+
+.mark-popover-remove {
+  align-self: flex-start;
+  color: var(--color-text-dim);
+}
+
+.mark-popover-remove:hover {
+  color: var(--sev-critical);
+  border-color: var(--sev-critical);
+}
+
 .segment-row {
   display: flex;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-5);
+  padding: var(--space-2) var(--space-3) var(--space-2) var(--space-3);
   border-left: 3px solid transparent;
   cursor: pointer;
   transition: background var(--duration-fast), border-color var(--duration-fast);

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -83,6 +83,13 @@
     </div>
   </div>
 
+  <!-- Mark popover (shared, repositioned per use) -->
+  <div id="markPopover" class="mark-popover hidden">
+    <div class="mark-popover-categories"></div>
+    <input class="mark-popover-label" type="text" placeholder="Label (optional)" autocomplete="off">
+    <button class="mark-popover-remove btn btn-small">Remove</button>
+  </div>
+
   <div id="toast" class="toast hidden"></div>
 
   <script src="transcripts.js"></script>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -5,6 +5,16 @@
   var POLL_INTERVAL = 3000;
   var SEARCH_DEBOUNCE = 300;
 
+  // Mark categories — mirrored from transcripts.py MARK_CATEGORIES
+  var MARK_CATEGORIES = {
+    pain_point: { label: "Pain Point", color: "#dc2626" },
+    delight:    { label: "Delight",    color: "#16a34a" },
+    quote:      { label: "Quote",      color: "#2563eb" },
+    insight:    { label: "Insight",    color: "#f97316" },
+    task:       { label: "Task Issue", color: "#8b5cf6" },
+    bookmark:   { label: "Bookmark",   color: "#0891b2" },
+  };
+
   // ---- State ----
 
   var state = {
@@ -18,6 +28,7 @@
     activeSegmentIndex: -1,
     editingTextEl: null,
     pollTimer: null,
+    lastMarkCategory: "bookmark",
   };
 
   // ---- Helpers ----
@@ -279,7 +290,13 @@
       var seg = state.segments[i];
       var activeClass = i === state.activeSegmentIndex ? " active" : "";
       var correctedClass = seg.corrected ? " segment-corrected" : "";
+      var markObj = seg.marks && seg.marks.length > 0 ? seg.marks[0] : null;
+      var markClass = markObj ? "segment-mark marked" : "segment-mark";
+      var markStyle = markObj ? ' style="background:' + (MARK_CATEGORIES[markObj.category] || MARK_CATEGORIES.bookmark).color + '"' : "";
+      var markLabel = markObj && markObj.label ? ' title="' + escapeHtml(markObj.label) + '"' : "";
+
       html += '<div class="segment-row' + activeClass + correctedClass + '" data-index="' + i + '" data-start="' + seg.start + '">';
+      html += '<span class="' + markClass + '" data-segment-id="' + escapeHtml(seg.id) + '"' + markStyle + markLabel + '></span>';
       html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
       // Split text into word spans
       var tokens = seg.text.split(/(\s+)/);
@@ -301,6 +318,7 @@
     for (var j = 0; j < rows.length; j++) {
       (function (row) {
         var textEl = row.querySelector(".segment-text");
+        var markEl = row.querySelector(".segment-mark");
         row.querySelector(".segment-timestamp").addEventListener("click", function (e) {
           e.stopPropagation();
           var start = parseFloat(row.getAttribute("data-start"));
@@ -315,6 +333,18 @@
         textEl.addEventListener("dblclick", function (e) {
           e.stopPropagation();
           startSegmentEditing(textEl);
+        });
+        markEl.addEventListener("click", function (e) {
+          e.stopPropagation();
+          var segId = markEl.getAttribute("data-segment-id");
+          var idx = parseInt(row.getAttribute("data-index"), 10);
+          var seg = state.segments[idx];
+          var mark = seg && seg.marks && seg.marks.length > 0 ? seg.marks[0] : null;
+          if (mark) {
+            showMarkPopover(markEl, segId, mark);
+          } else {
+            toggleMark(segId);
+          }
         });
       })(rows[j]);
     }
@@ -575,6 +605,132 @@
     });
   }
 
+  // ---- Marks ----
+
+  function toggleMark(segmentId) {
+    apiPost("api/marks", {
+      segment_ids: [segmentId],
+      category: state.lastMarkCategory,
+    }).then(function (data) {
+      if (data.ok) {
+        showToast("Marked");
+        if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+      }
+    });
+  }
+
+  function removeMark(markId) {
+    apiDelete("api/marks/" + markId).then(function (data) {
+      if (data.ok) {
+        showToast("Mark removed");
+        hideMarkPopover();
+        if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+      }
+    });
+  }
+
+  function updateMarkCategory(markId, category) {
+    state.lastMarkCategory = category;
+    apiPut("api/marks/" + markId, { category: category }).then(function (data) {
+      if (data.ok) {
+        hideMarkPopover();
+        if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+      }
+    });
+  }
+
+  function updateMarkLabel(markId, label) {
+    apiPut("api/marks/" + markId, { label: label || null });
+  }
+
+  function showMarkPopover(anchorEl, segmentId, markObj) {
+    var popover = qs("#markPopover");
+    hideMarkPopover();
+
+    // Build category pills
+    var catContainer = popover.querySelector(".mark-popover-categories");
+    catContainer.innerHTML = "";
+    var cats = Object.keys(MARK_CATEGORIES);
+    for (var i = 0; i < cats.length; i++) {
+      (function (key) {
+        var cat = MARK_CATEGORIES[key];
+        var pill = document.createElement("button");
+        pill.className = "mark-cat-pill" + (markObj.category === key ? " active" : "");
+        pill.style.background = cat.color;
+        pill.title = cat.label;
+        pill.addEventListener("click", function (e) {
+          e.stopPropagation();
+          updateMarkCategory(markObj.id, key);
+        });
+        catContainer.appendChild(pill);
+      })(cats[i]);
+    }
+
+    // Label input
+    var labelInput = popover.querySelector(".mark-popover-label");
+    labelInput.value = markObj.label || "";
+    labelInput._markId = markObj.id;
+    labelInput.onblur = function () {
+      var val = labelInput.value.trim();
+      if (val !== (markObj.label || "")) {
+        updateMarkLabel(markObj.id, val);
+      }
+    };
+    labelInput.onkeydown = function (e) {
+      if (e.key === "Enter") { e.preventDefault(); labelInput.blur(); hideMarkPopover(); }
+      if (e.key === "Escape") { e.preventDefault(); hideMarkPopover(); }
+    };
+
+    // Remove button
+    var removeBtn = popover.querySelector(".mark-popover-remove");
+    removeBtn.onclick = function (e) {
+      e.stopPropagation();
+      removeMark(markObj.id);
+    };
+
+    // Position below anchor
+    var rect = anchorEl.getBoundingClientRect();
+    popover.style.top = (rect.bottom + window.scrollY + 4) + "px";
+    popover.style.left = (rect.left + window.scrollX - 4) + "px";
+    popover.classList.remove("hidden");
+
+    // Close on outside click (deferred so this click doesn't trigger it)
+    setTimeout(function () {
+      document.addEventListener("click", _popoverOutsideClick);
+    }, 0);
+  }
+
+  function _popoverOutsideClick(e) {
+    var popover = qs("#markPopover");
+    if (popover && !popover.contains(e.target)) {
+      hideMarkPopover();
+    }
+  }
+
+  function hideMarkPopover() {
+    var popover = qs("#markPopover");
+    if (popover) popover.classList.add("hidden");
+    document.removeEventListener("click", _popoverOutsideClick);
+  }
+
+  function markAllSearchResults() {
+    if (!state.searchResults || !state.searchResults.results) return;
+    var ids = [];
+    state.searchResults.results.forEach(function (r) {
+      if (r.segment_id) ids.push(r.segment_id);
+    });
+    if (ids.length === 0) return;
+    apiPost("api/marks", {
+      segment_ids: ids,
+      category: state.lastMarkCategory,
+    }).then(function (data) {
+      if (data.ok) {
+        showToast("Marked " + data.marks.length + " segment" + (data.marks.length === 1 ? "" : "s"));
+        if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+      }
+    });
+  }
+
   // ---- Search ----
 
   var _searchTimer = null;
@@ -629,6 +785,18 @@
 
     countEl.textContent = data.total_count + " match" + (data.total_count === 1 ? "" : "es");
 
+    // Add "Mark All" button next to count
+    var markAllBtn = qs("#searchMarkAllBtn");
+    if (!markAllBtn) {
+      markAllBtn = document.createElement("button");
+      markAllBtn.id = "searchMarkAllBtn";
+      markAllBtn.className = "btn btn-small";
+      markAllBtn.textContent = "Mark All";
+      countEl.parentNode.insertBefore(markAllBtn, countEl.nextSibling);
+    }
+    markAllBtn.classList.remove("hidden");
+    markAllBtn.onclick = function () { markAllSearchResults(); };
+
     // Group results by participant
     var groups = {};
     var order = [];
@@ -677,6 +845,8 @@
   function hideSearchResults() {
     qs("#searchResults").classList.add("hidden");
     qs("#searchCount").textContent = "";
+    var markAllBtn = qs("#searchMarkAllBtn");
+    if (markAllBtn) markAllBtn.classList.add("hidden");
     state.searchResults = null;
   }
 

--- a/plans/TRANSCRIPT-PLAN.md
+++ b/plans/TRANSCRIPT-PLAN.md
@@ -159,46 +159,85 @@ The workspace can trigger and monitor transcription jobs, not just view results.
 
 ---
 
-## Phase 3: Studio Transcript Intake
+## Phase 3: Segment Marking + Studio Transcript Intake
 
-Surface transcript data inside Studio as a lightweight intake tab for cross-referencing during artifact work.
+Pre-filter transcript content via a marking/curation system in the Transcript workspace, then surface curated marks in Studio as an intake tab for artifact generation. Follows the Screenspace Intake precedent: raw data → human curation → clustered cards → artifacts.
 
-### Intake tab
+### Key design decisions
 
-- [ ] Third tab in Studio's `#sheetPreview` area: **"Transcript Intake"** alongside "Sheet Preview" and "Screenspace Intake"
-- [ ] Tab only appears when source transcripts exist in the transcripts manifest (at least one participant transcribed); hidden otherwise
-- [ ] Loads transcript data via the Transcript workspace API (`../transcripts/api/...`), following the same cross-blueprint pattern Studio uses for Screenspace events (`../screenspace/api/events`)
+- **Marks are individual segment flags** stored as a separate manifest structure (like corrections). Raw segments stay immutable. Merging into groups happens at display time in Studio's clustering algorithm.
+- **Optional color categories** (pain point, delight, quote, insight, task, bookmark) + optional free-text labels on each mark.
+- **Studio Intake defaults to marks only**, with a toggle to show all segments.
+- **Search → bulk mark** leverages the existing search API (which returns `segment_id`).
+- **Full transcript text remains available in Viewers** (Phase 4) — marks only control the Transcript→Studio intake pipeline.
 
-### Intake tab contents
+### Mark data model
 
-- [ ] **Participant filter**: dropdown or chip bar to filter by participant
-- [ ] **Search**: keyword search across transcript content, scoped to selected participant(s) or all; calls `../transcripts/api/search`
-- [ ] **Segment list**: matching transcript segments displayed as compact cards — timestamp, participant badge, text snippet
-- [ ] **"New only" toggle**: filter to segments not yet associated with any artifact (helps find uncaptured moments)
-- [ ] **Drag to artifact area**: segments dragged using the standardized drag data format:
+- [x] Marks stored in `transcripts_manifest.json` under a top-level `"marks"` key (parallel to `"source_transcripts"` and `"corrections"`)
+- [x] Mark schema: `{"id": "m_{hex8}", "segment_id": "P01:42", "category": str|null, "label": str|null, "created": iso8601}`
+- [x] One mark per segment (POST deduplicates on `segment_id` — if mark exists, update it)
+- [x] `MARK_CATEGORIES` constant in `transcripts.py`: `pain_point` (#dc2626), `delight` (#16a34a), `quote` (#2563eb), `insight` (#f97316), `task` (#8b5cf6), `bookmark` (#0891b2)
+- [x] Re-transcription resilience: marks reference segment IDs that are index-based. When segment IDs change, marks API returns `valid: false` for unresolvable marks. UI shows orphaned marks dimmed with option to dismiss.
+
+### Manifest changes (`transcripts.py`)
+
+- [x] `_empty_transcripts_manifest()` → add `"marks": []`
+- [x] `load_transcripts_manifest()` → add `"marks": data.get("marks") or []` to returned dict
+- [x] `save_transcripts_manifest()` → add `marks` parameter (default `None` = preserve on-disk marks); include in serialized data
+
+### Mark API endpoints (`transcripts_server.py`)
+
+- [x] `GET /transcripts/api/marks` — list all marks, enriched with resolved segment data (participant, start, end, text, valid flag) + categories definition
+- [x] `POST /transcripts/api/marks` — create marks; body: `{segment_ids: [...], category?, label?}`; each segment gets its own `m_{hex8}` ID
+- [x] `PUT /transcripts/api/marks/<id>` — update category or label
+- [x] `DELETE /transcripts/api/marks/<id>` — remove a mark; also support bulk: `DELETE /transcripts/api/marks` with `{ids: [...]}`
+- [x] Update `_do_persist()` to pass `marks=_manifest.get("marks")` to `save_transcripts_manifest()`
+- [x] Enrich `api_transcript()` response with per-segment marks (build `marks_by_segment_id` lookup)
+
+### Transcript workspace marking UI
+
+- [x] **Gutter mark column**: add a mark dot before the timestamp in each `.segment-row` — `[mark-dot] [timestamp] [text]`. Unmarked: empty circle (border only). Marked: filled circle with category color.
+- [x] **`toggleMark(segmentId)`**: click gutter dot — if unmarked → POST create mark (uses `state.lastMarkCategory`); if marked → show popover
+- [x] **`showMarkPopover(el, segmentId, markObj)`**: floating popover with 6 category color pills, label text input, "Remove" action. Single shared DOM element repositioned each time.
+- [x] **`markAllSearchResults()`**: collect all `segment_id` from `state.searchResults.results`, POST bulk create. "Mark All" button shown in search results header next to count.
+- [x] Add `markPopover` HTML element to `transcripts.html`
+- [x] CSS for `.segment-mark`, `.segment-mark.marked`, `.mark-popover`, category pills
+
+### Studio Transcript Intake tab
+
+- [x] Third tab in Studio's `#sheetPreview` area: **"Transcript Intake"** alongside "Sheet Preview" and "Screenspace Intake"
+- [x] Tab only appears when `/api/status` reports `transcripts: true`; hidden otherwise
+- [x] `#transcriptIntakePanel` with: merge gap threshold input (1–60s, default 5), "Show all segments" toggle, "Add All to Artifacts"/"Add All to Reel" buttons, category filter pills, participant filter pills, canvas timeline, cards grid
+- [x] `pollTranscriptIntakeMarks()` — fetch `../transcripts/api/marks`, cluster, render; polled every 10s when tab active (same pattern as `pollIntakeEvents()`)
+- [x] `clusterTranscriptMarks(marks, thresholdSec)` — group by participant, merge marks whose segments are within `thresholdSec` gap (same algorithm shape as `clusterIntakeEvents()`)
+- [x] Cards show: category color dot, participant + time range, truncated transcript text (~80 chars), duration badge
+- [x] **Drag data format**:
   ```javascript
   {
     participant: str,
-    desc: str,             // matched text snippet (truncated)
-    segStart: float,       // segment start in seconds
-    segDuration: float,    // segment end - start
+    desc: str,              // category label or "transcript"
+    segStart: float,        // cluster start in seconds
+    segDuration: float,     // cluster end - start
     source: "transcript",
-    search_query: str,     // provenance: the search term that found this
-    segment_ids: [str],    // provenance: segment IDs (e.g., ["P01:42", "P01:43"])
+    mark_ids: [str],        // provenance: mark IDs (e.g., ["m_abc123", "m_def456"])
   }
   ```
-- [ ] Artifacts generated from transcript intake carry `source: "transcript"`, `segment_ids: [...]`, `intake_label: "search: <query>"` — matching the Screenspace pattern in `server.py`
+- [x] Artifacts generated from transcript intake carry `source: "transcript"`, `mark_ids: [...]` — matching the Screenspace pattern in `server.py`
+- [x] Update `syncPreviewTab()` for three-tab switching with independent poll timers
+- [x] `filteredTranscriptIntakeClusters()` — filter by category pills, participant pills
+- [x] `renderTranscriptIntakeTimeline()` — canvas timeline with category-colored markers
 
-### Cross-referencing with Screenspace events
+### Studio generation integration
+
+- [x] Update drop handlers in `initDropTargets()` to recognize `source: "transcript"` for both artifact and reel zones
+- [ ] Update `onGenerateArtifacts()` to partition transcript items and route to `api/generate-intake` with `source: "transcript"`
+- [ ] Update `_generate_intake_clips()` in `server.py` to look up video path in `transcripts_server._participants` when `source === "transcript"`
+
+### Cross-referencing with Screenspace events (deferred)
 
 - [ ] **On Screenspace intake cards**: when transcript data is available, show a "transcript context" line with the text at the card's time range (client-side join by participant + timestamp)
 - [ ] **On transcript search results**: when Screenspace events exist at the same timestamp, show a detector badge on the segment card (e.g., "change event detected here")
 - [ ] Cross-referencing is pure client-side — both data sources available in memory, joined by participant + timestamp at display time
-
-### Studio API additions
-
-- [ ] `GET /studio/api/transcripts` — return transcript summary from transcripts manifest (participant list with segment counts); full segment data fetched via `../transcripts/api/transcript/<participant>`
-- [ ] No duplicate search endpoint — Studio calls `../transcripts/api/search` directly
 
 ---
 
@@ -258,3 +297,6 @@ Not in scope for Phases 1–4, but the segment schema is designed to accommodate
 - **Standalone discovery** — the workspace discovers source media from the input directory without a spreadsheet. Reuses the shared video discovery utility (factored from Screenspace's `_discover_participant_videos`). Participant ID extraction from filenames (`{study}_{participant}.mp4`) must be robust to naming variations.
 - **Sidecar cache removal** — researchers who relied on `.transcript.json` files for non-manifest workflows will lose that caching. The manifest becomes the only persistence path. If this causes friction, consider a lightweight in-memory LRU cache in `_transcribe_segments()` as a session-only speedup.
 - **Always-on blueprint overhead** — registering the transcript blueprint unconditionally means its routes exist even when no transcripts have been generated. Endpoints return empty results. The `/api/status` response should clearly indicate whether transcript data is available vs. whether the endpoint is reachable.
+- **Mark orphaning on re-transcription** — segment IDs are index-based and reassigned on every save. Re-transcription changes indices, orphaning existing marks. The marks API returns a `valid` flag so the UI can show orphaned marks dimmed. Low cost of a few orphaned marks vs. high cost of silently deleting user curation.
+- **Mark categories are hardcoded** — not user-configurable for V1. If needed later, categories can move to a `"mark_categories"` key in the manifest with the hardcoded set as defaults.
+- **Clustering threshold in Studio** — the time-gap merge threshold for transcript marks (default 5s) may need different tuning than Screenspace events. Transcript segments are typically 2–5s each, so a 5s gap means adjacent marked segments always merge. Monitor whether users want finer control.

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -373,12 +373,12 @@ class TestGetCorrectionsKeywords:
 class TestTranscriptsManifest:
     def test_empty_manifest_default(self):
         m = transcripts._empty_transcripts_manifest()
-        assert m == {"source_transcripts": {}, "corrections": []}
+        assert m == {"source_transcripts": {}, "corrections": [], "marks": []}
 
     def test_load_missing_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         m = transcripts.load_transcripts_manifest()
-        assert m == {"source_transcripts": {}, "corrections": []}
+        assert m == {"source_transcripts": {}, "corrections": [], "marks": []}
 
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
@@ -451,7 +451,7 @@ class TestTranscriptsManifest:
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         (tmp_path / config.TRANSCRIPTS_MANIFEST_FILENAME).write_text("not json")
         m = transcripts.load_transcripts_manifest()
-        assert m == {"source_transcripts": {}, "corrections": []}
+        assert m == {"source_transcripts": {}, "corrections": [], "marks": []}
 
 
 # ---------------------------------------------------------------------------

--- a/transcripts.py
+++ b/transcripts.py
@@ -19,8 +19,8 @@ Key functions:
   get_transcript_extension(fmt) → file extension string for a format
 
 Manifest I/O:
-  load_transcripts_manifest() → dict with source_transcripts and corrections keys
-  save_transcripts_manifest(source_transcripts, corrections) → assigns segment IDs, writes JSON
+  load_transcripts_manifest() → dict with source_transcripts, corrections, and marks keys
+  save_transcripts_manifest(source_transcripts, corrections, marks=None) → assigns segment IDs, writes JSON
 
 Corrections:
   apply_corrections(segments, corrections) → new segment list with from→to substitutions applied
@@ -72,6 +72,20 @@ class ManifestSegment(TypedDict):
     start: float
     end: float
     text: str
+
+
+# ---------------------------------------------------------------------------
+# Mark categories (shared constant — mirrored in transcripts.js)
+# ---------------------------------------------------------------------------
+
+MARK_CATEGORIES: dict[str, dict[str, str]] = {
+    "pain_point": {"label": "Pain Point", "color": "#dc2626"},
+    "delight": {"label": "Delight", "color": "#16a34a"},
+    "quote": {"label": "Quote", "color": "#2563eb"},
+    "insight": {"label": "Insight", "color": "#f97316"},
+    "task": {"label": "Task Issue", "color": "#8b5cf6"},
+    "bookmark": {"label": "Bookmark", "color": "#0891b2"},
+}
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +201,7 @@ def transcribe_video(
 
 
 def _empty_transcripts_manifest() -> dict[str, Any]:
-    return {"source_transcripts": {}, "corrections": []}
+    return {"source_transcripts": {}, "corrections": [], "marks": []}
 
 
 def load_transcripts_manifest() -> dict[str, Any]:
@@ -210,23 +224,43 @@ def load_transcripts_manifest() -> dict[str, Any]:
     return {
         "source_transcripts": data.get("source_transcripts") or {},
         "corrections": data.get("corrections") or [],
+        "marks": data.get("marks") or [],
     }
 
 
 def save_transcripts_manifest(
     source_transcripts: dict[str, Any],
     corrections: list[dict[str, Any]],
+    marks: list[dict[str, Any]] | None = None,
 ) -> Optional[Path]:
     """Write the transcripts manifest to disk.
 
     Assigns segment IDs (``"{participant}:{index}"``) at storage time.
+    *marks* defaults to ``None`` which preserves whatever marks are already on
+    disk (load → merge → save).  Pass an explicit list to overwrite.
     Returns the manifest path on success, or ``None`` on failure.
     """
     for participant_id, entry in source_transcripts.items():
         for idx, seg in enumerate(entry.get("segments", [])):
             seg["id"] = f"{participant_id}:{idx}"
 
-    data = {"source_transcripts": source_transcripts, "corrections": corrections}
+    # When marks is None, preserve existing marks from disk
+    if marks is None:
+        manifest_path = (
+            Path(utils.get_effective_output_dir())
+            / config.TRANSCRIPTS_MANIFEST_FILENAME
+        )
+        try:
+            existing = json.loads(manifest_path.read_text(encoding="utf-8"))
+            marks = existing.get("marks") or []
+        except (OSError, json.JSONDecodeError):
+            marks = []
+
+    data = {
+        "source_transcripts": source_transcripts,
+        "corrections": corrections,
+        "marks": marks,
+    }
     manifest_path = (
         Path(utils.get_effective_output_dir()) / config.TRANSCRIPTS_MANIFEST_FILENAME
     )

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -15,6 +15,10 @@ API endpoints (all under /transcripts/):
   GET  /api/corrections                           - list all study-local corrections
   POST /api/corrections                           - add a correction manually
   DELETE /api/corrections/<id>                    - remove a correction
+  GET  /api/marks                                 - list all marks with resolved segment data
+  POST /api/marks                                 - create marks for segments
+  PUT  /api/marks/<id>                            - update a mark's category or label
+  DELETE /api/marks/<id>                          - remove a mark (or bulk delete with JSON body)
   GET  /api/search?q=<query>                      - keyword search across all participants
   POST /api/transcribe                            - enqueue participant(s) for transcription
   GET  /api/transcribe/status                     - poll transcription task status
@@ -124,15 +128,23 @@ def api_transcript(participant: str) -> FlaskResponse:
     # Apply corrections to get corrected text
     corrected_segments = transcripts.apply_corrections(raw_segments, corrections)
 
-    # Build response segments with corrected flag
+    # Build marks-by-segment-id lookup
+    marks_by_seg: Dict[str, List[Dict[str, Any]]] = {}
+    for mark in _manifest.get("marks", []):
+        sid = mark.get("segment_id", "")
+        marks_by_seg.setdefault(sid, []).append(mark)
+
+    # Build response segments with corrected flag and marks
     segments = []
     for raw, corrected in zip(raw_segments, corrected_segments):
+        seg_id = raw.get("id", "")
         seg: Dict[str, Any] = {
-            "id": raw.get("id", ""),
+            "id": seg_id,
             "start": corrected["start"],
             "end": corrected["end"],
             "text": corrected["text"],
             "corrected": raw["text"] != corrected["text"],
+            "marks": marks_by_seg.get(seg_id, []),
         }
         segments.append(seg)
 
@@ -292,6 +304,175 @@ def api_corrections_delete(correction_id: str) -> FlaskResponse:
     return jsonify({"ok": True})
 
 
+# ---- Marks ----
+
+
+def _resolve_mark(mark: Dict[str, Any]) -> Dict[str, Any]:
+    """Enrich a mark with its segment's data (participant, start, end, text, valid)."""
+    seg_id = mark.get("segment_id", "")
+    # segment IDs are "{participant}:{index}"
+    parts = seg_id.split(":", 1)
+    if len(parts) != 2:
+        return {
+            **mark,
+            "valid": False,
+            "participant": "",
+            "start": 0,
+            "end": 0,
+            "text": "",
+        }
+    pid, idx_str = parts
+    try:
+        idx = int(idx_str)
+    except ValueError:
+        return {
+            **mark,
+            "valid": False,
+            "participant": pid,
+            "start": 0,
+            "end": 0,
+            "text": "",
+        }
+
+    src = _manifest.get("source_transcripts", {})
+    entry = src.get(pid, {})
+    segments = entry.get("segments", [])
+    if idx < 0 or idx >= len(segments):
+        return {
+            **mark,
+            "valid": False,
+            "participant": pid,
+            "start": 0,
+            "end": 0,
+            "text": "",
+        }
+
+    raw_seg = segments[idx]
+    corrections = _manifest.get("corrections", [])
+    corrected = transcripts.apply_corrections([raw_seg], corrections)
+    seg = corrected[0]
+    return {
+        **mark,
+        "valid": True,
+        "participant": pid,
+        "start": seg["start"],
+        "end": seg["end"],
+        "text": seg["text"],
+    }
+
+
+@transcripts_bp.route("/api/marks")
+def api_marks_list() -> FlaskResponse:
+    """List all marks, enriched with resolved segment data."""
+    with _manifest_lock:
+        raw_marks = list(_manifest.get("marks", []))
+        resolved = [_resolve_mark(m) for m in raw_marks]
+    return jsonify(
+        {
+            "ok": True,
+            "marks": resolved,
+            "categories": transcripts.MARK_CATEGORIES,
+        }
+    )
+
+
+@transcripts_bp.route("/api/marks", methods=["POST"])
+def api_marks_add() -> FlaskResponse:
+    """Create marks for one or more segments."""
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+
+    segment_ids = data.get("segment_ids", [])
+    if not segment_ids:
+        return jsonify({"ok": False, "error": "segment_ids required"}), 400
+
+    category = data.get("category") or None
+    label = data.get("label") or None
+    now = datetime.now(timezone.utc).isoformat()
+
+    created = []
+    with _manifest_lock:
+        marks = _manifest.setdefault("marks", [])
+        existing_by_seg = {m["segment_id"]: m for m in marks}
+
+        for sid in segment_ids:
+            if sid in existing_by_seg:
+                # Update existing mark
+                m = existing_by_seg[sid]
+                if category is not None:
+                    m["category"] = category
+                if label is not None:
+                    m["label"] = label
+                created.append(m)
+            else:
+                m = {
+                    "id": f"m_{uuid.uuid4().hex[:8]}",
+                    "segment_id": sid,
+                    "category": category,
+                    "label": label,
+                    "created": now,
+                }
+                marks.append(m)
+                existing_by_seg[sid] = m
+                created.append(m)
+
+    _persist_manifest()
+    return jsonify({"ok": True, "marks": created})
+
+
+@transcripts_bp.route("/api/marks/<mark_id>", methods=["PUT"])
+def api_marks_update(mark_id: str) -> FlaskResponse:
+    """Update a mark's category or label."""
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+
+    with _manifest_lock:
+        marks = _manifest.get("marks", [])
+        target = None
+        for m in marks:
+            if m.get("id") == mark_id:
+                target = m
+                break
+        if not target:
+            return jsonify({"ok": False, "error": "Mark not found"}), 404
+
+        if "category" in data:
+            target["category"] = data["category"] or None
+        if "label" in data:
+            target["label"] = data["label"] or None
+
+    _persist_manifest()
+    return jsonify({"ok": True, "mark": target})
+
+
+@transcripts_bp.route("/api/marks/<mark_id>", methods=["DELETE"])
+def api_marks_delete(mark_id: str) -> FlaskResponse:
+    """Remove a mark by ID, or bulk-delete with JSON body {ids: [...]}."""
+    # Bulk delete: DELETE /api/marks with {ids: [...]} — mark_id may be a placeholder
+    data = request.get_json(silent=True)
+    ids_to_remove: List[str] = []
+
+    if data and data.get("ids"):
+        ids_to_remove = data["ids"]
+    else:
+        ids_to_remove = [mark_id]
+
+    with _manifest_lock:
+        marks = _manifest.get("marks", [])
+        remove_set = set(ids_to_remove)
+        before = len(marks)
+        _manifest["marks"] = [m for m in marks if m.get("id") not in remove_set]
+        removed = before - len(_manifest["marks"])
+
+    if removed == 0:
+        return jsonify({"ok": False, "error": "Mark not found"}), 404
+
+    _persist_manifest()
+    return jsonify({"ok": True, "removed": removed})
+
+
 # ---- Search ----
 
 
@@ -449,6 +630,7 @@ def _do_persist() -> None:
     transcripts.save_transcripts_manifest(
         _manifest.get("source_transcripts", {}),
         _manifest.get("corrections", []),
+        marks=_manifest.get("marks"),
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a **segment marking system** to the Transcript workspace: clickable gutter dots with 6 color categories (pain point, delight, quote, insight, task, bookmark), free-text labels, and a "Mark All" bulk action on search results.
- Marks are stored as a separate structure in `transcripts_manifest.json` (like corrections), with full CRUD API endpoints that resolve segment data and handle re-transcription orphaning.
- Adds a **Transcript Intake tab** to Studio (third preview tab alongside Sheet Preview and Screenspace Intake) that polls marks, clusters adjacent ones by configurable time gap, and renders draggable cards with category filters, participant filters, and a canvas timeline.
- Drop targets in Studio accept `source: "transcript"` cards for both artifact and reel queues.

## Test plan

- [ ] Start Transcript workspace, transcribe a participant, click gutter dots to mark segments — verify persistence across reload
- [ ] Use category popover to change colors/labels, search and "Mark All"
- [ ] Start Studio, verify Transcript Intake tab appears, marks render as clustered cards
- [ ] Drag cards to Artifacts/Reel areas, adjust merge threshold, use category/participant filters
- [ ] Toggle "Show all segments" to browse full transcript in intake view