### PR TITLE
feat: add copy-to-clipboard button on transcript lines

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -659,6 +659,42 @@ body {
   background: none;
 }
 
+/* Copy button */
+
+.segment-copy {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--duration-fast), background var(--duration-fast);
+  color: var(--color-text-dim);
+}
+
+.segment-row:hover .segment-copy {
+  opacity: 1;
+}
+
+.segment-copy:hover {
+  background: var(--color-selected);
+  color: var(--color-text);
+}
+
+.segment-copy-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+  background-color: currentColor;
+  mask-image: url(icons/clipboard.svg);
+  -webkit-mask-image: url(icons/clipboard.svg);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+}
+
 /* Queue panel */
 
 #queuePanel {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -407,6 +407,7 @@
         }
       }
       html += '<span class="segment-text" data-id="' + escapeHtml(seg.id) + '">' + wordHtml + '</span>';
+      html += '<span class="segment-copy" title="Copy text"><span class="segment-copy-icon"></span></span>';
       html += '</div>';
     }
     container.innerHTML = html;
@@ -444,6 +445,15 @@
             toggleMark(segId);
           }
         });
+        row.querySelector(".segment-copy").addEventListener("click", function (e) {
+          e.stopPropagation();
+          var idx = parseInt(row.getAttribute("data-index"), 10);
+          var seg = state.segments[idx];
+          if (!seg) return;
+          navigator.clipboard.writeText(seg.text).then(function () {
+            showToast("Copied to clipboard");
+          });
+        });
       })(rows[j]);
     }
   }
@@ -475,6 +485,7 @@
       html += '<span class="' + markClass + '" data-segment-id="' + escapeHtml(segId) + '"' + markStyle + '></span>';
       html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
       html += '<span class="segment-text">' + escapeHtml(seg.text) + '</span>';
+      html += '<span class="segment-copy" title="Copy text"><span class="segment-copy-icon"></span></span>';
       html += '</div>';
     }
     html += '<div class="streaming-indicator">';
@@ -511,6 +522,15 @@
           } else {
             toggleMarkStreaming(segId, this);
           }
+        });
+        row.querySelector(".segment-copy").addEventListener("click", function (e) {
+          e.stopPropagation();
+          var idx = parseInt(row.getAttribute("data-index"), 10);
+          var seg = segments[idx];
+          if (!seg) return;
+          navigator.clipboard.writeText(seg.text).then(function () {
+            showToast("Copied to clipboard");
+          });
         });
       })(rows[j]);
     }

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.30"
+VERSIONNUM: str = "0.10.31"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Adds a clipboard icon button to the right of each transcript segment row that copies the line's text to the clipboard on click
- Button appears on hover, works in both completed and streaming transcription states
- Uses existing `clipboard.svg` icon with CSS mask-image pattern and shows toast feedback on copy

## Test plan
- [ ] Open Transcripts workspace with a transcribed video
- [ ] Hover a segment row — copy button should appear on the right
- [ ] Click copy button — toast confirms copy, video does not seek
- [ ] Start a new transcription — copy buttons appear on streaming segments too