### PR TITLE
refactor: tidy config, consolidate imports, tokenize frontend values (quality plan 10-12)

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -4,7 +4,6 @@
   "use strict";
 
   var THEME_STORAGE_KEY = "clipgen-screenspace-theme";
-  var POLL_INTERVAL = 3000;
   var FRAME_STEP = 1.0;
 
   var TASK_COLORS = DETECTOR_COLORS;

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -14,7 +14,7 @@
   --color-cell-valid: #93c5fd;
   --color-cell-selected: #c4b5fd;
   --color-heatmap: 168, 130, 214;
-  --color-cell-hover: rgba(29, 79, 114, 0.06);
+  --color-cell-hover: var(--color-accent-hover);
 }
 
 html {
@@ -684,7 +684,7 @@ body {
 
 #sheetGrid .col-participant.header-highlight,
 #sheetGrid .col-row-num-clickable.header-highlight {
-  background-color: rgba(29, 79, 114, 0.15);
+  background-color: var(--color-accent-highlight);
   color: var(--color-accent);
 }
 
@@ -1725,7 +1725,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
     --color-cell-text: #1e3a5f;
     --color-cell-valid: #1d4ed8;
     --color-cell-selected: #6d28d9;
-    --color-cell-hover: rgba(56, 189, 248, 0.08);
+    --color-cell-hover: var(--color-accent-hover);
     --color-heatmap: 192, 160, 235;
   }
 }
@@ -1736,14 +1736,14 @@ html[data-theme="dark"] {
   --color-cell-valid: #1d4ed8;
   --color-cell-selected: #6d28d9;
   --color-heatmap: 192, 160, 235;
-  --color-cell-hover: rgba(56, 189, 248, 0.08);
+  --color-cell-hover: var(--color-accent-hover);
 }
 
 /* Dark element overrides (shared by both @media and data-theme via specificity) */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) #sheetGrid .col-participant.header-highlight,
   :root:not([data-theme="light"]) #sheetGrid .col-row-num-clickable.header-highlight {
-    background-color: rgba(56, 189, 248, 0.18);
+    background-color: var(--color-accent-highlight);
   }
   :root:not([data-theme="light"]) .status-card,
   :root:not([data-theme="light"]) .confirm-card {
@@ -1778,7 +1778,7 @@ html[data-theme="dark"] {
 
 html[data-theme="dark"] #sheetGrid .col-participant.header-highlight,
 html[data-theme="dark"] #sheetGrid .col-row-num-clickable.header-highlight {
-  background-color: rgba(56, 189, 248, 0.18);
+  background-color: var(--color-accent-highlight);
 }
 
 html[data-theme="dark"] .status-card,

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -9,7 +9,7 @@
  * Z-INDEX:    --z-float (10) | --z-dropdown (100) | --z-modal (1000) | --z-overlay (2000) | --z-toast (3000)
  *
  * THEME:      --color-bg | --color-surface | --color-surface-alt | --color-text | --color-text-dim
- *             --color-accent | --color-border | --color-selected
+ *             --color-accent | --color-border | --color-selected | --color-accent-hover | --color-accent-highlight
  *             --color-panel-bg | --color-panel-border | --color-panel-shadow | --color-grid
  *             --font-mono
  * SEVERITY:   --sev-critical | --sev-high | --sev-medium | --sev-low | --sev-na
@@ -57,6 +57,8 @@
   --color-accent: #1d4f72;
   --color-border: #e0ddd7;
   --color-selected: rgba(29, 79, 114, 0.08);
+  --color-accent-hover: rgba(29, 79, 114, 0.06);
+  --color-accent-highlight: rgba(29, 79, 114, 0.15);
   --color-panel-bg: rgba(255, 255, 255, 0.97);
   --color-panel-border: rgba(148, 163, 184, 0.22);
   --color-panel-shadow: rgba(15, 23, 42, 0.12);
@@ -129,6 +131,8 @@
     --color-accent: #38bdf8;
     --color-border: #1f2933;
     --color-selected: rgba(56, 189, 248, 0.2);
+    --color-accent-hover: rgba(56, 189, 248, 0.08);
+    --color-accent-highlight: rgba(56, 189, 248, 0.18);
     --color-panel-bg: rgba(15, 23, 42, 0.98);
     --color-panel-border: rgba(148, 163, 184, 0.35);
     --color-panel-shadow: rgba(0, 0, 0, 0.7);
@@ -174,6 +178,8 @@ html[data-theme="dark"] {
   --color-accent: #38bdf8;
   --color-border: #1f2933;
   --color-selected: rgba(56, 189, 248, 0.2);
+  --color-accent-hover: rgba(56, 189, 248, 0.08);
+  --color-accent-highlight: rgba(56, 189, 248, 0.18);
   --color-panel-bg: rgba(15, 23, 42, 0.98);
   --color-panel-border: rgba(148, 163, 184, 0.35);
   --color-panel-shadow: rgba(0, 0, 0, 0.7);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2,7 +2,6 @@
   "use strict";
 
   var THEME_STORAGE_KEY = "clipgen-transcripts-theme";
-  var POLL_INTERVAL = 3000;
   var SEARCH_DEBOUNCE = 300;
 
   var fmtTime = formatTime;

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -94,6 +94,10 @@ var apiDelete = function (path) {
   });
 };
 
+// ---- Polling ----
+
+var POLL_INTERVAL = 3000;
+
 // ---- Mark categories (mirrored from transcripts.py MARK_CATEGORIES) ----
 // Kept in sync by tests/test_shared_constants.py — update both together.
 

--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,7 @@ import clipgen
 import config
 import files
 import spreadsheet
+import transcripts
 import utils
 import video
 import viewer
@@ -781,8 +782,6 @@ def _run_gallery_cli(args: argparse.Namespace) -> None:
 
 def _run_pre_transcribe(worksheet: Any, args: Any) -> None:
     """Pre-transcribe source videos for specified participants."""
-    import transcripts
-
     ctx = spreadsheet.build_sheet_context(worksheet)
     if ctx is None:
         utils.error_print("Cannot build sheet context.")

--- a/config.py
+++ b/config.py
@@ -1,15 +1,35 @@
 # -*- coding: utf-8 -*-
-"""Configuration constants for clipgen."""
+"""Configuration constants for clipgen.
+
+Sections
+--------
+  Core Runtime         Feature toggles, version, verbosity, debugging
+  Directories          Input/output path overrides
+  Spreadsheet          Column headers, participant prefixes, severity maps, annotations
+  Files & Durations    Clip limits, gallery, manifests, server port, workers
+  Sprite Sheets        Insights builder hover-to-scrub thumbnails
+  Screenspace          Analysis thresholds, sampling, matching, performance
+  Highlights Reel      Duration budget and scoring weights
+  Browse Mode          Interactive table display settings
+  Spreadsheet Commands Special command keywords for document selection
+  Display / Preview    Text truncation limits
+  Timestamps           Format constants for timestamp parsing
+  FFmpeg               Encoding parameters, compression
+  Source Video          Filename pattern for participant videos
+  Transcription        faster-whisper model and format settings
+  Rich Output          Terminal color/panel/progress settings
+  Settings Metadata    Descriptions and Studio UI metadata
+"""
 
 from typing import Any
 
 from icecream import ic
 
-# Configuration Constants
+# ── Core Runtime ─────────────────────────────────────────────────────
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.30"
+VERSIONNUM: str = "0.10.31"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -35,7 +55,7 @@ STANDARD: int = 1
 VERBOSE: int = 2
 VERBOSITY: int = STANDARD
 
-# Directory configuration
+# ── Directories ──────────────────────────────────────────────────────
 # When left empty, clipgen will use the current working directory for
 # both input (source videos) and output (generated artifacts), matching
 # the existing default behavior.
@@ -48,7 +68,7 @@ if DEBUGGING:
 else:
     ic.disable()
 
-# Spreadsheet Structure Constants
+# ── Spreadsheet ──────────────────────────────────────────────────────
 ID_HEADER: str = "ID"
 OBSERVATION_HEADER: str = "Observation"
 CATEGORY_HEADER: str = "Category"
@@ -84,7 +104,7 @@ IGNORED_TIMESTAMP_TOKENS: set[str] = {
     "x"
 }  # tokens skipped silently during timestamp parsing
 
-# File and Duration Constants
+# ── Files & Durations ────────────────────────────────────────────────
 MAX_FILENAME_LENGTH: int = 255
 MAX_CLIP_DURATION_SECONDS: int = (
     600  # 10 min; prompts user for confirmation before generating longer clips
@@ -117,13 +137,13 @@ STUDIO_SETTINGS_FILENAME: str = "studio_settings.json"
 STUDIO_CELL_EXPAND_HOVER: bool = True
 GOOGLE_API_MAX_RETRIES: int = 3  # Retries for transient Google API errors (5xx)
 
-# Sprite sheet constants (for insights builder hover-to-scrub)
+# ── Sprite Sheets ────────────────────────────────────────────────────
 SPRITE_SHEET_FRAME_COUNT: int = 20
 SPRITE_SHEET_THUMB_WIDTH: int = 160
 SPRITE_SHEET_MIN_INTERVAL: int = 1
 STUDIO_THUMBNAIL_WIDTH: int = 200
 
-# Screenspace constants
+# ── Screenspace ──────────────────────────────────────────────────────
 SCREENSPACE_MANIFEST_FILENAME: str = "screenspace_manifest.json"
 TRANSCRIPTS_MANIFEST_FILENAME: str = "transcripts_manifest.json"
 SCREENSPACE_DEFAULT_INTERVAL: float = (
@@ -165,7 +185,7 @@ SCREENSPACE_INACTIVITY_MIN_DURATION: float = (
     2.0  # min seconds to report an inactivity span
 )
 
-# Highlights reel constants
+# ── Highlights Reel ──────────────────────────────────────────────────
 HIGHLIGHTS_REEL_DURATION_SECONDS: int = 180  # 3-minute budget for highlights reel
 HIGHLIGHTS_WEIGHT_SEVERITY: float = (
     1.0  # scoring weight for severity in highlights reel ranking
@@ -173,13 +193,13 @@ HIGHLIGHTS_WEIGHT_SEVERITY: float = (
 HIGHLIGHTS_WEIGHT_UNIQUENESS: float = 0.5  # scoring weight for participant uniqueness
 HIGHLIGHTS_WEIGHT_KEYWORD: float = 0.3  # scoring weight for !key annotation
 
-# Browse Mode Constants
+# ── Browse Mode ──────────────────────────────────────────────────────
 BROWSE_LINES_TO_DISPLAY: int = 5  # Number of rows to show at once when browsing
 BROWSE_LINES_TO_SCROLL: int = 5  # Number of rows to move when scrolling up/down
 BROWSE_DESCRIPTION_MAX_WIDTH: int = 40  # Max width for description column in table
 BROWSE_TIMESTAMP_MAX_WIDTH: int = 15  # Max width for each timestamp column
 
-# Spreadsheet Selection Commands
+# ── Spreadsheet Commands ─────────────────────────────────────────────
 COMMAND_LIST_ALL: str = "all"
 COMMAND_LIST_NEW: str = "new"
 COMMAND_OPEN_LAST: str = "last"
@@ -190,7 +210,7 @@ NUM_NEWEST_DOCS_TO_SHOW: int = (
     3  # Number of newest documents to show when using 'new' command
 )
 
-# Display / preview constants
+# ── Display / Preview ────────────────────────────────────────────────
 DESCRIPTION_PREVIEW_LENGTH: int = 50  # Max chars for description in previews
 PROGRESS_DESCRIPTION_LENGTH: int = 30  # Max chars for description in progress bar
 REEL_PREVIEW_CLIP_COUNT: int = 10  # Number of clips to show in reel mode preview
@@ -198,12 +218,12 @@ MAX_SKIPPED_TIMESTAMPS_TO_SHOW: int = (
     3  # Max skipped timestamps to list in parse_timestamps warning
 )
 
-# Timestamp format constants
+# ── Timestamps ───────────────────────────────────────────────────────
 SECONDS_PER_HOUR: int = 3600
 SECONDS_PER_MINUTE: int = 60
 MAX_MMSS_LENGTH: int = 5  # Max length of an MM:SS timestamp string
 
-# ffmpeg constants
+# ── FFmpeg ────────────────────────────────────────────────────────────
 FFMPEG_LOGLEVEL: str = "16"  # ffmpeg -loglevel value (16 = error)
 FFMPEG_SCREENSHOT_QUALITY: str = "2"  # -q:v value for screenshots (1=best, 31=worst)
 GIF_FPS: int = 10
@@ -212,10 +232,10 @@ AUDIO_BITRATE_KBPS: int = 128
 COMPRESSION_SIZE_FACTOR: float = 0.95  # Target 95% of max to leave headroom
 MIN_VIDEO_BITRATE_KBPS: int = 100
 
-# Source video pattern
+# ── Source Video ──────────────────────────────────────────────────────
 SOURCE_VIDEO_PATTERN: str = r"_[PG]\d+\.mp4$"
 
-# Transcription constants (faster-whisper)
+# ── Transcription ────────────────────────────────────────────────────
 TRANSCRIBE_ENABLED: bool = False  # use --transcribe CLI flag to enable per run
 TRANSCRIBE_MODEL: str = "base"  # tiny, base, small, medium, large-v3
 TRANSCRIBE_LANGUAGE: str | None = None  # None = auto-detect
@@ -224,12 +244,12 @@ TRANSCRIBE_FORMAT: str = "md"  # md, srt, vtt
 TRANSCRIBE_INITIAL_PROMPT: str = "This is a recorded user experience research session."  # biases Whisper toward UX research terminology
 TRANSCRIBE_BEAM_SIZE: int = 5  # beam search width
 
-# Rich output settings
+# ── Rich Output ──────────────────────────────────────────────────────
 RICH_COLORS: bool = True  # Enable/disable colored output (set False for piped output)
 RICH_PANELS: bool = True  # Use bordered panels for errors/warnings/success messages
 RICH_PROGRESS: bool = True  # Show progress bars during batch/reel processing
 
-# Settings descriptions (used by interactive settings helpers)
+# ── Settings Metadata ────────────────────────────────────────────────
 SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "REENCODING": "Re-encode clips via ffmpeg instead of stream-copying. Slower but fixes some codec issues.",
     "AUDIO_NORMALIZE": "Normalize audio levels across generated clips for consistent volume.",
@@ -255,7 +275,6 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
 }
 
 # Studio-exposed settings with UI metadata (group, type, constraints).
-# Keys must match module-level attributes above and entries in SETTINGS_DESCRIPTIONS.
 STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
     "REENCODING": {"group": "Video Output", "type": "bool"},
     "AUDIO_NORMALIZE": {"group": "Video Output", "type": "bool"},

--- a/pipeline.py
+++ b/pipeline.py
@@ -25,6 +25,8 @@ from icecream import ic
 
 import config
 import files
+import titlecards
+import transcripts
 import utils
 import video
 import viewer
@@ -224,8 +226,6 @@ def _process_single_clip_segments(
             )
             clip_resolution = None
             if ok and config.TITLECARDS_ENABLED:
-                import titlecards
-
                 props = video.probe_video_properties(out_name)
                 if props:
                     clip_resolution = f"{props['width']}x{props['height']}"
@@ -233,8 +233,6 @@ def _process_single_clip_segments(
                     clip, out_name, resolution=clip_resolution
                 )
             if ok:
-                import titlecards
-
                 ok = titlecards.append_endcard_to_clip(
                     out_name, resolution=clip_resolution
                 )
@@ -402,7 +400,6 @@ def _embed_transcript_on_artifacts(
 
     Source priority: transcripts manifest -> in-memory cache. Modifies artifacts in-place.
     """
-    import transcripts
 
     participant = clip.get("participant", "")
     manifest = transcripts_manifest or transcripts.load_transcripts_manifest()
@@ -461,8 +458,6 @@ def _transcribe_segments(
     transcripts_manifest: dict[str, Any] | None = None,
 ) -> None:
     """Transcribe segments of a clip and write transcript files."""
-    import transcripts
-
     if base_video not in transcript_cache:
         participant = clip.get("participant", "")
         manifest = transcripts_manifest or transcripts.load_transcripts_manifest()
@@ -726,10 +721,8 @@ def process_clips(
     outputs_generated = 0
     outputs_skipped = skipped_no_times + skipped_no_video
 
-    # Lazy-load transcripts manifest once for embedding + transcription
-    import transcripts as _tr_mod
-
-    transcripts_manifest = _tr_mod.load_transcripts_manifest()
+    # Load transcripts manifest once for embedding + transcription
+    transcripts_manifest = transcripts.load_transcripts_manifest()
 
     for idx, (clip, base_video) in enumerate(prepared):
         generated_count, segment_details = results[idx]
@@ -801,8 +794,6 @@ def process_clips(
         "gif": "GIF(s)",
     }.get(output_format, "file(s)")
     if config.TITLECARDS_ENABLED:
-        import titlecards
-
         titlecards.clear_endcard_cache()
 
     if outputs_skipped > 0:
@@ -828,8 +819,6 @@ def _build_reel_transcript(
     Segments are derived from each component's source transcript,
     with timestamps offset by cumulative component durations + titlecard durations.
     """
-    import transcripts
-
     manifest = transcripts.load_transcripts_manifest()
     source_transcripts = manifest.get("source_transcripts", {})
     corrections = manifest.get("corrections", [])

--- a/plans/QUALITY-PLAN.md
+++ b/plans/QUALITY-PLAN.md
@@ -94,7 +94,7 @@ Both `viewer.html` and `timeline-viewer.html` exist. Studio/CLI per-participant 
 
 `config.py` is 301 lines of flat globals mutated from `cli.py`. `server.py` works around this with `_settings_defaults` snapshots and an `_override_config()` context manager.
 
-- [ ] Group related constants (screenspace thresholds, ffmpeg params, file format settings) into named sections or lightweight dataclass-like groupings
+- [x] Group related constants (screenspace thresholds, ffmpeg params, file format settings) into named sections or lightweight dataclass-like groupings
 - [x] Extract the CLI config-override block (`cli.py:1300-1312`) into a dedicated `apply_cli_overrides(args)` function
 
 ---
@@ -103,9 +103,9 @@ Both `viewer.html` and `timeline-viewer.html` exist. Studio/CLI per-participant 
 
 8 function-local imports of `transcripts`, `screenspace`, `screenspace_server`, and `transcripts_server` are scattered across the codebase as circular-dependency workarounds.
 
-- [ ] Map the actual dependency graph to determine which cycles are real vs. vestigial
-- [ ] Where possible, resolve by moving the needed function to a non-cyclic location or by restructuring imports
-- [ ] For genuinely optional heavy deps (easyocr), create a shared `utils.try_import(name)` pattern
+- [x] Map the actual dependency graph to determine which cycles are real vs. vestigial
+- [x] Where possible, resolve by moving the needed function to a non-cyclic location or by restructuring imports
+- [x] For genuinely optional heavy deps (easyocr), create a shared `utils.try_import(name)` pattern
 
 ---
 
@@ -113,6 +113,6 @@ Both `viewer.html` and `timeline-viewer.html` exist. Studio/CLI per-participant 
 
 Scattered `rgba()` values, canvas dimensions, poll intervals, and font-size scaling factors are hardcoded in JS and CSS.
 
-- [ ] Add opacity-variant tokens to `tokens.css` (e.g., `--alpha-subtle`, `--alpha-overlay`)
-- [ ] Replace hardcoded accent-with-opacity values in `studio.css` with token-derived values
-- [ ] Define `POLL_INTERVAL` in one place (currently duplicated in `screenspace.js` and `transcripts.js`)
+- [x] Add opacity-variant tokens to `tokens.css` (e.g., `--alpha-subtle`, `--alpha-overlay`)
+- [x] Replace hardcoded accent-with-opacity values in `studio.css` with token-derived values
+- [x] Define `POLL_INTERVAL` in one place (currently duplicated in `screenspace.js` and `transcripts.js`)

--- a/screenspace.py
+++ b/screenspace.py
@@ -1034,12 +1034,7 @@ def scan_text(
     EasyOCR is lazy-imported. Raises ``ImportError`` with install
     instructions if missing.
     """
-    try:
-        import easyocr  # noqa: F401 — validate availability
-    except ImportError:
-        raise ImportError(
-            "EasyOCR is required for text scan. Install with: uv add easyocr"
-        ) from None
+    utils.require_optional("easyocr", "text scan")
 
     if fuzzy_threshold <= 0:
         fuzzy_threshold = config.SCREENSPACE_OCR_FUZZY_THRESHOLD
@@ -1163,12 +1158,7 @@ def scan_numbers(
             f"Unknown operator '{operator}'. Must be one of: {', '.join(_VALID_OPERATORS)}"
         )
 
-    try:
-        import easyocr  # noqa: F401 — validate availability
-    except ImportError:
-        raise ImportError(
-            "EasyOCR is required for numbers scan. Install with: uv add easyocr"
-        ) from None
+    utils.require_optional("easyocr", "numbers scan")
 
     if languages is None:
         languages = ["en"]

--- a/utils.py
+++ b/utils.py
@@ -493,6 +493,16 @@ def resolve_output_path(name: str) -> Path:
     return base / path
 
 
+def require_optional(module_name: str, feature_label: str) -> None:
+    """Raise ImportError with install instructions if *module_name* is missing."""
+    try:
+        __import__(module_name)
+    except ImportError:
+        raise ImportError(
+            f"{module_name} is required for {feature_label}. Install with: uv add {module_name}"
+        ) from None
+
+
 def load_json_manifest(filename: str, *, default: Any = None) -> Any:
     """Load a JSON manifest from the output directory.
 


### PR DESCRIPTION
## Summary
- **Section 10**: Standardized `config.py` with a structured TOC and consistent `# ── Section ──` dividers across all 16 sections
- **Section 11**: Promoted 8 non-circular lazy imports (`transcripts`, `titlecards`) to module level in `pipeline.py` and `cli.py`; added `utils.require_optional()` helper and used it for easyocr validation in `screenspace.py`
- **Section 12**: Added `--color-accent-hover` / `--color-accent-highlight` tokens to `tokens.css`, replaced 6 hardcoded `rgba()` values in `studio.css`, moved `POLL_INTERVAL` from `screenspace.js`/`transcripts.js` into shared `utils.js`

## Test plan
- [x] Full test suite passes (471 tests)
- [x] Type checking clean (`ty check`)
- [ ] Verify Studio hover highlights and header highlights in light/dark mode
- [ ] Verify Screenspace and Transcripts task polling still works