### PR TITLE
refactor: deduplicate frontend JS utilities into shared utils.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - Features are often built incrementally across multiple sessions. Check for existing groundwork before starting from scratch.
 - Manifest-driven state persistence: JSON manifest files (clipgen, insights, screenspace, stashes, settings) follow the pattern of load-on-startup, save-after-mutations.
 - No hardcoded version numbers in evergreen docs (CLAUDE.md, README.md). Reference `VERSIONNUM` in `config.py` instead.
-- **Icons**: Prefer SVG icons from `assets/icons/` (316 Heroicons outline, kebab-case names like `pencil-square.svg`) over crafting new inline SVG paths or using text/emoji glyphs in web UIs.
+- **Icons**: Prefer SVG icons from `assets/icons/` (316 Heroicons outline, kebab-case names like `pencil-square.svg`) over crafting new inline SVG paths or using text/emoji glyphs in web UIs. **Never define SVG path data in JavaScript.** Use the CSS `mask-image` pattern to reference `.svg` files: create a `<span>` with `mask-image: url("icons/icon-name.svg")` and `background-color: currentColor`. See `XREF_BADGES` in `utils.js` and `.xref-badge-icon` in `tokens.css` for the canonical example. Icon routes already exist per blueprint (`/screenspace/icons/`, `/transcripts/icons/`, etc.).
 - **Linting/formatting**: Run `uv run ruff check --fix && uv run ruff format` after editing Python files. Run `uv run ty check` for type checking.
 - Commit early and commit often, so we can roll back changes more easily.
 - If a problem is reoccurring and survives fix attempts, check git logs for clues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ clipgen is a Python CLI tool that generates clips from timestamps stored in a Go
 | [screenspace_server.py](screenspace_server.py) | Screenspace Flask REST API: region CRUD, video frame extraction, task queue management, results retrieval |
 | [insights.py](insights.py) | Insights data model: CRUD operations for insight records, insights manifest read/write |
 | [insights_server.py](insights_server.py) | Insights Builder Flask REST API: insight CRUD, artifact browsing, sprite sheet generation, viewer export |
-| [assets/web/](assets/web/) | Static HTML/JS/CSS templates: timeline viewer (`viewer.html/js/css`), gallery (`gallery.html/js/css`), studio (`studio.html/js/css`), insights builder (`insights-builder.html/js/css`), insights viewer (`insights-viewer.html/js/css`), screenspace (`screenspace.html/js/css`) |
+| [assets/web/](assets/web/) | Static HTML/JS/CSS templates: timeline viewer (`viewer.html/js/css`), gallery (`gallery.html/js/css`), studio (`studio.html/js/css`), insights builder (`insights-builder.html/js/css`), insights viewer (`insights-viewer.html/js/css`), screenspace (`screenspace.html/js/css`). Shared utilities and constants live in `utils.js` (loaded before each page's main script) |
 
 ### Timeline HTML Viewer
 
@@ -92,7 +92,7 @@ Source video filenames follow `{study}_{participant}.mp4` (e.g. `mystudy_P01.mp4
 
 ## SVG icons
 
-316 Heroicons (outline, 24×24) live in [assets/icons/](assets/icons/) with kebab-case filenames. Use these for all web UI icons rather than writing new inline SVG paths. See the comment near `svgEditIcon()` in `screenspace.js` for the `createElementNS()` pattern.
+316 Heroicons (outline, 24×24) live in [assets/icons/](assets/icons/) with kebab-case filenames. Use these for all web UI icons rather than writing new inline SVG paths. The canonical pattern is CSS `mask-image` referencing `.svg` files — see `XREF_BADGES` in `utils.js` and `.xref-badge-icon` in `tokens.css`. Icon routes already exist per blueprint (`/screenspace/icons/`, `/transcripts/icons/`, etc.).
 
 ## Conventions and patterns
 

--- a/assets/web/gallery.html
+++ b/assets/web/gallery.html
@@ -42,6 +42,7 @@
   </div>
 
   <!-- CLIPGEN_DATA_HERE -->
+  <script src="utils.js" defer></script>
   <script src="gallery.js" defer></script>
 </body>
 </html>

--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -6,20 +6,6 @@
   var state = { artifacts: [], lightboxIndex: -1 };
   var THEME_STORAGE_KEY = "clipgen-gallery-theme";
 
-  function qs(sel) { return document.querySelector(sel); }
-
-  function formatTime(sec) {
-    if (sec == null || isNaN(sec)) return "--:--";
-    sec = Math.round(sec);
-    var h = Math.floor(sec / 3600);
-    var m = Math.floor((sec % 3600) / 60);
-    var s = sec % 60;
-    if (h > 0) return h + ":" + pad2(m) + ":" + pad2(s);
-    return m + ":" + pad2(s);
-  }
-
-  function pad2(n) { return n < 10 ? "0" + n : "" + n; }
-
   // ---- Theme ----
 
   function initThemeToggle() {

--- a/assets/web/insights-builder.html
+++ b/assets/web/insights-builder.html
@@ -90,6 +90,7 @@
 
   <div id="toast" class="toast hidden"></div>
 
+  <script src="utils.js" defer></script>
   <script src="insights-builder.js" defer></script>
 </body>
 </html>

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -47,46 +47,6 @@
 
   // ---- Helpers ----
 
-  function qs(sel) {
-    return document.querySelector(sel);
-  }
-  function qsa(sel) {
-    return document.querySelectorAll(sel);
-  }
-  function el(tag, cls, text) {
-    var e = document.createElement(tag);
-    if (cls) e.className = cls;
-    if (text !== undefined) e.textContent = text;
-    return e;
-  }
-  function truncate(str, max) {
-    if (!str) return "";
-    return str.length > max ? str.slice(0, max) + "\u2026" : str;
-  }
-
-  function severityClass(raw) {
-    if (!raw) return "";
-    var k = raw.trim().toLowerCase();
-    var map = {
-      critical: "sev-critical",
-      high: "sev-high",
-      medium: "sev-medium",
-      low: "sev-low",
-      "n/a": "sev-na",
-      positive: "sev-positive",
-      "very positive": "sev-very-positive",
-    };
-    return map[k] || "sev-unknown";
-  }
-
-  function formatTime(seconds) {
-    if (seconds == null) return "";
-    var s = Math.round(seconds);
-    var m = Math.floor(s / 60);
-    var sec = s % 60;
-    return m + ":" + (sec < 10 ? "0" : "") + sec;
-  }
-
   function countBucketArtifacts(insight) {
     var c = (insight.causes || {}).artifacts || [];
     var b = (insight.behaviors || {}).artifacts || [];

--- a/assets/web/insights-viewer.html
+++ b/assets/web/insights-viewer.html
@@ -28,6 +28,7 @@
   </footer>
 
   <!-- CLIPGEN_DATA_HERE -->
+  <script src="utils.js" defer></script>
   <script src="insights-viewer.js" defer></script>
 </body>
 </html>

--- a/assets/web/insights-viewer.js
+++ b/assets/web/insights-viewer.js
@@ -10,45 +10,6 @@
 
   // ---- Helpers ----
 
-  function qs(sel) {
-    return document.querySelector(sel);
-  }
-
-  function el(tag, cls, text) {
-    var e = document.createElement(tag);
-    if (cls) e.className = cls;
-    if (text !== undefined) e.textContent = text;
-    return e;
-  }
-
-  function truncate(str, max) {
-    if (!str) return "";
-    return str.length > max ? str.slice(0, max) + "\u2026" : str;
-  }
-
-  function severityClass(raw) {
-    if (!raw) return "";
-    var k = raw.trim().toLowerCase();
-    var map = {
-      critical: "sev-critical",
-      high: "sev-high",
-      medium: "sev-medium",
-      low: "sev-low",
-      "n/a": "sev-na",
-      positive: "sev-positive",
-      "very positive": "sev-very-positive",
-    };
-    return map[k] || "sev-unknown";
-  }
-
-  function formatTime(seconds) {
-    if (seconds == null) return "";
-    var s = Math.round(seconds);
-    var m = Math.floor(s / 60);
-    var sec = s % 60;
-    return m + ":" + (sec < 10 ? "0" : "") + sec;
-  }
-
   function countArtifacts(insight) {
     var c = (insight.causes || {}).artifacts || [];
     var b = (insight.behaviors || {}).artifacts || [];

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -194,6 +194,7 @@
   <div id="ssTooltip" class="ss-tooltip hidden"></div>
   <div id="toolInfoTooltip" class="tool-info-tooltip hidden"></div>
 
+  <script src="utils.js"></script>
   <script src="screenspace.js"></script>
 </body>
 </html>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -7,15 +7,7 @@
   var POLL_INTERVAL = 3000;
   var FRAME_STEP = 1.0;
 
-  var TASK_COLORS = (function () {
-    var types = ["multitool", "color", "change", "similarity", "text", "numbers", "timelapse", "template", "flow", "scene", "inactivity"];
-    var style = getComputedStyle(document.documentElement);
-    var map = {};
-    types.forEach(function (t) {
-      map[t] = style.getPropertyValue("--color-task-" + t).trim() || "#888";
-    });
-    return map;
-  })();
+  var TASK_COLORS = DETECTOR_COLORS;
 
   var SS_TYPE_ICON_PATHS = {
     multitool: { viewBox: "0 0 16 16", paths: [
@@ -161,15 +153,6 @@
 
   // ---- Helpers ----
 
-  function qs(sel) { return document.querySelector(sel); }
-  function qsa(sel) { return document.querySelectorAll(sel); }
-  function el(tag, cls, text) {
-    var e = document.createElement(tag);
-    if (cls) e.className = cls;
-    if (text !== undefined) e.textContent = text;
-    return e;
-  }
-
   function formatDuration(secs) {
     secs = Math.round(secs);
     if (secs >= 3600) {
@@ -233,44 +216,6 @@
 
   function taskTypeColor(type) {
     return TASK_COLORS[type] || "#888";
-  }
-
-  // ---- API helpers ----
-
-  function apiGet(path) {
-    return fetch(path).then(function (r) {
-      if (!r.ok) throw new Error("Server error " + r.status);
-      return r.json();
-    });
-  }
-
-  function apiPost(path, body) {
-    return fetch(path, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }).then(function (r) {
-      if (!r.ok) throw new Error("Server error " + r.status);
-      return r.json();
-    });
-  }
-
-  function apiDelete(path) {
-    return fetch(path, { method: "DELETE" }).then(function (r) {
-      if (!r.ok) throw new Error("Server error " + r.status);
-      return r.json();
-    });
-  }
-
-  function apiPut(path, body) {
-    return fetch(path, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }).then(function (r) {
-      if (!r.ok) throw new Error("Server error " + r.status);
-      return r.json();
-    });
   }
 
   function frameUrl(pid, ts) {

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2389,10 +2389,9 @@ html[data-theme="dark"] .log-panel {
   margin-left: 3px;
 }
 
-.xref-badge svg {
+.xref-badge .xref-badge-icon {
   width: 10px;
   height: 10px;
-  display: block;
 }
 
 .tr-intake-filter-cat {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -308,6 +308,7 @@
   </div>
 
   <div id="trIntakeTooltip" class="tr-intake-tooltip hidden"></div>
+  <script src="utils.js"></script>
   <script src="studio.js"></script>
 </body>
 </html>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -83,40 +83,6 @@
 
   // ---- Helpers ----
 
-  function qs(sel) {
-    return document.querySelector(sel);
-  }
-  function qsa(sel) {
-    return document.querySelectorAll(sel);
-  }
-
-  function el(tag, cls, text) {
-    var e = document.createElement(tag);
-    if (cls) e.className = cls;
-    if (text !== undefined) e.textContent = text;
-    return e;
-  }
-
-  function truncate(str, max) {
-    if (!str) return "";
-    return str.length > max ? str.slice(0, max) + "\u2026" : str;
-  }
-
-  function severityClass(raw) {
-    if (!raw) return "";
-    var k = raw.trim().toLowerCase();
-    var map = {
-      critical: "sev-critical",
-      high: "sev-high",
-      medium: "sev-medium",
-      low: "sev-low",
-      "n/a": "sev-na",
-      positive: "sev-positive",
-      "very positive": "sev-very-positive",
-    };
-    return map[k] || "sev-unknown";
-  }
-
   function cellKey(participant, rowNum) {
     return participant + "." + rowNum;
   }
@@ -3323,19 +3289,7 @@
 
   // ---- Screenspace Intake ----
 
-  var INTAKE_DETECTOR_COLORS = {
-    multitool: "#2563eb",
-    color: "#8b5cf6",
-    change: "#f97316",
-    similarity: "#0ea5e9",
-    text: "#10b981",
-    numbers: "#eab308",
-    timelapse: "#ec4899",
-    template: "#f43f5e",
-    flow: "#6366f1",
-    scene: "#14b8a6",
-    inactivity: "#78716c",
-  };
+  var INTAKE_DETECTOR_COLORS = DETECTOR_COLORS;
 
   var INTAKE_DETECTOR_ICON_FILES = {
     multitool: "link",

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3379,17 +3379,17 @@
       });
   }
 
-  var SS_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
-  var TR_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M1 8.74053C1 9.72321 1.71341 10.5653 2.68906 10.6827C3.5937 10.7915 4.50678 10.8729 5.42746 10.926C5.78969 10.9469 6.11506 11.1572 6.27733 11.4817L7.32918 13.5854C7.45622 13.8395 7.71592 14 8 14C8.28408 14 8.54378 13.8395 8.67082 13.5854L9.72265 11.4817C9.88492 11.1572 10.2103 10.9469 10.5725 10.9261C11.4932 10.873 12.4063 10.7916 13.3109 10.6828C14.2866 10.5654 15 9.72332 15 8.74062V4.25938C15 3.27668 14.2866 2.43458 13.3109 2.3172C11.57 2.10777 9.79777 2 8.00039 2C6.20273 2 4.43025 2.10781 2.68906 2.3173C1.71341 2.43469 1 3.27679 1 4.25947V8.74053ZM4 5.25C4 4.83579 4.33579 4.5 4.75 4.5H11.25C11.6642 4.5 12 4.83579 12 5.25C12 5.66421 11.6642 6 11.25 6H4.75C4.33579 6 4 5.66421 4 5.25ZM4.75 7C4.33579 7 4 7.33579 4 7.75C4 8.16421 4.33579 8.5 4.75 8.5H7.25C7.66421 8.5 8 8.16421 8 7.75C8 7.33579 7.66421 7 7.25 7H4.75Z"/></svg>';
-  var SHEET_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 11C15 12.1046 14.1046 13 13 13H3C1.89543 13 1 12.1046 1 11V5C1 3.89543 1.89543 3 3 3H13C14.1046 3 15 3.89543 15 5V11ZM7.25 7.5C7.25 7.22386 7.02614 7 6.75 7H3C2.72386 7 2.5 7.22386 2.5 7.5V8C2.5 8.27614 2.72386 8.5 3 8.5H6.75C7.02614 8.5 7.25 8.27614 7.25 8V7.5ZM8.75 10.5C8.75 10.2239 8.97386 10 9.25 10H13C13.2761 10 13.5 10.2239 13.5 10.5V11C13.5 11.2761 13.2761 11.5 13 11.5H9.25C8.97386 11.5 8.75 11.2761 8.75 11V10.5ZM13.5 8V7.5C13.5 7.22386 13.2761 7 13 7H9.25C8.97386 7 8.75 7.22386 8.75 7.5V8C8.75 8.27614 8.97386 8.5 9.25 8.5H13C13.2761 8.5 13.5 8.27614 13.5 8ZM6.75 11.5C7.02614 11.5 7.25 11.2761 7.25 11V10.5C7.25 10.2239 7.02614 10 6.75 10H3C2.72386 10 2.5 10.2239 2.5 10.5V11C2.5 11.2761 2.72386 11.5 3 11.5H6.75Z"/></svg>';
+  var XREF_ICON_BASE = "../screenspace/icons/";
 
-  var XREF_BADGE_COLOR = {
-    screenspace: "rgba(52, 152, 219, 0.85)",
-    transcript: "rgba(16, 163, 74, 0.85)",
-    sheet: "rgba(234, 179, 8, 0.85)",
-  };
+  function xrefBadgeIcon(iconName) {
+    var span = el("span", "xref-badge-icon");
+    var url = 'url("' + XREF_ICON_BASE + iconName + '.svg")';
+    span.style.maskImage = url;
+    span.style.webkitMaskImage = url;
+    return span;
+  }
 
-  // selfBadge: optional { svg, color, title } to prepend as the "self" source badge
+  // selfBadge: optional { icon, color, title } to prepend as the "self" source badge
   function buildXrefBadges(xref, selfSource, selfBadge) {
     var badges = [];
     if (selfBadge) badges.push(selfBadge);
@@ -3400,7 +3400,7 @@
         var et = xref.screenspaceEvents[i].event_type || xref.screenspaceEvents[i].detector;
         if (!seen[et]) { seen[et] = true; types.push(et); }
       }
-      badges.push({ svg: SS_BADGE_SVG, color: XREF_BADGE_COLOR.screenspace, title: types.join(", ") });
+      badges.push({ icon: XREF_BADGES.screenspace.icon, color: XREF_BADGES.screenspace.color, title: types.join(", ") });
     }
     if (selfSource !== "transcript" && xref.transcriptSnippets.length > 0) {
       var trTexts = [];
@@ -3408,14 +3408,14 @@
         var t = xref.transcriptSnippets[j].text;
         trTexts.push(t.length > 80 ? t.substring(0, 80) + "\u2026" : t);
       }
-      badges.push({ svg: TR_BADGE_SVG, color: XREF_BADGE_COLOR.transcript, title: trTexts.join("\n") });
+      badges.push({ icon: XREF_BADGES.transcript.icon, color: XREF_BADGES.transcript.color, title: trTexts.join("\n") });
     }
     if (xref.sheetObservations.length > 0) {
       var obsTexts = [];
       for (var k = 0; k < xref.sheetObservations.length && k < 3; k++) {
         obsTexts.push(xref.sheetObservations[k].observation);
       }
-      badges.push({ svg: SHEET_BADGE_SVG, color: XREF_BADGE_COLOR.sheet, title: obsTexts.join("\n") });
+      badges.push({ icon: XREF_BADGES.sheet.icon, color: XREF_BADGES.sheet.color, title: obsTexts.join("\n") });
     }
     if (badges.length === 0) return null;
     var container = el("span", "xref-badge-stack");
@@ -3423,7 +3423,7 @@
       var badge = el("span", "xref-badge");
       badge.style.background = badges[b].color;
       badge.style.zIndex = badges.length - b;
-      badge.innerHTML = badges[b].svg;
+      badge.appendChild(xrefBadgeIcon(badges[b].icon));
       badge.title = badges[b].title;
       container.appendChild(badge);
     }
@@ -3642,7 +3642,7 @@
 
       // Source + cross-reference badges (SS self-badge leads the stack)
       var xref = findOverlappingData(c.participant, c.start, c.end);
-      var ssSelf = { svg: SS_BADGE_SVG, color: XREF_BADGE_COLOR.screenspace, title: c.event_type || "Screenspace" };
+      var ssSelf = { icon: XREF_BADGES.screenspace.icon, color: XREF_BADGES.screenspace.color, title: c.event_type || "Screenspace" };
       var badgeStack = buildXrefBadges(xref, "screenspace", ssSelf);
       if (badgeStack) thumb.appendChild(badgeStack);
       if (xref.transcriptSnippets.length > 0) {
@@ -4086,7 +4086,7 @@
 
       // Source + cross-reference badges (TR self-badge leads the stack)
       var xref = findOverlappingData(c.participant, c.start, c.end);
-      var trSelf = { svg: TR_BADGE_SVG, color: XREF_BADGE_COLOR.transcript, title: c.label || c.category || "Transcript" };
+      var trSelf = { icon: XREF_BADGES.transcript.icon, color: XREF_BADGES.transcript.color, title: c.label || c.category || "Transcript" };
       var badgeStack = buildXrefBadges(xref, "transcript", trSelf);
       if (badgeStack) thumb.appendChild(badgeStack);
 

--- a/assets/web/timeline-viewer.html
+++ b/assets/web/timeline-viewer.html
@@ -79,6 +79,7 @@
   </div>
 
   <!-- CLIPGEN_DATA_HERE -->
+  <script src="utils.js" defer></script>
   <script src="viewer.js" defer></script>
 </body>
 </html>

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -221,3 +221,12 @@ html[data-theme="dark"] {
 @media (prefers-reduced-motion: reduce) {
   .skeleton { animation: none; }
 }
+/* Cross-reference badge icon (mask-image from assets/icons/) */
+.xref-badge-icon {
+  display: block;
+  background-color: currentColor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -609,10 +609,9 @@ body {
   pointer-events: auto;
 }
 
-.segment-xref-badge svg {
+.segment-xref-badge .xref-badge-icon {
   width: 9px;
   height: 9px;
-  display: block;
 }
 
 .segment-text {

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -97,6 +97,7 @@
 
   <div id="toast" class="toast hidden"></div>
 
+  <script src="utils.js"></script>
   <script src="transcripts.js"></script>
 </body>
 </html>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -386,11 +386,11 @@
               var et = xref.screenspaceEvents[ei].event_type || xref.screenspaceEvents[ei].detector;
               if (!evSeen[et]) { evSeen[et] = true; evTypes.push(et); }
             }
-            html += '<span class="segment-xref-badge" style="background:' + XREF_BADGE_COLOR.screenspace + '" title="' + escapeHtml(evTypes.join(", ")) + '">' + SS_BADGE_SVG + '</span>';
+            html += '<span class="segment-xref-badge" style="background:' + XREF_BADGES.screenspace.color + '" title="' + escapeHtml(evTypes.join(", ")) + '"><span class="xref-badge-icon" style="mask-image:url(icons/' + XREF_BADGES.screenspace.icon + '.svg);-webkit-mask-image:url(icons/' + XREF_BADGES.screenspace.icon + '.svg)"></span></span>';
           }
           if (xref.sheetObservations.length > 0) {
             var obsTitle = xref.sheetObservations[0].observation;
-            html += '<span class="segment-xref-badge" style="background:' + XREF_BADGE_COLOR.sheet + '" title="' + escapeHtml(obsTitle) + '">' + SHEET_BADGE_SVG + '</span>';
+            html += '<span class="segment-xref-badge" style="background:' + XREF_BADGES.sheet.color + '" title="' + escapeHtml(obsTitle) + '"><span class="xref-badge-icon" style="mask-image:url(icons/' + XREF_BADGES.sheet.icon + '.svg);-webkit-mask-image:url(icons/' + XREF_BADGES.sheet.icon + '.svg)"></span></span>';
           }
           html += '</span>';
         }

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -5,34 +5,8 @@
   var POLL_INTERVAL = 3000;
   var SEARCH_DEBOUNCE = 300;
 
-  // Mark categories — mirrored from transcripts.py MARK_CATEGORIES
-  var MARK_CATEGORIES = {
-    pain_point: { label: "Pain Point", color: "#dc2626" },
-    delight:    { label: "Delight",    color: "#16a34a" },
-    quote:      { label: "Quote",      color: "#2563eb" },
-    insight:    { label: "Insight",    color: "#f97316" },
-    task:       { label: "Task Issue", color: "#8b5cf6" },
-    bookmark:   { label: "Bookmark",   color: "#0891b2" },
-  };
-
-  // Cross-reference badge SVGs and colors — mirrored from studio.js
-  var SS_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2C2.67157 2 2 2.67157 2 3.5V5.5C2 6.32843 2.67157 7 3.5 7H5.5C6.32843 7 7 6.32843 7 5.5V3.5C7 2.67157 6.32843 2 5.5 2H3.5Z"/><path d="M3.5 9C2.67157 9 2 9.67157 2 10.5V12.5C2 13.3284 2.67157 14 3.5 14H5.5C6.32843 14 7 13.3284 7 12.5V10.5C7 9.67157 6.32843 9 5.5 9H3.5Z"/><path d="M9 3.5C9 2.67157 9.67157 2 10.5 2H12.5C13.3284 2 14 2.67157 14 3.5V5.5C14 6.32843 13.3284 7 12.5 7H10.5C9.67157 7 9 6.32843 9 5.5V3.5Z"/><path d="M10.5 9C9.67157 9 9 9.67157 9 10.5V12.5C9 13.3284 9.67157 14 10.5 14H12.5C13.3284 14 14 13.3284 14 12.5V10.5C14 9.67157 13.3284 9 12.5 9H10.5Z"/></svg>';
-  var SHEET_BADGE_SVG = '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 11C15 12.1046 14.1046 13 13 13H3C1.89543 13 1 12.1046 1 11V5C1 3.89543 1.89543 3 3 3H13C14.1046 3 15 3.89543 15 5V11ZM7.25 7.5C7.25 7.22386 7.02614 7 6.75 7H3C2.72386 7 2.5 7.22386 2.5 7.5V8C2.5 8.27614 2.72386 8.5 3 8.5H6.75C7.02614 8.5 7.25 8.27614 7.25 8V7.5ZM8.75 10.5C8.75 10.2239 8.97386 10 9.25 10H13C13.2761 10 13.5 10.2239 13.5 10.5V11C13.5 11.2761 13.2761 11.5 13 11.5H9.25C8.97386 11.5 8.75 11.2761 8.75 11V10.5ZM13.5 8V7.5C13.5 7.22386 13.2761 7 13 7H9.25C8.97386 7 8.75 7.22386 8.75 7.5V8C8.75 8.27614 8.97386 8.5 9.25 8.5H13C13.2761 8.5 13.5 8.27614 13.5 8ZM6.75 11.5C7.02614 11.5 7.25 11.2761 7.25 11V10.5C7.25 10.2239 7.02614 10 6.75 10H3C2.72386 10 2.5 10.2239 2.5 10.5V11C2.5 11.2761 2.72386 11.5 3 11.5H6.75Z"/></svg>';
-
-  var XREF_BADGE_COLOR = {
-    screenspace: "rgba(52, 152, 219, 0.85)",
-    sheet: "rgba(234, 179, 8, 0.85)",
-  };
-
-  // ---- State ----
-
-  // Screenspace detector colors — mirrored from studio.js INTAKE_DETECTOR_COLORS
-  var SS_DETECTOR_COLORS = {
-    multitool: "#2563eb", color: "#8b5cf6", change: "#f97316",
-    similarity: "#0ea5e9", text: "#10b981", numbers: "#eab308",
-    timelapse: "#ec4899", template: "#f43f5e", flow: "#6366f1",
-    scene: "#14b8a6", inactivity: "#78716c",
-  };
+  var fmtTime = formatTime;
+  var SS_DETECTOR_COLORS = DETECTOR_COLORS;
 
   var state = {
     participants: [],
@@ -58,43 +32,6 @@
   };
 
   // ---- Helpers ----
-
-  function qs(sel) { return document.querySelector(sel); }
-
-  function apiGet(path) {
-    return fetch(path).then(function (r) { return r.json(); });
-  }
-
-  function apiPost(path, body) {
-    return fetch(path, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }).then(function (r) { return r.json(); });
-  }
-
-  function apiPut(path, body) {
-    return fetch(path, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }).then(function (r) { return r.json(); });
-  }
-
-  function apiDelete(path) {
-    return fetch(path, { method: "DELETE" }).then(function (r) { return r.json(); });
-  }
-
-  function fmtTime(seconds) {
-    var total = Math.floor(seconds);
-    var h = Math.floor(total / 3600);
-    var m = Math.floor((total % 3600) / 60);
-    var s = total % 60;
-    if (h > 0) return h + ":" + pad2(m) + ":" + pad2(s);
-    return m + ":" + pad2(s);
-  }
-
-  function pad2(n) { return n < 10 ? "0" + n : "" + n; }
 
   function escapeHtml(str) {
     var div = document.createElement("div");

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -1,0 +1,144 @@
+/* clipgen shared utilities – utils.js
+ *
+ * Common helpers extracted from individual page scripts.
+ * Loaded before the page-specific JS in both Flask-served and
+ * inlined/exported viewers.
+ *
+ * All declarations are global vars (no IIFE) so page scripts
+ * running inside their own IIFEs can access them via scope chain.
+ */
+
+// ---- DOM helpers ----
+
+var qs = function (sel) { return document.querySelector(sel); };
+var qsa = function (sel) { return document.querySelectorAll(sel); };
+
+var el = function (tag, cls, text) {
+  var e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text !== undefined) e.textContent = text;
+  return e;
+};
+
+// ---- Formatting ----
+
+var pad2 = function (n) { return n < 10 ? "0" + n : "" + n; };
+
+var formatTime = function (sec) {
+  if (sec == null || isNaN(sec)) return "--:--";
+  var total = Math.floor(sec);
+  var h = Math.floor(total / 3600);
+  var m = Math.floor((total % 3600) / 60);
+  var s = total % 60;
+  if (h > 0) return h + ":" + pad2(m) + ":" + pad2(s);
+  return m + ":" + pad2(s);
+};
+
+var truncate = function (str, max) {
+  if (!str) return "";
+  return str.length > max ? str.slice(0, max) + "\u2026" : str;
+};
+
+// ---- Severity ----
+
+var severityClass = function (raw) {
+  if (!raw || !String(raw).trim()) return "";
+  var k = String(raw).trim().toLowerCase();
+  var map = {
+    critical: "sev-critical",
+    high: "sev-high",
+    medium: "sev-medium",
+    low: "sev-low",
+    "n/a": "sev-na",
+    positive: "sev-positive",
+    "very positive": "sev-very-positive",
+  };
+  return map[k] || "sev-unknown";
+};
+
+// ---- API helpers (always check r.ok) ----
+
+var apiGet = function (path) {
+  return fetch(path).then(function (r) {
+    if (!r.ok) throw new Error("Server error " + r.status);
+    return r.json();
+  });
+};
+
+var apiPost = function (path, body) {
+  return fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).then(function (r) {
+    if (!r.ok) throw new Error("Server error " + r.status);
+    return r.json();
+  });
+};
+
+var apiPut = function (path, body) {
+  return fetch(path, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).then(function (r) {
+    if (!r.ok) throw new Error("Server error " + r.status);
+    return r.json();
+  });
+};
+
+var apiDelete = function (path) {
+  return fetch(path, { method: "DELETE" }).then(function (r) {
+    if (!r.ok) throw new Error("Server error " + r.status);
+    return r.json();
+  });
+};
+
+// ---- Mark categories (mirrored from transcripts.py MARK_CATEGORIES) ----
+// Kept in sync by tests/test_shared_constants.py — update both together.
+
+var MARK_CATEGORIES = {
+  pain_point: { label: "Pain Point", color: "#dc2626" },
+  delight:    { label: "Delight",    color: "#16a34a" },
+  quote:      { label: "Quote",      color: "#2563eb" },
+  insight:    { label: "Insight",    color: "#f97316" },
+  task:       { label: "Task Issue", color: "#8b5cf6" },
+  bookmark:   { label: "Bookmark",   color: "#0891b2" },
+};
+
+// ---- Cross-reference badge metadata ----
+// Icon names reference files in assets/icons/; rendered via CSS mask-image.
+
+var XREF_BADGES = {
+  screenspace: { icon: "squares-2x2", color: "rgba(52, 152, 219, 0.85)" },
+  transcript:  { icon: "chat-bubble-bottom-center-text", color: "rgba(16, 163, 74, 0.85)" },
+  sheet:       { icon: "table-cells", color: "rgba(234, 179, 8, 0.85)" },
+};
+
+// ---- Detector colors ----
+// Read from CSS custom properties (tokens.css) with hardcoded fallback
+// for exported viewers that may lack tokens.css at parse time.
+
+var DETECTOR_COLORS = (function () {
+  var types = [
+    "multitool", "color", "change", "similarity", "text",
+    "numbers", "timelapse", "template", "flow", "scene", "inactivity",
+  ];
+  var fallback = {
+    multitool: "#2563eb", color: "#8b5cf6", change: "#f97316",
+    similarity: "#0ea5e9", text: "#10b981", numbers: "#eab308",
+    timelapse: "#ec4899", template: "#f43f5e", flow: "#6366f1",
+    scene: "#14b8a6", inactivity: "#78716c",
+  };
+  try {
+    var style = getComputedStyle(document.documentElement);
+    var map = {};
+    types.forEach(function (t) {
+      var val = style.getPropertyValue("--color-task-" + t).trim();
+      map[t] = val || fallback[t] || "#888";
+    });
+    return map;
+  } catch (_) {
+    return fallback;
+  }
+})();

--- a/assets/web/viewer.html
+++ b/assets/web/viewer.html
@@ -123,6 +123,7 @@
   </div>
 
   <!-- CLIPGEN_DATA_HERE -->
+  <script src="utils.js" defer></script>
   <script src="viewer.js" defer></script>
 </body>
 </html>

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -44,21 +44,7 @@
 
   // ---- Helpers ----
 
-  function formatTime(sec) {
-    if (sec == null || isNaN(sec)) return "--:--";
-    sec = Math.round(sec);
-    var h = Math.floor(sec / 3600);
-    var m = Math.floor((sec % 3600) / 60);
-    var s = sec % 60;
-    if (h > 0) {
-      return h + ":" + pad2(m) + ":" + pad2(s);
-    }
-    return m + ":" + pad2(s);
-  }
-
-  function pad2(n) {
-    return n < 10 ? "0" + n : "" + n;
-  }
+  var severityClassForLabel = severityClass;
 
   var SEVERITY_SORT = {
     "sev-critical": -4,
@@ -70,21 +56,6 @@
     "sev-very-positive": 2,
     "sev-unknown": 998,
   };
-
-  function severityClassForLabel(raw) {
-    if (!raw || !String(raw).trim()) return "";
-    var k = String(raw).trim().toLowerCase();
-    var map = {
-      critical: "sev-critical",
-      high: "sev-high",
-      medium: "sev-medium",
-      low: "sev-low",
-      "n/a": "sev-na",
-      positive: "sev-positive",
-      "very positive": "sev-very-positive",
-    };
-    return map[k] || "sev-unknown";
-  }
 
   function markerTypeClass(type) {
     var t = type || "clip";
@@ -133,21 +104,6 @@
     pillEl.classList.remove("hidden");
     pillEl.textContent = sev;
     pillEl.className = "detail-badge detail-severity " + severityClassForLabel(sev);
-  }
-
-  function qs(sel) {
-    return document.querySelector(sel);
-  }
-
-  function qsa(sel) {
-    return document.querySelectorAll(sel);
-  }
-
-  function el(tag, cls, text) {
-    var e = document.createElement(tag);
-    if (cls) e.className = cls;
-    if (text !== undefined) e.textContent = text;
-    return e;
   }
 
   // ---- Clip thumbnails ----
@@ -2020,15 +1976,7 @@
 
   // ---- Screenspace track ----
 
-  var SS_DETECTOR_COLORS = (function () {
-    var types = ["multitool", "color", "change", "similarity", "text", "numbers", "template", "flow", "scene", "inactivity"];
-    var style = getComputedStyle(document.documentElement);
-    var map = {};
-    types.forEach(function (t) {
-      map[t] = style.getPropertyValue("--color-task-" + t).trim() || "#888";
-    });
-    return map;
-  })();
+  var SS_DETECTOR_COLORS = DETECTOR_COLORS;
 
   var SS_DETECTOR_ICON_PATHS = {
     multitool: { viewBox: "0 0 16 16", paths: [

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -1,0 +1,41 @@
+"""Verify that JS constants in utils.js stay in sync with their Python sources."""
+
+import json
+import re
+from pathlib import Path
+
+import transcripts
+
+
+def _parse_js_mark_categories() -> dict:
+    """Extract MARK_CATEGORIES from assets/web/utils.js as a Python dict."""
+    js_path = Path(__file__).resolve().parent.parent / "assets" / "web" / "utils.js"
+    text = js_path.read_text(encoding="utf-8")
+    # Grab the object literal assigned to MARK_CATEGORIES
+    match = re.search(
+        r"var\s+MARK_CATEGORIES\s*=\s*\{(.+?)\};",
+        text,
+        re.DOTALL,
+    )
+    assert match, "MARK_CATEGORIES not found in utils.js"
+    raw = "{" + match.group(1) + "}"
+    # Convert JS object to valid JSON: unquoted keys → quoted keys
+    raw = re.sub(r"(\w+)\s*:", r'"\1":', raw)
+    # Remove trailing commas
+    raw = re.sub(r",\s*([}\]])", r"\1", raw)
+    return json.loads(raw)
+
+
+def test_mark_categories_match_python():
+    js_cats = _parse_js_mark_categories()
+    py_cats = transcripts.MARK_CATEGORIES
+    assert set(js_cats.keys()) == set(py_cats.keys()), (
+        f"Key mismatch: JS={sorted(js_cats)} vs Python={sorted(py_cats)}"
+    )
+    for key in py_cats:
+        assert js_cats[key]["label"] == py_cats[key]["label"], (
+            f"MARK_CATEGORIES[{key!r}].label differs"
+        )
+        assert js_cats[key]["color"] == py_cats[key]["color"], (
+            f"MARK_CATEGORIES[{key!r}].color differs"
+        )

--- a/tests/test_viewer_inline.py
+++ b/tests/test_viewer_inline.py
@@ -21,6 +21,7 @@ def test_generate_timeline_viewer_inlines_css_and_js(tmp_path, monkeypatch):
     # The output should inline CSS/JS instead of linking external files.
     assert '<link rel="stylesheet" href="viewer.css">' not in html
     assert '<script src="viewer.js" defer></script>' not in html
+    assert '<script src="utils.js" defer></script>' not in html
 
     # Expect a style block that contains a recognizable piece of the source CSS.
     assert "<style>" in html
@@ -32,3 +33,6 @@ def test_generate_timeline_viewer_inlines_css_and_js(tmp_path, monkeypatch):
         "clipgen Timeline Viewer \u2013 viewer.js" in html
         or "window.CLIPGEN_DATA" in html
     )
+
+    # Shared utilities from utils.js should be inlined into the script block.
+    assert "clipgen shared utilities" in html or "var severityClass" in html

--- a/viewer.py
+++ b/viewer.py
@@ -260,6 +260,14 @@ def _generate_viewer_html(
         except OSError:
             pass
 
+    # Prepend shared utilities so standalone viewers have them
+    utils_js_path = assets_dir / "utils.js"
+    if utils_js_path.is_file():
+        try:
+            js_text = utils_js_path.read_text(encoding="utf-8") + "\n" + js_text
+        except OSError:
+            pass
+
     # Inline CSS
     css_link_tag = f'<link rel="stylesheet" href="{css_name}">'
     inline_css_block = f"<style>\n{css_text}\n</style>"
@@ -267,6 +275,10 @@ def _generate_viewer_html(
         template_html = template_html.replace(css_link_tag, inline_css_block)
     elif "</head>" in template_html:
         template_html = template_html.replace("</head>", f"{inline_css_block}\n</head>")
+
+    # Remove utils.js script tag (content already prepended to main JS)
+    utils_js_tag = '<script src="utils.js" defer></script>\n  '
+    template_html = template_html.replace(utils_js_tag, "")
 
     # Inline JS
     js_script_tag = f'<script src="{js_name}" defer></script>'


### PR DESCRIPTION
## Summary

- Extract duplicated utility functions (`qs`, `qsa`, `el`, `formatTime`, `severityClass`, `apiGet/Post/Put/Delete`, etc.) and shared constants (`MARK_CATEGORIES`, `DETECTOR_COLORS`, `XREF_BADGES`) from 7 page scripts into a new `assets/web/utils.js`, loaded before each page's main script
- Replace inline badge SVG strings with CSS `mask-image` references to existing icon files in `assets/icons/`, eliminating ~50 lines of duplicated SVG path data
- Fix missing `!r.ok` error checks in transcripts.js API helpers (now use the shared implementation that always throws on failure)
- Add CI drift test (`test_shared_constants.py`) to catch `MARK_CATEGORIES` going out of sync between Python and JS
- Update `viewer.py` to inline `utils.js` into exported standalone HTML viewers

Net result: **-339 lines removed, +246 added** across 24 files (net −93 lines).

## Test plan
- [x] All 465 existing tests pass
- [ ] Manual: open Studio, Screenspace, Transcripts, Insights Builder — verify no JS console errors
- [ ] Manual: verify xref badges render correctly in Studio and Transcripts views
- [ ] Manual: generate a timeline viewer export and confirm standalone HTML works