### PR TITLE
refactor: deduplicate manifest I/O and consolidate interactive prompts

### DIFF
--- a/insights.py
+++ b/insights.py
@@ -25,7 +25,7 @@ Key functions:
 
 from __future__ import annotations
 
-import json
+
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -45,16 +45,7 @@ def load_insights_manifest() -> Dict[str, Any]:
     Returns a dict with 'meta' and 'insights' keys.
     Handles missing 'summary' field on legacy insights (defaults to "").
     """
-    manifest_path = (
-        Path(utils.get_effective_output_dir()) / config.INSIGHTS_MANIFEST_FILENAME
-    )
-    if not manifest_path.is_file():
-        return _empty_manifest()
-    try:
-        data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _empty_manifest()
-
+    data = utils.load_json_manifest(config.INSIGHTS_MANIFEST_FILENAME)
     if not isinstance(data, dict):
         return _empty_manifest()
 
@@ -78,20 +69,11 @@ def save_insights_manifest(
     meta["generatedAt"] = datetime.now(timezone.utc).isoformat()
     meta.setdefault("version", config.VERSIONNUM)
 
-    manifest_path = (
-        Path(utils.get_effective_output_dir()) / config.INSIGHTS_MANIFEST_FILENAME
+    return utils.save_json_manifest(
+        config.INSIGHTS_MANIFEST_FILENAME,
+        {"meta": meta, "insights": insights},
+        warn_label="insights manifest",
     )
-    try:
-        manifest_path.write_text(
-            json.dumps(
-                {"meta": meta, "insights": insights}, ensure_ascii=False, indent=2
-            ),
-            encoding="utf-8",
-        )
-        return manifest_path
-    except OSError as e:
-        utils.warning_print(f"Could not write insights manifest: {e}")
-        return None
 
 
 def create_insight(

--- a/interactive.py
+++ b/interactive.py
@@ -14,7 +14,7 @@ the caller should re-prompt or abort).
 import shutil
 import sys
 import webbrowser
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import config
 import spreadsheet
@@ -38,75 +38,108 @@ def prompt_batch_confirm(ctx: SheetContext) -> bool:
     return yn == "y"
 
 
-def prompt_category_selection(ctx: SheetContext) -> Optional[List[str]]:
-    """Show categories, prompt for selection, return selected names or None."""
-    all_categories = spreadsheet.collect_categories(ctx)
-    if not all_categories:
-        utils.info_print("No categories found in the spreadsheet.")
-        return None
-    utils.info_print("Available categories:")
-    for i, cat in enumerate(all_categories, 1):
-        utils.info_print(f"  {i}. {cat}")
+def prompt_multi_selection(
+    items: List[str],
+    *,
+    header: str,
+    prompt_text: str,
+    confirm_label: str,
+    no_match_msg: str,
+    display_item: Optional[Callable[[int, str], None]] = None,
+    confirm_display: Callable[[str], str] = lambda x: x,
+    normalize_token: Callable[[str], str] = str.lower,
+    fuzzy_match: Optional[Callable[[str, List[str]], Optional[str]]] = None,
+) -> List[str]:
+    """Generic multi-selection prompt: display items, accept indices or text, confirm.
+
+    *display_item(index, item)* prints one item (default: ``"  {i}. {item}"``).
+    *confirm_display(item)* formats an item for the confirmation list.
+    *normalize_token* is applied to both user input and items for comparison.
+    *fuzzy_match(token, items)* is an optional fallback when exact match fails.
+    """
+    utils.info_print(header)
+    for i, item in enumerate(items, 1):
+        if display_item is not None:
+            display_item(i, item)
+        else:
+            utils.info_print(f"  {i}. {item}")
+
     while True:
-        selection = utils.read_user_input(
-            '\nEnter category numbers (comma-separated, e.g., "1,3,5") or "all":\n>> '
-        )
+        selection = utils.read_user_input(f"\n{prompt_text}\n>> ")
         if selection.lower() == "all":
-            return all_categories
+            return items
+
         try:
             indices = [int(x.strip()) for x in selection.split(",")]
-            selected_categories = []
-            invalid_indices = []
+            selected: List[str] = []
+            invalid_indices: List[int] = []
             for idx in indices:
-                if 1 <= idx <= len(all_categories):
-                    if all_categories[idx - 1] not in selected_categories:
-                        selected_categories.append(all_categories[idx - 1])
+                if 1 <= idx <= len(items):
+                    if items[idx - 1] not in selected:
+                        selected.append(items[idx - 1])
                 else:
                     invalid_indices.append(idx)
             if invalid_indices:
                 utils.info_print(
                     f"  Invalid index(es): {', '.join(str(i) for i in invalid_indices)}"
                 )
-            if selected_categories:
-                utils.info_print("Selected categories:")
-                for cat in selected_categories:
-                    utils.info_print(f"  - {cat}")
+            if selected:
+                utils.info_print(confirm_label)
+                for item in selected:
+                    utils.info_print(f"  - {confirm_display(item)}")
                 yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
                 if yn == "y":
-                    return selected_categories
+                    return selected
             else:
-                utils.info_print("No valid categories selected. Please try again.")
+                utils.info_print("No valid selections. Please try again.")
         except ValueError:
             tokens = [t.strip() for t in selection.split(",") if t.strip()]
-            matched_categories = []
-            unmatched = []
+            matched: List[str] = []
+            unmatched: List[str] = []
             for token in tokens:
+                normalized = normalize_token(token)
                 exact = next(
-                    (c for c in all_categories if c.lower() == token.lower()), None
+                    (it for it in items if normalize_token(it) == normalized),
+                    None,
                 )
                 if exact:
-                    if exact not in matched_categories:
-                        matched_categories.append(exact)
+                    if exact not in matched:
+                        matched.append(exact)
                     continue
-                suggestion = utils.suggest_close_match(token, all_categories)
-                if suggestion is not None:
-                    if suggestion not in matched_categories:
-                        matched_categories.append(suggestion)
-                else:
-                    unmatched.append(token)
+                if fuzzy_match is not None:
+                    suggestion = fuzzy_match(token, items)
+                    if suggestion is not None:
+                        if suggestion not in matched:
+                            matched.append(suggestion)
+                        continue
+                unmatched.append(token)
             if unmatched:
                 utils.info_print(f"Could not match: {', '.join(unmatched)}")
-            if matched_categories:
-                utils.info_print("Selected categories:")
-                for cat in matched_categories:
-                    utils.info_print(f"  - {cat}")
+            if matched:
+                utils.info_print(confirm_label)
+                for item in matched:
+                    utils.info_print(f"  - {confirm_display(item)}")
                 yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
                 if yn == "y":
-                    return matched_categories
+                    return matched
             else:
-                utils.info_print(
-                    "No valid categories matched. Enter numbers (e.g. 1,3,5) or category names."
-                )
+                utils.info_print(no_match_msg)
+
+
+def prompt_category_selection(ctx: SheetContext) -> Optional[List[str]]:
+    """Show categories, prompt for selection, return selected names or None."""
+    all_categories = spreadsheet.collect_categories(ctx)
+    if not all_categories:
+        utils.info_print("No categories found in the spreadsheet.")
+        return None
+    return prompt_multi_selection(
+        all_categories,
+        header="Available categories:",
+        prompt_text='Enter category numbers (comma-separated, e.g., "1,3,5") or "all":',
+        confirm_label="Selected categories:",
+        no_match_msg="No valid categories matched. Enter numbers (e.g. 1,3,5) or category names.",
+        fuzzy_match=utils.suggest_close_match,
+    )
 
 
 def prompt_severity_selection(ctx: SheetContext) -> Optional[List[str]]:
@@ -115,73 +148,27 @@ def prompt_severity_selection(ctx: SheetContext) -> Optional[List[str]]:
     if not all_severities:
         utils.info_print("No severity values found in the spreadsheet.")
         return None
-    utils.info_print("Available severity levels (most severe first):")
-    for i, sev in enumerate(all_severities, 1):
+
+    def _display_severity(index: int, sev: str) -> None:
         count = severity_counts.get(sev, 0)
         count_label = "1 row" if count == 1 else f"{count} rows"
         display = f"{utils.format_severity_display(sev)} \u2014 {count_label}"
         style = utils.get_severity_style(sev)
         if utils._use_rich() and utils.console is not None and style:
-            utils.console.print(f"  {i}. [{style}]{display}[/{style}]")
+            utils.console.print(f"  {index}. [{style}]{display}[/{style}]")
         else:
-            utils.info_print(f"  {i}. {display}")
-    while True:
-        selection = utils.read_user_input(
-            '\nEnter severity numbers (comma-separated, e.g., "1,2") or "all":\n>> '
-        )
-        if selection.lower() == "all":
-            return all_severities
-        try:
-            indices = [int(x.strip()) for x in selection.split(",")]
-            selected = []
-            invalid_indices = []
-            for idx in indices:
-                if 1 <= idx <= len(all_severities):
-                    if all_severities[idx - 1] not in selected:
-                        selected.append(all_severities[idx - 1])
-                else:
-                    invalid_indices.append(idx)
-            if invalid_indices:
-                utils.info_print(
-                    f"  Invalid index(es): {', '.join(str(i) for i in invalid_indices)}"
-                )
-            if selected:
-                utils.info_print("Selected severities:")
-                for sev in selected:
-                    utils.info_print(f"  - {utils.format_severity_display(sev)}")
-                yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
-                if yn == "y":
-                    return selected
-            else:
-                utils.info_print("No valid severities selected. Please try again.")
-        except ValueError:
-            tokens = [t.strip() for t in selection.split(",") if t.strip()]
-            matched = []
-            unmatched = []
-            for token in tokens:
-                normalized = utils.normalize_severity(token)
-                exact = next(
-                    (s for s in all_severities if s.lower() == normalized.lower()),
-                    None,
-                )
-                if exact:
-                    if exact not in matched:
-                        matched.append(exact)
-                else:
-                    unmatched.append(token)
-            if unmatched:
-                utils.info_print(f"Could not match: {', '.join(unmatched)}")
-            if matched:
-                utils.info_print("Selected severities:")
-                for sev in matched:
-                    utils.info_print(f"  - {utils.format_severity_display(sev)}")
-                yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
-                if yn == "y":
-                    return matched
-            else:
-                utils.info_print(
-                    "No valid severities matched. Enter numbers or severity names."
-                )
+            utils.info_print(f"  {index}. {display}")
+
+    return prompt_multi_selection(
+        all_severities,
+        header="Available severity levels (most severe first):",
+        prompt_text='Enter severity numbers (comma-separated, e.g., "1,2") or "all":',
+        confirm_label="Selected severities:",
+        no_match_msg="No valid severities matched. Enter numbers or severity names.",
+        display_item=_display_severity,
+        confirm_display=utils.format_severity_display,
+        normalize_token=lambda t: utils.normalize_severity(t).lower(),
+    )
 
 
 def prompt_line_selection(ctx: SheetContext) -> Optional[List[int]]:
@@ -408,66 +395,22 @@ def prompt_keyword_selection(ctx: SheetContext) -> Optional[List[str]]:
         if yn == "y":
             return [aid]
         return None
-    utils.info_print("Available annotation types:")
-    for i, aid in enumerate(all_annotations, 1):
+
+    def _display_annotation(index: int, aid: str) -> None:
         count = annotation_counts.get(aid, 0)
         count_label = "1 cell" if count == 1 else f"{count} cells"
-        utils.info_print(f"  {i}. !{aid} — {count_label}")
-    while True:
-        selection = utils.read_user_input(
-            '\nEnter annotation numbers (comma-separated, e.g., "1,2") or "all":\n>> '
-        )
-        if selection.lower() == "all":
-            return all_annotations
-        try:
-            indices = [int(x.strip()) for x in selection.split(",")]
-            selected = []
-            invalid_indices = []
-            for idx in indices:
-                if 1 <= idx <= len(all_annotations):
-                    if all_annotations[idx - 1] not in selected:
-                        selected.append(all_annotations[idx - 1])
-                else:
-                    invalid_indices.append(idx)
-            if invalid_indices:
-                utils.info_print(
-                    f"  Invalid index(es): {', '.join(str(i) for i in invalid_indices)}"
-                )
-            if selected:
-                utils.info_print("Selected annotations:")
-                for aid in selected:
-                    utils.info_print(f"  - !{aid}")
-                yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
-                if yn == "y":
-                    return selected
-            else:
-                utils.info_print("No valid annotations selected. Please try again.")
-        except ValueError:
-            tokens = [
-                t.strip().lower().lstrip("!") for t in selection.split(",") if t.strip()
-            ]
-            matched = []
-            unmatched = []
-            for token in tokens:
-                exact = next((a for a in all_annotations if a.lower() == token), None)
-                if exact:
-                    if exact not in matched:
-                        matched.append(exact)
-                else:
-                    unmatched.append(token)
-            if unmatched:
-                utils.info_print(f"Could not match: {', '.join(unmatched)}")
-            if matched:
-                utils.info_print("Selected annotations:")
-                for aid in matched:
-                    utils.info_print(f"  - !{aid}")
-                yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
-                if yn == "y":
-                    return matched
-            else:
-                utils.info_print(
-                    "No valid annotations matched. Enter numbers or annotation names."
-                )
+        utils.info_print(f"  {index}. !{aid} \u2014 {count_label}")
+
+    return prompt_multi_selection(
+        all_annotations,
+        header="Available annotation types:",
+        prompt_text='Enter annotation numbers (comma-separated, e.g., "1,2") or "all":',
+        confirm_label="Selected annotations:",
+        no_match_msg="No valid annotations matched. Enter numbers or annotation names.",
+        display_item=_display_annotation,
+        confirm_display=lambda aid: f"!{aid}",
+        normalize_token=lambda t: t.strip().lower().lstrip("!"),
+    )
 
 
 # ---- Browse mode ----

--- a/plans/QUALITY-PLAN.md
+++ b/plans/QUALITY-PLAN.md
@@ -8,9 +8,9 @@ Addressing organic growth, duplication, and overly defensive patterns identified
 
 The same load/save JSON pattern is repeated in `viewer.py`, `insights.py`, `screenspace.py`, `transcripts.py`, and `server.py` (stashes, settings).
 
-- [ ] Add `utils.load_json_manifest(path, default)` and `utils.save_json_manifest(path, data)` helpers
-- [ ] Replace all 5+ load sites and 5+ save sites with calls to the shared helpers
-- [ ] Ensure consistent error handling (log on write failure, return default on read failure)
+- [x] Add `utils.load_json_manifest(path, default)` and `utils.save_json_manifest(path, data)` helpers
+- [x] Replace all 5+ load sites and 5+ save sites with calls to the shared helpers
+- [x] Ensure consistent error handling (log on write failure, return default on read failure)
 
 ---
 
@@ -18,8 +18,8 @@ The same load/save JSON pattern is repeated in `viewer.py`, `insights.py`, `scre
 
 `prompt_category_selection`, `prompt_severity_selection`, and `prompt_keyword_selection` in `interactive.py` are near-identical 70-line functions differing only in source list, display formatter, and fuzzy-match strategy.
 
-- [ ] Extract a generic `prompt_multi_selection()` that accepts: item list, display callback, fuzzy-match callback, and prompt text
-- [ ] Rewrite the three functions as thin wrappers calling the generic helper
+- [x] Extract a generic `prompt_multi_selection()` that accepts: item list, display callback, fuzzy-match callback, and prompt text
+- [x] Rewrite the three functions as thin wrappers calling the generic helper
 
 ---
 

--- a/screenspace.py
+++ b/screenspace.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import copy
 import difflib
-import json
+
 import math
 import queue
 import re
@@ -2920,15 +2920,7 @@ def load_screenspace_manifest() -> Dict[str, Any]:
 
     Returns a dict with ``regions`` and ``tasks`` keys.
     """
-    manifest_path = (
-        Path(utils.get_effective_output_dir()) / config.SCREENSPACE_MANIFEST_FILENAME
-    )
-    if not manifest_path.is_file():
-        return _empty_screenspace_manifest()
-    try:
-        data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _empty_screenspace_manifest()
+    data = utils.load_json_manifest(config.SCREENSPACE_MANIFEST_FILENAME)
     if not isinstance(data, dict):
         return _empty_screenspace_manifest()
     return {
@@ -2950,9 +2942,6 @@ def save_screenspace_manifest(
     Strips internal fields (prefixed with ``_``) from tasks before writing.
     Returns the manifest path on success, or ``None`` on failure.
     """
-    manifest_path = (
-        Path(utils.get_effective_output_dir()) / config.SCREENSPACE_MANIFEST_FILENAME
-    )
     clean_tasks = []
     for task in tasks:
         ct = {k: v for k, v in task.items() if not k.startswith("_")}
@@ -2979,24 +2968,16 @@ def save_screenspace_manifest(
                 {k: v for k, v in r.items() if k != "flow_grid"} for r in ct["result"]
             ]
         clean_tasks.append(ct)
-    try:
-        manifest_path.write_text(
-            json.dumps(
-                {
-                    "regions": regions,
-                    "tasks": clean_tasks,
-                    "events": events or [],
-                    "stashes": stashes or [],
-                },
-                ensure_ascii=False,
-                indent=2,
-            ),
-            encoding="utf-8",
-        )
-        return manifest_path
-    except OSError as e:
-        utils.warning_print(f"Could not write screenspace manifest: {e}")
-        return None
+    return utils.save_json_manifest(
+        config.SCREENSPACE_MANIFEST_FILENAME,
+        {
+            "regions": regions,
+            "tasks": clean_tasks,
+            "events": events or [],
+            "stashes": stashes or [],
+        },
+        warn_label="screenspace manifest",
+    )
 
 
 def create_event(

--- a/server.py
+++ b/server.py
@@ -386,78 +386,32 @@ def _generate_intake_clips(
 
 
 def _load_stashes() -> List[Dict[str, Any]]:
-    stash_path = (
-        Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
-    )
-    if not stash_path.is_file():
-        return []
-    try:
-        data = json.loads(stash_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
+    data = utils.load_json_manifest(config.STASHES_MANIFEST_FILENAME, default=[])
     if not isinstance(data, list):
         return []
     return data
 
 
 def _save_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
-    stash_path = (
-        Path(utils.get_effective_output_dir()) / config.STASHES_MANIFEST_FILENAME
-    )
-    try:
-        stash_path.parent.mkdir(parents=True, exist_ok=True)
-        stash_path.write_text(
-            json.dumps(stashes, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
-        return stash_path
-    except OSError:
-        return None
+    return utils.save_json_manifest(config.STASHES_MANIFEST_FILENAME, stashes)
 
 
 def _load_artifact_stashes() -> List[Dict[str, Any]]:
-    stash_path = (
-        Path(utils.get_effective_output_dir())
-        / config.ARTIFACT_STASHES_MANIFEST_FILENAME
+    data = utils.load_json_manifest(
+        config.ARTIFACT_STASHES_MANIFEST_FILENAME, default=[]
     )
-    if not stash_path.is_file():
-        return []
-    try:
-        data = json.loads(stash_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
     if not isinstance(data, list):
         return []
     return data
 
 
 def _save_artifact_stashes(stashes: List[Dict[str, Any]]) -> Optional[Path]:
-    stash_path = (
-        Path(utils.get_effective_output_dir())
-        / config.ARTIFACT_STASHES_MANIFEST_FILENAME
-    )
-    try:
-        stash_path.parent.mkdir(parents=True, exist_ok=True)
-        stash_path.write_text(
-            json.dumps(stashes, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
-        return stash_path
-    except OSError:
-        return None
+    return utils.save_json_manifest(config.ARTIFACT_STASHES_MANIFEST_FILENAME, stashes)
 
 
 def _load_studio_settings() -> Dict[str, Any]:
     """Load studio_settings.json and apply non-default values to config module."""
-    settings_path = (
-        Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
-    )
-    if not settings_path.is_file():
-        return {}
-    try:
-        data = json.loads(settings_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
+    data = utils.load_json_manifest(config.STUDIO_SETTINGS_FILENAME, default={})
     if not isinstance(data, dict):
         return {}
 
@@ -489,29 +443,21 @@ def _load_studio_settings() -> Dict[str, Any]:
 
 def _save_studio_settings(overrides: Dict[str, Any]) -> Optional[Path]:
     """Write only non-default settings to studio_settings.json."""
-    settings_path = (
-        Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
-    )
     to_save = {}
     for name, value in overrides.items():
         if name in _settings_defaults and value != _settings_defaults[name]:
             to_save[name] = value
     if not to_save:
+        settings_path = (
+            Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
+        )
         if settings_path.is_file():
             try:
                 settings_path.unlink()
             except OSError:
                 pass
         return None
-    try:
-        settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text(
-            json.dumps(to_save, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
-        return settings_path
-    except OSError:
-        return None
+    return utils.save_json_manifest(config.STUDIO_SETTINGS_FILENAME, to_save)
 
 
 def _find_existing_artifacts(

--- a/transcripts.py
+++ b/transcripts.py
@@ -35,7 +35,7 @@ Standalone transcript file output (type "transcript" artifacts) is opt-in via --
 from __future__ import annotations
 
 import copy
-import json
+
 import queue
 import re
 import threading
@@ -211,15 +211,7 @@ def load_transcripts_manifest() -> dict[str, Any]:
     Returns a dict with ``source_transcripts`` and ``corrections`` keys.
     Missing or corrupt files return an empty manifest.
     """
-    manifest_path = (
-        Path(utils.get_effective_output_dir()) / config.TRANSCRIPTS_MANIFEST_FILENAME
-    )
-    if not manifest_path.is_file():
-        return _empty_transcripts_manifest()
-    try:
-        data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _empty_transcripts_manifest()
+    data = utils.load_json_manifest(config.TRANSCRIPTS_MANIFEST_FILENAME)
     if not isinstance(data, dict):
         return _empty_transcripts_manifest()
     return {
@@ -247,32 +239,21 @@ def save_transcripts_manifest(
 
     # When marks is None, preserve existing marks from disk
     if marks is None:
-        manifest_path = (
-            Path(utils.get_effective_output_dir())
-            / config.TRANSCRIPTS_MANIFEST_FILENAME
+        existing = utils.load_json_manifest(
+            config.TRANSCRIPTS_MANIFEST_FILENAME, default={}
         )
-        try:
-            existing = json.loads(manifest_path.read_text(encoding="utf-8"))
-            marks = existing.get("marks") or []
-        except (OSError, json.JSONDecodeError):
-            marks = []
+        marks = (existing.get("marks") or []) if isinstance(existing, dict) else []
 
     data = {
         "source_transcripts": source_transcripts,
         "corrections": corrections,
         "marks": marks,
     }
-    manifest_path = (
-        Path(utils.get_effective_output_dir()) / config.TRANSCRIPTS_MANIFEST_FILENAME
+    return utils.save_json_manifest(
+        config.TRANSCRIPTS_MANIFEST_FILENAME,
+        data,
+        warn_label="transcripts manifest",
     )
-    try:
-        manifest_path.write_text(
-            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
-        return manifest_path
-    except OSError as exc:
-        utils.warning_print(f"Failed to save transcripts manifest: {exc}")
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import difflib
+import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -492,6 +493,41 @@ def resolve_output_path(name: str) -> Path:
     if path.is_absolute():
         return path
     return base / path
+
+
+def load_json_manifest(filename: str, *, default: Any = None) -> Any:
+    """Load a JSON manifest from the output directory.
+
+    Returns parsed data, or *default* on missing/corrupt file.
+    """
+    path = Path(get_effective_output_dir()) / filename
+    if not path.is_file():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def save_json_manifest(
+    filename: str, data: Any, *, warn_label: str = ""
+) -> Path | None:
+    """Write *data* as JSON to *filename* in the output directory.
+
+    Creates parent dirs.  Returns the path on success, ``None`` on failure.
+    Logs a warning on write failure using *warn_label*.
+    """
+    path = Path(get_effective_output_dir()) / filename
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        return path
+    except OSError as exc:
+        if warn_label:
+            warning_print(f"Could not write {warn_label}: {exc}")
+        return None
 
 
 def get_bundled_assets_root() -> Path:

--- a/viewer.py
+++ b/viewer.py
@@ -404,21 +404,17 @@ def _load_manifest_both() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
 
     Returns (artifacts, reels). Both default to [] on missing/corrupt file.
     """
-    manifest_path = Path(utils.get_effective_output_dir()) / config.MANIFEST_FILENAME
-    if not manifest_path.is_file():
+    data = utils.load_json_manifest(config.MANIFEST_FILENAME)
+    if not isinstance(data, dict):
         return ([], [])
-    try:
-        data = json.loads(manifest_path.read_text(encoding="utf-8"))
-        raw = data.get("artifacts", [])
-        valid = [a for a in raw if _is_valid_artifact(a)]
-        if len(valid) < len(raw):
-            utils.warning_print(
-                f"Manifest contained {len(raw) - len(valid)} artifact(s) with "
-                "missing fields; skipped."
-            )
-        return (valid, data.get("reels", []))
-    except (OSError, json.JSONDecodeError, AttributeError):
-        return ([], [])
+    raw = data.get("artifacts", [])
+    valid = [a for a in raw if _is_valid_artifact(a)]
+    if len(valid) < len(raw):
+        utils.warning_print(
+            f"Manifest contained {len(raw) - len(valid)} artifact(s) with "
+            "missing fields; skipped."
+        )
+    return (valid, data.get("reels", []))
 
 
 def load_manifest_artifacts() -> List[Dict[str, Any]]:
@@ -471,12 +467,6 @@ def save_manifest(
         output_format=output_format,
     )
 
-    manifest_path = Path(utils.get_effective_output_dir()) / config.MANIFEST_FILENAME
-    try:
-        manifest_path.write_text(
-            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
-        return manifest_path
-    except OSError as e:
-        utils.warning_print(f"Could not write manifest: {e}")
-        return None
+    return utils.save_json_manifest(
+        config.MANIFEST_FILENAME, data, warn_label="manifest"
+    )


### PR DESCRIPTION
## Summary

- Adds `load_json_manifest()` and `save_json_manifest()` helpers to `utils.py`, replacing 14 identical JSON read/write boilerplate sites across `viewer.py`, `insights.py`, `transcripts.py`, `screenspace.py`, and `server.py`.
- Extracts a generic `prompt_multi_selection()` in `interactive.py`, reducing three near-identical ~70-line functions (`prompt_category_selection`, `prompt_severity_selection`, `prompt_keyword_selection`) to thin wrappers with callbacks for display, normalization, and fuzzy matching.
- Net reduction of 141 lines. All 464 existing tests pass.

## Test plan
- [x] Full test suite passes (`pytest` — 464 tests)
- [x] Ruff lint and format clean
- [x] All module imports verified