### PR TITLE
Stream partial transcript segments during transcription

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -503,6 +503,32 @@ body {
   border-left-color: var(--color-accent);
 }
 
+.segment-streaming {
+  opacity: 0.85;
+}
+
+.streaming-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  color: var(--color-text-dim);
+  font-size: var(--text-sm);
+}
+
+.streaming-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  animation: streaming-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes streaming-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
 .segment-timestamp {
   flex: 0 0 5rem;
   font-family: var(--font-mono);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -29,6 +29,7 @@
     editingTextEl: null,
     pollTimer: null,
     lastMarkCategory: "bookmark",
+    streamingParticipant: null,
   };
 
   // ---- Helpers ----
@@ -231,17 +232,32 @@
 
     // Update status
     var statusEl = qs("#transcriptStatus");
+    var taskForPid = null;
+    state.tasks.forEach(function (t) {
+      if (t.participant === pid && (t.status === "running" || t.status === "queued")) {
+        taskForPid = t;
+      }
+    });
     if (p.has_transcript) {
       statusEl.textContent = p.segment_count + " segments";
+    } else if (taskForPid && taskForPid.status === "running") {
+      statusEl.textContent = "transcribing\u2026 " + Math.round((taskForPid.progress || 0) * 100) + "%";
+    } else if (taskForPid && taskForPid.status === "queued") {
+      statusEl.textContent = "queued";
     } else {
       statusEl.textContent = "not transcribed";
     }
 
     // Load transcript
     if (p.has_transcript) {
+      state.streamingParticipant = null;
       loadTranscript(pid);
+    } else if (taskForPid && taskForPid.status === "running" && taskForPid.partial_segments && taskForPid.partial_segments.length > 0) {
+      renderPartialSegments(taskForPid.partial_segments, taskForPid.progress);
+      state.streamingParticipant = pid;
     } else {
       state.segments = [];
+      state.streamingParticipant = null;
       renderSegments();
     }
   }
@@ -347,6 +363,53 @@
           }
         });
       })(rows[j]);
+    }
+  }
+
+  function renderPartialSegments(segments, progress) {
+    var container = qs("#segmentList");
+    var empty = qs("#transcriptEmpty");
+    var pid = state.streamingParticipant || state.selectedParticipant;
+    empty.classList.add("hidden");
+
+    // Only auto-scroll if user is near the bottom
+    var nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
+
+    var html = "";
+    for (var i = 0; i < segments.length; i++) {
+      var seg = segments[i];
+      var segId = pid + ":" + i;
+      html += '<div class="segment-row segment-streaming" data-index="' + i + '" data-start="' + seg.start + '">';
+      html += '<span class="segment-mark" data-segment-id="' + escapeHtml(segId) + '"></span>';
+      html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
+      html += '<span class="segment-text">' + escapeHtml(seg.text) + '</span>';
+      html += '</div>';
+    }
+    html += '<div class="streaming-indicator">';
+    html += '<span class="streaming-dot"></span>';
+    html += 'Transcribing\u2026 ' + Math.round(progress * 100) + '%';
+    html += '</div>';
+
+    container.innerHTML = html;
+
+    // Click-to-seek on timestamps and mark clicks
+    var rows = container.querySelectorAll(".segment-streaming");
+    for (var j = 0; j < rows.length; j++) {
+      (function (row) {
+        row.querySelector(".segment-timestamp").addEventListener("click", function (e) {
+          e.stopPropagation();
+          seekVideo(parseFloat(row.getAttribute("data-start")));
+        });
+        row.querySelector(".segment-mark").addEventListener("click", function (e) {
+          e.stopPropagation();
+          var segId = this.getAttribute("data-segment-id");
+          toggleMarkStreaming(segId, this);
+        });
+      })(rows[j]);
+    }
+
+    if (nearBottom) {
+      container.scrollTop = container.scrollHeight;
     }
   }
 
@@ -619,6 +682,20 @@
     });
   }
 
+  function toggleMarkStreaming(segmentId, markEl) {
+    var cat = MARK_CATEGORIES[state.lastMarkCategory] || MARK_CATEGORIES.bookmark;
+    apiPost("api/marks", {
+      segment_ids: [segmentId],
+      category: state.lastMarkCategory,
+    }).then(function (data) {
+      if (data.ok) {
+        showToast("Marked");
+        markEl.classList.add("marked");
+        markEl.style.background = cat.color;
+      }
+    });
+  }
+
   function removeMark(markId) {
     apiDelete("api/marks/" + markId).then(function (data) {
       if (data.ok) {
@@ -767,9 +844,45 @@
     state.searchQuery = query;
     apiGet("api/search?q=" + encodeURIComponent(query)).then(function (data) {
       if (!data.ok) return;
+      // Merge client-side search of partial segments for the streaming participant
+      if (state.streamingParticipant) {
+        var partials = _searchPartialSegments(query, state.streamingParticipant);
+        if (partials.length > 0) {
+          data.results = data.results.concat(partials);
+          data.total_count += partials.length;
+          data.counts_by_participant[state.streamingParticipant] =
+            (data.counts_by_participant[state.streamingParticipant] || 0) + partials.length;
+        }
+      }
       state.searchResults = data;
       renderSearchResults(data);
     });
+  }
+
+  function _searchPartialSegments(query, pid) {
+    var results = [];
+    var lowerQ = query.toLowerCase();
+    var task = null;
+    state.tasks.forEach(function (t) {
+      if (t.participant === pid && t.status === "running" && t.partial_segments) {
+        task = t;
+      }
+    });
+    if (!task) return results;
+    for (var i = 0; i < task.partial_segments.length; i++) {
+      var seg = task.partial_segments[i];
+      if (seg.text.toLowerCase().indexOf(lowerQ) >= 0) {
+        results.push({
+          participant: pid,
+          segment_id: pid + ":" + i,
+          start: seg.start,
+          end: seg.end,
+          text: seg.text,
+          count: 1,
+        });
+      }
+    }
+    return results;
   }
 
   function renderSearchResults(data) {
@@ -1031,6 +1144,25 @@
       if (!data.ok) return;
       state.tasks = data.tasks;
 
+      // Stream partial segments for the selected participant's running task
+      var selectedRunningTask = null;
+      if (state.selectedParticipant) {
+        data.tasks.forEach(function (t) {
+          if (t.participant === state.selectedParticipant && t.status === "running" && t.partial_segments) {
+            selectedRunningTask = t;
+          }
+        });
+      }
+      if (selectedRunningTask && selectedRunningTask.partial_segments.length > 0) {
+        renderPartialSegments(selectedRunningTask.partial_segments, selectedRunningTask.progress);
+        state.streamingParticipant = state.selectedParticipant;
+        // Update status text
+        var statusEl = qs("#transcriptStatus");
+        if (statusEl) statusEl.textContent = "transcribing\u2026 " + Math.round(selectedRunningTask.progress * 100) + "%";
+      } else if (state.streamingParticipant) {
+        state.streamingParticipant = null;
+      }
+
       var hasActive = false;
       var newlyCompleted = [];
       data.tasks.forEach(function (t) {
@@ -1045,6 +1177,7 @@
       if (newlyCompleted.length > 0) {
         loadParticipants().then(function () {
           if (state.selectedParticipant && newlyCompleted.indexOf(state.selectedParticipant) >= 0) {
+            state.streamingParticipant = null;
             loadTranscript(state.selectedParticipant);
           }
         });

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.24"
+VERSIONNUM: str = "0.10.25"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/transcripts.py
+++ b/transcripts.py
@@ -133,7 +133,7 @@ def transcribe_video(
     language: Optional[str] = None,
     initial_prompt: Optional[str] = None,
     context_keywords: Optional[List[str]] = None,
-    on_segment: Optional[Callable[[float], None]] = None,
+    on_segment: Optional[Callable[[float, "TranscriptSegment"], None]] = None,
 ) -> Optional[TranscriptResult]:
     """Transcribe a video file and return timestamped segments.
 
@@ -143,7 +143,8 @@ def transcribe_video(
         initial_prompt: Override the default initial prompt.
         context_keywords: Extra keywords to append to the prompt.
         on_segment: Optional callback invoked after each segment with the
-            segment's end time (seconds).  Useful for progress tracking.
+            segment's end time (seconds) and the TranscriptSegment.
+            Useful for progress tracking and streaming partial results.
 
     Returns:
         TranscriptResult with segments, or None on failure.
@@ -180,7 +181,7 @@ def transcribe_video(
                 continue
             segments.append(TranscriptSegment(start=seg.start, end=seg.end, text=text))
             if on_segment is not None:
-                on_segment(seg.end)
+                on_segment(seg.end, segments[-1])
         detected_lang = (
             info.language if hasattr(info, "language") else (lang or "unknown")
         )
@@ -631,6 +632,7 @@ def create_transcript_task(participant: str, video_path: str) -> Dict[str, Any]:
         "video_path": video_path,
         "status": TASK_STATUS_QUEUED,
         "progress": 0.0,
+        "partial_segments": [],
         "result": None,
         "error": None,
         "created_at": datetime.now(timezone.utc).isoformat(),
@@ -749,10 +751,11 @@ class TranscriptWorker:
         corrections = manifest.get("corrections", [])
         context_kw = get_corrections_keywords(corrections) or None
 
-        def _on_seg(end_time: float) -> None:
-            if duration > 0:
-                with self._lock:
+        def _on_seg(end_time: float, segment: TranscriptSegment) -> None:
+            with self._lock:
+                if duration > 0:
                     task["progress"] = min(end_time / duration, 0.99)
+                task["partial_segments"].append(segment)
 
         try:
             result = transcribe_video(
@@ -764,12 +767,14 @@ class TranscriptWorker:
                 with self._lock:
                     task["status"] = TASK_STATUS_FAILED
                     task["error"] = "Transcription returned None"
+                    task["partial_segments"] = []
                     task["completed_at"] = datetime.now(timezone.utc).isoformat()
                 return
 
             with self._lock:
                 task["status"] = TASK_STATUS_COMPLETED
                 task["progress"] = 1.0
+                task["partial_segments"] = []
                 task["result"] = {
                     "segments": result["segments"],
                     "language": result["language"],
@@ -783,4 +788,5 @@ class TranscriptWorker:
             with self._lock:
                 task["status"] = TASK_STATUS_FAILED
                 task["error"] = str(exc)
+                task["partial_segments"] = []
                 task["completed_at"] = datetime.now(timezone.utc).isoformat()

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -586,17 +586,18 @@ def api_transcribe_status() -> FlaskResponse:
     tasks = []
     if _worker:
         for t in _worker.get_all_tasks():
-            tasks.append(
-                {
-                    "id": t["id"],
-                    "participant": t["participant"],
-                    "status": t["status"],
-                    "progress": t["progress"],
-                    "error": t.get("error"),
-                    "created_at": t.get("created_at"),
-                    "completed_at": t.get("completed_at"),
-                }
-            )
+            task_info = {
+                "id": t["id"],
+                "participant": t["participant"],
+                "status": t["status"],
+                "progress": t["progress"],
+                "error": t.get("error"),
+                "created_at": t.get("created_at"),
+                "completed_at": t.get("completed_at"),
+            }
+            if t["status"] == transcripts.TASK_STATUS_RUNNING:
+                task_info["partial_segments"] = t.get("partial_segments", [])
+            tasks.append(task_info)
     return jsonify(
         {
             "ok": True,


### PR DESCRIPTION
## Summary
- Progressively shows transcribed segments in the transcript panel while transcription is running, instead of waiting for completion with only a progress percentage
- Accumulates segments on the task dict via the `on_segment` callback and serves them through the existing 3-second polling cycle
- Marks can be placed on streaming segments (click the dot); search also covers partial segments via client-side matching
- Streaming indicator with pulsing dot and live percentage at the bottom of the segment list; auto-scrolls to follow new segments

## Test plan
- [ ] Start Studio, open `/transcripts/`, select an untranscribed participant
- [ ] Click Transcribe — verify partial segments appear within a few seconds and grow over time
- [ ] Click a mark dot during streaming — verify it turns colored and persists after completion
- [ ] Search for a word during streaming — verify matches from partial segments appear in results
- [ ] Verify seamless transition to full transcript (with marks/editing/corrections) on completion
- [ ] Switch participants during transcription and switch back — verify partial segments resume