### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,34 @@ Patterns distilled from recurring post-review and post-merge fixes across the pr
 - **Data contract completeness**: When creating records consumed by the frontend (artifacts, events, tasks), include all fields the renderer expects — even optional ones. Missing fields cause empty/broken cards.
 - **New flags in mode detection**: When adding a CLI flag, verify it appears in the mode-detection logic (`cli.py`), not just in argparse definition.
 - **Bundled/frozen paths**: Use `utils.get_bundled_assets_root()` for asset resolution, never raw `Path(__file__).parent`. Test that asset paths resolve in both source and PyInstaller environments.
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+clipgen is a self-contained Python CLI tool with no databases or Docker services. System dependencies (`ffmpeg`, `ffprobe`, Python 3.12) are pre-installed on the VM. The update script handles `uv` installation and Python dependency sync only.
+
+### Dependency installation
+
+Dependencies are installed via `uv pip install ".[dev]" --torch-backend cpu`. The `--torch-backend cpu` flag avoids downloading ~2.5 GB of CUDA/nvidia packages that are not needed in this environment. Do **not** use plain `uv sync` for Cloud Agent sessions — it pulls GPU-capable torch and is much slower.
+
+### Running commands
+
+| Task | Command |
+|------|---------|
+| Lint | `uvx ruff check` and `uvx ruff format --check` |
+| Type check | `uvx ty check` |
+| Tests | `uv run --no-sync pytest -c tests/pytest.ini` |
+| Run app (CLI help) | `uv run clipgen.py --help` |
+| Run Screenspace UI | `uv run clipgen.py --screenspace -i DIR -o DIR` (no spreadsheet needed) |
+| Run Insights UI | `uv run clipgen.py --insights -i DIR -o DIR` (reads from manifest) |
+| Run Studio UI | `uv run clipgen.py --studio` (requires a spreadsheet) |
+
+All web UIs serve on `http://127.0.0.1:8089`. The Flask server starts automatically when launching `--studio`, `--screenspace`, or `--insights`.
+
+### Gotchas
+
+- `uv run` auto-creates `.venv` if missing; always prefer `uv run` over activating the venv manually.
+- The first `uv run clipgen.py` invocation after a CPU-only pip install may re-resolve and download GPU torch packages via `uv.lock`. To avoid this, use `uv run --no-sync` after the initial `uv pip install ".[dev]" --torch-backend cpu` setup, or run commands that don't trigger a full sync (like `uvx` for ruff/ty).
+- Google Sheets integration requires OAuth credentials not available in Cloud Agent VMs. Use local Excel files or mocked tests instead.
+- DBus errors in the Flask server log are harmless — they come from Chrome attempting DBus connections in the headless VM environment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable development environment guidance for future cloud agents.

### What's included

- **Environment overview**: Documents that clipgen is self-contained (no Docker/databases) with ffmpeg and Python 3.12 as system deps.
- **Dependency installation**: Documents the `--torch-backend cpu` flag to avoid ~2.5 GB CUDA downloads in cloud VMs.
- **Command reference table**: Quick-reference for lint, type check, tests, and all app launch modes.
- **Gotchas**: Non-obvious caveats discovered during setup (GPU torch re-resolution, DBus errors, Google Sheets auth unavailability).

### Verification

All checks passed in the cloud environment:

- `uvx ruff check` — all checks passed
- `uvx ruff format --check` — 39 files already formatted
- `uvx ty check` — all checks passed
- `uv run --no-sync pytest -c tests/pytest.ini` — 464 passed, 4 warnings
- `uv run clipgen.py --screenspace` — Flask server started, Screenspace UI loaded in browser

[Screenspace UI loaded in Chrome](https://cursor.com/agents/bc-ffdabd64-126b-48b4-8a9a-a5b4eb377e8f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenspace_ui_loaded.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffdabd64-126b-48b4-8a9a-a5b4eb377e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffdabd64-126b-48b4-8a9a-a5b4eb377e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

