### PR TITLE
fix: enable word editing and click-to-play during transcript streaming

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -517,6 +517,12 @@
     var pid = state.streamingParticipant || state.selectedParticipant;
     empty.classList.add("hidden");
 
+    // If user is actively editing a segment, skip DOM rebuild to preserve edit state
+    if (state.editingTextEl && state.editingTextEl.isConnected) return;
+
+    // Invalidate cached segment rows since we're rebuilding DOM
+    _cachedSegmentRows = null;
+
     // Only auto-scroll if user is near the bottom
     var nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
 
@@ -541,13 +547,23 @@
 
     container.innerHTML = html;
 
-    // Click-to-seek on timestamps and mark clicks
+    // Click-to-seek on timestamps/text, dblclick-to-edit, and mark clicks
     var rows = container.querySelectorAll(".segment-streaming");
     for (var j = 0; j < rows.length; j++) {
       (function (row) {
+        var textEl = row.querySelector(".segment-text");
         row.querySelector(".segment-timestamp").addEventListener("click", function (e) {
           e.stopPropagation();
           seekVideo(parseFloat(row.getAttribute("data-start")));
+        });
+        textEl.addEventListener("click", function (e) {
+          e.stopPropagation();
+          if (state.editingTextEl === textEl) return;
+          seekVideo(parseFloat(row.getAttribute("data-start")));
+        });
+        textEl.addEventListener("dblclick", function (e) {
+          e.stopPropagation();
+          startSegmentEditing(textEl);
         });
         row.querySelector(".segment-mark").addEventListener("click", function (e) {
           e.stopPropagation();
@@ -751,6 +767,8 @@
     if (state.editingTextEl === textEl) state.editingTextEl = null;
 
     if (cancel || !newText || newText === originalText) {
+      // During streaming, skip reload — next poll will re-render
+      if (state.streamingParticipant) return;
       // Reload to restore clean word spans
       var pid = state.selectedParticipant;
       if (pid) loadTranscript(pid);
@@ -836,6 +854,8 @@
       if (updated) parts.push(updated === 1 ? "1 correction saved" : updated + " corrections saved");
       if (removed) parts.push(removed === 1 ? "1 reverted" : removed + " reverted");
       showToast(parts.join(", ") || "No changes");
+      // During streaming, skip reload — corrections are persisted and will apply on completion
+      if (state.streamingParticipant) return;
       var pid = state.selectedParticipant;
       if (pid) {
         loadTranscript(pid);


### PR DESCRIPTION
## Summary
- Adds missing text click (seek video) and dblclick (inline edit) listeners to streaming transcript segments, matching the behavior of finalized transcripts.
- Guards `renderPartialSegments` against full DOM rebuilds while the user is actively editing, so the 3-second poll cycle no longer destroys edit state.
- Skips `loadTranscript` calls in `finishSegmentEditing` and `saveCorrections` during streaming to prevent wiping the streaming view; corrections are persisted via API and applied when transcription completes.
- Invalidates `_cachedSegmentRows` on each streaming rebuild so video time-sync highlighting uses fresh DOM references.

## Test plan
- [ ] Start a transcription, wait for partial segments to appear, and click segment text — video should seek to that time
- [ ] Double-click a streaming segment to enter edit mode; wait 3+ seconds and confirm the edit field persists
- [ ] Complete an edit (Enter) during streaming — toast confirms correction saved, streaming view stays intact
- [ ] Cancel an edit (Escape) during streaming — streaming view stays intact
- [ ] After transcription completes, verify corrections are applied in the full transcript