### PR TITLE
feat: cross-reference badges and tooltips across intake data sources

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2362,6 +2362,39 @@ html[data-theme="dark"] .log-panel {
   display: block;
 }
 
+/* Cross-reference badges on intake cards */
+.xref-badge-stack {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  display: flex;
+  flex-direction: row;
+  z-index: 1;
+}
+
+.xref-badge-stack .xref-badge {
+  position: relative;
+  padding: 3px;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  line-height: 0;
+  transition: margin var(--duration-fast) ease;
+}
+
+.xref-badge-stack .xref-badge + .xref-badge {
+  margin-left: -10px;
+}
+
+.queue-card:hover .xref-badge-stack .xref-badge + .xref-badge {
+  margin-left: 3px;
+}
+
+.xref-badge svg {
+  width: 10px;
+  height: 10px;
+  display: block;
+}
+
 .tr-intake-filter-cat {
   font-size: var(--text-xs);
 }

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -199,7 +199,7 @@
   }
 
   function parseClipTimestamps(raw) {
-    var DEFAULT_DUR = 60;
+    var DEFAULT_DUR = (state.sheetData && state.sheetData.defaultDuration) || 60;
     var cleaned = raw
       .toLowerCase()
       .replace(/!key/g, "")
@@ -254,6 +254,60 @@
     var g = parseInt(hex.slice(3, 5), 16);
     var b = parseInt(hex.slice(5, 7), 16);
     return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
+  }
+
+  // Cross-referencing: find overlapping data from other sources for a given
+  // participant + time range. Used by both Screenspace and Transcript intake
+  // card renderers to surface context from sibling data sources.
+  function findOverlappingData(participant, start, end) {
+    var result = { transcriptSnippets: [], screenspaceEvents: [], sheetObservations: [] };
+
+    // Transcript marks/clusters
+    for (var i = 0; i < state.trIntakeClusters.length; i++) {
+      var tc = state.trIntakeClusters[i];
+      if (tc.participant === participant && tc.start < end && tc.end > start) {
+        result.transcriptSnippets.push({ text: tc.text || tc.label || "", category: tc.category, start: tc.start, end: tc.end });
+      }
+    }
+
+    // Screenspace event clusters
+    for (var j = 0; j < state.intakeClusters.length; j++) {
+      var sc = state.intakeClusters[j];
+      if (sc.participant === participant && sc.start < end && sc.end > start) {
+        result.screenspaceEvents.push({ detector: sc.detector, event_type: sc.event_type, start: sc.start, end: sc.end });
+      }
+    }
+
+    // Sheet observations
+    if (state.sheetData && state.sheetData.rows) {
+      for (var k = 0; k < state.sheetData.rows.length; k++) {
+        var row = state.sheetData.rows[k];
+        var cell = row.cells[participant];
+        if (!cell || !cell.valid) continue;
+        var segs = parseClipTimestamps(cell.value);
+        for (var s = 0; s < segs.length; s++) {
+          var segEnd = segs[s].startSeconds + segs[s].duration;
+          if (segs[s].startSeconds < end && segEnd > start) {
+            result.sheetObservations.push({ observation: row.observation, category: row.category, severity: row.severity });
+            break;
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
+  function positionTooltip(tooltipEl, anchorRect) {
+    var ttW = tooltipEl.offsetWidth;
+    var ttH = tooltipEl.offsetHeight;
+    var left = anchorRect.left + anchorRect.width / 2 - ttW / 2;
+    var top = anchorRect.top - ttH - 6;
+    if (top < 4) top = anchorRect.bottom + 6;
+    if (left < 4) left = 4;
+    if (left + ttW > window.innerWidth - 4) left = window.innerWidth - ttW - 4;
+    tooltipEl.style.left = left + "px";
+    tooltipEl.style.top = top + "px";
   }
 
   function intakeComputeTickInterval(visLen) {
@@ -3372,6 +3426,55 @@
   }
 
   var SS_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
+  var TR_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M1 8.74053C1 9.72321 1.71341 10.5653 2.68906 10.6827C3.5937 10.7915 4.50678 10.8729 5.42746 10.926C5.78969 10.9469 6.11506 11.1572 6.27733 11.4817L7.32918 13.5854C7.45622 13.8395 7.71592 14 8 14C8.28408 14 8.54378 13.8395 8.67082 13.5854L9.72265 11.4817C9.88492 11.1572 10.2103 10.9469 10.5725 10.9261C11.4932 10.873 12.4063 10.7916 13.3109 10.6828C14.2866 10.5654 15 9.72332 15 8.74062V4.25938C15 3.27668 14.2866 2.43458 13.3109 2.3172C11.57 2.10777 9.79777 2 8.00039 2C6.20273 2 4.43025 2.10781 2.68906 2.3173C1.71341 2.43469 1 3.27679 1 4.25947V8.74053ZM4 5.25C4 4.83579 4.33579 4.5 4.75 4.5H11.25C11.6642 4.5 12 4.83579 12 5.25C12 5.66421 11.6642 6 11.25 6H4.75C4.33579 6 4 5.66421 4 5.25ZM4.75 7C4.33579 7 4 7.33579 4 7.75C4 8.16421 4.33579 8.5 4.75 8.5H7.25C7.66421 8.5 8 8.16421 8 7.75C8 7.33579 7.66421 7 7.25 7H4.75Z"/></svg>';
+  var SHEET_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 11C15 12.1046 14.1046 13 13 13H3C1.89543 13 1 12.1046 1 11V5C1 3.89543 1.89543 3 3 3H13C14.1046 3 15 3.89543 15 5V11ZM7.25 7.5C7.25 7.22386 7.02614 7 6.75 7H3C2.72386 7 2.5 7.22386 2.5 7.5V8C2.5 8.27614 2.72386 8.5 3 8.5H6.75C7.02614 8.5 7.25 8.27614 7.25 8V7.5ZM8.75 10.5C8.75 10.2239 8.97386 10 9.25 10H13C13.2761 10 13.5 10.2239 13.5 10.5V11C13.5 11.2761 13.2761 11.5 13 11.5H9.25C8.97386 11.5 8.75 11.2761 8.75 11V10.5ZM13.5 8V7.5C13.5 7.22386 13.2761 7 13 7H9.25C8.97386 7 8.75 7.22386 8.75 7.5V8C8.75 8.27614 8.97386 8.5 9.25 8.5H13C13.2761 8.5 13.5 8.27614 13.5 8ZM6.75 11.5C7.02614 11.5 7.25 11.2761 7.25 11V10.5C7.25 10.2239 7.02614 10 6.75 10H3C2.72386 10 2.5 10.2239 2.5 10.5V11C2.5 11.2761 2.72386 11.5 3 11.5H6.75Z"/></svg>';
+
+  var XREF_BADGE_COLOR = {
+    screenspace: "rgba(52, 152, 219, 0.85)",
+    transcript: "rgba(16, 163, 74, 0.85)",
+    sheet: "rgba(234, 179, 8, 0.85)",
+  };
+
+  // selfBadge: optional { svg, color, title } to prepend as the "self" source badge
+  function buildXrefBadges(xref, selfSource, selfBadge) {
+    var badges = [];
+    if (selfBadge) badges.push(selfBadge);
+    if (selfSource !== "screenspace" && xref.screenspaceEvents.length > 0) {
+      var types = [];
+      var seen = {};
+      for (var i = 0; i < xref.screenspaceEvents.length; i++) {
+        var et = xref.screenspaceEvents[i].event_type || xref.screenspaceEvents[i].detector;
+        if (!seen[et]) { seen[et] = true; types.push(et); }
+      }
+      badges.push({ svg: SS_BADGE_SVG, color: XREF_BADGE_COLOR.screenspace, title: types.join(", ") });
+    }
+    if (selfSource !== "transcript" && xref.transcriptSnippets.length > 0) {
+      var trTexts = [];
+      for (var j = 0; j < xref.transcriptSnippets.length && j < 3; j++) {
+        var t = xref.transcriptSnippets[j].text;
+        trTexts.push(t.length > 80 ? t.substring(0, 80) + "\u2026" : t);
+      }
+      badges.push({ svg: TR_BADGE_SVG, color: XREF_BADGE_COLOR.transcript, title: trTexts.join("\n") });
+    }
+    if (xref.sheetObservations.length > 0) {
+      var obsTexts = [];
+      for (var k = 0; k < xref.sheetObservations.length && k < 3; k++) {
+        obsTexts.push(xref.sheetObservations[k].observation);
+      }
+      badges.push({ svg: SHEET_BADGE_SVG, color: XREF_BADGE_COLOR.sheet, title: obsTexts.join("\n") });
+    }
+    if (badges.length === 0) return null;
+    var container = el("span", "xref-badge-stack");
+    for (var b = 0; b < badges.length; b++) {
+      var badge = el("span", "xref-badge");
+      badge.style.background = badges[b].color;
+      badge.style.zIndex = badges.length - b;
+      badge.innerHTML = badges[b].svg;
+      badge.title = badges[b].title;
+      container.appendChild(badge);
+    }
+    return container;
+  }
 
   var _intakeHitRects = [];
   var _trIntakeHitRects = [];
@@ -3579,13 +3682,18 @@
       thumb.appendChild(img);
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
 
-      var ssBadge = el("span", "queue-card-source-badge");
-      ssBadge.innerHTML = SS_BADGE_SVG;
-      thumb.appendChild(ssBadge);
-
       var detDot = el("span", "intake-card-det-dot");
       detDot.style.background = INTAKE_DETECTOR_COLORS[c.detector] || "#888";
       thumb.appendChild(detDot);
+
+      // Source + cross-reference badges (SS self-badge leads the stack)
+      var xref = findOverlappingData(c.participant, c.start, c.end);
+      var ssSelf = { svg: SS_BADGE_SVG, color: XREF_BADGE_COLOR.screenspace, title: c.event_type || "Screenspace" };
+      var badgeStack = buildXrefBadges(xref, "screenspace", ssSelf);
+      if (badgeStack) thumb.appendChild(badgeStack);
+      if (xref.transcriptSnippets.length > 0) {
+        card.dataset.transcriptContext = xref.transcriptSnippets.map(function (s) { return s.text; }).join("\n");
+      }
 
       card.appendChild(thumb);
 
@@ -3711,7 +3819,7 @@
       if (cluster) intakeDismissCluster(cluster);
     });
 
-    // Card hover → highlight timeline marker
+    // Card hover → highlight timeline marker + transcript tooltip
     intakeCards.addEventListener("mouseover", function (e) {
       var card = e.target.closest(".intake-queue-card");
       if (!card) return;
@@ -3720,12 +3828,25 @@
         state.intakeHoveredIdx = idx;
         renderIntakeTimeline();
       }
+      var trTooltip = qs("#trIntakeTooltip");
+      if (trTooltip && state.trIntakeTooltipsEnabled) {
+        var tooltipText = card.dataset.transcriptContext || "";
+        if (tooltipText) {
+          trTooltip.textContent = tooltipText;
+          trTooltip.classList.remove("hidden");
+          positionTooltip(trTooltip, card.getBoundingClientRect());
+        } else {
+          trTooltip.classList.add("hidden");
+        }
+      }
     });
     intakeCards.addEventListener("mouseleave", function () {
       if (state.intakeHoveredIdx !== -1) {
         state.intakeHoveredIdx = -1;
         renderIntakeTimeline();
       }
+      var trTooltip = qs("#trIntakeTooltip");
+      if (trTooltip) trTooltip.classList.add("hidden");
     });
 
     // Timeline canvas interactions
@@ -4008,6 +4129,13 @@
       dur.className = "queue-card-duration";
       dur.textContent = formatDuration(segDuration);
       thumb.appendChild(dur);
+
+      // Source + cross-reference badges (TR self-badge leads the stack)
+      var xref = findOverlappingData(c.participant, c.start, c.end);
+      var trSelf = { svg: TR_BADGE_SVG, color: XREF_BADGE_COLOR.transcript, title: c.label || c.category || "Transcript" };
+      var badgeStack = buildXrefBadges(xref, "transcript", trSelf);
+      if (badgeStack) thumb.appendChild(badgeStack);
+
       card.appendChild(thumb);
 
       // Metadata
@@ -4254,16 +4382,7 @@
         if (fullText) {
           trTooltip.textContent = fullText;
           trTooltip.classList.remove("hidden");
-          var rect = card.getBoundingClientRect();
-          var ttW = trTooltip.offsetWidth;
-          var ttH = trTooltip.offsetHeight;
-          var left = rect.left + rect.width / 2 - ttW / 2;
-          var top = rect.top - ttH - 6;
-          if (top < 4) top = rect.bottom + 6;
-          if (left < 4) left = 4;
-          if (left + ttW > window.innerWidth - 4) left = window.innerWidth - ttW - 4;
-          trTooltip.style.left = left + "px";
-          trTooltip.style.top = top + "px";
+          positionTooltip(trTooltip, card.getBoundingClientRect());
         } else {
           trTooltip.classList.add("hidden");
         }

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -160,6 +160,29 @@ body {
 
 /* Theme toggle (matches Screenspace/Studio) */
 
+#tooltipToggle {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text);
+  transition: opacity var(--duration-fast), background var(--duration-fast);
+}
+
+#tooltipToggle:hover {
+  background: var(--color-surface);
+}
+
+#tooltipToggle[aria-pressed="false"] {
+  opacity: 0.4;
+}
+
 #themeToggle {
   position: relative;
   width: 32px;
@@ -319,6 +342,33 @@ body {
   background: rgba(234, 179, 8, 0.3);
   border-radius: 2px;
   padding: 0 1px;
+}
+
+.search-xref-events {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  margin-left: var(--space-2);
+  flex-shrink: 0;
+}
+
+.search-xref-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  display: inline-block;
+}
+
+.search-xref-sheet {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  margin-top: 2px;
 }
 
 /* Main content */
@@ -536,6 +586,33 @@ body {
   color: var(--color-text-dim);
   padding-top: 2px;
   user-select: none;
+  position: relative;
+}
+
+.segment-xref-badges {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  pointer-events: none;
+}
+
+.segment-xref-badge {
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  line-height: 0;
+  display: inline-block;
+  pointer-events: auto;
+}
+
+.segment-xref-badge svg {
+  width: 9px;
+  height: 9px;
+  display: block;
 }
 
 .segment-text {

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -22,6 +22,11 @@
         <span id="transcriptStatus" class="transcript-status"></span>
         <button id="queueBtn" type="button" class="btn btn-small">Queue</button>
         <button id="correctionsBtn" type="button" class="btn btn-small">Corrections</button>
+        <button id="tooltipToggle" type="button" aria-label="Toggle cross-reference tooltips" aria-pressed="true" title="Toggle cross-reference tooltips">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M1 8.74053C1 9.72321 1.71341 10.5653 2.68906 10.6827C3.5937 10.7915 4.50678 10.8729 5.42746 10.926C5.78969 10.9469 6.11506 11.1572 6.27733 11.4817L7.32918 13.5854C7.45622 13.8395 7.71592 14 8 14C8.28408 14 8.54378 13.8395 8.67082 13.5854L9.72265 11.4817C9.88492 11.1572 10.2103 10.9469 10.5725 10.9261C11.4932 10.873 12.4063 10.7916 13.3109 10.6828C14.2866 10.5654 15 9.72332 15 8.74062V4.25938C15 3.27668 14.2866 2.43458 13.3109 2.3172C11.57 2.10777 9.79777 2 8.00039 2C6.20273 2 4.43025 2.10781 2.68906 2.3173C1.71341 2.43469 1 3.27679 1 4.25947V8.74053ZM4 5.25C4 4.83579 4.33579 4.5 4.75 4.5H11.25C11.6642 4.5 12 4.83579 12 5.25C12 5.66421 11.6642 6 11.25 6H4.75C4.33579 6 4 5.66421 4 5.25ZM4.75 7C4.33579 7 4 7.33579 4 7.75C4 8.16421 4.33579 8.5 4.75 8.5H7.25C7.66421 8.5 8 8.16421 8 7.75C8 7.33579 7.66421 7 7.25 7H4.75Z"/>
+          </svg>
+        </button>
         <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
           <span class="theme-toggle-icon theme-icon-sun"></span>
           <span class="theme-toggle-icon theme-icon-moon"></span>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -15,7 +15,24 @@
     bookmark:   { label: "Bookmark",   color: "#0891b2" },
   };
 
+  // Cross-reference badge SVGs and colors — mirrored from studio.js
+  var SS_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
+  var SHEET_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 11C15 12.1046 14.1046 13 13 13H3C1.89543 13 1 12.1046 1 11V5C1 3.89543 1.89543 3 3 3H13C14.1046 3 15 3.89543 15 5V11ZM7.25 7.5C7.25 7.22386 7.02614 7 6.75 7H3C2.72386 7 2.5 7.22386 2.5 7.5V8C2.5 8.27614 2.72386 8.5 3 8.5H6.75C7.02614 8.5 7.25 8.27614 7.25 8V7.5ZM8.75 10.5C8.75 10.2239 8.97386 10 9.25 10H13C13.2761 10 13.5 10.2239 13.5 10.5V11C13.5 11.2761 13.2761 11.5 13 11.5H9.25C8.97386 11.5 8.75 11.2761 8.75 11V10.5ZM13.5 8V7.5C13.5 7.22386 13.2761 7 13 7H9.25C8.97386 7 8.75 7.22386 8.75 7.5V8C8.75 8.27614 8.97386 8.5 9.25 8.5H13C13.2761 8.5 13.5 8.27614 13.5 8ZM6.75 11.5C7.02614 11.5 7.25 11.2761 7.25 11V10.5C7.25 10.2239 7.02614 10 6.75 10H3C2.72386 10 2.5 10.2239 2.5 10.5V11C2.5 11.2761 2.72386 11.5 3 11.5H6.75Z"/></svg>';
+
+  var XREF_BADGE_COLOR = {
+    screenspace: "rgba(52, 152, 219, 0.85)",
+    sheet: "rgba(234, 179, 8, 0.85)",
+  };
+
   // ---- State ----
+
+  // Screenspace detector colors — mirrored from studio.js INTAKE_DETECTOR_COLORS
+  var SS_DETECTOR_COLORS = {
+    multitool: "#2563eb", color: "#8b5cf6", change: "#f97316",
+    similarity: "#0ea5e9", text: "#10b981", numbers: "#eab308",
+    timelapse: "#ec4899", template: "#f43f5e", flow: "#6366f1",
+    scene: "#14b8a6", inactivity: "#78716c",
+  };
 
   var state = {
     participants: [],
@@ -30,6 +47,14 @@
     pollTimer: null,
     lastMarkCategory: "bookmark",
     streamingParticipant: null,
+    ssEvents: [],
+    ssEventsLoaded: false,
+    sheetRows: [],
+    sheetParticipants: [],
+    sheetDefaultDuration: 60,
+    sheetLoaded: false,
+    xrefPollTimer: null,
+    tooltipsEnabled: true,
   };
 
   // ---- Helpers ----
@@ -143,7 +168,96 @@
       if (data.studio) qs("#studioLink").classList.remove("hidden");
       if (data.insights) qs("#insightsLink").classList.remove("hidden");
       if (data.screenspace) qs("#screenspaceLink").classList.remove("hidden");
+      if (data.screenspace || data.studio) {
+        loadCrossRefData();
+        state.xrefPollTimer = setInterval(loadCrossRefData, 30000);
+      }
     }).catch(function () {});
+  }
+
+  // ---- Cross-reference data ----
+
+  function loadCrossRefData() {
+    fetch("../screenspace/api/events?excluded=false")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          state.ssEvents = data.events || [];
+          state.ssEventsLoaded = true;
+          if (state.searchResults) renderSearchResults(state.searchResults);
+        }
+      })
+      .catch(function () {});
+
+    fetch("../studio/api/sheet")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          state.sheetRows = data.rows || [];
+          state.sheetParticipants = data.participants || [];
+          state.sheetDefaultDuration = data.defaultDuration || 60;
+          state.sheetLoaded = true;
+          if (state.searchResults) renderSearchResults(state.searchResults);
+        }
+      })
+      .catch(function () {});
+  }
+
+  function parseTS(str) {
+    var parts = str.split(":");
+    if (parts.length === 3) return (+parts[0]) * 3600 + (+parts[1]) * 60 + (+parts[2]);
+    if (parts.length === 2) return (+parts[0]) * 60 + (+parts[1]);
+    return NaN;
+  }
+
+  function parseSheetTimestamps(raw) {
+    var DEFAULT_DUR = state.sheetDefaultDuration || 60;
+    var cleaned = raw.toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
+    var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
+    var segments = [];
+    for (var i = 0; i < tokens.length; i++) {
+      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
+      var dashIdx = -1;
+      for (var d = 1; d < tok.length; d++) {
+        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") { dashIdx = d; break; }
+      }
+      if (dashIdx > 0) {
+        var s = parseTS(tok.substring(0, dashIdx));
+        var e = parseTS(tok.substring(dashIdx + 1));
+        if (!isNaN(s) && !isNaN(e)) segments.push({ start: Math.floor(s), duration: Math.max(0, e - s) });
+      } else if (tok.indexOf(":") > 0) {
+        var sec = parseTS(tok);
+        if (!isNaN(sec)) segments.push({ start: Math.floor(sec), duration: DEFAULT_DUR });
+      }
+    }
+    return segments;
+  }
+
+  function findOverlapsForSearch(participant, start, end) {
+    var result = { screenspaceEvents: [], sheetObservations: [] };
+
+    for (var i = 0; i < state.ssEvents.length; i++) {
+      var ev = state.ssEvents[i];
+      if (ev.participant === participant && ev.time_in < end && ev.time_out > start) {
+        result.screenspaceEvents.push(ev);
+      }
+    }
+
+    for (var j = 0; j < state.sheetRows.length; j++) {
+      var row = state.sheetRows[j];
+      var cell = row.cells[participant];
+      if (!cell || !cell.valid) continue;
+      var segs = parseSheetTimestamps(cell.value);
+      for (var k = 0; k < segs.length; k++) {
+        var segEnd = segs[k].start + segs[k].duration;
+        if (segs[k].start < end && segEnd > start) {
+          result.sheetObservations.push({ observation: row.observation, category: row.category });
+          break;
+        }
+      }
+    }
+
+    return result;
   }
 
   // ---- Participants ----
@@ -322,7 +436,29 @@
 
       html += '<div class="segment-row' + activeClass + correctedClass + '" data-index="' + i + '" data-start="' + seg.start + '">';
       html += '<span class="' + markClass + '" data-segment-id="' + escapeHtml(seg.id) + '"' + markStyle + markLabel + '></span>';
-      html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
+      html += '<span class="segment-timestamp">' + fmtTime(seg.start);
+      // Cross-reference badges in gutter (inside timestamp, positioned at right edge)
+      if (state.tooltipsEnabled) {
+        var xref = findOverlapsForSearch(state.selectedParticipant, seg.start, seg.end);
+        if (xref.screenspaceEvents.length > 0 || xref.sheetObservations.length > 0) {
+          html += '<span class="segment-xref-badges">';
+          if (xref.screenspaceEvents.length > 0) {
+            var evTypes = [];
+            var evSeen = {};
+            for (var ei = 0; ei < xref.screenspaceEvents.length; ei++) {
+              var et = xref.screenspaceEvents[ei].event_type || xref.screenspaceEvents[ei].detector;
+              if (!evSeen[et]) { evSeen[et] = true; evTypes.push(et); }
+            }
+            html += '<span class="segment-xref-badge" style="background:' + XREF_BADGE_COLOR.screenspace + '" title="' + escapeHtml(evTypes.join(", ")) + '">' + SS_BADGE_SVG + '</span>';
+          }
+          if (xref.sheetObservations.length > 0) {
+            var obsTitle = xref.sheetObservations[0].observation;
+            html += '<span class="segment-xref-badge" style="background:' + XREF_BADGE_COLOR.sheet + '" title="' + escapeHtml(obsTitle) + '">' + SHEET_BADGE_SVG + '</span>';
+          }
+          html += '</span>';
+        }
+      }
+      html += '</span>';
       // Split text into word spans
       var tokens = seg.text.split(/(\s+)/);
       var wordHtml = "";
@@ -1002,9 +1138,27 @@
       var count = data.counts_by_participant[pid] || 0;
       html += '<div class="search-group-header">' + escapeHtml(pid) + ' (' + count + ')</div>';
       groups[pid].forEach(function (r) {
+        var xref = findOverlapsForSearch(r.participant, r.start, r.end);
         html += '<div class="search-result-row" data-participant="' + escapeHtml(r.participant) + '" data-start="' + r.start + '">';
         html += '<span class="search-result-time">' + fmtTime(r.start) + '</span>';
         html += '<span class="search-result-text">' + highlightQuery(r.text, state.searchQuery) + '</span>';
+        if (state.tooltipsEnabled && xref.screenspaceEvents.length > 0) {
+          var seen = {};
+          html += '<span class="search-xref-events">';
+          for (var ei = 0; ei < xref.screenspaceEvents.length; ei++) {
+            var det = xref.screenspaceEvents[ei].detector;
+            if (seen[det]) continue;
+            seen[det] = true;
+            var evColor = SS_DETECTOR_COLORS[det] || "#888";
+            html += '<span class="search-xref-dot" style="background:' + evColor + '" title="' + escapeHtml(xref.screenspaceEvents[ei].event_type || det) + '"></span>';
+          }
+          html += '</span>';
+        }
+        if (state.tooltipsEnabled && xref.sheetObservations.length > 0) {
+          var obsText = xref.sheetObservations[0].observation;
+          var truncObs = obsText.length > 50 ? obsText.substring(0, 50) + "\u2026" : obsText;
+          html += '<span class="search-xref-sheet" title="' + escapeHtml(obsText) + '">' + escapeHtml(truncObs) + '</span>';
+        }
         html += '</div>';
       });
     });
@@ -1374,10 +1528,22 @@
     });
   }
 
+  function initTooltipToggle() {
+    var btn = qs("#tooltipToggle");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      state.tooltipsEnabled = !state.tooltipsEnabled;
+      btn.setAttribute("aria-pressed", state.tooltipsEnabled ? "true" : "false");
+      if (state.searchResults) renderSearchResults(state.searchResults);
+      if (state.segments.length > 0) renderSegments();
+    });
+  }
+
   // ---- Boot ----
 
   document.addEventListener("DOMContentLoaded", function () {
     initThemeToggle();
+    initTooltipToggle();
     checkNavLinks();
     initSearch();
     initQueuePanel();

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.28"
+VERSIONNUM: str = "0.10.29"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/plans/TRANSCRIPT-PLAN.md
+++ b/plans/TRANSCRIPT-PLAN.md
@@ -241,14 +241,15 @@ Hover-to-reveal full transcript text on intake cards and other transcript-bearin
 - [x] **Tooltip toggle**: button in Studio header (`#tooltipToggle`, chat-bubble icon) next to the dark mode toggle. On by default (`state.trIntakeTooltipsEnabled`). Dims to 40% opacity when off.
 - [ ] **Timeline Viewer**: extend tooltip behavior to transcript sidebar segments (Phase 4)
 - [ ] **Insights Builder**: extend tooltip behavior to artifact transcript text when browsing evidence (Phase 4)
-- [ ] **Screenspace Intake cards**: show transcript context tooltip on Screenspace intake cards when transcript data is available at the card's time range (deferred, alongside cross-referencing)
-- [ ] **Toggle in all frontends**: add tooltip toggle to all viewers and workspaces where transcript data is surfaced. Scoping to Studio intake first to validate the interaction pattern.
+- [x] **Screenspace Intake cards**: show transcript context tooltip on Screenspace intake cards when transcript data is available at the card's time range (deferred, alongside cross-referencing)
+- [x] **Toggle in all frontends**: add tooltip toggle to all viewers and workspaces where transcript data is surfaced. Scoping to Studio intake first to validate the interaction pattern.
 
-### Cross-referencing with Screenspace events (deferred)
+### Cross-referencing with Screenspace and Spreadsheet events
 
-- [ ] **On Screenspace intake cards**: when transcript data is available, show a "transcript context" line with the text at the card's time range (client-side join by participant + timestamp)
-- [ ] **On transcript search results**: when Screenspace events exist at the same timestamp, show a detector badge on the segment card (e.g., "change event detected here")
-- [ ] Cross-referencing is pure client-side — both data sources available in memory, joined by participant + timestamp at display time
+- [x] **On Screenspace intake cards**: when transcript data is available, show a "transcript context" line with the text at the card's time range (client-side join by participant + timestamp). Also shows sheet observation text when available.
+- [x] **On Transcript intake cards**: when Screenspace events exist at the same timestamp, show detector color dots. Also shows sheet observation text when available.
+- [x] **On transcript search results**: when Screenspace events exist at the same timestamp, show a detector badge on the segment card (e.g., "change event detected here"). Also shows sheet observation text when available.
+- [x] Cross-referencing is pure client-side — all data sources available in memory, joined by participant + timestamp at display time. Uses `findOverlappingData()` (studio.js) and `findOverlapsForSearch()` (transcripts.js).
 
 ---
 

--- a/server.py
+++ b/server.py
@@ -230,6 +230,7 @@ def api_sheet() -> FlaskResponse:
             "titlecardsEnabled": config.TITLECARDS_ENABLED,
             "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
             "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
+            "defaultDuration": config.DEFAULT_DURATION_SECONDS,
             "participants": participants,
             "rows": rows,
         }


### PR DESCRIPTION
## Summary

- Adds client-side cross-referencing between Transcript, Screenspace, and Spreadsheet data sources using time-range overlap joins by participant
- Intake cards in Studio show stacking icon badges (bottom-left corner) indicating which other data sources have overlapping events; badges unstack on hover to reveal individual sources
- Transcript workspace shows cross-ref badges in the segment gutter and on search results (SS detector dots + sheet observation text)
- Adds tooltip toggle button to Transcript workspace header to control cross-ref badge visibility
- Exposes `DEFAULT_DURATION_SECONDS` from server config so single-timestamp sheet entries expand correctly for overlap matching

## Test plan
- [ ] Launch Studio with `--studio` and a study that has both Screenspace events and source transcripts
- [ ] Verify Screenspace intake cards show badge stack (SS + transcript + sheet badges) in bottom-left corner
- [ ] Verify Transcript intake cards show badge stack (transcript + SS + sheet badges)
- [ ] Hover intake cards — badges should unstack horizontally with animation
- [ ] Open Transcript workspace — segments with overlapping SS/sheet data show gutter badges
- [ ] Search in Transcript workspace — results show detector dots and sheet observation text
- [ ] Toggle the tooltip button — badges should appear/disappear in both segments and search results
- [ ] Run `uv run --extra dev pytest -c tests/pytest.ini` — all existing tests pass