### PR TITLE
Transcript intake generation, staleness badge, and intake UI fixes

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2110,7 +2110,8 @@ html[data-theme="dark"] .log-panel {
   color: var(--color-text);
 }
 
-#intakeTimeline {
+#intakeTimeline,
+#trIntakeTimeline {
   width: 100%;
   height: 48px;
   border-radius: calc(var(--radius) - 2px);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -46,6 +46,10 @@
     trIntakeHoveredIdx: -1,
   };
 
+  function isIntakeSource(source) {
+    return source === "screenspace" || source === "transcript";
+  }
+
   var SEVERITY_ORDER = [
     { label: "Critical", rank: -4 },
     { label: "High", rank: -3 },
@@ -1622,7 +1626,7 @@
 
     for (var i = 0; i < n; i++) {
       var item = state.artifactQueue[i];
-      var isIntake = item.source === "screenspace";
+      var isIntake = isIntakeSource(item.source);
       var segStart, segDuration;
       if (item.segStart !== undefined && item.segDuration !== undefined) {
         segStart = item.segStart;
@@ -1638,7 +1642,7 @@
       var card = el("div", "queue-card" + (isIntake ? " queue-card-intake" : ""));
       card.setAttribute("data-participant", item.participant);
       card.setAttribute("data-row", isIntake ? "" : item.row);
-      if (isIntake) card.setAttribute("data-source", "screenspace");
+      if (isIntake) card.setAttribute("data-source", item.source);
       card.setAttribute("data-seg-idx", segIdx);
       card.setAttribute("draggable", "true");
       (function (itm, isI) {
@@ -1648,7 +1652,7 @@
             desc: itm.desc,
             segStart: itm.segStart,
             segDuration: itm.segDuration,
-            source: isI ? "screenspace" : "artifact",
+            source: isI ? itm.source : "artifact",
           };
           if (!isI) {
             data.row = itm.row;
@@ -1658,6 +1662,7 @@
           } else {
             data.event_type = itm.event_type;
             data.event_ids = itm.event_ids;
+            data.mark_ids = itm.mark_ids;
           }
           ev.dataTransfer.setData("application/json", JSON.stringify(data));
           ev.dataTransfer.effectAllowed = "copyMove";
@@ -1684,7 +1689,11 @@
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
       if (isIntake) {
         var ssBadge = el("span", "queue-card-source-badge");
-        ssBadge.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
+        if (item.source === "transcript") {
+          ssBadge.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3 3h10v1.5H3zM3 7h8v1.5H3zM3 11h10v1.5H3z"/></svg>';
+        } else {
+          ssBadge.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
+        }
         thumb.appendChild(ssBadge);
       }
       card.appendChild(thumb);
@@ -1749,7 +1758,7 @@
     var totalDur = 0;
     for (var i = 0; i < n; i++) {
       var item = state.reelQueue[i];
-      var isIntake = item.source === "screenspace";
+      var isIntake = isIntakeSource(item.source);
       var segStart, segDuration;
       if (item.segStart !== undefined && item.segDuration !== undefined) {
         segStart = item.segStart;
@@ -1767,7 +1776,7 @@
       card.setAttribute("data-reel-idx", i);
       card.setAttribute("data-participant", item.participant);
       card.setAttribute("data-row", isIntake ? "" : item.row);
-      if (isIntake) card.setAttribute("data-source", "screenspace");
+      if (isIntake) card.setAttribute("data-source", item.source);
       card.setAttribute("data-seg-idx", segIdx);
       card.setAttribute("draggable", "true");
 
@@ -1790,7 +1799,11 @@
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
       if (isIntake) {
         var ssBadge = el("span", "queue-card-source-badge");
-        ssBadge.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
+        if (item.source === "transcript") {
+          ssBadge.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3 3h10v1.5H3zM3 7h8v1.5H3zM3 11h10v1.5H3z"/></svg>';
+        } else {
+          ssBadge.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
+        }
         thumb.appendChild(ssBadge);
       }
       card.appendChild(thumb);
@@ -2349,7 +2362,7 @@
     var sheetItems = [];
     var intakeItems = [];
     for (var ci = 0; ci < items.length; ci++) {
-      if (items[ci].source === "screenspace") {
+      if (isIntakeSource(items[ci].source)) {
         intakeItems.push(items[ci]);
       } else {
         sheetItems.push(items[ci]);
@@ -2466,6 +2479,8 @@
           end: itm.segStart + itm.segDuration,
           event_type: itm.event_type || itm.desc || "",
           event_ids: itm.event_ids || [],
+          source: itm.source || "screenspace",
+          mark_ids: itm.mark_ids || [],
         };
       });
 
@@ -2476,7 +2491,7 @@
       })
         .then(function (r) { return r.json(); })
         .then(function (data) {
-          var intakeCards = list.querySelectorAll('[data-source="screenspace"]');
+          var intakeCards = list.querySelectorAll('[data-source="screenspace"], [data-source="transcript"]');
           if (data.ok && data.results) {
             for (var ri = 0; ri < data.results.length; ri++) {
               var res = data.results[ri];
@@ -2497,7 +2512,7 @@
           finishBranch();
         })
         .catch(function () {
-          var intakeCards = list.querySelectorAll('[data-source="screenspace"]');
+          var intakeCards = list.querySelectorAll('[data-source="screenspace"], [data-source="transcript"]');
           for (var j = 0; j < intakeCards.length; j++) setCardResult(intakeCards[j], false);
           totalFail += intakeItems.length;
           finishBranch();
@@ -2514,7 +2529,7 @@
     // Determine if we have intake items — use direct endpoint for mixed/intake reels
     var hasIntake = false;
     for (var ci = 0; ci < state.reelQueue.length; ci++) {
-      if (state.reelQueue[ci].source === "screenspace") { hasIntake = true; break; }
+      if (isIntakeSource(state.reelQueue[ci].source)) { hasIntake = true; break; }
     }
 
     var reelBody;
@@ -2537,6 +2552,7 @@
           participant: item.participant,
           start: segStart,
           end: segStart + segDuration,
+          source: item.source || "screenspace",
         });
       }
       reelBody = { segments: segments };

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3372,6 +3372,7 @@
   var SS_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
 
   var _intakeHitRects = [];
+  var _trIntakeHitRects = [];
 
   function sizeIntakeCanvas() {
     var canvas = qs("#intakeTimeline");
@@ -3972,9 +3973,24 @@
       card.draggable = true;
       card.dataset.trIntakeIdx = i;
 
-      // Thumbnail area with category dot and duration
+      // Thumbnail area with frame, category dot, and duration
       var thumb = document.createElement("div");
       thumb.className = "queue-card-thumb";
+
+      var segDuration = Math.max(0, c.end - c.start);
+      var img = document.createElement("img");
+      img.src = "../screenspace/api/video/frame/" + encodeURIComponent(c.participant) + "/" + c.start;
+      img.loading = "lazy";
+      img.alt = "";
+      img.draggable = false;
+      (function (cardEl, thumbEl) {
+        img.addEventListener("error", function () {
+          this.remove();
+          thumbEl.appendChild(el("span", "", "\u2715"));
+          cardEl.classList.add("queue-card-error");
+        });
+      })(card, thumb);
+      thumb.appendChild(img);
 
       var catColor = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
       var dot = document.createElement("span");
@@ -3984,7 +4000,7 @@
 
       var dur = document.createElement("span");
       dur.className = "queue-card-duration";
-      dur.textContent = formatDuration(Math.max(0, c.end - c.start));
+      dur.textContent = formatDuration(segDuration);
       thumb.appendChild(dur);
       card.appendChild(thumb);
 
@@ -4085,49 +4101,101 @@
     var canvas = qs("#trIntakeTimeline");
     if (!canvas) return;
     var ctx = canvas.getContext("2d");
-    var w = canvas.clientWidth;
-    var h = 48;
+    var dpr = window.devicePixelRatio || 1;
+    var w = canvas.width / dpr;
+    var h = canvas.height / dpr;
+    if (w <= 0 || h <= 0) return;
+
+    var cs = getComputedStyle(document.documentElement);
+    var surfaceAlt = cs.getPropertyValue("--color-surface-alt").trim() || "#f1ece4";
+    var borderColor = cs.getPropertyValue("--color-border").trim() || "#e0ddd7";
+    var textDim = cs.getPropertyValue("--color-text-dim").trim() || "#888";
+    var fontMono = cs.getPropertyValue("--font-mono").trim() || "monospace";
+
     ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = surfaceAlt;
+    ctx.fillRect(0, 0, w, h);
 
     var filtered = filteredTranscriptIntakeClusters();
-    if (filtered.length === 0) return;
+    if (!filtered.length) {
+      ctx.fillStyle = textDim;
+      ctx.font = "12px -apple-system, sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillText("No marks", w / 2, h / 2 + 4);
+      ctx.textAlign = "start";
+      _trIntakeHitRects = [];
+      return;
+    }
 
-    // Find time range
-    var minT = Infinity, maxT = 0;
+    var maxEnd = 0;
     for (var i = 0; i < filtered.length; i++) {
-      if (filtered[i].start < minT) minT = filtered[i].start;
-      if (filtered[i].end > maxT) maxT = filtered[i].end;
+      if (filtered[i].end > maxEnd) maxEnd = filtered[i].end;
     }
-    if (maxT <= minT) maxT = minT + 1;
-    var range = maxT - minT;
-    var pad = 8;
-    var usableW = w - pad * 2;
+    var duration = Math.max(maxEnd * 1.05, 60);
 
-    // Draw time ruler
-    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-text-dim") || "#888";
-    ctx.font = "10px monospace";
+    function timeToX(t) {
+      return (t / duration) * w;
+    }
+
+    // Time ruler ticks
+    var tickInterval = intakeComputeTickInterval(duration);
+    var firstTick = Math.ceil(0 / tickInterval) * tickInterval;
+    ctx.strokeStyle = borderColor;
+    ctx.fillStyle = textDim;
+    ctx.font = "10px " + fontMono;
     ctx.textAlign = "center";
-    var tickCount = Math.min(Math.floor(usableW / 60), 10);
-    for (var t = 0; t <= tickCount; t++) {
-      var frac = t / tickCount;
-      var sec = minT + frac * range;
-      var x = pad + frac * usableW;
-      ctx.fillText(formatDuration(sec), x, 10);
-      ctx.fillRect(x, 12, 1, 4);
+    ctx.lineWidth = 1;
+    for (var t = firstTick; t <= duration; t += tickInterval) {
+      var x = timeToX(t);
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, 8);
+      ctx.stroke();
+      ctx.fillText(formatDuration(t), x, 18);
     }
+    ctx.textAlign = "start";
 
-    // Draw cluster markers
-    for (var j = 0; j < filtered.length; j++) {
-      var c = filtered[j];
-      var x1 = pad + ((c.start - minT) / range) * usableW;
-      var x2 = pad + ((c.end - minT) / range) * usableW;
-      var mw = Math.max(x2 - x1, 4);
+    // Cluster markers
+    var markerY = 22;
+    var markerH = h - markerY - 4;
+    _trIntakeHitRects = [];
+
+    for (var ci = 0; ci < filtered.length; ci++) {
+      var c = filtered[ci];
       var color = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
-      ctx.fillStyle = color;
-      ctx.globalAlpha = j === state.trIntakeHoveredIdx ? 1.0 : 0.6;
-      ctx.fillRect(x1, 20, mw, 24);
+      var highlighted = state.trIntakeHoveredIdx === ci;
+      var dimmed = state.trIntakeHoveredIdx !== -1 && !highlighted;
+      var alpha = highlighted ? 0.85 : (dimmed ? 0.15 : 0.5);
+
+      var x1 = timeToX(c.start);
+      var x2 = timeToX(c.end);
+      var mw = Math.max(x2 - x1, 3);
+
+      ctx.fillStyle = hexToRgba(color, alpha);
+      ctx.fillRect(x1, markerY, mw, markerH);
+
+      _trIntakeHitRects.push({ x1: x1, x2: x1 + mw, y: markerY, h: markerH, clusterIdx: ci });
     }
-    ctx.globalAlpha = 1.0;
+  }
+
+  function trIntakeHitTest(mx, my) {
+    for (var i = _trIntakeHitRects.length - 1; i >= 0; i--) {
+      var hr = _trIntakeHitRects[i];
+      if (mx >= hr.x1 && mx <= hr.x2 && my >= hr.y && my <= hr.y + hr.h) return hr;
+    }
+    return null;
+  }
+
+  function highlightTrIntakeCard(idx) {
+    var cards = qsa(".tr-intake-queue-card");
+    for (var i = 0; i < cards.length; i++) {
+      if (i === idx) {
+        cards[i].classList.add("intake-highlight");
+        cards[i].scrollIntoView({ block: "nearest", behavior: "smooth" });
+      } else {
+        cards[i].classList.remove("intake-highlight");
+      }
+    }
   }
 
   function initTranscriptIntake() {
@@ -4164,13 +4232,63 @@
         .catch(function () {});
     });
 
+    // Card hover → highlight timeline marker
+    trIntakeCards.addEventListener("mouseover", function (e) {
+      var card = e.target.closest(".tr-intake-queue-card");
+      if (!card) return;
+      var idx = parseInt(card.dataset.trIntakeIdx);
+      if (state.trIntakeHoveredIdx !== idx) {
+        state.trIntakeHoveredIdx = idx;
+        renderTrIntakeTimeline();
+      }
+    });
+    trIntakeCards.addEventListener("mouseleave", function () {
+      if (state.trIntakeHoveredIdx !== -1) {
+        state.trIntakeHoveredIdx = -1;
+        renderTrIntakeTimeline();
+      }
+    });
+
+    // Timeline canvas interactions
+    var trIntakeCanvas = qs("#trIntakeTimeline");
+    if (trIntakeCanvas) {
+      trIntakeCanvas.addEventListener("mousemove", function (e) {
+        var rect = trIntakeCanvas.getBoundingClientRect();
+        var mx = e.clientX - rect.left;
+        var my = e.clientY - rect.top;
+        var hit = trIntakeHitTest(mx, my);
+        var idx = hit ? hit.clusterIdx : -1;
+        if (state.trIntakeHoveredIdx !== idx) {
+          state.trIntakeHoveredIdx = idx;
+          renderTrIntakeTimeline();
+          highlightTrIntakeCard(idx);
+        }
+      });
+      trIntakeCanvas.addEventListener("mouseleave", function () {
+        if (state.trIntakeHoveredIdx !== -1) {
+          state.trIntakeHoveredIdx = -1;
+          renderTrIntakeTimeline();
+          highlightTrIntakeCard(-1);
+        }
+      });
+      trIntakeCanvas.addEventListener("click", function (e) {
+        var rect = trIntakeCanvas.getBoundingClientRect();
+        var mx = e.clientX - rect.left;
+        var my = e.clientY - rect.top;
+        var hit = trIntakeHitTest(mx, my);
+        if (!hit) return;
+        var cluster = filteredTranscriptIntakeClusters()[hit.clusterIdx];
+        if (!cluster) return;
+        if (e.shiftKey) trIntakeAddToReel(cluster);
+        else trIntakeAddToArtifacts(cluster);
+      });
+    }
+
     // Cluster threshold change
     var thresholdInput = qs("#trIntakeClusterThreshold");
     if (thresholdInput) {
       thresholdInput.addEventListener("change", function () {
-        var val = parseInt(this.value) || 5;
-        state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, val);
-        renderTranscriptIntake();
+        pollTranscriptIntakeMarks();
       });
     }
 

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -679,6 +679,20 @@ body {
   margin-top: var(--space-1);
 }
 
+.transcript-stale {
+  color: #f59e0b;
+}
+
+.queue-stale-badge {
+  display: inline-block;
+  font-size: var(--text-xs);
+  color: #f59e0b;
+  padding: 2px 6px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-sm);
+  margin-left: var(--space-2);
+}
+
 /* Modal */
 
 .modal {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -182,7 +182,7 @@
     state.participants.forEach(function (p) {
       var opt = document.createElement("option");
       opt.value = p.id;
-      opt.textContent = p.id + (p.has_transcript ? " \u2713" : "");
+      opt.textContent = p.id + (p.has_transcript ? " \u2713" : "") + (p.has_stale_artifacts ? " \u26a0" : "");
       sel.appendChild(opt);
     });
     if (state.selectedParticipant) {
@@ -240,12 +240,21 @@
     });
     if (p.has_transcript) {
       statusEl.textContent = p.segment_count + " segments";
+      if (p.has_stale_artifacts) {
+        statusEl.textContent += " \u2022 artifacts outdated";
+        statusEl.classList.add("transcript-stale");
+      } else {
+        statusEl.classList.remove("transcript-stale");
+      }
     } else if (taskForPid && taskForPid.status === "running") {
       statusEl.textContent = "transcribing\u2026 " + Math.round((taskForPid.progress || 0) * 100) + "%";
+      statusEl.classList.remove("transcript-stale");
     } else if (taskForPid && taskForPid.status === "queued") {
       statusEl.textContent = "queued";
+      statusEl.classList.remove("transcript-stale");
     } else {
       statusEl.textContent = "not transcribed";
+      statusEl.classList.remove("transcript-stale");
     }
 
     // Load transcript
@@ -1073,7 +1082,11 @@
       if (!p.has_transcript && (!taskByPid[p.id] || taskByPid[p.id].status === "failed" || taskByPid[p.id].status === "cancelled")) {
         html += '<div class="queue-item-action"><button class="btn btn-small" data-transcribe="' + escapeHtml(p.id) + '">Transcribe</button></div>';
       } else if (p.has_transcript && (!taskByPid[p.id] || taskByPid[p.id].status === "completed")) {
-        html += '<div class="queue-item-action"><button class="btn btn-small" data-retranscribe="' + escapeHtml(p.id) + '">Re-transcribe</button></div>';
+        html += '<div class="queue-item-action"><button class="btn btn-small" data-retranscribe="' + escapeHtml(p.id) + '">Re-transcribe</button>';
+        if (p.has_stale_artifacts) {
+          html += '<span class="queue-stale-badge">artifacts outdated</span>';
+        }
+        html += '</div>';
       }
 
       html += '</div>';

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -388,8 +388,11 @@
     for (var i = 0; i < segments.length; i++) {
       var seg = segments[i];
       var segId = pid + ":" + i;
+      var cachedColor = _streamingMarks[segId];
+      var markClass = "segment-mark" + (cachedColor ? " marked" : "");
+      var markStyle = cachedColor ? ' style="background:' + cachedColor + '"' : "";
       html += '<div class="segment-row segment-streaming" data-index="' + i + '" data-start="' + seg.start + '">';
-      html += '<span class="segment-mark" data-segment-id="' + escapeHtml(segId) + '"></span>';
+      html += '<span class="' + markClass + '" data-segment-id="' + escapeHtml(segId) + '"' + markStyle + '></span>';
       html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
       html += '<span class="segment-text">' + escapeHtml(seg.text) + '</span>';
       html += '</div>';
@@ -421,6 +424,9 @@
       container.scrollTop = container.scrollHeight;
     }
   }
+
+  // Cache marks made during streaming so they survive DOM rebuilds
+  var _streamingMarks = {};
 
   var _pendingSeekTime = null;
   var _seekRaf = 0;
@@ -701,6 +707,7 @@
         showToast("Marked");
         markEl.classList.add("marked");
         markEl.style.background = cat.color;
+        _streamingMarks[segmentId] = cat.color;
       }
     });
   }
@@ -1188,6 +1195,7 @@
 
       // Refresh participants and transcript as each task completes
       if (newlyCompleted.length > 0) {
+        _streamingMarks = {};
         loadParticipants().then(function () {
           if (state.selectedParticipant && newlyCompleted.indexOf(state.selectedParticipant) >= 0) {
             state.streamingParticipant = null;

--- a/clipgen.py
+++ b/clipgen.py
@@ -741,6 +741,7 @@ def _embed_transcript_on_artifacts(
     corrections = manifest.get("corrections", [])
 
     full_transcript = None
+    transcript_version = ""
     if participant and participant in source_transcripts:
         entry = source_transcripts[participant]
         raw_segments = entry.get("segments", [])
@@ -751,6 +752,7 @@ def _embed_transcript_on_artifacts(
             source_file=entry.get("source_file", str(base_video)),
             model=entry.get("model", ""),
         )
+        transcript_version = entry.get("transcribed_at", "")
     elif base_video in transcript_cache and transcript_cache[base_video]:
         full_transcript = transcript_cache[base_video]
 
@@ -777,6 +779,8 @@ def _embed_transcript_on_artifacts(
             )
         if transcript_segments:
             artifacts[art_idx]["transcript"] = transcript_segments
+            if transcript_version:
+                artifacts[art_idx]["transcript_version"] = transcript_version
 
 
 def _transcribe_segments(

--- a/plans/TRANSCRIPT-PLAN.md
+++ b/plans/TRANSCRIPT-PLAN.md
@@ -129,7 +129,7 @@ The workspace can trigger and monitor transcription jobs, not just view results.
   - `POST /transcripts/api/transcribe` — enqueue participant(s) for transcription
   - `GET /transcripts/api/transcribe/status` — poll transcription job status
 - [x] Transcription results are stored to `source_transcripts` in the transcripts manifest, same as `--pre-transcribe`
-- [ ] Re-transcription staleness: when a participant is re-transcribed, flag any clip artifacts with embedded `transcript` fields for that participant as stale. Surface a "transcript outdated" badge in the workspace UI.
+- [x] Re-transcription staleness: when a participant is re-transcribed, flag any clip artifacts with embedded `transcript` fields for that participant as stale. Surface a "transcript outdated" badge in the workspace UI.
 
 ### API endpoints
 
@@ -230,8 +230,8 @@ Pre-filter transcript content via a marking/curation system in the Transcript wo
 ### Studio generation integration
 
 - [x] Update drop handlers in `initDropTargets()` to recognize `source: "transcript"` for both artifact and reel zones
-- [ ] Update `onGenerateArtifacts()` to partition transcript items and route to `api/generate-intake` with `source: "transcript"`
-- [ ] Update `_generate_intake_clips()` in `server.py` to look up video path in `transcripts_server._participants` when `source === "transcript"`
+- [x] Update `onGenerateArtifacts()` to partition transcript items and route to `api/generate-intake` with `source: "transcript"`
+- [x] Update `_generate_intake_clips()` in `server.py` to look up video path in `transcripts_server._participants` when `source === "transcript"`
 
 ### Cross-referencing with Screenspace events (deferred)
 

--- a/server.py
+++ b/server.py
@@ -271,19 +271,41 @@ def _save_manifest_quiet() -> None:
         utils.warning_print(f"Failed to save manifest: {e}")
 
 
+def _resolve_intake_video_path(
+    participant: str, source: str = ""
+) -> Optional[str]:
+    """Resolve a video path for an intake participant.
+
+    Tries the source-specific participant list first, then falls back to the
+    other.  Both lists are populated from the same source videos so the
+    fallback is a safety net.
+    """
+    import screenspace_server
+    import transcripts_server
+
+    lists = (
+        [transcripts_server._participants, screenspace_server._participants]
+        if source == "transcript"
+        else [screenspace_server._participants, transcripts_server._participants]
+    )
+    for plist in lists:
+        for p in plist:
+            if p["id"] == participant and p.get("has_video"):
+                return p["video_path"]
+    return None
+
+
 def _generate_intake_clips(
     items: List[Dict[str, Any]],
     output_format: str = "clip",
     study: str = "",
 ) -> List[Dict[str, Any]]:
-    """Generate clips from intake items and return successful artifact dicts.
+    """Generate clips from intake items (Screenspace or Transcript).
 
     Each returned dict has an extra ``"_ok"`` key (True on success, False if
     the video was missing or ffmpeg failed) plus an ``"_error"`` string so
     callers can report per-item results without duplicating the loop.
     """
-    import screenspace_server
-
     output_dir = Path(utils.get_effective_output_dir())
     results: List[Dict[str, Any]] = []
 
@@ -293,12 +315,10 @@ def _generate_intake_clips(
         end = float(item.get("end", 0))
         event_type = item.get("event_type", "")
         event_ids = item.get("event_ids", [])
+        source = item.get("source", "screenspace")
+        mark_ids = item.get("mark_ids", [])
 
-        video_path = None
-        for p in screenspace_server._participants:
-            if p["id"] == participant and p.get("has_video"):
-                video_path = p["video_path"]
-                break
+        video_path = _resolve_intake_video_path(participant, source)
 
         if not video_path:
             results.append({"_ok": False, "_error": f"No video for {participant}"})
@@ -323,6 +343,11 @@ def _generate_intake_clips(
         )
 
         if success:
+            default_desc = (
+                "Transcript intake"
+                if source == "transcript"
+                else "Screenspace intake"
+            )
             artifact: Dict[str, Any] = {
                 "id": f"intake_{span_hash}_s0",
                 "type": output_format,
@@ -334,18 +359,29 @@ def _generate_intake_clips(
                 "participant": participant,
                 "category": "",
                 "severity": "",
-                "description": event_type or "Screenspace intake",
+                "description": event_type or default_desc,
                 "cellRow": None,
                 "cellCol": None,
                 "cellA1": "",
                 "annotations": [],
-                "source": "screenspace",
+                "source": source,
                 "event_ids": event_ids,
+                "mark_ids": mark_ids,
                 "intake_label": event_type,
                 "sourceVideo": Path(video_path).name,
                 "_ok": True,
                 "_error": "",
             }
+            if source == "transcript":
+                import transcripts_server
+
+                with transcripts_server._manifest_lock:
+                    src_entry = transcripts_server._manifest.get(
+                        "source_transcripts", {}
+                    ).get(participant, {})
+                artifact["transcript_version"] = src_entry.get(
+                    "transcribed_at", ""
+                )
             results.append(artifact)
         else:
             results.append({"_ok": False, "_error": "ffmpeg failed"})
@@ -1095,7 +1131,7 @@ def api_settings_put() -> FlaskResponse:
 
 @studio_bp.route("/api/generate-intake", methods=["POST"])
 def api_generate_intake() -> FlaskResponse:
-    """Generate clips from Screenspace intake spans."""
+    """Generate clips from intake spans (Screenspace or Transcript)."""
     data = request.get_json(silent=True) or {}
     items = data.get("items", [])
     if not items:
@@ -1123,8 +1159,6 @@ def api_generate_intake() -> FlaskResponse:
 def api_reel_direct() -> FlaskResponse:
     """Build a reel from direct timestamp segments (for intake / mixed queues)."""
     import tempfile
-
-    import screenspace_server
 
     data = request.get_json(silent=True) or {}
     segments = data.get("segments", [])
@@ -1157,11 +1191,8 @@ def api_reel_direct() -> FlaskResponse:
                 if end <= start:
                     continue
 
-                video_path = None
-                for p in screenspace_server._participants:
-                    if p["id"] == participant and p.get("has_video"):
-                        video_path = p["video_path"]
-                        break
+                source = seg.get("source", "screenspace")
+                video_path = _resolve_intake_video_path(participant, source)
 
                 if not video_path:
                     continue
@@ -1198,7 +1229,7 @@ def api_reel_direct() -> FlaskResponse:
                 reel_record: Dict[str, Any] = {
                     "id": f"reel_intake_{hashlib.md5(reel_name.encode()).hexdigest()[:8]}",
                     "file": Path(reel_name).name,
-                    "source": "screenspace",
+                    "source": "intake",
                     "description": f"Intake reel ({len(clip_paths)} segments)",
                 }
                 _generated_reels.append(reel_record)

--- a/server.py
+++ b/server.py
@@ -271,9 +271,7 @@ def _save_manifest_quiet() -> None:
         utils.warning_print(f"Failed to save manifest: {e}")
 
 
-def _resolve_intake_video_path(
-    participant: str, source: str = ""
-) -> Optional[str]:
+def _resolve_intake_video_path(participant: str, source: str = "") -> Optional[str]:
     """Resolve a video path for an intake participant.
 
     Tries the source-specific participant list first, then falls back to the
@@ -344,9 +342,7 @@ def _generate_intake_clips(
 
         if success:
             default_desc = (
-                "Transcript intake"
-                if source == "transcript"
-                else "Screenspace intake"
+                "Transcript intake" if source == "transcript" else "Screenspace intake"
             )
             artifact: Dict[str, Any] = {
                 "id": f"intake_{span_hash}_s0",
@@ -379,9 +375,7 @@ def _generate_intake_clips(
                     src_entry = transcripts_server._manifest.get(
                         "source_transcripts", {}
                     ).get(participant, {})
-                artifact["transcript_version"] = src_entry.get(
-                    "transcribed_at", ""
-                )
+                artifact["transcript_version"] = src_entry.get("transcribed_at", "")
             results.append(artifact)
         else:
             results.append({"_ok": False, "_error": "ffmpeg failed"})

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -87,6 +87,8 @@ def serve_media(filename: str) -> FlaskResponse:
 @transcripts_bp.route("/api/participants")
 def api_participants() -> FlaskResponse:
     """List discovered source videos with transcription status."""
+    import viewer
+
     result = []
     with _manifest_lock:
         src = _manifest.get("source_transcripts", {})
@@ -107,6 +109,30 @@ def api_participants() -> FlaskResponse:
                 info["model"] = entry.get("model", "")
                 info["transcribed_at"] = entry.get("transcribed_at", "")
             result.append(info)
+
+    # Check for stale artifacts (transcript outdated relative to source)
+    artifacts = viewer.load_manifest_artifacts()
+    for info in result:
+        if not info.get("has_transcript"):
+            info["has_stale_artifacts"] = False
+            continue
+        pid = info["id"]
+        current_ta = info.get("transcribed_at", "")
+        if not current_ta:
+            info["has_stale_artifacts"] = False
+            continue
+        has_stale = False
+        for art in artifacts:
+            if art.get("participant") != pid:
+                continue
+            if not art.get("transcript"):
+                continue
+            art_tv = art.get("transcript_version", "")
+            if not art_tv or art_tv < current_ta:
+                has_stale = True
+                break
+        info["has_stale_artifacts"] = has_stale
+
     return jsonify({"ok": True, "participants": result})
 
 


### PR DESCRIPTION
## Summary

- **Transcript intake generation pipeline**: Route transcript-source items through Studio's artifact and reel generation pipelines (`isIntakeSource()` helper, `_resolve_intake_video_path()` server helper, source/mark_ids propagation through `onGenerate`, `onBuildReel`, `_generate_intake_clips`, `api_reel_direct`)
- **Re-transcription staleness badge**: Track `transcript_version` on artifacts, detect when a participant's transcript has been updated since artifacts were generated, and show "artifacts outdated" warnings in the Transcript workspace UI
- **Intake UI fixes**: Full timeline interaction parity with Screenspace (hover cross-highlighting, click-to-add, hit rectangles), video frame thumbnails on intake cards, fix "Show all" reverting on merge gap change, fix streaming marks visually reverting during live transcription via `_streamingMarks` cache

## Test plan
- [ ] In Studio Transcript Intake, drag a card to artifact queue and generate — verify clip is created with `source: "transcript"` and `mark_ids`
- [ ] Drag transcript cards to reel queue and build reel — verify reel is created
- [ ] Hover timeline markers and cards — verify cross-highlighting works
- [ ] Click timeline to add cards — verify click-to-add works
- [ ] Toggle "Show all", then change merge gap — verify list doesn't revert
- [ ] Mark segments during streaming — verify marks persist visually
- [ ] Re-transcribe a participant after generating artifacts — verify staleness badge appears