### PR TITLE
fix: transcript intake streaming marks and state restoration

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -388,7 +388,8 @@
     for (var i = 0; i < segments.length; i++) {
       var seg = segments[i];
       var segId = pid + ":" + i;
-      var cachedColor = _streamingMarks[segId];
+      var cachedMark = _streamingMarks[segId];
+      var cachedColor = cachedMark ? cachedMark.color : null;
       var markClass = "segment-mark" + (cachedColor ? " marked" : "");
       var markStyle = cachedColor ? ' style="background:' + cachedColor + '"' : "";
       html += '<div class="segment-row segment-streaming" data-index="' + i + '" data-start="' + seg.start + '">';
@@ -415,7 +416,12 @@
         row.querySelector(".segment-mark").addEventListener("click", function (e) {
           e.stopPropagation();
           var segId = this.getAttribute("data-segment-id");
-          toggleMarkStreaming(segId, this);
+          var existing = _streamingMarks[segId];
+          if (existing) {
+            showMarkPopover(this, segId, existing);
+          } else {
+            toggleMarkStreaming(segId, this);
+          }
         });
       })(rows[j]);
     }
@@ -425,8 +431,29 @@
     }
   }
 
-  // Cache marks made during streaming so they survive DOM rebuilds
+  // Cache marks made during streaming so they survive DOM rebuilds.
+  // Each entry: { color, id, category, label }
   var _streamingMarks = {};
+  var _streamingMarksLoaded = false;
+
+  function _loadStreamingMarks(pid) {
+    if (_streamingMarksLoaded) return;
+    _streamingMarksLoaded = true;
+    apiGet("api/marks").then(function (data) {
+      if (!data.ok) return;
+      data.marks.forEach(function (m) {
+        if (!m.valid || m.participant !== pid) return;
+        if (_streamingMarks[m.segment_id]) return; // don't overwrite fresh marks
+        var cat = MARK_CATEGORIES[m.category] || MARK_CATEGORIES.bookmark;
+        _streamingMarks[m.segment_id] = {
+          color: cat.color,
+          id: m.id,
+          category: m.category,
+          label: m.label || "",
+        };
+      });
+    });
+  }
 
   var _pendingSeekTime = null;
   var _seekRaf = 0;
@@ -703,11 +730,17 @@
       segment_ids: [segmentId],
       category: state.lastMarkCategory,
     }).then(function (data) {
-      if (data.ok) {
+      if (data.ok && data.marks && data.marks.length > 0) {
+        var m = data.marks[0];
         showToast("Marked");
         markEl.classList.add("marked");
         markEl.style.background = cat.color;
-        _streamingMarks[segmentId] = cat.color;
+        _streamingMarks[segmentId] = {
+          color: cat.color,
+          id: m.id,
+          category: m.category,
+          label: m.label || "",
+        };
       }
     });
   }
@@ -717,7 +750,14 @@
       if (data.ok) {
         showToast("Mark removed");
         hideMarkPopover();
-        if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+        if (state.streamingParticipant) {
+          for (var key in _streamingMarks) {
+            if (_streamingMarks[key].id === markId) { delete _streamingMarks[key]; break; }
+          }
+          pollTaskStatus();
+        } else if (state.selectedParticipant) {
+          loadTranscript(state.selectedParticipant);
+        }
       }
     });
   }
@@ -727,13 +767,33 @@
     apiPut("api/marks/" + markId, { category: category }).then(function (data) {
       if (data.ok) {
         hideMarkPopover();
-        if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+        if (state.streamingParticipant) {
+          var cat = MARK_CATEGORIES[category] || MARK_CATEGORIES.bookmark;
+          for (var key in _streamingMarks) {
+            if (_streamingMarks[key].id === markId) {
+              _streamingMarks[key].category = category;
+              _streamingMarks[key].color = cat.color;
+              break;
+            }
+          }
+          pollTaskStatus();
+        } else if (state.selectedParticipant) {
+          loadTranscript(state.selectedParticipant);
+        }
       }
     });
   }
 
   function updateMarkLabel(markId, label) {
     apiPut("api/marks/" + markId, { label: label || null });
+    if (state.streamingParticipant) {
+      for (var key in _streamingMarks) {
+        if (_streamingMarks[key].id === markId) {
+          _streamingMarks[key].label = label || "";
+          break;
+        }
+      }
+    }
   }
 
   function showMarkPopover(anchorEl, segmentId, markObj) {
@@ -1176,6 +1236,7 @@
       if (selectedRunningTask && selectedRunningTask.partial_segments.length > 0) {
         renderPartialSegments(selectedRunningTask.partial_segments, selectedRunningTask.progress);
         state.streamingParticipant = state.selectedParticipant;
+        _loadStreamingMarks(state.selectedParticipant);
         // Update status text
         var statusEl = qs("#transcriptStatus");
         if (statusEl) statusEl.textContent = "transcribing\u2026 " + Math.round(selectedRunningTask.progress * 100) + "%";
@@ -1196,6 +1257,7 @@
       // Refresh participants and transcript as each task completes
       if (newlyCompleted.length > 0) {
         _streamingMarks = {};
+        _streamingMarksLoaded = false;
         loadParticipants().then(function () {
           if (state.selectedParticipant && newlyCompleted.indexOf(state.selectedParticipant) >= 0) {
             state.streamingParticipant = null;
@@ -1204,7 +1266,9 @@
         });
       }
 
-      if (!hasActive) {
+      if (hasActive) {
+        startPolling();
+      } else {
         stopPolling();
         _refreshedCompletedPids = {};
       }
@@ -1319,6 +1383,15 @@
     initQueuePanel();
     initCorrectionsModal();
     initVideoSync();
+
+    // Pause polling when tab is hidden; resume when visible
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        pollTaskStatus();
+      }
+    });
 
     // Participant select handler
     qs("#participantSelect").addEventListener("change", function () {

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.26"
+VERSIONNUM: str = "0.10.27"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.27"
+VERSIONNUM: str = "0.10.28"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -333,8 +333,16 @@ def api_corrections_delete(correction_id: str) -> FlaskResponse:
 # ---- Marks ----
 
 
-def _resolve_mark(mark: Dict[str, Any]) -> Dict[str, Any]:
-    """Enrich a mark with its segment's data (participant, start, end, text, valid)."""
+def _resolve_mark(
+    mark: Dict[str, Any],
+    partial_lookup: Optional[Dict[str, list]] = None,
+) -> Dict[str, Any]:
+    """Enrich a mark with its segment's data (participant, start, end, text, valid).
+
+    *partial_lookup* maps participant IDs to ``partial_segments`` lists from
+    running transcription tasks, allowing marks made during streaming to
+    resolve before the transcript is persisted.
+    """
     seg_id = mark.get("segment_id", "")
     # segment IDs are "{participant}:{index}"
     parts = seg_id.split(":", 1)
@@ -360,39 +368,69 @@ def _resolve_mark(mark: Dict[str, Any]) -> Dict[str, Any]:
             "text": "",
         }
 
+    # Try persisted transcript first
     src = _manifest.get("source_transcripts", {})
     entry = src.get(pid, {})
     segments = entry.get("segments", [])
-    if idx < 0 or idx >= len(segments):
+    if 0 <= idx < len(segments):
+        raw_seg = segments[idx]
+        corrections = _manifest.get("corrections", [])
+        corrected = transcripts.apply_corrections([raw_seg], corrections)
+        seg = corrected[0]
         return {
             **mark,
-            "valid": False,
+            "valid": True,
             "participant": pid,
-            "start": 0,
-            "end": 0,
-            "text": "",
+            "start": seg["start"],
+            "end": seg["end"],
+            "text": seg["text"],
         }
 
-    raw_seg = segments[idx]
-    corrections = _manifest.get("corrections", [])
-    corrected = transcripts.apply_corrections([raw_seg], corrections)
-    seg = corrected[0]
+    # Fall back to partial segments from a running transcription task
+    if partial_lookup:
+        partial_segs = partial_lookup.get(pid, [])
+        if 0 <= idx < len(partial_segs):
+            seg = partial_segs[idx]
+            return {
+                **mark,
+                "valid": True,
+                "participant": pid,
+                "start": seg["start"],
+                "end": seg["end"],
+                "text": seg["text"],
+            }
+
     return {
         **mark,
-        "valid": True,
+        "valid": False,
         "participant": pid,
-        "start": seg["start"],
-        "end": seg["end"],
-        "text": seg["text"],
+        "start": 0,
+        "end": 0,
+        "text": "",
     }
+
+
+def _build_partial_lookup() -> Dict[str, list]:
+    """Build a participant→partial_segments map from running transcription tasks."""
+    if not _worker:
+        return {}
+    lookup: Dict[str, list] = {}
+    for task in _worker.get_all_tasks():
+        if task["status"] == transcripts.TASK_STATUS_RUNNING:
+            segs = task.get("partial_segments", [])
+            if segs:
+                lookup[task["participant"]] = segs
+    return lookup
 
 
 @transcripts_bp.route("/api/marks")
 def api_marks_list() -> FlaskResponse:
     """List all marks, enriched with resolved segment data."""
+    # Build partial lookup outside _manifest_lock (get_all_tasks acquires worker lock)
+    partial_lookup = _build_partial_lookup()
     with _manifest_lock:
         raw_marks = list(_manifest.get("marks", []))
-        resolved = [_resolve_mark(m) for m in raw_marks]
+        resolved = [_resolve_mark(m, partial_lookup) for m in raw_marks]
     return jsonify(
         {
             "ok": True,


### PR DESCRIPTION
## Summary

- **Marks resolve during streaming**: `_resolve_mark()` now falls back to the worker's in-memory `partial_segments` when segments aren't yet persisted, so marks made during streaming appear in Transcript Intake immediately instead of requiring transcription to finish.
- **Streaming marks restored on navigation**: When navigating back to the Transcripts page during active streaming, existing marks are fetched from the API and restored visually (previously the client-side cache was lost on page reload).
- **Mark popover works during streaming**: Clicking an existing mark during streaming opens the category/label popover; `removeMark`, `updateMarkCategory`, and `updateMarkLabel` are now streaming-aware so they don't break the streaming view.
- **Auto-start polling on page load**: `pollTaskStatus()` now calls `startPolling()` when active tasks are detected, fixing frozen header progress and stale queue panel after navigation.
- **Visibility handler**: Polling pauses when the tab is hidden and resumes on focus.

## Test plan
- [ ] Run `uv run --extra dev pytest -c tests/pytest.ini` (464 tests pass)
- [ ] Start Studio, begin transcription, mark segments during streaming, switch to Transcript Intake tab — marks should appear
- [ ] Navigate to Studio and back to Transcripts during streaming — marks should be visually restored
- [ ] Click an existing mark during streaming — popover should open for category/label editing
- [ ] Navigate to Transcripts page during active transcription — header progress and queue panel should update continuously