### PR TITLE
feat: add cancellation for reel generation and transcription

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1344,6 +1344,15 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   font-size: var(--text-xs);
 }
 
+.btn-cancel {
+  color: var(--sev-critical);
+  border-color: var(--sev-critical);
+}
+
+.btn-cancel:hover {
+  background: rgba(220, 38, 38, 0.1);
+}
+
 .btn-icon svg {
   flex-shrink: 0;
 }

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -228,6 +228,7 @@
           </svg>
           Build Reel
         </button>
+        <button id="cancelReelBtn" class="btn btn-small btn-cancel hidden">Cancel</button>
         <button id="stashReelBtn" class="btn btn-small btn-icon" disabled data-tooltip="Add clips to the reel first">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M3 2C2.44772 2 2 2.44772 2 3V4C2 4.55228 2.44772 5 3 5H13C13.5523 5 14 4.55228 14 4V3C14 2.44772 13.5523 2 13 2H3Z"/>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2247,6 +2247,7 @@
     qs("#stashArtifactsBtn").addEventListener("click", stashCurrentArtifacts);
     qs("#generateBtn").addEventListener("click", onGenerate);
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
+    qs("#cancelReelBtn").addEventListener("click", onCancelReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
     qs("#buildTimelineViewerBtn").addEventListener("click", onBuildTimelineViewer);
     qs("#buildHighlightsBtn").addEventListener("click", onBuildHighlights);
@@ -2327,6 +2328,14 @@
     var p = card.getAttribute("data-participant");
     var r = card.getAttribute("data-row");
     if (p && r) delete state.cellResults[cellKey(p, parseInt(r, 10))];
+  }
+
+  function clearCardStatus(card) {
+    card.classList.remove("queue-card-queued", "queue-card-success", "queue-card-fail");
+    var overlay = card.querySelector(".card-gen-overlay");
+    if (overlay) overlay.remove();
+    var badge = card.querySelector(".card-result-badge");
+    if (badge) badge.remove();
   }
 
   function setCardResult(card, success) {
@@ -2542,11 +2551,17 @@
     }
   }
 
+  function onCancelReel() {
+    qs("#cancelReelBtn").classList.add("hidden");
+    fetch("api/reel/cancel", { method: "POST" });
+  }
+
   function onBuildReel() {
     if (state.generating || state.reelQueue.length === 0) return;
     state.generating = true;
     setGeneratingLock(true);
     setTitleSpinner("reelSpinner", true);
+    qs("#cancelReelBtn").classList.remove("hidden");
 
     // Determine if we have intake items — use direct endpoint for mixed/intake reels
     var hasIntake = false;
@@ -2614,13 +2629,21 @@
         state.generating = false;
         setTitleSpinner("reelSpinner", false);
         setGeneratingLock(false);
+        qs("#cancelReelBtn").classList.add("hidden");
 
+        var cancelled = !!data.cancelled;
         var cards = list.querySelectorAll(".queue-card");
         for (var j = 0; j < cards.length; j++) {
-          setCardResult(cards[j], !!data.ok);
+          if (cancelled) {
+            clearCardStatus(cards[j]);
+          } else {
+            setCardResult(cards[j], !!data.ok);
+          }
         }
 
-        if (data.ok) {
+        if (cancelled) {
+          showResult(null, "Reel generation cancelled");
+        } else if (data.ok) {
           showResult("Reel built successfully", null);
         } else {
           showResult(null, data.error || "Reel build failed");
@@ -2631,6 +2654,7 @@
         state.generating = false;
         setTitleSpinner("reelSpinner", false);
         setGeneratingLock(false);
+        qs("#cancelReelBtn").classList.add("hidden");
 
         var cards = list.querySelectorAll(".queue-card");
         for (var j = 0; j < cards.length; j++) {

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -737,6 +737,28 @@ body {
   color: var(--sev-critical);
 }
 
+.queue-item-status.status-cancelled {
+  color: var(--color-text-dim);
+}
+
+.queue-item-cancel {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: var(--radius-sm);
+  transition: background var(--duration-fast), color var(--duration-fast);
+  font-size: var(--text-sm);
+  line-height: 1;
+  margin-left: auto;
+}
+
+.queue-item-cancel:hover {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--sev-critical);
+}
+
 .queue-progress {
   height: 4px;
   background: var(--color-surface-alt);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1183,6 +1183,7 @@
     var statusClass = "";
     var progress = 0;
     var showProgress = false;
+    var taskId = null;
 
     if (p.has_transcript && (!task || task.status === "completed")) {
       status = "completed";
@@ -1190,6 +1191,7 @@
       progress = 100;
     } else if (task) {
       status = task.status;
+      taskId = task.id;
       if (task.status === "running") {
         statusClass = "status-running";
         progress = Math.round(task.progress * 100);
@@ -1199,12 +1201,14 @@
       } else if (task.status === "failed") {
         statusClass = "status-failed";
         status = "failed";
+      } else if (task.status === "cancelled") {
+        statusClass = "status-cancelled";
       } else if (task.status === "completed") {
         statusClass = "status-completed";
         progress = 100;
       }
     }
-    return { status: status, statusClass: statusClass, progress: progress, showProgress: showProgress };
+    return { status: status, statusClass: statusClass, progress: progress, showProgress: showProgress, taskId: taskId };
   }
 
   function renderQueue() {
@@ -1251,6 +1255,9 @@
       html += '<div class="queue-item-header">';
       html += '<span class="queue-item-id">' + escapeHtml(p.id) + '</span>';
       html += '<span class="queue-item-status ' + s.statusClass + '">' + s.status + (s.showProgress ? " " + s.progress + "%" : "") + '</span>';
+      if (s.taskId && (s.status === "running" || s.status === "queued")) {
+        html += '<button class="queue-item-cancel" data-cancel-task="' + escapeHtml(s.taskId) + '" title="Cancel">&times;</button>';
+      }
       html += '</div>';
 
       if (s.showProgress || s.progress === 100) {
@@ -1286,6 +1293,16 @@
       retranscribeBtns[j].addEventListener("click", function () {
         var pid = this.getAttribute("data-retranscribe");
         transcribeParticipants([pid], true);
+      });
+    }
+
+    var cancelBtns = container.querySelectorAll("[data-cancel-task]");
+    for (var c = 0; c < cancelBtns.length; c++) {
+      cancelBtns[c].addEventListener("click", function () {
+        var taskId = this.getAttribute("data-cancel-task");
+        apiDelete("api/transcribe/" + taskId).then(function () {
+          pollTaskStatus();
+        });
       });
     }
   }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.29"
+VERSIONNUM: str = "0.10.30"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/pipeline.py
+++ b/pipeline.py
@@ -268,6 +268,7 @@ def _run_clip_pipeline(
     show_fallback_counter: bool = False,
     secondary_task_label: str | None = None,
     parallel: bool = False,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> tuple[list[Any], set[str]]:
     """Run shared clip-processing pipeline and return per-clip results.
 
@@ -303,6 +304,10 @@ def _run_clip_pipeline(
                         for idx, clip in enumerate(clips_list)
                     }
                     for future in concurrent.futures.as_completed(future_to_idx):
+                        if cancel_flag and cancel_flag():
+                            for f in future_to_idx:
+                                f.cancel()
+                            break
                         idx = future_to_idx[future]
                         try:
                             results[idx] = future.result()
@@ -326,6 +331,10 @@ def _run_clip_pipeline(
                     for idx, clip in enumerate(clips_list)
                 }
                 for future in concurrent.futures.as_completed(future_to_idx):
+                    if cancel_flag and cancel_flag():
+                        for f in future_to_idx:
+                            f.cancel()
+                        break
                     idx = future_to_idx[future]
                     try:
                         results[idx] = future.result()
@@ -351,6 +360,8 @@ def _run_clip_pipeline(
                         secondary_task_label, total=total_clips
                     )
                 for clip in clips_list:
+                    if cancel_flag and cancel_flag():
+                        break
                     desc_preview = (clip.get("desc") or "")[
                         : config.PROGRESS_DESCRIPTION_LENGTH
                     ]
@@ -364,6 +375,8 @@ def _run_clip_pipeline(
             _active_secondary_task = None
         else:
             for index, clip in enumerate(clips_list, start=1):
+                if cancel_flag and cancel_flag():
+                    break
                 if (
                     show_fallback_counter
                     and getattr(config, "VERBOSITY", config.STANDARD) >= config.VERBOSE
@@ -869,6 +882,7 @@ def _build_reel_transcript(
 def process_reel(
     clips_list: list[ClipRecord],
     output_file: str | None = None,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> tuple[int, list[dict[str, Any]]]:
     """Process clips for reel mode: generate individual clips, concatenate into one video, clean up.
 
@@ -930,7 +944,22 @@ def process_reel(
         task_label="Generating reel clips",
         per_clip_fn=process_reel_clip,
         parallel=True,
+        cancel_flag=cancel_flag,
     )
+
+    # If cancelled, clean up any partial clip files and bail out
+    if cancel_flag and cancel_flag():
+        for item in all_results:
+            if item is None:
+                continue
+            segment_paths, _ = item
+            for entry in segment_paths:
+                try:
+                    Path(entry[0]).unlink(missing_ok=True)
+                except OSError:
+                    pass
+        return (0, [])
+
     # Assemble ordered paths and components from per-clip results
     components: list[dict[str, Any]] = []
     clip_paths = []

--- a/pipeline.py
+++ b/pipeline.py
@@ -976,14 +976,39 @@ def process_reel(
     elif output_file is None:
         output_file = files.get_unique_filename(f"reel{config.FILEFORMAT}")
 
+    # Check cancel flag before starting concatenation
+    if cancel_flag and cancel_flag():
+        for path in clip_paths:
+            try:
+                Path(path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        return (0, [])
+
     def _concat() -> bool:
-        return video.concatenate_clips(clip_paths, output_file, reencode_on_fail=True)
+        return video.concatenate_clips(
+            clip_paths, output_file, reencode_on_fail=True, cancel_flag=cancel_flag
+        )
 
     ok = (
         utils.run_with_spinner("Concatenating clips into final reel...", _concat)
         if utils.use_progress()
         else _concat()
     )
+
+    # If cancelled during concatenation, clean up output and temp clips
+    if cancel_flag and cancel_flag():
+        try:
+            Path(output_file).unlink(missing_ok=True)
+        except OSError:
+            pass
+        for path in clip_paths:
+            try:
+                Path(path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        return (0, [])
+
     for path in clip_paths:
         try:
             clip_path = Path(path)

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ Studio API endpoints (all under /studio/):
   POST /api/highlights-preview – preview highlights reel selection without generating
   POST /api/reel               – build a reel from specified cells
   POST /api/reel-direct        – build a reel from explicit clip paths
+  POST /api/reel/cancel        – cancel an in-progress reel build
   POST /api/viewer             – generate timeline viewer from session artifacts
   POST /api/timeline-viewer    – batch-export all clips and generate timeline viewer
   POST /api/gallery            – generate gallery from a video file
@@ -32,6 +33,7 @@ import hashlib
 import json
 import os
 import sys
+import threading
 import webbrowser
 from contextlib import contextmanager
 from pathlib import Path
@@ -64,6 +66,7 @@ _sheet_context: spreadsheet.SheetContext | None = None
 _generated_artifacts: list[dict[str, Any]] = []
 _generated_reels: list[dict[str, Any]] = []
 _thumbnail_cache: dict[tuple, bytes] = {}
+_reel_cancel_event = threading.Event()
 
 # Snapshot config defaults before any settings file is loaded.
 _settings_defaults: dict[str, Any] = {
@@ -740,7 +743,19 @@ def api_reel() -> FlaskResponse:
                             }
                         )
 
-            generated, reel_records = pipeline.process_reel(clips)
+            _reel_cancel_event.clear()
+            cancel_flag = _reel_cancel_event.is_set
+            generated, reel_records = pipeline.process_reel(
+                clips, cancel_flag=cancel_flag
+            )
+            if _reel_cancel_event.is_set():
+                return jsonify(
+                    {
+                        "ok": False,
+                        "error": "Reel generation cancelled",
+                        "cancelled": True,
+                    }
+                )
             _generated_reels.extend(reel_records)
             _save_manifest_quiet()
             return jsonify({"ok": True, "generated": generated, "reels": reel_records})
@@ -1173,9 +1188,14 @@ def api_reel_direct() -> FlaskResponse:
     clip_paths: list[str] = []
     temp_clips: list[str] = []
 
+    _reel_cancel_event.clear()
+
     with _override_config(**overrides):
         try:
             for seg in segments:
+                if _reel_cancel_event.is_set():
+                    break
+
                 participant = seg.get("participant", "")
                 start = float(seg.get("start", 0))
                 end = float(seg.get("end", 0))
@@ -1202,6 +1222,15 @@ def api_reel_direct() -> FlaskResponse:
                 )
                 if ok:
                     clip_paths.append(tmp_path)
+
+            if _reel_cancel_event.is_set():
+                return jsonify(
+                    {
+                        "ok": False,
+                        "error": "Reel generation cancelled",
+                        "cancelled": True,
+                    }
+                )
 
             if not clip_paths:
                 return (
@@ -1237,6 +1266,13 @@ def api_reel_direct() -> FlaskResponse:
                     Path(tmp).unlink(missing_ok=True)
                 except OSError:
                     pass
+
+
+@studio_bp.route("/api/reel/cancel", methods=["POST"])
+def api_reel_cancel() -> FlaskResponse:
+    """Signal cancellation for the in-progress reel build."""
+    _reel_cancel_event.set()
+    return jsonify({"ok": True})
 
 
 # ---- State initialization ----

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import clipgen
 import config
+import pipeline
 
 
 def _prepared_clip(raw_clip, times):
@@ -201,3 +202,35 @@ def test_resolve_clip_workers(monkeypatch):
 
     monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
     assert pipeline._resolve_clip_workers() == 1
+
+
+def test_run_clip_pipeline_cancel_flag(monkeypatch):
+    """cancel_flag should stop processing remaining clips."""
+    monkeypatch.setattr(pipeline.utils, "create_progress_bar", lambda: None)
+
+    processed = []
+
+    def per_clip_fn(clip, missing_videos):
+        processed.append(clip["id"])
+        return clip["id"]
+
+    clips = [{"id": i, "desc": "", "participant": ""} for i in range(5)]
+
+    # Cancel after the first clip is processed
+    call_count = {"n": 0}
+
+    def cancel_after_first():
+        call_count["n"] += 1
+        return call_count["n"] > 1
+
+    results, _ = pipeline._run_clip_pipeline(
+        clips,
+        empty_warning="",
+        intro_message="",
+        task_label="test",
+        per_clip_fn=per_clip_fn,
+        cancel_flag=cancel_after_first,
+    )
+    # Should have processed only the first clip before cancel was detected
+    assert len(results) == 1
+    assert processed == [0]

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1118,3 +1118,13 @@ def test_save_studio_settings_non_defaults_only(monkeypatch, tmp_path):
     )
     assert result is None
     assert not settings_file.is_file()
+
+
+def test_api_reel_cancel_endpoint(client):
+    """POST /api/reel/cancel should set the cancel event and return ok."""
+    server._reel_cancel_event.clear()
+    resp = client.post("/studio/api/reel/cancel")
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["ok"] is True
+    assert server._reel_cancel_event.is_set()

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -563,9 +563,42 @@ class TestTranscriptWorker:
         assert t is not None
         assert t["status"] == "cancelled"
 
+    def test_cancel_running_task(self):
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", "/v.mp4")
+        worker.enqueue(task)
+        # Simulate the worker picking up the task
+        with worker._lock:
+            worker._tasks[task["id"]]["status"] = "running"
+        assert worker.cancel(task["id"]) is True
+        t = worker.get_task(task["id"])
+        assert t is not None
+        assert t["_cancelled"] is True
+
     def test_cancel_nonexistent(self):
         worker = transcripts.TranscriptWorker()
         assert worker.cancel("nonexistent") is False
+
+    def test_remove_task(self):
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", "/v.mp4")
+        worker.enqueue(task)
+        assert worker.remove_task(task["id"]) is True
+        assert worker.get_task(task["id"]) is None
+
+    def test_remove_running_task_sets_cancelled(self):
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", "/v.mp4")
+        worker.enqueue(task)
+        with worker._lock:
+            worker._tasks[task["id"]]["status"] = "running"
+        assert worker.remove_task(task["id"]) is True
+        # Task is removed, but the _cancelled flag was set before removal
+        assert worker.get_task(task["id"]) is None
+
+    def test_remove_nonexistent(self):
+        worker = transcripts.TranscriptWorker()
+        assert worker.remove_task("nonexistent") is False
 
     def test_is_alive_before_start(self):
         worker = transcripts.TranscriptWorker()

--- a/transcripts.py
+++ b/transcripts.py
@@ -603,6 +603,10 @@ TASK_STATUS_CANCELLED = "cancelled"
 _TRANSCRIPT_SENTINEL = object()
 
 
+class _TranscriptionCancelled(Exception):
+    """Raised inside the on_segment callback to abort a running transcription."""
+
+
 def create_transcript_task(participant: str, video_path: str) -> dict[str, Any]:
     """Create a new transcription task dict ready to enqueue."""
     return {
@@ -616,6 +620,7 @@ def create_transcript_task(participant: str, video_path: str) -> dict[str, Any]:
         "error": None,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "completed_at": None,
+        "_cancelled": False,
     }
 
 
@@ -663,13 +668,29 @@ class TranscriptWorker:
         return task_id
 
     def cancel(self, task_id: str) -> bool:
-        """Cancel a queued task. Returns True if cancelled."""
+        """Cancel a queued or running task. Returns True if cancelled."""
         with self._lock:
             task = self._tasks.get(task_id)
-            if task and task["status"] == TASK_STATUS_QUEUED:
+            if task is None:
+                return False
+            if task["status"] in (TASK_STATUS_QUEUED, TASK_STATUS_CANCELLED):
                 task["status"] = TASK_STATUS_CANCELLED
                 return True
+            if task["status"] == TASK_STATUS_RUNNING:
+                task["_cancelled"] = True
+                return True
         return False
+
+    def remove_task(self, task_id: str) -> bool:
+        """Cancel (if active) and fully remove a task."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return False
+            if task["status"] == TASK_STATUS_RUNNING:
+                task["_cancelled"] = True
+            self._tasks.pop(task_id, None)
+            return True
 
     def get_task(self, task_id: str) -> dict[str, Any] | None:
         """Return a task dict by ID (thread-safe copy)."""
@@ -732,6 +753,8 @@ class TranscriptWorker:
 
         def _on_seg(end_time: float, segment: TranscriptSegment) -> None:
             with self._lock:
+                if task.get("_cancelled"):
+                    raise _TranscriptionCancelled
                 if duration > 0:
                     task["progress"] = min(end_time / duration, 0.99)
                 task["partial_segments"].append(segment)
@@ -761,6 +784,12 @@ class TranscriptWorker:
                     "source_file": result["source_file"],
                     "transcribed_at": datetime.now(timezone.utc).isoformat(),
                 }
+                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+
+        except _TranscriptionCancelled:
+            with self._lock:
+                task["status"] = TASK_STATUS_CANCELLED
+                task["partial_segments"] = []
                 task["completed_at"] = datetime.now(timezone.utc).isoformat()
 
         except Exception as exc:

--- a/transcripts.py
+++ b/transcripts.py
@@ -189,6 +189,8 @@ def transcribe_video(
             source_file=str(video_path),
             model=config.TRANSCRIBE_MODEL,
         )
+    except _TranscriptionCancelled:
+        raise
     except Exception as exc:
         utils.warning_print(f"Transcription failed for {Path(video_path).name}: {exc}")
         return None
@@ -752,9 +754,11 @@ class TranscriptWorker:
         context_kw = get_corrections_keywords(corrections) or None
 
         def _on_seg(end_time: float, segment: TranscriptSegment) -> None:
+            # Check cancel flag outside the lock to avoid deadlock — the
+            # except handler also acquires self._lock.
+            if task.get("_cancelled"):
+                raise _TranscriptionCancelled
             with self._lock:
-                if task.get("_cancelled"):
-                    raise _TranscriptionCancelled
                 if duration > 0:
                     task["progress"] = min(end_time / duration, 0.99)
                 task["partial_segments"].append(segment)

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -22,6 +22,7 @@ API endpoints (all under /transcripts/):
   GET  /api/search?q=<query>                      - keyword search across all participants
   POST /api/transcribe                            - enqueue participant(s) for transcription
   GET  /api/transcribe/status                     - poll transcription task status
+  DELETE /api/transcribe/<task_id>                 - cancel or dismiss a transcription task
 """
 
 import threading
@@ -647,6 +648,25 @@ def api_transcribe_status() -> FlaskResponse:
             "worker_alive": _worker.is_alive if _worker else False,
         }
     )
+
+
+@transcripts_bp.route("/api/transcribe/<task_id>", methods=["DELETE"])
+def api_transcribe_cancel(task_id: str) -> FlaskResponse:
+    """Cancel or dismiss a transcription task. ?dismiss=true fully removes it."""
+    if not _worker:
+        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+
+    if request.args.get("dismiss") == "true":
+        if not _worker.remove_task(task_id):
+            return jsonify({"ok": False, "error": "Task not found"}), 404
+        _persist_manifest()
+        return jsonify({"ok": True})
+
+    if _worker.cancel(task_id):
+        _persist_manifest()
+        return jsonify({"ok": True})
+
+    return jsonify({"ok": False, "error": "Task not found or already finished"}), 400
 
 
 # ---- Manifest persistence ----

--- a/video.py
+++ b/video.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 from collections import Counter
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -77,9 +78,35 @@ def run_ffmpeg_process(
     input_file: str,
     output_file: str,
     os_error_message: str,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> subprocess.CompletedProcess[str] | None:
-    """Run an ffmpeg subprocess and wrap common OS-level failures."""
+    """Run an ffmpeg subprocess and wrap common OS-level failures.
+
+    When *cancel_flag* is supplied and returns ``True`` during execution,
+    the ffmpeg process is terminated and ``None`` is returned.
+    """
     try:
+        if cancel_flag is not None:
+            proc = subprocess.Popen(
+                ffmpeg_command,
+                encoding="utf-8",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            while proc.poll() is None:
+                if cancel_flag():
+                    proc.terminate()
+                    proc.wait(timeout=5)
+                    return None
+                try:
+                    proc.wait(timeout=0.5)
+                except subprocess.TimeoutExpired:
+                    continue
+            stdout = proc.stdout.read() if proc.stdout else ""
+            stderr = proc.stderr.read() if proc.stderr else ""
+            return subprocess.CompletedProcess(
+                ffmpeg_command, proc.returncode, stdout, stderr
+            )
         return subprocess.run(ffmpeg_command, encoding="utf-8", capture_output=True)
     except FileNotFoundError:
         utils.error_print(
@@ -1110,7 +1137,10 @@ def _build_filter_complex_concat(
 
 
 def concatenate_clips(
-    clip_paths: list[str], output_file: str, reencode_on_fail: bool = True
+    clip_paths: list[str],
+    output_file: str,
+    reencode_on_fail: bool = True,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> bool:
     """Concatenate multiple video clips into a single file.
 
@@ -1150,15 +1180,20 @@ def concatenate_clips(
         utils.warning_print(
             "Re-encoding all clips to produce a compatible reel (this may take longer)."
         )
-        return _concatenate_filter_complex(clip_paths, props_list, output_file)
+        return _concatenate_filter_complex(
+            clip_paths, props_list, output_file, cancel_flag=cancel_flag
+        )
 
-    return _concatenate_demuxer(clip_paths, output_file, reencode_on_fail)
+    return _concatenate_demuxer(
+        clip_paths, output_file, reencode_on_fail, cancel_flag=cancel_flag
+    )
 
 
 def _concatenate_filter_complex(
     clip_paths: list[str],
     props_list: list[dict[str, Any] | None],
     output_file: str,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> bool:
     """Concatenate clips using filter_complex (handles resolution/audio mismatches)."""
     target_w, target_h = _pick_target_resolution(props_list)
@@ -1182,6 +1217,7 @@ def _concatenate_filter_complex(
             input_file=clip_paths[0],
             output_file=output_file,
             os_error_message="Filter-complex concatenation failed.",
+            cancel_flag=cancel_flag,
         )
         if result is None or result.returncode != 0:
             error_details = [
@@ -1205,7 +1241,10 @@ def _concatenate_filter_complex(
 
 
 def _concatenate_demuxer(
-    clip_paths: list[str], output_file: str, reencode_on_fail: bool
+    clip_paths: list[str],
+    output_file: str,
+    reencode_on_fail: bool,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> bool:
     """Concatenate clips using concat demuxer (fast path for matching properties)."""
     with tempfile.NamedTemporaryFile(
@@ -1240,6 +1279,7 @@ def _concatenate_demuxer(
             input_file=concat_list_file,
             output_file=output_file,
             os_error_message="Concatenation failed.",
+            cancel_flag=cancel_flag,
         )
         if ffmpeg_result is None:
             return False
@@ -1270,6 +1310,7 @@ def _concatenate_demuxer(
                 input_file=concat_list_file,
                 output_file=output_file,
                 os_error_message="Concatenation failed during re-encoding fallback.",
+                cancel_flag=cancel_flag,
             )
             if ffmpeg_result is None:
                 return False


### PR DESCRIPTION
## Summary

- Adds cancel buttons for **Reel generation** (Studio) and **Transcription** (Transcripts) — two long-running tasks that previously could not be stopped once started.
- Reel cancellation uses a `threading.Event` + `POST /api/reel/cancel` endpoint; ffmpeg subprocesses are terminated via `Popen` polling instead of blocking `subprocess.run`, so cancel takes effect even mid-concatenation.
- Transcription cancellation extends `TranscriptWorker.cancel()` to handle running tasks via a `_cancelled` flag checked per-segment, with a new `DELETE /api/transcribe/<task_id>` endpoint and cancel buttons in the queue panel.
- Both patterns follow the existing Screenspace task dismissal UX.

## Test plan
- [ ] Start a reel build in Studio → click Cancel → verify spinner stops, temp files cleaned up, "cancelled" message shown
- [ ] Start a transcription → click Cancel → verify status shows "cancelled" (not "failed"), participant shows "Transcribe" button again
- [ ] Enqueue multiple transcriptions → cancel a queued one → verify it cancels without affecting the running task
- [ ] Run `uv run --extra dev pytest -c tests/pytest.ini` — all 471 tests pass