### PR TITLE
refactor: narrow exceptions and break up god functions (quality plan 5-6)

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2603,6 +2603,353 @@
     }
   }
 
+  function renderColorParams(container) {
+    var pickerGroup = el("div", "color-picker-group");
+
+    var palette = document.createElement("canvas");
+    palette.id = "colorPalette";
+    palette.className = "color-palette-canvas";
+    pickerGroup.appendChild(palette);
+
+    var bright = document.createElement("canvas");
+    bright.id = "colorBrightness";
+    bright.className = "color-brightness-strip";
+    pickerGroup.appendChild(bright);
+
+    var inputRow = el("div", "color-input-row");
+    var preview = el("div", "color-preview");
+    preview.id = "colorPreview";
+    inputRow.appendChild(preview);
+
+    var hexInput = document.createElement("input");
+    hexInput.type = "text";
+    hexInput.autocomplete = "off";
+    hexInput.id = "paramColorHex";
+    hexInput.className = "color-hex-input";
+    hexInput.placeholder = "#000000";
+    hexInput.maxLength = 7;
+    inputRow.appendChild(hexInput);
+
+    var pipetteBtn = el("button", "btn btn-small btn-pipette");
+    pipetteBtn.id = "pipetteBtn";
+    pipetteBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 4C15 5.39788 14.0439 6.57245 12.75 6.90549V8.5C12.75 8.69891 12.671 8.88968 12.5303 9.03033L12.0303 9.53033C11.7374 9.82322 11.2626 9.82322 10.9697 9.53033L10.25 8.81069L5.57322 13.4875C5.24503 13.8157 4.79992 14.0001 4.33579 14.0001H3.66421C3.59791 14.0001 3.53432 14.0264 3.48744 14.0733L2.78033 14.7804C2.63968 14.921 2.44891 15.0001 2.25 15.0001C2.05109 15.0001 1.86032 14.921 1.71967 14.7804L1.21967 14.2804C0.926777 13.9875 0.926777 13.5126 1.21967 13.2197L1.92678 12.5126C1.97366 12.4657 2 12.4021 2 12.3358V11.6643C2 11.2001 2.18437 10.755 2.51256 10.4268L7.18937 5.75003L6.46967 5.03033C6.17678 4.73744 6.17678 4.26256 6.46967 3.96967L6.96967 3.46967C7.11032 3.32902 7.30109 3.25 7.5 3.25H9.09451C9.42755 1.95608 10.6021 1 12 1C13.6569 1 15 2.34315 15 4ZM9.18937 7.75003L8.25003 6.81069L3.57322 11.4875C3.52634 11.5344 3.5 11.598 3.5 11.6643V12.3358C3.5 12.3938 3.49713 12.4514 3.49146 12.5086C3.54862 12.5029 3.60627 12.5001 3.66421 12.5001H4.33579C4.40209 12.5001 4.46568 12.4737 4.51256 12.4268L9.18937 7.75003Z"/></svg>';
+    pipetteBtn.title = "Pick color from video frame";
+    pipetteBtn.addEventListener("click", function () {
+      if (state.pipetteActive) deactivatePipette();
+      else activatePipette();
+    });
+    inputRow.appendChild(pipetteBtn);
+
+    var sampleBtn = el("button", "btn btn-small", "From Region");
+    sampleBtn.addEventListener("click", sampleColorFromRegion);
+    inputRow.appendChild(sampleBtn);
+
+    pickerGroup.appendChild(inputRow);
+
+    var hiddenH = document.createElement("input");
+    hiddenH.type = "hidden"; hiddenH.id = "paramColorH"; hiddenH.value = "90";
+    var hiddenS = document.createElement("input");
+    hiddenS.type = "hidden"; hiddenS.id = "paramColorS"; hiddenS.value = "200";
+    var hiddenV = document.createElement("input");
+    hiddenV.type = "hidden"; hiddenV.id = "paramColorV"; hiddenV.value = "200";
+    pickerGroup.appendChild(hiddenH);
+    pickerGroup.appendChild(hiddenS);
+    pickerGroup.appendChild(hiddenV);
+
+    container.appendChild(pickerGroup);
+
+    var paletteDragging = false;
+    var brightDragging = false;
+    function pickFromPalette(e) {
+      var rect = palette.getBoundingClientRect();
+      var x = clamp(e.clientX - rect.left, 0, rect.width);
+      var y = clamp(e.clientY - rect.top, 0, rect.height);
+      var h = Math.round((x / rect.width) * 180);
+      var s = Math.round((1 - y / rect.height) * 255);
+      var curV = parseFloat(qs("#paramColorV").value) || 0;
+      setTargetColor(h, s, curV);
+    }
+    palette.addEventListener("mousedown", function (e) {
+      e.preventDefault();
+      paletteDragging = true;
+      pickFromPalette(e);
+    });
+
+    function pickFromBrightness(e) {
+      var rect = bright.getBoundingClientRect();
+      var x = clamp(e.clientX - rect.left, 0, rect.width);
+      var v = Math.round((x / rect.width) * 255);
+      var curH = parseFloat(qs("#paramColorH").value) || 0;
+      var curS = parseFloat(qs("#paramColorS").value) || 0;
+      setTargetColor(curH, curS, v);
+    }
+    bright.addEventListener("mousedown", function (e) {
+      e.preventDefault();
+      brightDragging = true;
+      pickFromBrightness(e);
+    });
+
+    if (_paletteDocListeners) {
+      document.removeEventListener("mousemove", _paletteDocListeners.move);
+      document.removeEventListener("mouseup", _paletteDocListeners.up);
+    }
+    function onDocMove(e) {
+      if (paletteDragging) pickFromPalette(e);
+      if (brightDragging) pickFromBrightness(e);
+    }
+    function onDocUp() { paletteDragging = false; brightDragging = false; }
+    document.addEventListener("mousemove", onDocMove);
+    document.addEventListener("mouseup", onDocUp);
+    _paletteDocListeners = { move: onDocMove, up: onDocUp };
+
+    hexInput.addEventListener("input", function () {
+      var rgb = hexToRgb(hexInput.value);
+      if (rgb) {
+        var hsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
+        var hEl = qs("#paramColorH"), sEl = qs("#paramColorS"), vEl = qs("#paramColorV");
+        if (hEl) hEl.value = hsv.h;
+        if (sEl) sEl.value = hsv.s;
+        if (vEl) vEl.value = hsv.v;
+        updateColorPreview();
+        renderColorPalette();
+        renderBrightnessStrip();
+      }
+    });
+
+    var tolSlider = rangeInput("paramColorTol", 0, 100, 30);
+    addParamRow(container, "Tolerance", tolSlider, "paramColorTolVal");
+    tolSlider.addEventListener("input", function () {
+      renderColorPalette();
+    });
+    renderIntervalSlot("paramColorInterval", 0.5, 60, 1.0, 0.5);
+
+    renderColorPalette();
+    renderBrightnessStrip();
+    updateColorPreview();
+    var initRgb = hsvToRgb(90, 200, 200);
+    hexInput.value = rgbToHex(initRgb.r, initRgb.g, initRgb.b);
+  }
+
+  function renderSimilarityParams(container) {
+    var refRow = el("div", "param-row");
+    var refLabel = el("span", "param-label", "Reference");
+    var refControl = el("div", "param-control");
+    var refBtn = el("button", "btn btn-small", "Capture Current Frame");
+    refBtn.addEventListener("click", function () {
+      state.referenceTimestamp = state.currentTimestamp;
+      renderWorkflowParams();
+      showToast("Reference frame captured at " + formatTimestamp(state.currentTimestamp));
+    });
+    refControl.appendChild(refBtn);
+    if (state.referenceTimestamp !== null) {
+      var refTs = el("span", "param-value", formatTimestamp(state.referenceTimestamp));
+      refControl.appendChild(refTs);
+    }
+    refRow.appendChild(refLabel);
+    refRow.appendChild(refControl);
+    container.appendChild(refRow);
+    addParamRow(container, "Threshold", rangeInput("paramSimThresh", 0.50, 1.00, 0.90, 0.01), "paramSimThreshVal");
+    renderIntervalSlot("paramSimInterval", 0.5, 60, 1.0, 0.5);
+  }
+
+  function renderTextParams(container) {
+    addParamRow(container, "Search text", textInput("paramTextSearch", "Enter text to find..."));
+    addParamRow(container, "Fuzzy Thr.", rangeInput("paramTextFuzzy", 0.50, 1.00, 0.80, 0.01), "paramTextFuzzyVal");
+    renderIntervalSlot("paramTextInterval", 0.5, 60, 2.0, 0.5);
+    var langRow = el("div", "param-row");
+    langRow.appendChild(el("span", "param-label", "Language"));
+    var langControl = el("div", "param-control");
+    var langSel = document.createElement("select");
+    langSel.id = "paramTextLang";
+    [["en", "English"], ["es", "Spanish"], ["fr", "French"], ["de", "German"],
+     ["ja", "Japanese"], ["ko", "Korean"], ["zh", "Chinese"]].forEach(function (pair) {
+      var opt = el("option", null, pair[1]);
+      opt.value = pair[0];
+      langSel.appendChild(opt);
+    });
+    langControl.appendChild(langSel);
+    langRow.appendChild(langControl);
+    container.appendChild(langRow);
+  }
+
+  function renderNumbersParams(container) {
+    var opRow = el("div", "param-row");
+    opRow.appendChild(el("span", "param-label", "Operator"));
+    var opControl = el("div", "param-control");
+    var opSel = document.createElement("select");
+    opSel.id = "paramNumOperator";
+    [["gt", "Greater than (>)"], ["lt", "Less than (<)"], ["eq", "Equal to (=)"],
+     ["gte", "Greater or equal (\u2265)"], ["lte", "Less or equal (\u2264)"], ["range", "In range"]].forEach(function (pair) {
+      var opt = el("option", null, pair[1]);
+      opt.value = pair[0];
+      opSel.appendChild(opt);
+    });
+    opSel.addEventListener("change", function () {
+      var rangeRow = qs("#paramNumRangeRow");
+      var targetRow = qs("#paramNumTargetRow");
+      if (opSel.value === "range") {
+        if (rangeRow) rangeRow.style.display = "";
+        if (targetRow) targetRow.style.display = "none";
+      } else {
+        if (rangeRow) rangeRow.style.display = "none";
+        if (targetRow) targetRow.style.display = "";
+      }
+    });
+    opControl.appendChild(opSel);
+    opRow.appendChild(opControl);
+    container.appendChild(opRow);
+    var targetRow = el("div", "param-row");
+    targetRow.id = "paramNumTargetRow";
+    targetRow.appendChild(el("span", "param-label", "Target value"));
+    var targetCtrl = el("div", "param-control");
+    targetCtrl.appendChild(numberInput("paramNumTarget", -999999, 999999, 100, 1));
+    targetRow.appendChild(targetCtrl);
+    container.appendChild(targetRow);
+    var numRangeRow = el("div", "param-row");
+    numRangeRow.id = "paramNumRangeRow";
+    numRangeRow.style.display = "none";
+    numRangeRow.appendChild(el("span", "param-label", "Range"));
+    var rangeCtrl = el("div", "param-control");
+    rangeCtrl.appendChild(numberInput("paramNumMin", -999999, 999999, 0, 1));
+    rangeCtrl.appendChild(el("span", "param-value", "\u2013"));
+    rangeCtrl.appendChild(numberInput("paramNumMax", -999999, 999999, 100, 1));
+    numRangeRow.appendChild(rangeCtrl);
+    container.appendChild(numRangeRow);
+    renderIntervalSlot("paramNumInterval", 0.5, 60, 2.0, 0.5);
+  }
+
+  function renderTimelapseParams(container) {
+    addParamRow(container, "Speed", numberInput("paramTlSpeed", 2, 100, 10, 1));
+    addParamRow(container, "Sample every", numberInput("paramTlSampleInterval", 0, 60, 0, 0.5), "paramTlSampleIntervalVal");
+    var siHint = el("span", "param-hint", "seconds (0 = every frame)");
+    container.lastChild.querySelector(".param-control").appendChild(siHint);
+    var fmtRow = el("div", "param-row");
+    fmtRow.appendChild(el("span", "param-label", "Format"));
+    var fmtControl = el("div", "param-control");
+    var fmtSel = document.createElement("select");
+    fmtSel.id = "paramTlFormat";
+    [["mp4", "Video (.mp4)"], ["gif", "GIF (.gif)"]].forEach(function (pair) {
+      var opt = el("option", null, pair[1]);
+      opt.value = pair[0];
+      fmtSel.appendChild(opt);
+    });
+    fmtControl.appendChild(fmtSel);
+    fmtRow.appendChild(fmtControl);
+    container.appendChild(fmtRow);
+  }
+
+  function renderTemplateParams(container) {
+    var tmplRefRow = el("div", "param-row");
+    tmplRefRow.appendChild(el("span", "param-label", "Template"));
+    var tmplRefCtrl = el("div", "param-control");
+    var tmplCapBtn = el("button", "btn btn-small", "Capture Region");
+    tmplCapBtn.addEventListener("click", function () {
+      state.referenceTimestamp = state.currentTimestamp;
+      state.uploadedTemplate = null;
+      renderWorkflowParams();
+      showToast("Template captured at " + formatTimestamp(state.currentTimestamp));
+    });
+    tmplRefCtrl.appendChild(tmplCapBtn);
+
+    var tmplFileInput = document.createElement("input");
+    tmplFileInput.type = "file";
+    tmplFileInput.accept = "image/png";
+    tmplFileInput.style.display = "none";
+    tmplFileInput.addEventListener("change", function () {
+      var file = tmplFileInput.files[0];
+      if (!file) return;
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        var dataUrl = e.target.result;
+        var b64 = dataUrl.split(",")[1];
+        state.uploadedTemplate = { name: file.name, data: b64 };
+        state.referenceTimestamp = null;
+        renderWorkflowParams();
+        showToast("Template loaded: " + file.name);
+      };
+      reader.readAsDataURL(file);
+    });
+    var tmplUploadBtn = el("button", "btn btn-small", "Upload PNG");
+    tmplUploadBtn.addEventListener("click", function () { tmplFileInput.click(); });
+    tmplRefCtrl.appendChild(tmplUploadBtn);
+    tmplRefCtrl.appendChild(tmplFileInput);
+
+    if (state.uploadedTemplate) {
+      var uploadInfo = el("span", "param-value template-upload-info");
+      var uploadThumb = document.createElement("img");
+      uploadThumb.src = "data:image/png;base64," + state.uploadedTemplate.data;
+      uploadThumb.alt = state.uploadedTemplate.name;
+      uploadInfo.appendChild(uploadThumb);
+      uploadInfo.appendChild(document.createTextNode(state.uploadedTemplate.name));
+      var clearBtn = el("button", "btn btn-small", "\u00d7");
+      clearBtn.addEventListener("click", function () {
+        state.uploadedTemplate = null;
+        renderWorkflowParams();
+      });
+      uploadInfo.appendChild(clearBtn);
+      tmplRefCtrl.appendChild(uploadInfo);
+    } else if (state.referenceTimestamp !== null) {
+      tmplRefCtrl.appendChild(el("span", "param-value", formatTimestamp(state.referenceTimestamp)));
+    }
+    tmplRefRow.appendChild(tmplRefCtrl);
+    container.appendChild(tmplRefRow);
+    addParamRow(container, "Threshold", rangeInput("paramTemplateThresh", 0.50, 1.00, 0.70, 0.01), "paramTemplateThreshVal");
+    renderIntervalSlot("paramTemplateInterval", 0.5, 60, 1.0, 0.5);
+  }
+
+  function renderSceneParams(container) {
+    var sceneList = el("div", "scene-reference-list");
+    sceneList.id = "sceneRefList";
+    state.sceneReferences.forEach(function (ref, i) {
+      if (ref.threshold === undefined) ref.threshold = 0.75;
+      var item = el("div", "scene-ref-item");
+      item.appendChild(el("span", "scene-ref-name", ref.name));
+      item.appendChild(el("span", "param-value", formatTimestamp(ref.timestamp)));
+      var threshSlider = document.createElement("input");
+      threshSlider.type = "range";
+      threshSlider.min = "0.50";
+      threshSlider.max = "1.00";
+      threshSlider.step = "0.01";
+      threshSlider.value = String(ref.threshold);
+      threshSlider.className = "scene-ref-thresh";
+      var threshVal = el("span", "param-value", String(ref.threshold));
+      threshSlider.addEventListener("input", (function (idx) {
+        return function () {
+          state.sceneReferences[idx].threshold = parseFloat(threshSlider.value);
+          threshVal.textContent = threshSlider.value;
+        };
+      })(i));
+      item.appendChild(threshSlider);
+      item.appendChild(threshVal);
+      var rmBtn = el("button", "btn btn-small", "\u00d7");
+      rmBtn.addEventListener("click", function () {
+        state.sceneReferences.splice(i, 1);
+        renderWorkflowParams();
+      });
+      item.appendChild(rmBtn);
+      sceneList.appendChild(item);
+    });
+    container.appendChild(sceneList);
+    var addScRow = el("div", "param-row");
+    addScRow.appendChild(el("span", "param-label", "Add Scene"));
+    var addScCtrl = el("div", "param-control");
+    var scNameInp = textInput("paramSceneName", "e.g. menu, gameplay");
+    addScCtrl.appendChild(scNameInp);
+    var scCapBtn = el("button", "btn btn-small", "Capture");
+    scCapBtn.addEventListener("click", function () {
+      var nameEl = qs("#paramSceneName");
+      var name = nameEl ? nameEl.value.trim() : "";
+      if (!name) { showToast("Enter a scene name"); return; }
+      state.sceneReferences.push({ name: name, timestamp: state.currentTimestamp, threshold: 0.75 });
+      renderWorkflowParams();
+      showToast("Scene '" + name + "' at " + formatTimestamp(state.currentTimestamp));
+    });
+    addScCtrl.appendChild(scCapBtn);
+    addScRow.appendChild(addScCtrl);
+    container.appendChild(addScRow);
+    renderIntervalSlot("paramSceneInterval", 0.5, 60, 1.0, 0.5);
+  }
+
   function renderWorkflowParams() {
     var container = qs("#workflowParams");
     container.innerHTML = "";
@@ -2612,7 +2959,6 @@
     if (intervalSlot) intervalSlot.innerHTML = "";
     var type = state.activeWorkflow;
 
-    // Hide global region picker for multitool (per-step regions instead)
     var regionPickerWrap = qs("#runRegionPicker");
     if (regionPickerWrap) regionPickerWrap.style.display = type === "multitool" ? "none" : "";
 
@@ -2627,365 +2973,23 @@
       return;
     }
 
-    if (type === "color") {
-      // Color picker group: palette + brightness + hex/pipette
-      var pickerGroup = el("div", "color-picker-group");
-
-      // Hue-Saturation palette canvas
-      var palette = document.createElement("canvas");
-      palette.id = "colorPalette";
-      palette.className = "color-palette-canvas";
-      pickerGroup.appendChild(palette);
-
-      // Brightness strip
-      var bright = document.createElement("canvas");
-      bright.id = "colorBrightness";
-      bright.className = "color-brightness-strip";
-      pickerGroup.appendChild(bright);
-
-      // Color input row: preview swatch + hex input + pipette button
-      var inputRow = el("div", "color-input-row");
-      var preview = el("div", "color-preview");
-      preview.id = "colorPreview";
-      inputRow.appendChild(preview);
-
-      var hexInput = document.createElement("input");
-      hexInput.type = "text";
-      hexInput.autocomplete = "off";
-      hexInput.id = "paramColorHex";
-      hexInput.className = "color-hex-input";
-      hexInput.placeholder = "#000000";
-      hexInput.maxLength = 7;
-      inputRow.appendChild(hexInput);
-
-      var pipetteBtn = el("button", "btn btn-small btn-pipette");
-      pipetteBtn.id = "pipetteBtn";
-      pipetteBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 4C15 5.39788 14.0439 6.57245 12.75 6.90549V8.5C12.75 8.69891 12.671 8.88968 12.5303 9.03033L12.0303 9.53033C11.7374 9.82322 11.2626 9.82322 10.9697 9.53033L10.25 8.81069L5.57322 13.4875C5.24503 13.8157 4.79992 14.0001 4.33579 14.0001H3.66421C3.59791 14.0001 3.53432 14.0264 3.48744 14.0733L2.78033 14.7804C2.63968 14.921 2.44891 15.0001 2.25 15.0001C2.05109 15.0001 1.86032 14.921 1.71967 14.7804L1.21967 14.2804C0.926777 13.9875 0.926777 13.5126 1.21967 13.2197L1.92678 12.5126C1.97366 12.4657 2 12.4021 2 12.3358V11.6643C2 11.2001 2.18437 10.755 2.51256 10.4268L7.18937 5.75003L6.46967 5.03033C6.17678 4.73744 6.17678 4.26256 6.46967 3.96967L6.96967 3.46967C7.11032 3.32902 7.30109 3.25 7.5 3.25H9.09451C9.42755 1.95608 10.6021 1 12 1C13.6569 1 15 2.34315 15 4ZM9.18937 7.75003L8.25003 6.81069L3.57322 11.4875C3.52634 11.5344 3.5 11.598 3.5 11.6643V12.3358C3.5 12.3938 3.49713 12.4514 3.49146 12.5086C3.54862 12.5029 3.60627 12.5001 3.66421 12.5001H4.33579C4.40209 12.5001 4.46568 12.4737 4.51256 12.4268L9.18937 7.75003Z"/></svg>';
-      pipetteBtn.title = "Pick color from video frame";
-      pipetteBtn.addEventListener("click", function () {
-        if (state.pipetteActive) deactivatePipette();
-        else activatePipette();
-      });
-      inputRow.appendChild(pipetteBtn);
-
-      var sampleBtn = el("button", "btn btn-small", "From Region");
-      sampleBtn.addEventListener("click", sampleColorFromRegion);
-      inputRow.appendChild(sampleBtn);
-
-      pickerGroup.appendChild(inputRow);
-
-      // Hidden inputs for gatherWorkflowParams() contract
-      var hiddenH = document.createElement("input");
-      hiddenH.type = "hidden"; hiddenH.id = "paramColorH"; hiddenH.value = "90";
-      var hiddenS = document.createElement("input");
-      hiddenS.type = "hidden"; hiddenS.id = "paramColorS"; hiddenS.value = "200";
-      var hiddenV = document.createElement("input");
-      hiddenV.type = "hidden"; hiddenV.id = "paramColorV"; hiddenV.value = "200";
-      pickerGroup.appendChild(hiddenH);
-      pickerGroup.appendChild(hiddenS);
-      pickerGroup.appendChild(hiddenV);
-
-      container.appendChild(pickerGroup);
-
-      // Palette canvas events
-      var paletteDragging = false;
-      var brightDragging = false;
-      function pickFromPalette(e) {
-        var rect = palette.getBoundingClientRect();
-        var x = clamp(e.clientX - rect.left, 0, rect.width);
-        var y = clamp(e.clientY - rect.top, 0, rect.height);
-        var h = Math.round((x / rect.width) * 180);
-        var s = Math.round((1 - y / rect.height) * 255);
-        var curV = parseFloat(qs("#paramColorV").value) || 0;
-        setTargetColor(h, s, curV);
-      }
-      palette.addEventListener("mousedown", function (e) {
-        e.preventDefault();
-        paletteDragging = true;
-        pickFromPalette(e);
-      });
-
-      // Brightness strip events
-      function pickFromBrightness(e) {
-        var rect = bright.getBoundingClientRect();
-        var x = clamp(e.clientX - rect.left, 0, rect.width);
-        var v = Math.round((x / rect.width) * 255);
-        var curH = parseFloat(qs("#paramColorH").value) || 0;
-        var curS = parseFloat(qs("#paramColorS").value) || 0;
-        setTargetColor(curH, curS, v);
-      }
-      bright.addEventListener("mousedown", function (e) {
-        e.preventDefault();
-        brightDragging = true;
-        pickFromBrightness(e);
-      });
-
-      // Remove previous document-level listeners before adding new ones
-      if (_paletteDocListeners) {
-        document.removeEventListener("mousemove", _paletteDocListeners.move);
-        document.removeEventListener("mouseup", _paletteDocListeners.up);
-      }
-      function onDocMove(e) {
-        if (paletteDragging) pickFromPalette(e);
-        if (brightDragging) pickFromBrightness(e);
-      }
-      function onDocUp() { paletteDragging = false; brightDragging = false; }
-      document.addEventListener("mousemove", onDocMove);
-      document.addEventListener("mouseup", onDocUp);
-      _paletteDocListeners = { move: onDocMove, up: onDocUp };
-
-      // Hex input event
-      hexInput.addEventListener("input", function () {
-        var rgb = hexToRgb(hexInput.value);
-        if (rgb) {
-          var hsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
-          // Update hidden inputs and visuals without re-setting the hex field
-          var hEl = qs("#paramColorH"), sEl = qs("#paramColorS"), vEl = qs("#paramColorV");
-          if (hEl) hEl.value = hsv.h;
-          if (sEl) sEl.value = hsv.s;
-          if (vEl) vEl.value = hsv.v;
-          updateColorPreview();
-          renderColorPalette();
-          renderBrightnessStrip();
-        }
-      });
-
-      // Unified tolerance slider
-      var tolSlider = rangeInput("paramColorTol", 0, 100, 30);
-      addParamRow(container, "Tolerance", tolSlider, "paramColorTolVal");
-      tolSlider.addEventListener("input", function () {
-        renderColorPalette();
-      });
-      renderIntervalSlot("paramColorInterval", 0.5, 60, 1.0, 0.5);
-
-      // Initial render of palette and preview
-      renderColorPalette();
-      renderBrightnessStrip();
-      updateColorPreview();
-      var initRgb = hsvToRgb(90, 200, 200);
-      hexInput.value = rgbToHex(initRgb.r, initRgb.g, initRgb.b);
-    } else if (type === "change") {
+    if (type === "color") renderColorParams(container);
+    else if (type === "change") {
       addParamRow(container, "Threshold", rangeInput("paramChangeThresh", 0.01, 0.50, 0.03, 0.01), "paramChangeThreshVal");
       addParamRow(container, "Noise Thr.", rangeInput("paramChangeNoise", 0, 100, 30, 1), "paramChangeNoiseVal");
       renderIntervalSlot("paramChangeInterval", 0.5, 60, 1.0, 0.5);
-    } else if (type === "similarity") {
-      var refRow = el("div", "param-row");
-      var refLabel = el("span", "param-label", "Reference");
-      var refControl = el("div", "param-control");
-      var refBtn = el("button", "btn btn-small", "Capture Current Frame");
-      refBtn.addEventListener("click", function () {
-        state.referenceTimestamp = state.currentTimestamp;
-        renderWorkflowParams();
-        showToast("Reference frame captured at " + formatTimestamp(state.currentTimestamp));
-      });
-      refControl.appendChild(refBtn);
-      if (state.referenceTimestamp !== null) {
-        var refTs = el("span", "param-value", formatTimestamp(state.referenceTimestamp));
-        refControl.appendChild(refTs);
-      }
-      refRow.appendChild(refLabel);
-      refRow.appendChild(refControl);
-      container.appendChild(refRow);
-      addParamRow(container, "Threshold", rangeInput("paramSimThresh", 0.50, 1.00, 0.90, 0.01), "paramSimThreshVal");
-      renderIntervalSlot("paramSimInterval", 0.5, 60, 1.0, 0.5);
-    } else if (type === "text") {
-      addParamRow(container, "Search text", textInput("paramTextSearch", "Enter text to find..."));
-      addParamRow(container, "Fuzzy Thr.", rangeInput("paramTextFuzzy", 0.50, 1.00, 0.80, 0.01), "paramTextFuzzyVal");
-      renderIntervalSlot("paramTextInterval", 0.5, 60, 2.0, 0.5);
-      var langRow = el("div", "param-row");
-      langRow.appendChild(el("span", "param-label", "Language"));
-      var langControl = el("div", "param-control");
-      var langSel = document.createElement("select");
-      langSel.id = "paramTextLang";
-      [["en", "English"], ["es", "Spanish"], ["fr", "French"], ["de", "German"],
-       ["ja", "Japanese"], ["ko", "Korean"], ["zh", "Chinese"]].forEach(function (pair) {
-        var opt = el("option", null, pair[1]);
-        opt.value = pair[0];
-        langSel.appendChild(opt);
-      });
-      langControl.appendChild(langSel);
-      langRow.appendChild(langControl);
-      container.appendChild(langRow);
-    } else if (type === "numbers") {
-      // Operator selector
-      var opRow = el("div", "param-row");
-      opRow.appendChild(el("span", "param-label", "Operator"));
-      var opControl = el("div", "param-control");
-      var opSel = document.createElement("select");
-      opSel.id = "paramNumOperator";
-      [["gt", "Greater than (>)"], ["lt", "Less than (<)"], ["eq", "Equal to (=)"],
-       ["gte", "Greater or equal (\u2265)"], ["lte", "Less or equal (\u2264)"], ["range", "In range"]].forEach(function (pair) {
-        var opt = el("option", null, pair[1]);
-        opt.value = pair[0];
-        opSel.appendChild(opt);
-      });
-      opSel.addEventListener("change", function () {
-        var rangeRow = qs("#paramNumRangeRow");
-        var targetRow = qs("#paramNumTargetRow");
-        if (opSel.value === "range") {
-          if (rangeRow) rangeRow.style.display = "";
-          if (targetRow) targetRow.style.display = "none";
-        } else {
-          if (rangeRow) rangeRow.style.display = "none";
-          if (targetRow) targetRow.style.display = "";
-        }
-      });
-      opControl.appendChild(opSel);
-      opRow.appendChild(opControl);
-      container.appendChild(opRow);
-      // Target value (for non-range operators)
-      var targetRow = el("div", "param-row");
-      targetRow.id = "paramNumTargetRow";
-      targetRow.appendChild(el("span", "param-label", "Target value"));
-      var targetCtrl = el("div", "param-control");
-      targetCtrl.appendChild(numberInput("paramNumTarget", -999999, 999999, 100, 1));
-      targetRow.appendChild(targetCtrl);
-      container.appendChild(targetRow);
-      // Range min/max (hidden by default)
-      var numRangeRow = el("div", "param-row");
-      numRangeRow.id = "paramNumRangeRow";
-      numRangeRow.style.display = "none";
-      numRangeRow.appendChild(el("span", "param-label", "Range"));
-      var rangeCtrl = el("div", "param-control");
-      rangeCtrl.appendChild(numberInput("paramNumMin", -999999, 999999, 0, 1));
-      rangeCtrl.appendChild(el("span", "param-value", "\u2013"));
-      rangeCtrl.appendChild(numberInput("paramNumMax", -999999, 999999, 100, 1));
-      numRangeRow.appendChild(rangeCtrl);
-      container.appendChild(numRangeRow);
-      renderIntervalSlot("paramNumInterval", 0.5, 60, 2.0, 0.5);
-    } else if (type === "timelapse") {
-      addParamRow(container, "Speed", numberInput("paramTlSpeed", 2, 100, 10, 1));
-      addParamRow(container, "Sample every", numberInput("paramTlSampleInterval", 0, 60, 0, 0.5), "paramTlSampleIntervalVal");
-      var siHint = el("span", "param-hint", "seconds (0 = every frame)");
-      container.lastChild.querySelector(".param-control").appendChild(siHint);
-      var fmtRow = el("div", "param-row");
-      fmtRow.appendChild(el("span", "param-label", "Format"));
-      var fmtControl = el("div", "param-control");
-      var fmtSel = document.createElement("select");
-      fmtSel.id = "paramTlFormat";
-      [["mp4", "Video (.mp4)"], ["gif", "GIF (.gif)"]].forEach(function (pair) {
-        var opt = el("option", null, pair[1]);
-        opt.value = pair[0];
-        fmtSel.appendChild(opt);
-      });
-      fmtControl.appendChild(fmtSel);
-      fmtRow.appendChild(fmtControl);
-      container.appendChild(fmtRow);
-    } else if (type === "template") {
-      var tmplRefRow = el("div", "param-row");
-      tmplRefRow.appendChild(el("span", "param-label", "Template"));
-      var tmplRefCtrl = el("div", "param-control");
-      var tmplCapBtn = el("button", "btn btn-small", "Capture Region");
-      tmplCapBtn.addEventListener("click", function () {
-        state.referenceTimestamp = state.currentTimestamp;
-        state.uploadedTemplate = null;
-        renderWorkflowParams();
-        showToast("Template captured at " + formatTimestamp(state.currentTimestamp));
-      });
-      tmplRefCtrl.appendChild(tmplCapBtn);
-
-      // Upload PNG button
-      var tmplFileInput = document.createElement("input");
-      tmplFileInput.type = "file";
-      tmplFileInput.accept = "image/png";
-      tmplFileInput.style.display = "none";
-      tmplFileInput.addEventListener("change", function () {
-        var file = tmplFileInput.files[0];
-        if (!file) return;
-        var reader = new FileReader();
-        reader.onload = function (e) {
-          // Store base64 data (strip the data:image/png;base64, prefix)
-          var dataUrl = e.target.result;
-          var b64 = dataUrl.split(",")[1];
-          state.uploadedTemplate = { name: file.name, data: b64 };
-          state.referenceTimestamp = null;
-          renderWorkflowParams();
-          showToast("Template loaded: " + file.name);
-        };
-        reader.readAsDataURL(file);
-      });
-      var tmplUploadBtn = el("button", "btn btn-small", "Upload PNG");
-      tmplUploadBtn.addEventListener("click", function () { tmplFileInput.click(); });
-      tmplRefCtrl.appendChild(tmplUploadBtn);
-      tmplRefCtrl.appendChild(tmplFileInput);
-
-      // Status indicator
-      if (state.uploadedTemplate) {
-        var uploadInfo = el("span", "param-value template-upload-info");
-        var uploadThumb = document.createElement("img");
-        uploadThumb.src = "data:image/png;base64," + state.uploadedTemplate.data;
-        uploadThumb.alt = state.uploadedTemplate.name;
-        uploadInfo.appendChild(uploadThumb);
-        uploadInfo.appendChild(document.createTextNode(state.uploadedTemplate.name));
-        var clearBtn = el("button", "btn btn-small", "\u00d7");
-        clearBtn.addEventListener("click", function () {
-          state.uploadedTemplate = null;
-          renderWorkflowParams();
-        });
-        uploadInfo.appendChild(clearBtn);
-        tmplRefCtrl.appendChild(uploadInfo);
-      } else if (state.referenceTimestamp !== null) {
-        tmplRefCtrl.appendChild(el("span", "param-value", formatTimestamp(state.referenceTimestamp)));
-      }
-      tmplRefRow.appendChild(tmplRefCtrl);
-      container.appendChild(tmplRefRow);
-      addParamRow(container, "Threshold", rangeInput("paramTemplateThresh", 0.50, 1.00, 0.70, 0.01), "paramTemplateThreshVal");
-      renderIntervalSlot("paramTemplateInterval", 0.5, 60, 1.0, 0.5);
-    } else if (type === "flow") {
+    }
+    else if (type === "similarity") renderSimilarityParams(container);
+    else if (type === "text") renderTextParams(container);
+    else if (type === "numbers") renderNumbersParams(container);
+    else if (type === "timelapse") renderTimelapseParams(container);
+    else if (type === "template") renderTemplateParams(container);
+    else if (type === "flow") {
       addParamRow(container, "Magnitude", rangeInput("paramFlowMag", 0.5, 20.0, 2.0, 0.5), "paramFlowMagVal");
       renderIntervalSlot("paramFlowInterval", 0.5, 60, 1.0, 0.5);
-    } else if (type === "scene") {
-      var sceneList = el("div", "scene-reference-list");
-      sceneList.id = "sceneRefList";
-      state.sceneReferences.forEach(function (ref, i) {
-        if (ref.threshold === undefined) ref.threshold = 0.75;
-        var item = el("div", "scene-ref-item");
-        item.appendChild(el("span", "scene-ref-name", ref.name));
-        item.appendChild(el("span", "param-value", formatTimestamp(ref.timestamp)));
-        var threshSlider = document.createElement("input");
-        threshSlider.type = "range";
-        threshSlider.min = "0.50";
-        threshSlider.max = "1.00";
-        threshSlider.step = "0.01";
-        threshSlider.value = String(ref.threshold);
-        threshSlider.className = "scene-ref-thresh";
-        var threshVal = el("span", "param-value", String(ref.threshold));
-        threshSlider.addEventListener("input", (function (idx) {
-          return function () {
-            state.sceneReferences[idx].threshold = parseFloat(threshSlider.value);
-            threshVal.textContent = threshSlider.value;
-          };
-        })(i));
-        item.appendChild(threshSlider);
-        item.appendChild(threshVal);
-        var rmBtn = el("button", "btn btn-small", "\u00d7");
-        rmBtn.addEventListener("click", function () {
-          state.sceneReferences.splice(i, 1);
-          renderWorkflowParams();
-        });
-        item.appendChild(rmBtn);
-        sceneList.appendChild(item);
-      });
-      container.appendChild(sceneList);
-      var addScRow = el("div", "param-row");
-      addScRow.appendChild(el("span", "param-label", "Add Scene"));
-      var addScCtrl = el("div", "param-control");
-      var scNameInp = textInput("paramSceneName", "e.g. menu, gameplay");
-      addScCtrl.appendChild(scNameInp);
-      var scCapBtn = el("button", "btn btn-small", "Capture");
-      scCapBtn.addEventListener("click", function () {
-        var nameEl = qs("#paramSceneName");
-        var name = nameEl ? nameEl.value.trim() : "";
-        if (!name) { showToast("Enter a scene name"); return; }
-        state.sceneReferences.push({ name: name, timestamp: state.currentTimestamp, threshold: 0.75 });
-        renderWorkflowParams();
-        showToast("Scene '" + name + "' at " + formatTimestamp(state.currentTimestamp));
-      });
-      addScCtrl.appendChild(scCapBtn);
-      addScRow.appendChild(addScCtrl);
-      container.appendChild(addScRow);
-      renderIntervalSlot("paramSceneInterval", 0.5, 60, 1.0, 0.5);
-    } else if (type === "inactivity") {
+    }
+    else if (type === "scene") renderSceneParams(container);
+    else if (type === "inactivity") {
       addParamRow(container, "Sensitivity", rangeInput("paramInactThresh", 0, 30, 10, 1), "paramInactThreshVal");
       addParamRow(container, "Min duration (s)", numberInput("paramInactMinDur", 0.5, 60, 2.0, 0.5));
       renderIntervalSlot("paramInactInterval", 0.5, 60, 1.0, 0.5);
@@ -2999,7 +3003,6 @@
       addParamRow(container, "Detect first", dfCb);
     }
 
-    // Hide scan mode picker for timelapse (fast scan doesn't apply)
     var scanPicker = qs("#runScanModePicker");
     if (scanPicker) scanPicker.style.display = type === "timelapse" ? "none" : "";
     var scanBtn = scanPicker && scanPicker.querySelector(".scan-toggle-btn");

--- a/cli.py
+++ b/cli.py
@@ -1035,16 +1035,15 @@ def run_cli_mode(worksheet: Any, args: Any, cli_mode_args: CliModeArgs) -> None:
 # ---- Main entry point ----
 
 
-def main() -> None:
-    """Main entry point for clipgen."""
-    setup_encoding()
+def _validate_mode_conflicts(
+    args: Any,
+) -> tuple[bool, bool, bool, bool, bool, Any, bool]:
+    """Validate mutually exclusive mode flags and exit on conflict.
 
-    # Parse command-line arguments
-    args = parse_arguments()
-    if config.DEBUGGING:
-        ic(args)
-
-    # Determine if running in CLI mode (any mode argument provided)
+    Returns:
+        (timeline_viewer, studio_mode, insights_mode, screenspace_mode,
+         transcripts_mode, gallery_arg, pre_transcribe_mode)
+    """
     mixed_selectors = getattr(args, "mixed", None)
     timeline_viewer = getattr(args, "timeline_viewer", False)
 
@@ -1265,74 +1264,55 @@ def main() -> None:
             )
             sys.exit(1)
 
-    cli_mode = (
-        args.batch
-        or args.lines
-        or args.range
-        or args.category
-        or args.cell
-        or args.participant
-        or args.keyword
-        or args.severity
-        or mixed_selectors
-        or args.reel
-        or args.chronologic
-        or args.highlights
-        or args.screen
-        or args.gif
-        or timeline_viewer
+    return (
+        timeline_viewer,
+        studio_mode,
+        insights_mode,
+        screenspace_mode,
+        transcripts_mode,
+        gallery_arg,
+        pre_transcribe_mode,
     )
 
-    # Set verbosity: quiet by default in CLI mode, standard in interactive mode
+
+def _apply_config_overrides(args: Any, cli_mode: bool) -> CliModeArgs:
+    """Apply per-run config overrides from CLI args.
+
+    Returns parsed CLI mode arguments.
+    """
     if cli_mode:
         config.VERBOSITY = config.VERBOSE if args.verbose else config.QUIET
     else:
         config.VERBOSITY = config.VERBOSE if args.verbose else config.STANDARD
 
-    # Optional per-run override for titlecards setting
     if getattr(args, "titlecards", None) is not None:
         config.TITLECARDS_ENABLED = bool(args.titlecards)
-
-    # Optional per-run override for filmstrip setting
     if getattr(args, "filmstrip", None) is not None:
         config.FILMSTRIP_ENABLED = bool(args.filmstrip)
-
-    # Optional per-run overrides for input/output directories
     if getattr(args, "input", None) is not None:
         config.INPUT_DIR = args.input
     if getattr(args, "output", None) is not None:
         config.OUTPUT_DIR = args.output
-
     if getattr(args, "manifest", False):
         config.MANIFEST_ENABLED = True
-
     if getattr(args, "transcribe", False):
         config.TRANSCRIBE_ENABLED = True
     if getattr(args, "transcript_format", None):
         config.TRANSCRIBE_FORMAT = args.transcript_format
 
-    # Parse CLI arguments for line, range, and cell modes
-    cli_mode_args = parse_cli_mode_args(args)
+    return parse_cli_mode_args(args)
 
-    # Change working directory to runtime location (script/executable)
-    os.chdir(get_runtime_working_dir())
-    utils.standard_print(
-        "-------------------------------------------------------------------------------"
-    )
-    utils.standard_print(
-        f"Welcome to clipgen v{config.VERSIONNUM}\nWorking directory: {os.getcwd()}\nPlace video files and the credentials.json file in this directory."
-    )
-    utils.debug_print(
-        "Debug mode is ON. Several limitations apply and more things will be printed."
-    )
 
-    # Sanity-check input/output directories before proceeding
-    utils.validate_runtime_directories()
+def _dispatch_standalone_mode(
+    args: Any,
+    cli_mode: bool,
+    gallery_arg: Any,
+) -> bool:
+    """Handle standalone modes that don't need a spreadsheet.
 
-    if not video.check_ffmpeg_tools_available():
-        sys.exit(1)
-
-    # Standalone viewer: regenerate viewer from saved manifest, no spreadsheet needed
+    Returns True if a standalone mode was dispatched (caller should exit).
+    """
+    # Standalone viewer: regenerate viewer from saved manifest
     if getattr(args, "viewer", False) and not cli_mode:
         existing_artifacts = viewer.load_manifest_artifacts()
         if not existing_artifacts:
@@ -1356,35 +1336,35 @@ def main() -> None:
         viewer_path = viewer.generate_timeline_viewer(data)
         if viewer_path:
             utils.info_print(f"Timeline viewer created from manifest: {viewer_path}")
-        sys.exit(0)
+        return True
 
-    # Standalone insights builder: no spreadsheet needed, reads from manifest
+    # Standalone insights builder
     if getattr(args, "insights", False):
         import server
 
         server.start_combined_server(worksheet=None, default_page="insights")
-        sys.exit(0)
+        return True
 
-    # Standalone screenspace: can work without spreadsheet (discovers videos from input dir)
+    # Standalone screenspace (no spreadsheet)
     if getattr(args, "screenspace", False) and not args.spreadsheet:
         import server
 
         server.start_combined_server(worksheet=None, default_page="screenspace")
-        sys.exit(0)
+        return True
 
-    # Standalone transcripts: no spreadsheet needed, discovers videos from input dir
+    # Standalone transcripts (no spreadsheet)
     if getattr(args, "transcripts", False) and not args.spreadsheet:
         import server
 
         server.start_combined_server(worksheet=None, default_page="transcripts")
-        sys.exit(0)
+        return True
 
-    # Standalone gallery: generate interval captures + gallery viewer, no spreadsheet needed
+    # Standalone gallery
     if gallery_arg is not None:
         _run_gallery_cli(args)
-        sys.exit(0)
+        return True
 
-    # Standalone regenerate: re-export all media artifacts and reels from saved manifest
+    # Standalone regenerate from manifest
     if getattr(args, "regenerate", False) and not cli_mode:
         existing_artifacts, existing_reels = viewer._load_manifest_both()
         if not existing_artifacts and not existing_reels:
@@ -1407,6 +1387,71 @@ def main() -> None:
             existing_artifacts, reels=existing_reels
         )
         utils.info_print(f"Regenerated {regenerated} of {total} item(s).")
+        return True
+
+    return False
+
+
+def main() -> None:
+    """Main entry point for clipgen."""
+    setup_encoding()
+
+    args = parse_arguments()
+    if config.DEBUGGING:
+        ic(args)
+
+    # Validate mutually exclusive mode flags
+    (
+        timeline_viewer,
+        studio_mode,
+        insights_mode,
+        screenspace_mode,
+        transcripts_mode,
+        gallery_arg,
+        pre_transcribe_mode,
+    ) = _validate_mode_conflicts(args)
+
+    # Determine if running in CLI mode (any mode argument provided)
+    mixed_selectors = getattr(args, "mixed", None)
+    cli_mode = (
+        args.batch
+        or args.lines
+        or args.range
+        or args.category
+        or args.cell
+        or args.participant
+        or args.keyword
+        or args.severity
+        or mixed_selectors
+        or args.reel
+        or args.chronologic
+        or args.highlights
+        or args.screen
+        or args.gif
+        or timeline_viewer
+    )
+
+    cli_mode_args = _apply_config_overrides(args, cli_mode)
+
+    # Change working directory to runtime location (script/executable)
+    os.chdir(get_runtime_working_dir())
+    utils.standard_print(
+        "-------------------------------------------------------------------------------"
+    )
+    utils.standard_print(
+        f"Welcome to clipgen v{config.VERSIONNUM}\nWorking directory: {os.getcwd()}\nPlace video files and the credentials.json file in this directory."
+    )
+    utils.debug_print(
+        "Debug mode is ON. Several limitations apply and more things will be printed."
+    )
+
+    # Sanity-check input/output directories before proceeding
+    utils.validate_runtime_directories()
+
+    if not video.check_ffmpeg_tools_available():
+        sys.exit(1)
+
+    if _dispatch_standalone_mode(args, cli_mode, gallery_arg):
         sys.exit(0)
 
     # Authenticate with Google (once per run) – skip for local Excel files

--- a/clipgen.py
+++ b/clipgen.py
@@ -883,14 +883,7 @@ def _transcribe_segments(
     cell = clip.get("cell")
     cell_row = getattr(cell, "row", None)
     cell_col = getattr(cell, "col", None)
-    try:
-        cell_a1 = (
-            gspread.utils.rowcol_to_a1(cell_row, cell_col)
-            if cell_row and cell_col
-            else ""
-        )
-    except Exception:
-        cell_a1 = ""
+    cell_a1 = utils.safe_cell_a1(cell_row, cell_col)
     annotations = list(clip.get("cell_annotations", []))
 
     for seg_idx, (out_path, start_str, end_str) in enumerate(segment_details):

--- a/interactive.py
+++ b/interactive.py
@@ -668,51 +668,45 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
         utils.check_navigation_keywords(value)
         return value
 
-    # Navigation loop
-    while True:
-        raw_input = _read_browse_key().strip()
-        user_input = raw_input.lower()
+    def _handle_navigation(cmd: str, cur: int) -> tuple[bool, int]:
+        """Handle navigation commands: up/down/page/jump/open/format switch.
 
-        if user_input == _NOOP:
-            continue
-        elif user_input in ("quit", "q"):
-            utils.info_print("Exiting browse mode.")
-            break
-        elif user_input in ("up", "u"):
-            if current_row > first_data_row:
-                new_row = max(
-                    first_data_row, current_row - config.BROWSE_LINES_TO_SCROLL
-                )
-                current_row = new_row
-                display_rows(current_row, config.BROWSE_LINES_TO_DISPLAY)
+        Returns (handled, new_current_row).
+        """
+        nonlocal output_format
+        if cmd in ("up", "u"):
+            if cur > first_data_row:
+                cur = max(first_data_row, cur - config.BROWSE_LINES_TO_SCROLL)
+                display_rows(cur, config.BROWSE_LINES_TO_DISPLAY)
             else:
                 utils.info_print("Already at the first row.")
-        elif user_input in ("down", "d", ""):
-            if current_row < last_data_row:
-                new_row = min(
-                    last_data_row, current_row + config.BROWSE_LINES_TO_SCROLL
-                )
-                current_row = new_row
-                display_rows(current_row, config.BROWSE_LINES_TO_DISPLAY)
+            return True, cur
+        if cmd in ("down", "d", ""):
+            if cur < last_data_row:
+                cur = min(last_data_row, cur + config.BROWSE_LINES_TO_SCROLL)
+                display_rows(cur, config.BROWSE_LINES_TO_DISPLAY)
             else:
                 utils.info_print("Already at the last row.")
-        elif user_input in ("pageup", "pu"):
-            new_row = max(first_data_row, current_row - config.BROWSE_LINES_TO_DISPLAY)
-            if new_row != current_row:
-                current_row = new_row
-                display_rows(current_row, config.BROWSE_LINES_TO_DISPLAY)
+            return True, cur
+        if cmd in ("pageup", "pu"):
+            new_row = max(first_data_row, cur - config.BROWSE_LINES_TO_DISPLAY)
+            if new_row != cur:
+                cur = new_row
+                display_rows(cur, config.BROWSE_LINES_TO_DISPLAY)
             else:
                 utils.info_print("Already at the first row.")
-        elif user_input in ("pagedown", "pd"):
-            new_row = min(last_data_row, current_row + config.BROWSE_LINES_TO_DISPLAY)
-            if new_row != current_row:
-                current_row = new_row
-                display_rows(current_row, config.BROWSE_LINES_TO_DISPLAY)
+            return True, cur
+        if cmd in ("pagedown", "pd"):
+            new_row = min(last_data_row, cur + config.BROWSE_LINES_TO_DISPLAY)
+            if new_row != cur:
+                cur = new_row
+                display_rows(cur, config.BROWSE_LINES_TO_DISPLAY)
             else:
                 utils.info_print("Already at the last row.")
-        elif user_input.startswith("jump ") or user_input.startswith("j "):
+            return True, cur
+        if cmd.startswith("jump ") or cmd.startswith("j "):
             try:
-                parts = user_input.split()
+                parts = cmd.split()
                 if len(parts) >= 2:
                     target_row = int(parts[1]) - 1
                     if target_row < first_data_row:
@@ -724,15 +718,16 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
                             f"Row number must be at most {last_data_row + 1}."
                         )
                     else:
-                        current_row = target_row
-                        display_rows(current_row, config.BROWSE_LINES_TO_DISPLAY)
+                        cur = target_row
+                        display_rows(cur, config.BROWSE_LINES_TO_DISPLAY)
                 else:
                     utils.info_print("Usage: jump <row_number> or j <row_number>")
             except ValueError:
                 utils.info_print(
                     "Invalid row number. Usage: jump <row_number> or j <row_number>"
                 )
-        elif user_input in ("open", "o"):
+            return True, cur
+        if cmd in ("open", "o"):
             spreadsheet_url = getattr(getattr(sheet, "spreadsheet", None), "url", None)
             if not spreadsheet_url:
                 utils.info_print(
@@ -747,75 +742,98 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
                     utils.info_print("Spreadsheet opened in your default browser.")
                 except OSError as e:
                     utils.error_print("Could not open browser.", [f"Error: {e}"])
-        elif user_input in ("screen", "sc"):
+            return True, cur
+        if cmd in ("screen", "sc"):
             output_format = "screen"
             utils.info_print("Switched to screenshot mode.")
-        elif user_input == "gif":
+            return True, cur
+        if cmd == "gif":
             output_format = "gif"
             utils.info_print("Switched to GIF mode.")
-        elif user_input == "clip":
+            return True, cur
+        if cmd == "clip":
             output_format = "clip"
             utils.info_print("Switched to clip mode.")
-        else:
-            # Try selector parsing for artifact generation
-            if process_fn is not None:
-                parsed = spreadsheet.parse_reel_input(raw_input)
-                has_selectors = (
-                    parsed.get("batch")
-                    or parsed.get("keyword")
-                    or parsed["lines"]
-                    or parsed["ranges"]
-                    or parsed["cells"]
-                    or parsed["participants"]
-                    or parsed["categories"]
-                )
-                if has_selectors:
-                    if parsed.get("chronologic"):
-                        utils.info_print(
-                            "Chronologic selector is not supported in browse mode."
-                        )
-                    else:
-                        clips = spreadsheet.generate_list(
-                            sheet, "reel", reel_input=raw_input
-                        )
-                        if clips:
-                            format_label = {
-                                "clip": "clip(s)",
-                                "screen": "screenshot(s)",
-                                "gif": "GIF(s)",
-                            }.get(output_format, "file(s)")
-                            utils.info_print(
-                                f"Generating {len(clips)} {format_label}..."
-                            )
-                            outputs_generated, _ = process_fn(clips, output_format)
-                            utils.info_print(
-                                f"Done! Generated {outputs_generated} {format_label}."
-                            )
-                        else:
-                            utils.info_print("No clips found for the given selectors.")
-                    continue
+            return True, cur
+        return False, cur
 
-            # Treat unrecognized input as a search query
-            matches = _search_rows(user_input)
-            if not matches:
-                matches = _search_rows(user_input, fuzzy=True)
-                if matches:
+    def _handle_selector_or_search(raw: str, cmd: str, cur: int) -> int:
+        """Try selector-based generation, then fall back to search.
+
+        Returns new current_row.
+        """
+        if process_fn is not None:
+            parsed = spreadsheet.parse_reel_input(raw)
+            has_selectors = (
+                parsed.get("batch")
+                or parsed.get("keyword")
+                or parsed["lines"]
+                or parsed["ranges"]
+                or parsed["cells"]
+                or parsed["participants"]
+                or parsed["categories"]
+            )
+            if has_selectors:
+                if parsed.get("chronologic"):
                     utils.info_print(
-                        f"No exact matches for '{user_input}'. Showing approximate matches:"
-                    )
-            if matches:
-                match_row_nums = [str(m + 1) for m in matches]
-                if len(match_row_nums) > 20:
-                    shown = ", ".join(match_row_nums[:20])
-                    extra = len(match_row_nums) - 20
-                    utils.info_print(
-                        f"Found {len(matches)} matching row(s): {shown} \u2026 and {extra} more"
+                        "Chronologic selector is not supported in browse mode."
                     )
                 else:
-                    utils.info_print(
-                        f"Found {len(matches)} matching row(s): {', '.join(match_row_nums)}"
-                    )
-                current_row = matches[0]
-                display_rows(current_row, config.BROWSE_LINES_TO_DISPLAY)
+                    clips = spreadsheet.generate_list(sheet, "reel", reel_input=raw)
+                    if clips:
+                        format_label = {
+                            "clip": "clip(s)",
+                            "screen": "screenshot(s)",
+                            "gif": "GIF(s)",
+                        }.get(output_format, "file(s)")
+                        utils.info_print(f"Generating {len(clips)} {format_label}...")
+                        outputs_generated, _ = process_fn(clips, output_format)
+                        utils.info_print(
+                            f"Done! Generated {outputs_generated} {format_label}."
+                        )
+                    else:
+                        utils.info_print("No clips found for the given selectors.")
+                return cur
+
+        # Treat unrecognized input as a search query
+        matches = _search_rows(cmd)
+        if not matches:
+            matches = _search_rows(cmd, fuzzy=True)
+            if matches:
+                utils.info_print(
+                    f"No exact matches for '{cmd}'. Showing approximate matches:"
+                )
+        if matches:
+            match_row_nums = [str(m + 1) for m in matches]
+            if len(match_row_nums) > 20:
+                shown = ", ".join(match_row_nums[:20])
+                extra = len(match_row_nums) - 20
+                utils.info_print(
+                    f"Found {len(matches)} matching row(s): {shown} \u2026 and {extra} more"
+                )
             else:
-                utils.info_print(f"No rows matching '{user_input}'.")
+                utils.info_print(
+                    f"Found {len(matches)} matching row(s): {', '.join(match_row_nums)}"
+                )
+            cur = matches[0]
+            display_rows(cur, config.BROWSE_LINES_TO_DISPLAY)
+        else:
+            utils.info_print(f"No rows matching '{cmd}'.")
+        return cur
+
+    # Navigation loop
+    while True:
+        raw_input = _read_browse_key().strip()
+        user_input = raw_input.lower()
+
+        if user_input == _NOOP:
+            continue
+        if user_input in ("quit", "q"):
+            utils.info_print("Exiting browse mode.")
+            break
+
+        handled, current_row = _handle_navigation(user_input, current_row)
+        if handled:
+            continue
+
+        current_row = _handle_selector_or_search(raw_input, user_input, current_row)

--- a/plans/QUALITY-PLAN.md
+++ b/plans/QUALITY-PLAN.md
@@ -27,9 +27,9 @@ The same load/save JSON pattern is repeated in `viewer.py`, `insights.py`, `scre
 
 `formatTime()`, `qs()`/`qsa()`/`el()`, `severityClass()`, and `apiGet()`/`apiPost()` are cloned across 4-7 standalone JS files.
 
-- [ ] Evaluate whether a shared `utils.js` can be injected at build/inline time alongside each HTML file
-- [ ] If not feasible, document the canonical version of each utility and add a comment pointing to it in each copy, so future changes are propagated deliberately
-- [ ] Standardize `apiGet`/`apiPost` error handling (screenspace.js checks `!r.ok`, transcripts.js doesn't)
+- [x] Evaluate whether a shared `utils.js` can be injected at build/inline time alongside each HTML file
+- [x] If not feasible, document the canonical version of each utility and add a comment pointing to it in each copy, so future changes are propagated deliberately
+- [x] Standardize `apiGet`/`apiPost` error handling (screenspace.js checks `!r.ok`, transcripts.js doesn't)
 
 ---
 
@@ -37,8 +37,8 @@ The same load/save JSON pattern is repeated in `viewer.py`, `insights.py`, `scre
 
 `transcripts.js` manually mirrors `MARK_CATEGORIES`, `SS_DETECTOR_COLORS`, and badge SVGs from Python/other JS with "mirrored from" comments.
 
-- [ ] Evaluate serving these values from a `/api/constants` endpoint or injecting them into `window.CLIPGEN_DATA` at page load
-- [ ] If kept as manual mirrors, add a test or CI check that compares the JS and Python values
+- [x] Evaluate serving these values from a `/api/constants` endpoint or injecting them into `window.CLIPGEN_DATA` at page load
+- [x] If kept as manual mirrors, add a test or CI check that compares the JS and Python values
 
 ---
 
@@ -46,8 +46,8 @@ The same load/save JSON pattern is repeated in `viewer.py`, `insights.py`, `scre
 
 9 `except Exception:` blocks across `clipgen.py`, `viewer.py`, `screenspace.py`, `transcripts.py`, and `video.py` swallow errors too broadly.
 
-- [ ] Replace each with the narrowest applicable exception type (e.g., `ValueError` for cell A1 conversion, `OSError` for file I/O, `FileNotFoundError` for ffmpeg)
-- [ ] Extract the duplicated cell_a1 conversion pattern (`clipgen.py:894`, `viewer.py:89`) into a shared `utils.safe_cell_a1(row, col)` helper
+- [x] Replace each with the narrowest applicable exception type (e.g., `ValueError` for cell A1 conversion, `OSError` for file I/O, `FileNotFoundError` for ffmpeg)
+- [x] Extract the duplicated cell_a1 conversion pattern (`clipgen.py:894`, `viewer.py:89`) into a shared `utils.safe_cell_a1(row, col)` helper
 
 ---
 
@@ -55,11 +55,11 @@ The same load/save JSON pattern is repeated in `viewer.py`, `insights.py`, `scre
 
 Six functions exceed 150 lines with mixed concerns.
 
-- [ ] `cli.py main()` (~388 lines): extract config-override application, mode detection, and dispatch into separate functions
-- [ ] `interactive.py browse_spreadsheet()` (~358 lines): extract display, search, and nested helper functions to module level
-- [ ] `screenspace_server.py api_tasks_create()` (~313 lines): separate validation, parameter normalization, and task creation
-- [ ] `screenspace.js renderWorkflowParams()` (~536 lines): split into per-workflow-type render functions
-- [ ] `studio.js renderIntake()` (~437 lines): separate clustering, filtering, and rendering logic
+- [x] `cli.py main()` (~388 lines): extract config-override application, mode detection, and dispatch into separate functions
+- [x] `interactive.py browse_spreadsheet()` (~358 lines): extract display, search, and nested helper functions to module level
+- [x] `screenspace_server.py api_tasks_create()` (~313 lines): separate validation, parameter normalization, and task creation
+- [x] `screenspace.js renderWorkflowParams()` (~536 lines): split into per-workflow-type render functions
+- [x] `studio.js renderIntake()` (~437 lines): already 94 lines, no refactoring needed
 
 ---
 
@@ -95,7 +95,7 @@ Both `viewer.html` and `timeline-viewer.html` exist. Studio/CLI per-participant 
 `config.py` is 301 lines of flat globals mutated from `cli.py`. `server.py` works around this with `_settings_defaults` snapshots and an `_override_config()` context manager.
 
 - [ ] Group related constants (screenspace thresholds, ffmpeg params, file format settings) into named sections or lightweight dataclass-like groupings
-- [ ] Extract the CLI config-override block (`cli.py:1300-1312`) into a dedicated `apply_cli_overrides(args)` function
+- [x] Extract the CLI config-override block (`cli.py:1300-1312`) into a dedicated `apply_cli_overrides(args)` function
 
 ---
 

--- a/screenspace.py
+++ b/screenspace.py
@@ -2535,8 +2535,10 @@ class ScreenspaceWorker:
                         if self.on_progress_update:
                             try:
                                 self.on_progress_update()
-                            except Exception:
-                                pass
+                            except Exception as exc:
+                                utils.warning_print(
+                                    f"on_progress_update callback failed: {exc}"
+                                )
 
                     # 2. If paused, wait
                     if self._paused.is_set():
@@ -2556,16 +2558,20 @@ class ScreenspaceWorker:
                     priority, created_at, task_id = item
                     if task_id is _SENTINEL:
                         # Wait for active tasks to finish
-                        for f in active.values():
+                        for drain_tid, f in active.items():
                             try:
                                 f.result(timeout=10)
-                            except Exception:
-                                pass
+                            except Exception as exc:
+                                utils.debug_print(
+                                    f"Task {drain_tid} raised during shutdown: {exc}"
+                                )
                         if self.on_task_complete:
                             try:
                                 self.on_task_complete()
-                            except Exception:
-                                pass
+                            except Exception as exc:
+                                utils.warning_print(
+                                    f"on_task_complete callback failed during shutdown: {exc}"
+                                )
                         break
 
                     if self._paused.is_set():

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -488,16 +488,14 @@ def api_tasks_get(task_id: str) -> FlaskResponse:
     return jsonify({"ok": True, "task": _clean_task(task)})
 
 
-@screenspace_bp.route("/api/tasks", methods=["POST"])
-def api_tasks_create() -> FlaskResponse:
-    """Enqueue a new analysis task."""
-    if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+def _validate_task_request(
+    data: dict[str, Any],
+) -> tuple[str, str, str, dict[str, Any], dict[str, Any]] | FlaskResponse:
+    """Validate the task creation request body.
 
-    data = request.get_json(silent=True)
-    if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
-
+    Returns (task_type, participant, region_name, parameters, all_known_regions)
+    on success, or a Flask error response on failure.
+    """
     task_type = data.get("type", "").strip()
     if task_type not in _VALID_TASK_TYPES:
         return jsonify(
@@ -529,7 +527,7 @@ def api_tasks_create() -> FlaskResponse:
     if not region_name and not has_uploaded_template and task_type != "multitool":
         return jsonify({"ok": False, "error": "region is required"}), 400
 
-    # Early validation for multitool steps (before video path lookup)
+    # Early validation for multitool steps
     if task_type == "multitool":
         mt_steps = parameters.get("steps")
         if not mt_steps or not isinstance(mt_steps, list) or len(mt_steps) < 2:
@@ -553,7 +551,7 @@ def api_tasks_create() -> FlaskResponse:
     for stash in _manifest.get("stashes", []):
         all_known_regions.update(stash.get("regions", {}))
 
-    # Multitool validates per-step regions; non-multitool validates global region
+    # Validate regions
     if task_type == "multitool":
         mt_steps_early: list[dict[str, Any]] = parameters.get("steps", [])
         for i, step in enumerate(mt_steps_early):
@@ -575,45 +573,16 @@ def api_tasks_create() -> FlaskResponse:
                 {"ok": False, "error": f"Region '{region_name}' not found"}
             ), 400
 
-    video_path = _find_participant_video(participant)
-    if video_path is None:
-        return jsonify(
-            {"ok": False, "error": f"No video for participant {participant}"}
-        ), 400
+    return task_type, participant, region_name, parameters, all_known_regions
 
-    source_video = ""
-    for p in _participants:
-        if p["id"] == participant:
-            source_video = Path(p["video_path"]).name
-            break
 
-    props = video.probe_video_properties(video_path)
+def _coerce_task_params(
+    task_type: str, parameters: dict[str, Any]
+) -> dict[str, Any] | FlaskResponse:
+    """Coerce and validate type-specific parameter values.
 
-    def _resolve_region_coords(name: str) -> dict[str, Any]:
-        """Convert a named region to pixel coordinates."""
-        rd = all_known_regions[name]
-        if props and props.get("width") and props.get("height"):
-            return _denormalize_region(rd, props["width"], props["height"])
-        return {k: rd[k] for k in ("x", "y", "w", "h") if k in rd}
-
-    if region_name and region_name in all_known_regions:
-        region_coords = _resolve_region_coords(region_name)
-    elif task_type == "multitool":
-        # Multitool uses per-step regions; use first step's region for top-level metadata
-        first_step_region = parameters.get("steps", [{}])[0].get("region", "")
-        if first_step_region and first_step_region in all_known_regions:
-            region_name = first_step_region
-            region_coords = _resolve_region_coords(first_step_region)
-        else:
-            region_name = "per_step"
-            region_coords = {"x": 0, "y": 0, "w": 0, "h": 0}
-    else:
-        # Full-frame template scan -- sentinel region
-        region_name = "full_frame"
-        region_coords = {"x": 0, "y": 0, "w": 0, "h": 0}
-
-    import screenspace
-
+    Returns the updated parameters on success, or a Flask error response on failure.
+    """
     try:
         if task_type == "similarity":
             parameters["reference_timestamp"] = _coerce_float(
@@ -656,7 +625,21 @@ def api_tasks_create() -> FlaskResponse:
     except ValueError as exc:
         return jsonify({"ok": False, "error": str(exc)}), 400
 
-    # Similarity tasks: extract reference frame from video at given timestamp
+    return parameters
+
+
+def _extract_task_media(
+    task_type: str,
+    parameters: dict[str, Any],
+    video_path: str,
+    region_coords: dict[str, Any],
+) -> dict[str, Any] | FlaskResponse:
+    """Extract reference frames / template images for non-multitool tasks.
+
+    Returns the updated parameters on success, or a Flask error response on failure.
+    """
+    import screenspace
+
     if task_type == "similarity":
         ref_ts = cast(float, parameters["reference_timestamp"])
         frame = video.extract_frame_at_timestamp(video_path, float(ref_ts))
@@ -667,7 +650,6 @@ def api_tasks_create() -> FlaskResponse:
         ref_region = screenspace.extract_region(frame, region_coords)
         parameters["reference_frame"] = ref_region
 
-    # Template tasks: use uploaded PNG or extract template region from video
     if task_type == "template":
         import base64
 
@@ -676,7 +658,6 @@ def api_tasks_create() -> FlaskResponse:
 
         upload_b64 = parameters.pop("template_image_data", None)
         if upload_b64:
-            # Decode uploaded PNG (may have alpha channel for masking)
             try:
                 img_bytes = base64.b64decode(upload_b64)
                 img_arr = np.frombuffer(img_bytes, dtype=np.uint8)
@@ -688,10 +669,8 @@ def api_tasks_create() -> FlaskResponse:
             if img is None:
                 return jsonify({"ok": False, "error": "Invalid image data"}), 400
             if len(img.shape) == 2:
-                # Grayscale → convert to BGR
                 img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
             if img.shape[2] == 4:
-                # Extract alpha as mask, convert to BGR for template
                 parameters["template_mask"] = img[:, :, 3]
                 parameters["template_image"] = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
             else:
@@ -707,7 +686,6 @@ def api_tasks_create() -> FlaskResponse:
                 frame, region_coords
             )
 
-    # Scene tasks: extract reference frame for each scene type
     if task_type == "scene":
         scene_refs = cast(list[dict[str, Any]], parameters["scene_references"])
         reference_scenes = []
@@ -729,95 +707,190 @@ def api_tasks_create() -> FlaskResponse:
             reference_scenes.append(scene_entry)
         parameters["reference_scenes"] = reference_scenes
 
-    # Multitool tasks: resolve per-step regions and prepare parameters
-    if task_type == "multitool":
-        import base64
+    return parameters
 
-        import cv2
-        import numpy as np
 
-        steps = parameters.get("steps", [])
-        for i, step in enumerate(steps):
-            stype = step.get("type", "")
+def _prepare_multitool_steps(
+    parameters: dict[str, Any],
+    all_known_regions: dict[str, Any],
+    video_path: str,
+    region_coords: dict[str, Any],
+    resolve_region_fn: Any,
+) -> dict[str, Any] | FlaskResponse:
+    """Resolve per-step regions and extract media for multitool tasks.
 
-            # Resolve this step's region to pixel coords
-            step_region_name = (step.get("region") or "").strip()
-            if step_region_name and step_region_name in all_known_regions:
-                step["region_coords"] = _resolve_region_coords(step_region_name)
+    Returns the updated parameters on success, or a Flask error response on failure.
+    """
+    import base64
+
+    import cv2
+    import numpy as np
+    import screenspace
+
+    steps = parameters.get("steps", [])
+    for i, step in enumerate(steps):
+        stype = step.get("type", "")
+
+        # Resolve this step's region to pixel coords
+        step_region_name = (step.get("region") or "").strip()
+        if step_region_name and step_region_name in all_known_regions:
+            step["region_coords"] = resolve_region_fn(step_region_name)
+        else:
+            step["region_coords"] = region_coords  # fallback to top-level
+
+        step_rc = step["region_coords"]
+
+        if stype == "similarity":
+            ref_ts = cast(float, step["reference_timestamp"])
+            frame = video.extract_frame_at_timestamp(video_path, float(ref_ts))
+            if frame is None:
+                return jsonify(
+                    {
+                        "ok": False,
+                        "error": f"Step {i}: could not read reference frame",
+                    }
+                ), 400
+            step["reference_frame"] = screenspace.extract_region(frame, step_rc)
+
+        elif stype == "template":
+            upload_b64 = step.pop("template_image_data", None)
+            if upload_b64:
+                try:
+                    img_bytes = base64.b64decode(upload_b64)
+                    img_arr = np.frombuffer(img_bytes, dtype=np.uint8)
+                    img = cv2.imdecode(img_arr, cv2.IMREAD_UNCHANGED)
+                except (ValueError, binascii.Error):
+                    return jsonify(
+                        {
+                            "ok": False,
+                            "error": f"Step {i}: could not decode uploaded image",
+                        }
+                    ), 400
+                if img is None:
+                    return jsonify(
+                        {"ok": False, "error": f"Step {i}: invalid image data"}
+                    ), 400
+                if len(img.shape) == 2:
+                    img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+                if img.shape[2] == 4:
+                    step["template_mask"] = img[:, :, 3]
+                    step["template_image"] = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+                else:
+                    step["template_image"] = img
             else:
-                step["region_coords"] = region_coords  # fallback to top-level
-
-            step_rc = step["region_coords"]
-
-            if stype == "similarity":
                 ref_ts = cast(float, step["reference_timestamp"])
                 frame = video.extract_frame_at_timestamp(video_path, float(ref_ts))
                 if frame is None:
                     return jsonify(
                         {
                             "ok": False,
-                            "error": f"Step {i}: could not read reference frame",
+                            "error": f"Step {i}: could not read template frame",
                         }
                     ), 400
-                step["reference_frame"] = screenspace.extract_region(frame, step_rc)
+                step["template_image"] = screenspace.extract_region(frame, step_rc)
 
-            elif stype == "template":
-                upload_b64 = step.pop("template_image_data", None)
-                if upload_b64:
-                    try:
-                        img_bytes = base64.b64decode(upload_b64)
-                        img_arr = np.frombuffer(img_bytes, dtype=np.uint8)
-                        img = cv2.imdecode(img_arr, cv2.IMREAD_UNCHANGED)
-                    except (ValueError, binascii.Error):
-                        return jsonify(
-                            {
-                                "ok": False,
-                                "error": f"Step {i}: could not decode uploaded image",
-                            }
-                        ), 400
-                    if img is None:
-                        return jsonify(
-                            {"ok": False, "error": f"Step {i}: invalid image data"}
-                        ), 400
-                    if len(img.shape) == 2:
-                        img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
-                    if img.shape[2] == 4:
-                        step["template_mask"] = img[:, :, 3]
-                        step["template_image"] = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
-                    else:
-                        step["template_image"] = img
-                else:
-                    ref_ts = cast(float, step["reference_timestamp"])
-                    frame = video.extract_frame_at_timestamp(video_path, float(ref_ts))
-                    if frame is None:
-                        return jsonify(
-                            {
-                                "ok": False,
-                                "error": f"Step {i}: could not read template frame",
-                            }
-                        ), 400
-                    step["template_image"] = screenspace.extract_region(frame, step_rc)
+        elif stype == "scene":
+            scene_refs = cast(list[dict[str, Any]], step["scene_references"])
+            ref_scenes_list = []
+            for ref in scene_refs:
+                frame = video.extract_frame_at_timestamp(
+                    video_path, float(ref["timestamp"])
+                )
+                if frame is None:
+                    return jsonify(
+                        {
+                            "ok": False,
+                            "error": f"Step {i}: could not read frame for scene '{ref['name']}'",
+                        }
+                    ), 400
+                ref_region = screenspace.extract_region(frame, step_rc)
+                scene_entry: dict = {"name": ref["name"], "frame": ref_region}
+                if "threshold" in ref:
+                    scene_entry["threshold"] = float(ref["threshold"])
+                ref_scenes_list.append(scene_entry)
+            step["reference_scenes"] = ref_scenes_list
 
-            elif stype == "scene":
-                scene_refs = cast(list[dict[str, Any]], step["scene_references"])
-                ref_scenes_list = []
-                for ref in scene_refs:
-                    frame = video.extract_frame_at_timestamp(
-                        video_path, float(ref["timestamp"])
-                    )
-                    if frame is None:
-                        return jsonify(
-                            {
-                                "ok": False,
-                                "error": f"Step {i}: could not read frame for scene '{ref['name']}'",
-                            }
-                        ), 400
-                    ref_region = screenspace.extract_region(frame, step_rc)
-                    scene_entry: dict = {"name": ref["name"], "frame": ref_region}
-                    if "threshold" in ref:
-                        scene_entry["threshold"] = float(ref["threshold"])
-                    ref_scenes_list.append(scene_entry)
-                step["reference_scenes"] = ref_scenes_list
+    return parameters
+
+
+@screenspace_bp.route("/api/tasks", methods=["POST"])
+def api_tasks_create() -> FlaskResponse:
+    """Enqueue a new analysis task."""
+    if not _worker:
+        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"ok": False, "error": "JSON body required"}), 400
+
+    validated = _validate_task_request(data)
+    if isinstance(validated, Response) or (
+        isinstance(validated, tuple) and len(validated) == 2
+    ):
+        return cast(FlaskResponse, validated)
+    assert isinstance(validated, tuple) and len(validated) == 5  # success tuple
+    task_type, participant, region_name, parameters, all_known_regions = cast(
+        tuple[str, str, str, dict[str, Any], dict[str, Any]], validated
+    )
+
+    video_path = _find_participant_video(participant)
+    if video_path is None:
+        return jsonify(
+            {"ok": False, "error": f"No video for participant {participant}"}
+        ), 400
+
+    source_video = ""
+    for p in _participants:
+        if p["id"] == participant:
+            source_video = Path(p["video_path"]).name
+            break
+
+    props = video.probe_video_properties(video_path)
+
+    def _resolve_region_coords(name: str) -> dict[str, Any]:
+        """Convert a named region to pixel coordinates."""
+        rd = all_known_regions[name]
+        if props and props.get("width") and props.get("height"):
+            return _denormalize_region(rd, props["width"], props["height"])
+        return {k: rd[k] for k in ("x", "y", "w", "h") if k in rd}
+
+    if region_name and region_name in all_known_regions:
+        region_coords = _resolve_region_coords(region_name)
+    elif task_type == "multitool":
+        first_step_region = parameters.get("steps", [{}])[0].get("region", "")
+        if first_step_region and first_step_region in all_known_regions:
+            region_name = first_step_region
+            region_coords = _resolve_region_coords(first_step_region)
+        else:
+            region_name = "per_step"
+            region_coords = {"x": 0, "y": 0, "w": 0, "h": 0}
+    else:
+        region_name = "full_frame"
+        region_coords = {"x": 0, "y": 0, "w": 0, "h": 0}
+
+    coerced = _coerce_task_params(task_type, parameters)
+    if isinstance(coerced, tuple):
+        return coerced  # Flask error response
+    parameters = cast(dict[str, Any], coerced)
+
+    extracted = _extract_task_media(task_type, parameters, video_path, region_coords)
+    if isinstance(extracted, tuple):
+        return extracted  # Flask error response
+    parameters = cast(dict[str, Any], extracted)
+
+    if task_type == "multitool":
+        prepared = _prepare_multitool_steps(
+            parameters,
+            all_known_regions,
+            video_path,
+            region_coords,
+            _resolve_region_coords,
+        )
+        if isinstance(prepared, tuple):
+            return prepared  # Flask error response
+        parameters = cast(dict[str, Any], prepared)
+
+    import screenspace
 
     task = screenspace.create_task(
         task_type=task_type,

--- a/transcripts.py
+++ b/transcripts.py
@@ -710,8 +710,8 @@ class TranscriptWorker:
             if self.on_task_complete:
                 try:
                     self.on_task_complete()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    utils.warning_print(f"on_task_complete callback failed: {exc}")
 
     def _execute_task(self, task: dict[str, Any]) -> None:
         """Run a single transcription task."""

--- a/utils.py
+++ b/utils.py
@@ -692,6 +692,16 @@ def letter_to_index(letter: str) -> int:
     return column_index - 1
 
 
+def safe_cell_a1(row: int | None, col: int | None) -> str:
+    """Convert 1-based row/col to A1 notation, returning '' on failure."""
+    import gspread.utils
+
+    try:
+        return gspread.utils.rowcol_to_a1(row, col) if row and col else ""
+    except (TypeError, ValueError):
+        return ""
+
+
 # ---- Timestamp parsing pipeline ----
 #
 # Reading order: token splitting/cleaning → add_duration → _parse_single_timestamp_token

--- a/video.py
+++ b/video.py
@@ -1362,7 +1362,8 @@ def _batch_extract_screenshots(
                 }
             )
         return artifacts if artifacts else None
-    except Exception:
+    except (OSError, ValueError, KeyError) as exc:
+        utils.debug_print(f"Batch screenshot extraction failed: {exc}")
         return None
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
@@ -1410,7 +1411,8 @@ def _parallel_extract_gifs(
                 completed += 1
                 try:
                     ok = future.result()
-                except Exception:
+                except (OSError, RuntimeError) as exc:
+                    utils.debug_print(f"GIF extraction task failed: {exc}")
                     ok = False
                 if ok:
                     artifacts.append(
@@ -1423,7 +1425,8 @@ def _parallel_extract_gifs(
                         }
                     )
                 utils.standard_print(f"  Captured {completed}/{total} at {ts_str}")
-    except Exception:
+    except (OSError, RuntimeError) as exc:
+        utils.debug_print(f"Parallel GIF extraction failed: {exc}")
         return None
 
     artifacts.sort(key=lambda a: a["timestamp"])

--- a/viewer.py
+++ b/viewer.py
@@ -33,7 +33,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-import gspread
 
 import config
 import files
@@ -80,14 +79,7 @@ def build_artifact_records_for_clip(
     cell = clip.get("cell")
     cell_row = getattr(cell, "row", None)
     cell_col = getattr(cell, "col", None)
-    try:
-        cell_a1 = (
-            gspread.utils.rowcol_to_a1(cell_row, cell_col)
-            if cell_row and cell_col
-            else ""
-        )
-    except Exception:
-        cell_a1 = ""
+    cell_a1 = utils.safe_cell_a1(cell_row, cell_col)
 
     annotations = list(clip.get("cell_annotations", []))
 


### PR DESCRIPTION
## Summary

- **Section 5 — Narrow broad exception handling**: Extracted `utils.safe_cell_a1()` to deduplicate identical cell_a1 conversion in `clipgen.py` and `viewer.py`. Narrowed `video.py` exceptions from `Exception` to specific types (`OSError`, `ValueError`, `KeyError`, `RuntimeError`). Added logging to callback exception handlers in `screenspace.py` and `transcripts.py`.
- **Section 6 — Break up god functions**: Extracted 3 helpers from `cli.py main()` (429→~100 lines), 2 navigation handlers from `interactive.py browse_spreadsheet()`, 4 helpers from `screenspace_server.py api_tasks_create()` (345→~60 lines), and 7 per-workflow render functions from `screenspace.js renderWorkflowParams()` (404→~40 lines). Skipped `studio.js renderIntake()` — already 94 lines, not ~437 as originally estimated.
- Also checked off sections 3 and 4 in QUALITY-PLAN.md (confirmed already complete from prior work).

## Test plan

- [x] `uv run ruff check --fix && uv run ruff format` — all clean
- [x] `uv run ty check` — no new errors
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 465 tests pass