### PR TITLE
feat: bundle gallery images as base64 data URIs in HTML

### DIFF
--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -121,7 +121,7 @@
       card.setAttribute("data-index", i);
 
       var img = document.createElement("img");
-      img.src = a.file;
+      img.src = a.data || a.file;
       img.alt = a.timestamp_formatted || formatTime(a.timestamp);
       img.loading = "lazy";
       card.appendChild(img);
@@ -169,7 +169,7 @@
     var content = qs("#lightboxContent");
     content.innerHTML = "";
     var img = document.createElement("img");
-    img.src = a.file;
+    img.src = a.data || a.file;
     img.alt = a.timestamp_formatted || formatTime(a.timestamp);
     content.appendChild(img);
 

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1520,6 +1520,11 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   font-family: var(--font-mono);
 }
 
+.gallery-drawer-checkbox {
+  margin: 0;
+  cursor: pointer;
+}
+
 /* Title spinner */
 
 .title-spinner {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -41,6 +41,10 @@
             <label class="gallery-drawer-label">Interval (s)
               <input id="galleryInterval" type="number" min="1" step="1" value="10" class="gallery-drawer-input">
             </label>
+            <label class="gallery-drawer-label gallery-drawer-bundle">
+              <input id="galleryBundle" type="checkbox" class="gallery-drawer-checkbox" autocomplete="off">
+              Bundle
+            </label>
           </div>
         </div>
         <button id="logBtn" type="button" class="btn btn-small btn-icon" title="Artifact Log">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2864,6 +2864,7 @@
     var format = qs("#galleryFormat").value;
     var interval = parseInt(qs("#galleryInterval").value, 10);
     if (!interval || interval < 1) interval = 10;
+    var bundle = qs("#galleryBundle").checked;
 
     drawer.classList.remove("open");
     btn.style.minWidth = "";
@@ -2880,7 +2881,7 @@
     fetch("api/gallery", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participant: participant, format: format, interval: interval }),
+      body: JSON.stringify({ participant: participant, format: format, interval: interval, bundle: bundle }),
     })
       .then(function (r) {
         if (!r.ok) throw new Error("Server error " + r.status);

--- a/cli.py
+++ b/cli.py
@@ -308,6 +308,11 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         metavar="SECONDS",
         help=f"Capture interval in seconds for gallery mode (default: {config.GALLERY_INTERVAL_SECONDS})",
     )
+    viewer_manifest.add_argument(
+        "--bundle",
+        action="store_true",
+        help="Embed gallery images as base64 data URIs in the HTML (makes it fully self-contained)",
+    )
 
     run_opts = parser.add_argument_group("run options")
     run_opts.add_argument(
@@ -757,6 +762,7 @@ def _run_gallery_cli(args: argparse.Namespace) -> None:
 
     output_format = "gif" if getattr(args, "gif", False) else "screen"
     interval = getattr(args, "interval", None) or config.GALLERY_INTERVAL_SECONDS
+    bundle = getattr(args, "bundle", False) or config.GALLERY_BUNDLE_ENABLED
 
     artifacts = video.generate_interval_captures(
         str(video_path),
@@ -774,6 +780,7 @@ def _run_gallery_cli(args: argparse.Namespace) -> None:
         video_duration=duration,
         output_format=output_format,
         interval=interval,
+        bundle=bundle,
     )
     gallery_path = viewer.generate_gallery_viewer(data)
     if gallery_path:
@@ -1223,7 +1230,7 @@ def _validate_mode_conflicts(
             utils.error_print(
                 "--gallery cannot be combined with selection modes, --viewer, --regenerate, --studio, or --timeline-viewer.",
                 [
-                    "Only --gif, --interval, -i/-o (directories), and -v (verbose) may be used alongside --gallery."
+                    "Only --gif, --interval, --bundle, -i/-o (directories), and -v (verbose) may be used alongside --gallery."
                 ],
             )
             sys.exit(1)

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.31"
+VERSIONNUM: str = "0.10.32"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -118,6 +118,7 @@ GALLERY_GIF_DURATION_SECONDS: int = 3  # Default per-GIF duration in gallery mod
 GALLERY_PARALLEL_WORKERS: int = (
     4  # Max concurrent ffmpeg processes for gallery GIF extraction
 )
+GALLERY_BUNDLE_ENABLED: bool = False  # embed images as base64 data URIs in gallery HTML
 CLIP_PARALLEL_WORKERS: int = 0  # Max concurrent ffmpeg processes for clip/screenshot/GIF generation; 0 = auto (min(4, cpu_count))
 MAX_FILESIZE_MB: int = 0  # Maximum output file size in MB (0 = disabled)
 MIN_SOURCE_VIDEO_SIZE_MB: int = 100  # Minimum file size (MB) to consider as a source video candidate during fuzzy matching
@@ -271,6 +272,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
     "FILMSTRIP_ENABLED": "Show thumbnail images on timeline markers instead of solid colors (in the HTML viewer).",
+    "GALLERY_BUNDLE_ENABLED": "Embed gallery images as base64 data URIs in the HTML file, making it fully self-contained.",
     "CLIP_PARALLEL_WORKERS": "Number of concurrent ffmpeg processes for clip generation. 0 = auto, 1 = sequential.",
 }
 

--- a/server.py
+++ b/server.py
@@ -870,6 +870,7 @@ def api_gallery() -> FlaskResponse:
     participant = data.get("participant", "")
     output_format = data.get("format", "screen")
     interval = data.get("interval", config.GALLERY_INTERVAL_SECONDS)
+    bundle = bool(data.get("bundle", config.GALLERY_BUNDLE_ENABLED))
 
     if not participant:
         return jsonify({"ok": False, "error": "No participant specified"}), 400
@@ -907,6 +908,7 @@ def api_gallery() -> FlaskResponse:
             video_duration=duration,
             output_format=output_format,
             interval=interval,
+            bundle=bundle,
         )
         gallery_path = viewer.generate_gallery_viewer(gallery_data)
         if gallery_path:

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -176,6 +176,57 @@ def test_finalize_insights_viewer_shows_all_when_no_finals():
 # ---- HTML generation (gallery + insights viewer) ----
 
 
+# ---- finalize_gallery_data bundling ----
+
+
+def test_finalize_gallery_data_bundle_embeds_png(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # Create a tiny PNG file (1x1 pixel)
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
+        b"\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00"
+        b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    (tmp_path / "cap_0_00.png").write_bytes(png_bytes)
+
+    artifacts = [{"file": "cap_0_00.png", "timestamp": 0.0, "type": "screen"}]
+    data = viewer.finalize_gallery_data(artifacts, bundle=True)
+
+    assert data["meta"]["bundled"] is True
+    data_uri = str(artifacts[0]["data"])
+    assert data_uri.startswith("data:image/png;base64,")
+
+
+def test_finalize_gallery_data_bundle_embeds_gif(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    gif_bytes = b"GIF89a\x01\x00\x01\x00\x00\xff\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x00;"
+    (tmp_path / "cap_0_00.gif").write_bytes(gif_bytes)
+
+    artifacts = [{"file": "cap_0_00.gif", "timestamp": 0.0, "type": "gif"}]
+    viewer.finalize_gallery_data(artifacts, bundle=True)
+
+    data_uri = str(artifacts[0]["data"])
+    assert data_uri.startswith("data:image/gif;base64,")
+
+
+def test_finalize_gallery_data_bundle_skips_missing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    artifacts = [{"file": "missing.png", "timestamp": 0.0, "type": "screen"}]
+    data = viewer.finalize_gallery_data(artifacts, bundle=True)
+
+    assert "data" not in artifacts[0]
+    assert data["meta"]["bundled"] is True
+
+
+def test_finalize_gallery_data_no_bundle_by_default():
+    artifacts = [{"file": "cap.png", "timestamp": 0.0, "type": "screen"}]
+    data = viewer.finalize_gallery_data(artifacts)
+
+    assert data["meta"]["bundled"] is False
+    assert "data" not in artifacts[0]
+
+
 def test_generate_gallery_viewer_inlines_css_and_js(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 

--- a/viewer.py
+++ b/viewer.py
@@ -27,6 +27,7 @@ Artifact manifest (save_manifest / load_manifest_*):
   Consumed by Insights Builder, --regenerate, and standalone --viewer.
 """
 
+import base64
 import json
 import math
 from datetime import datetime, timezone
@@ -324,8 +325,27 @@ def finalize_gallery_data(
     video_duration: int = 0,
     output_format: str = "screen",
     interval: int = 10,
+    bundle: bool = False,
 ) -> dict[str, Any]:
     """Construct the window.CLIPGEN_DATA structure for the gallery viewer."""
+    if bundle:
+        mime_map = {"screen": "image/png", "gif": "image/gif"}
+        output_dir = Path(utils.get_effective_output_dir())
+        for a in artifacts:
+            file_path = output_dir / a["file"]
+            if not file_path.is_file():
+                utils.warning_print(
+                    f"Bundle: file not found, skipping embed: {a['file']}"
+                )
+                continue
+            mime = mime_map.get(a.get("type", "screen"), "image/png")
+            try:
+                raw = file_path.read_bytes()
+                encoded = base64.b64encode(raw).decode("ascii")
+                a["data"] = f"data:{mime};base64,{encoded}"
+            except OSError as e:
+                utils.warning_print(f"Bundle: could not read {a['file']}: {e}")
+
     return {
         "meta": {
             "sourceVideo": source_video,
@@ -334,6 +354,7 @@ def finalize_gallery_data(
             "format": output_format,
             "interval": interval,
             "videoDuration": video_duration,
+            "bundled": bundle,
         },
         "artifacts": artifacts,
     }


### PR DESCRIPTION
## Summary

Adds opt-in image bundling for the Gallery Viewer, base64-encoding PNGs and GIFs as data URIs directly into the HTML file so it's fully self-contained and portable. Available via `--bundle` CLI flag and a new "Bundle" checkbox in the Studio gallery drawer (off by default). Includes `GALLERY_BUNDLE_ENABLED` config flag, server API support, and 4 new tests covering PNG/GIF embedding, missing-file fallback, and default behavior.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 475 passed
- [x] `uv run ruff check --fix && uv run ruff format` — clean
- [x] `uv run ty check` — clean
- [ ] Manual: `uv run clipgen.py --gallery <video> --bundle` → open HTML, images render without external files
- [ ] Manual: Studio gallery drawer → check Bundle → Confirm → same check