### PR TITLE
perf: DocumentFragment batching for Insights Builder

### DIFF
--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -181,16 +181,18 @@
 
   function fillSelect(sel, values, allLabel) {
     while (sel.options.length > 0) sel.remove(0);
+    var frag = document.createDocumentFragment();
     var opt = document.createElement("option");
     opt.value = "";
     opt.textContent = allLabel;
-    sel.appendChild(opt);
+    frag.appendChild(opt);
     for (var i = 0; i < values.length; i++) {
       var o = document.createElement("option");
       o.value = values[i];
       o.textContent = values[i];
-      sel.appendChild(o);
+      frag.appendChild(o);
     }
+    sel.appendChild(frag);
   }
 
   function populateFilters() {
@@ -409,9 +411,11 @@
       grid.appendChild(el("div", "empty-state", "No artifacts match filters."));
       return;
     }
+    var frag = document.createDocumentFragment();
     for (var i = 0; i < ordered.length; i++) {
-      grid.appendChild(createArtifactCard(ordered[i]));
+      frag.appendChild(createArtifactCard(ordered[i]));
     }
+    grid.appendChild(frag);
   }
 
   function createArtifactCard(artifact) {
@@ -754,6 +758,7 @@
 
     if (expandedIds.length > 1) {
       insightSelect.classList.remove("hidden");
+      var frag = document.createDocumentFragment();
       for (var i = 0; i < state.insights.length; i++) {
         var ins = state.insights[i];
         if (!state.expandedInsightIds[ins.id]) continue;
@@ -763,8 +768,9 @@
           state._popoverTargetInsight = this.dataset.insightId;
           insightSelect.classList.add("hidden");
         });
-        insightSelect.appendChild(btn);
+        frag.appendChild(btn);
       }
+      insightSelect.appendChild(frag);
     } else {
       insightSelect.classList.add("hidden");
       if (expandedIds.length === 1) {
@@ -970,9 +976,11 @@
       return;
     }
 
+    var frag = document.createDocumentFragment();
     for (var i = 0; i < state.insights.length; i++) {
-      container.appendChild(createInsightCard(state.insights[i]));
+      frag.appendChild(createInsightCard(state.insights[i]));
     }
+    container.appendChild(frag);
   }
 
   function createInsightCard(insight) {
@@ -1144,14 +1152,16 @@
     if (bucket.artifacts.length === 0) {
       dropzone.appendChild(el("div", "bucket-empty-hint", "Drag artifacts here"));
     } else {
+      var frag = document.createDocumentFragment();
       for (var i = 0; i < bucket.artifacts.length; i++) {
         var art = findArtifact(bucket.artifacts[i]);
         if (art) {
-          dropzone.appendChild(
+          frag.appendChild(
             createPreviewCard(art, insight.id, bucketName, i)
           );
         }
       }
+      dropzone.appendChild(frag);
     }
 
     // Drop events

--- a/plans/PERFORMANCE-PLAN.md
+++ b/plans/PERFORMANCE-PLAN.md
@@ -102,7 +102,7 @@ How fast clipgen *feels* to the user, independent of actual processing time.
 
 **Prior art:** DocumentFragment batching already applied to Studio grid rendering (`89bd136`).
 
-**Status (audit):** `renderList()` in [assets/web/viewer.js](../assets/web/viewer.js) and results rendering in [assets/web/screenspace.js](../assets/web/screenspace.js) now build a `DocumentFragment` and append once. **Remaining candidate:** [assets/web/insights-builder.js](../assets/web/insights-builder.js) artifact grid and insight cards still append per item in a loop — apply the same fragment pattern (or virtual scrolling for very large lists; pairs with 6A).
+**Status (audit):** `renderList()` in [assets/web/viewer.js](../assets/web/viewer.js) and results rendering in [assets/web/screenspace.js](../assets/web/screenspace.js) now build a `DocumentFragment` and append once. **Done:** [assets/web/insights-builder.js](../assets/web/insights-builder.js) now also uses `DocumentFragment` for artifact grid (`renderArtifactGrid`), insight cards (`renderInsightCards`), bucket preview cards (`createBucketSection`), popover buttons (`showAddPopover`), and filter selects (`fillSelect`).
 
 **Experiment:** Build cards inside a `DocumentFragment`, then append the fragment in a single DOM write. For 200+ artifacts this eliminates hundreds of reflows.
 
@@ -467,4 +467,4 @@ Additional opportunities identified in a fresh pass over the codebase (April 202
 | deferred | 21 | **8.4** — Batch screenshot extraction (clip pipeline) — deferred (existing parallelism covers this) | Medium — many screens / same video |
 | [x] | 22 | **8.5** — Highlights scoring pre-lowercase | Low — scales with artifacts |
 | [x] | 23 | **8.6** — Manifest single-read (`_load_manifest_both`) | Low — eliminates duplicate file parse |
-| [ ] | 24 | **1E (remainder)** — Insights Builder DOM batching / virtual scroll | Low–Medium — perceived smoothness |
+| [x] | 24 | **1E (remainder)** — Insights Builder DOM batching / virtual scroll | Low–Medium — perceived smoothness |


### PR DESCRIPTION
## Summary

- Converts 5 per-item DOM append loops in `insights-builder.js` to use `DocumentFragment` for single-write batching: `renderArtifactGrid`, `renderInsightCards`, `createBucketSection`, `showAddPopover`, and `fillSelect`
- Completes performance plan item 24 (section 1E remainder) — the same pattern already applied in `viewer.js` and `screenspace.js`
- Eliminates redundant reflows when rendering large artifact grids or insight card lists

## Test plan

- [x] All 471 tests pass
- [ ] Open Insights Builder with 50+ artifacts, verify grid renders correctly
- [ ] Create/expand multiple insight cards, verify cards and bucket sections render correctly