### PR TITLE
feat: add Ollama-powered transcript summarization

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -415,6 +415,109 @@ body {
   font-size: var(--text-sm);
 }
 
+/* ── AI Summary ─────────────────────────────────────────────── */
+
+#summarySection {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+#summaryHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  user-select: none;
+}
+
+.summary-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  background: var(--color-text-dim);
+  mask-image: url(icons/sparkles.svg);
+  -webkit-mask-image: url(icons/sparkles.svg);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+}
+
+.summary-title {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.summary-toggle-btn {
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+}
+
+.summary-chevron {
+  width: 14px;
+  height: 14px;
+  background: var(--color-text-dim);
+  mask-image: url(icons/chevron-down.svg);
+  -webkit-mask-image: url(icons/chevron-down.svg);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  transition: transform var(--duration-fast);
+}
+
+#summarySection.collapsed .summary-chevron {
+  transform: rotate(-90deg);
+}
+
+#summarySection.collapsed #summaryBody {
+  display: none;
+}
+
+#summaryBody {
+  padding: 0 var(--space-4) var(--space-3);
+}
+
+#summaryContent {
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+#summaryContent p {
+  margin: 0 0 var(--space-2);
+}
+
+#summaryContent ul {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-5);
+}
+
+#summaryContent li {
+  margin-bottom: var(--space-1);
+}
+
+#summaryContent li::marker {
+  color: var(--color-text-dim);
+}
+
+.summary-generating {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
 /* Transcript segments */
 
 #transcriptSection {

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -50,6 +50,19 @@
       </div>
     </section>
 
+    <section id="summarySection" class="hidden">
+      <div id="summaryHeader">
+        <span class="summary-icon"></span>
+        <span class="summary-title">AI Summary</span>
+        <button id="summaryToggle" type="button" class="summary-toggle-btn" aria-label="Toggle summary" aria-expanded="true">
+          <span class="summary-chevron"></span>
+        </button>
+      </div>
+      <div id="summaryBody">
+        <div id="summaryContent"></div>
+      </div>
+    </section>
+
     <section id="transcriptSection">
       <div id="segmentList"></div>
       <div id="transcriptEmpty" class="transcript-empty">

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -28,6 +28,7 @@
     sheetLoaded: false,
     xrefPollTimer: null,
     tooltipsEnabled: true,
+    summaryCollapsed: false,
   };
 
   // ---- Helpers ----
@@ -311,13 +312,16 @@
     if (p.has_transcript) {
       state.streamingParticipant = null;
       loadTranscript(pid);
+      loadSummary(pid);
     } else if (taskForPid && taskForPid.status === "running" && taskForPid.partial_segments && taskForPid.partial_segments.length > 0) {
       renderPartialSegments(taskForPid.partial_segments, taskForPid.progress);
       state.streamingParticipant = pid;
+      clearSummary();
     } else {
       state.segments = [];
       state.streamingParticipant = null;
       renderSegments();
+      clearSummary();
     }
   }
 
@@ -326,6 +330,7 @@
     qs("#videoEmpty").classList.remove("hidden");
     qs("#segmentList").innerHTML = "";
     qs("#transcriptEmpty").classList.remove("hidden");
+    clearSummary();
   }
 
   // ---- Transcript loading ----
@@ -340,6 +345,122 @@
       state.segments = data.segments;
       state.activeSegmentIndex = -1;
       renderSegments();
+    });
+  }
+
+  // ---- AI Summary ----
+
+  var _summaryPollTimer = null;
+
+  function loadSummary(pid) {
+    var section = qs("#summarySection");
+
+    apiGet("api/summary/" + pid).then(function (data) {
+      if (data.ok && data.summary) {
+        _stopSummaryPoll();
+        renderSummary(data.summary);
+      } else if (data.generating) {
+        renderSummaryGenerating();
+        _startSummaryPoll(pid);
+      } else {
+        section.classList.add("hidden");
+      }
+    }).catch(function () {
+      // Ollama unavailable or no summary — stay hidden
+      section.classList.add("hidden");
+    });
+  }
+
+  function _startSummaryPoll(pid) {
+    _stopSummaryPoll();
+    _summaryPollTimer = setInterval(function () {
+      if (state.selectedParticipant !== pid) {
+        _stopSummaryPoll();
+        return;
+      }
+      apiGet("api/summary/" + pid).then(function (data) {
+        if (data.ok && data.summary) {
+          _stopSummaryPoll();
+          renderSummary(data.summary);
+        } else if (!data.generating) {
+          // Generation finished without result — stop polling
+          _stopSummaryPoll();
+          qs("#summarySection").classList.add("hidden");
+        }
+      }).catch(function () {
+        _stopSummaryPoll();
+        qs("#summarySection").classList.add("hidden");
+      });
+    }, 3000);
+  }
+
+  function _stopSummaryPoll() {
+    if (_summaryPollTimer) {
+      clearInterval(_summaryPollTimer);
+      _summaryPollTimer = null;
+    }
+  }
+
+  function renderSummaryGenerating() {
+    var section = qs("#summarySection");
+    var content = qs("#summaryContent");
+    content.innerHTML = '<p class="summary-generating">Generating summary\u2026</p>';
+    section.classList.remove("hidden");
+    section.classList.toggle("collapsed", state.summaryCollapsed);
+    qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
+  }
+
+  function renderSummary(text) {
+    var section = qs("#summarySection");
+    var content = qs("#summaryContent");
+    var lines = text.split("\n");
+    var paragraphs = [];
+    var bullets = [];
+    var inBullets = false;
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (!line) continue;
+      if (line.indexOf("- ") === 0 || line.indexOf("* ") === 0) {
+        inBullets = true;
+        bullets.push(escapeHtml(line.substring(2)));
+      } else if (!inBullets) {
+        paragraphs.push(escapeHtml(line));
+      } else {
+        bullets.push(escapeHtml(line));
+      }
+    }
+
+    var html = "";
+    if (paragraphs.length > 0) {
+      html += "<p>" + paragraphs.join(" ") + "</p>";
+    }
+    if (bullets.length > 0) {
+      html += "<ul>";
+      for (var j = 0; j < bullets.length; j++) {
+        html += "<li>" + bullets[j] + "</li>";
+      }
+      html += "</ul>";
+    }
+
+    content.innerHTML = html;
+    section.classList.remove("hidden");
+    section.classList.toggle("collapsed", state.summaryCollapsed);
+    qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
+  }
+
+  function clearSummary() {
+    _stopSummaryPoll();
+    qs("#summarySection").classList.add("hidden");
+    qs("#summaryContent").innerHTML = "";
+  }
+
+  function initSummaryToggle() {
+    qs("#summaryHeader").addEventListener("click", function () {
+      var section = qs("#summarySection");
+      state.summaryCollapsed = !state.summaryCollapsed;
+      section.classList.toggle("collapsed", state.summaryCollapsed);
+      qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
     });
   }
 
@@ -1409,6 +1530,7 @@
           if (state.selectedParticipant && newlyCompleted.indexOf(state.selectedParticipant) >= 0) {
             state.streamingParticipant = null;
             loadTranscript(state.selectedParticipant);
+            loadSummary(state.selectedParticipant);
           }
         });
       }
@@ -1542,6 +1664,7 @@
     initQueuePanel();
     initCorrectionsModal();
     initVideoSync();
+    initSummaryToggle();
 
     // Pause polling when tab is hidden; resume when visible
     document.addEventListener("visibilitychange", function () {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.31"
+VERSIONNUM: str = "0.10.32"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -244,6 +244,12 @@ TRANSCRIBE_FORMAT: str = "md"  # md, srt, vtt
 TRANSCRIBE_INITIAL_PROMPT: str = "This is a recorded user experience research session."  # biases Whisper toward UX research terminology
 TRANSCRIBE_BEAM_SIZE: int = 5  # beam search width
 
+# ── Ollama (Local AI) ───────────────────────────────────────────────
+OLLAMA_SUMMARY_ENABLED: bool = True  # auto-generate transcript summaries via Ollama
+OLLAMA_SUMMARY_MODEL: str = "qwen3.5:0.8b"  # model for short transcripts
+OLLAMA_SUMMARY_MODEL_LARGE: str = "qwen3.5:9b"  # model for longer transcripts
+OLLAMA_BASE_URL: str = "http://localhost:11434"  # Ollama server address
+
 # ── Rich Output ──────────────────────────────────────────────────────
 RICH_COLORS: bool = True  # Enable/disable colored output (set False for piped output)
 RICH_PANELS: bool = True  # Use bordered panels for errors/warnings/success messages
@@ -272,6 +278,10 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
     "FILMSTRIP_ENABLED": "Show thumbnail images on timeline markers instead of solid colors (in the HTML viewer).",
     "CLIP_PARALLEL_WORKERS": "Number of concurrent ffmpeg processes for clip generation. 0 = auto, 1 = sequential.",
+    "OLLAMA_SUMMARY_ENABLED": "Auto-generate AI summaries of transcripts using a local Ollama model.",
+    "OLLAMA_SUMMARY_MODEL": "Ollama model for short transcripts (fast, small).",
+    "OLLAMA_SUMMARY_MODEL_LARGE": "Ollama model for longer transcripts (slower, more capable).",
+    "OLLAMA_BASE_URL": "Base URL of the local Ollama server.",
 }
 
 # Studio-exposed settings with UI metadata (group, type, constraints).
@@ -317,4 +327,8 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
         "step": 1,
     },
     "STUDIO_CELL_EXPAND_HOVER": {"group": "Sheet Preview", "type": "bool"},
+    "OLLAMA_SUMMARY_ENABLED": {"group": "AI Summary", "type": "bool"},
+    "OLLAMA_SUMMARY_MODEL": {"group": "AI Summary", "type": "str"},
+    "OLLAMA_SUMMARY_MODEL_LARGE": {"group": "AI Summary", "type": "str"},
+    "OLLAMA_BASE_URL": {"group": "AI Summary", "type": "str"},
 }

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""Ollama local LLM client for clipgen.
+
+Provides a reusable interface to the Ollama REST API for text generation.
+All functions fail gracefully (return None / False) and never raise on
+network errors. On connection refused, generate() auto-starts ``ollama serve``
+and retries once.
+
+Key functions:
+  is_available()            - check Ollama server connectivity
+  generate()                - send a prompt and get a text response
+  summarize_transcript()    - summarize transcript segments into paragraph + bullets
+"""
+
+import json
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+import config
+import utils
+
+_HEALTH_TIMEOUT = 5  # seconds for connectivity check
+_GENERATE_TIMEOUT = (
+    300  # seconds — generous to allow cold model loading + long transcripts
+)
+_START_POLL_INTERVAL = 0.5  # seconds between health-check polls after starting server
+_START_TIMEOUT = 10  # seconds to wait for server to become available after starting
+_MAX_TRANSCRIPT_CHARS = 6000  # truncate long transcripts to fit model context window
+_THINK_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
+
+
+def is_available() -> bool:
+    """Check whether the Ollama server is reachable.
+
+    Returns True if the server responds to GET /api/tags, False otherwise.
+    Does not log on failure — callers decide how to handle unavailability.
+    """
+    try:
+        req = urllib.request.Request(f"{config.OLLAMA_BASE_URL}/api/tags")
+        with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT):
+            return True
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def _is_connection_refused(exc: Exception) -> bool:
+    """Check whether an exception indicates connection refused (server not running)."""
+    if isinstance(exc, urllib.error.URLError) and isinstance(
+        exc.reason, ConnectionRefusedError
+    ):
+        return True
+    if isinstance(exc, ConnectionRefusedError):
+        return True
+    return False
+
+
+def _start_server() -> bool:
+    """Attempt to start ``ollama serve`` and wait for it to become available.
+
+    Returns True if the server is responding after startup, False otherwise.
+    """
+    utils.info_print("Starting Ollama server...")
+    try:
+        subprocess.Popen(
+            ["ollama", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        utils.warning_print("Ollama binary not found — is Ollama installed?")
+        return False
+    except OSError as exc:
+        utils.warning_print(f"Failed to start Ollama: {exc}")
+        return False
+
+    deadline = time.monotonic() + _START_TIMEOUT
+    while time.monotonic() < deadline:
+        if is_available():
+            utils.info_print("Ollama server started.")
+            return True
+        time.sleep(_START_POLL_INTERVAL)
+
+    utils.warning_print("Ollama server did not start within timeout.")
+    return False
+
+
+def _do_generate(
+    body: dict[str, Any],
+) -> str | None:
+    """Execute a single Ollama /api/generate request. Returns text or None."""
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{config.OLLAMA_BASE_URL}/api/generate",
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=_GENERATE_TIMEOUT) as resp:
+        result = json.loads(resp.read().decode("utf-8"))
+        text = result.get("response", "")
+        # Strip <think>...</think> blocks produced by reasoning models (e.g. qwen3.5)
+        text = _THINK_RE.sub("", text).strip()
+        if not text:
+            utils.warning_print(
+                f"Ollama returned empty response (model: {body.get('model')})"
+            )
+            return None
+        return text
+
+
+def generate(
+    prompt: str,
+    *,
+    model: str | None = None,
+    system: str | None = None,
+) -> str | None:
+    """Send a prompt to Ollama and return the generated text.
+
+    On connection refused, automatically attempts to start ``ollama serve``
+    and retries the request once.
+
+    Args:
+        prompt: The user prompt to send.
+        model: Ollama model name. Defaults to config.OLLAMA_SUMMARY_MODEL.
+        system: Optional system prompt.
+
+    Returns the generated text string, or None on any failure.
+    """
+    resolved_model = model or config.OLLAMA_SUMMARY_MODEL
+    body: dict[str, Any] = {
+        "model": resolved_model,
+        "prompt": prompt,
+        "stream": False,
+    }
+    if system:
+        body["system"] = system
+
+    try:
+        return _do_generate(body)
+    except urllib.error.HTTPError as exc:
+        utils.warning_print(f"Ollama generate failed (HTTP {exc.code}): {exc.reason}")
+        return None
+    except (urllib.error.URLError, OSError) as exc:
+        if not _is_connection_refused(exc):
+            utils.warning_print(f"Ollama generate failed (connection): {exc}")
+            return None
+        # Connection refused — try to start the server and retry once
+        if not _start_server():
+            return None
+        try:
+            return _do_generate(body)
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError) as retry_exc:
+            utils.warning_print(f"Ollama generate failed after retry: {retry_exc}")
+            return None
+        except (json.JSONDecodeError, KeyError, ValueError) as retry_exc:
+            utils.warning_print(f"Ollama generate failed (response): {retry_exc}")
+            return None
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        utils.warning_print(f"Ollama generate failed (response): {exc}")
+        return None
+
+
+_SUMMARIZE_PROMPT = """\
+Summarize this user research session transcript. Write a concise paragraph \
+(2-4 sentences) describing what happened in the session. Then list the key \
+topics or themes as bullet points (prefix each with "- ").
+
+Transcript:
+{text}"""
+
+_MIN_TEXT_LENGTH = 50  # skip summarization for very short transcripts
+_LARGE_MODEL_THRESHOLD = 1500  # chars — use the larger model above this
+
+
+def summarize_transcript(
+    segments: list[dict[str, Any]],
+    *,
+    model: str | None = None,
+) -> str | None:
+    """Summarize transcript segments into a paragraph + bullet points.
+
+    Automatically selects between OLLAMA_SUMMARY_MODEL (short transcripts) and
+    OLLAMA_SUMMARY_MODEL_LARGE (longer transcripts) unless an explicit model
+    override is provided.
+
+    Args:
+        segments: List of transcript segment dicts with "text" keys.
+        model: Ollama model override. Skips auto-selection when set.
+
+    Returns the summary string, or None if segments are empty/too short
+    or if generation fails.
+    """
+    text = " ".join(seg.get("text", "").strip() for seg in segments).strip()
+    if len(text) < _MIN_TEXT_LENGTH:
+        return None
+
+    # Auto-select model based on transcript length
+    if model is None:
+        if len(text) > _LARGE_MODEL_THRESHOLD:
+            model = config.OLLAMA_SUMMARY_MODEL_LARGE
+        else:
+            model = config.OLLAMA_SUMMARY_MODEL
+
+    # Truncate to fit model context window — keep beginning and end for
+    # a representative overview of the session
+    if len(text) > _MAX_TRANSCRIPT_CHARS:
+        half = _MAX_TRANSCRIPT_CHARS // 2
+        text = text[:half] + "\n[...]\n" + text[-half:]
+
+    utils.verbose_print(
+        f"Summarizing transcript ({len(segments)} segments, "
+        f"{len(text)} chars) with model {model}"
+    )
+    prompt = _SUMMARIZE_PROMPT.format(text=text)
+    result = generate(prompt, model=model)
+    if result:
+        utils.verbose_print(f"Summary generated ({len(result)} chars)")
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = ["pytest"]
 packages = []
 py-modules = [
     "cli", "clipgen", "config", "excel_io", "files", "google_api",
-    "insights", "insights_server", "interactive", "screenspace",
+    "insights", "insights_server", "interactive", "ollama_client", "screenspace",
     "screenspace_server", "server", "spreadsheet", "titlecards",
     "transcripts", "utils", "video", "viewer",
 ]

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""Tests for ollama_client module."""
+
+import io
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import ollama_client
+
+
+class TestIsAvailable:
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_true_when_server_responds(self, mock_urlopen):
+        mock_urlopen.return_value.__enter__ = lambda s: s
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        assert ollama_client.is_available() is True
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_false_on_connection_error(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        assert ollama_client.is_available() is False
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_false_on_timeout(self, mock_urlopen):
+        mock_urlopen.side_effect = OSError("timed out")
+        assert ollama_client.is_available() is False
+
+
+class TestGenerate:
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_response_text_on_success(self, mock_urlopen):
+        response_data = json.dumps({"response": "Hello world"}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        result = ollama_client.generate("test prompt")
+        assert result == "Hello world"
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_strips_think_tags_from_response(self, mock_urlopen):
+        raw = "<think>Let me analyze this...</think>\n\nHere is the summary."
+        response_data = json.dumps({"response": raw}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        result = ollama_client.generate("test prompt")
+        assert result == "Here is the summary."
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_none_when_only_think_tags(self, mock_urlopen):
+        raw = "<think>Thinking hard but producing nothing useful...</think>"
+        response_data = json.dumps({"response": raw}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        result = ollama_client.generate("test prompt")
+        assert result is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_none_on_connection_error(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        result = ollama_client.generate("test prompt")
+        assert result is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_none_on_http_error(self, mock_urlopen):
+        from email.message import Message
+
+        hdrs = Message()
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="",
+            code=404,
+            msg="Not Found",
+            hdrs=hdrs,
+            fp=None,
+        )
+        result = ollama_client.generate("test prompt")
+        assert result is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_none_on_invalid_json(self, mock_urlopen):
+        mock_resp = io.BytesIO(b"not json")
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        result = ollama_client.generate("test prompt")
+        assert result is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_uses_config_model_by_default(self, mock_urlopen):
+        response_data = json.dumps({"response": "ok"}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+
+        ollama_client.generate("test prompt")
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["model"] == "qwen3.5:0.8b"
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_uses_custom_model(self, mock_urlopen):
+        response_data = json.dumps({"response": "ok"}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+
+        ollama_client.generate("test prompt", model="llama3.1:8b")
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["model"] == "llama3.1:8b"
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_includes_system_prompt(self, mock_urlopen):
+        response_data = json.dumps({"response": "ok"}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+
+        ollama_client.generate("test prompt", system="You are helpful.")
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["system"] == "You are helpful."
+
+
+class TestAutoStartServer:
+    """Tests for the auto-start behavior when Ollama is not running."""
+
+    @patch("ollama_client._start_server", return_value=True)
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_retries_after_connection_refused(self, mock_urlopen, mock_start):
+        """On ConnectionRefusedError, start server and retry successfully."""
+        response_data = json.dumps({"response": "retried ok"}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+
+        # First call: connection refused; second call: success
+        mock_urlopen.side_effect = [
+            urllib.error.URLError(ConnectionRefusedError("Connection refused")),
+            MagicMock(__enter__=lambda s: mock_resp, __exit__=lambda s, *a: None),
+        ]
+        result = ollama_client.generate("test prompt")
+        assert result == "retried ok"
+        mock_start.assert_called_once()
+
+    @patch("ollama_client._start_server", return_value=False)
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_none_when_server_start_fails(self, mock_urlopen, mock_start):
+        """If server fails to start, return None without retrying."""
+        mock_urlopen.side_effect = urllib.error.URLError(
+            ConnectionRefusedError("Connection refused")
+        )
+        result = ollama_client.generate("test prompt")
+        assert result is None
+        mock_start.assert_called_once()
+
+    @patch("ollama_client._start_server")
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_does_not_start_server_on_other_errors(self, mock_urlopen, mock_start):
+        """Non-ConnectionRefused errors should not trigger auto-start."""
+        mock_urlopen.side_effect = urllib.error.URLError("DNS resolution failed")
+        result = ollama_client.generate("test prompt")
+        assert result is None
+        mock_start.assert_not_called()
+
+    @patch("ollama_client.subprocess.Popen")
+    @patch("ollama_client.is_available")
+    def test_start_server_polls_until_available(self, mock_avail, mock_popen):
+        """_start_server polls is_available until it returns True."""
+        mock_avail.side_effect = [False, False, True]
+        assert ollama_client._start_server() is True
+        assert mock_avail.call_count == 3
+        mock_popen.assert_called_once()
+
+    @patch("ollama_client.subprocess.Popen")
+    def test_start_server_returns_false_when_binary_missing(self, mock_popen):
+        """_start_server returns False when ollama is not installed."""
+        mock_popen.side_effect = FileNotFoundError("ollama not found")
+        assert ollama_client._start_server() is False
+
+
+class TestSummarizeTranscript:
+    def test_returns_none_for_empty_segments(self):
+        result = ollama_client.summarize_transcript([])
+        assert result is None
+
+    def test_returns_none_for_very_short_text(self):
+        result = ollama_client.summarize_transcript([{"text": "Hi"}])
+        assert result is None
+
+    @patch("ollama_client.generate")
+    def test_concatenates_segment_text(self, mock_generate):
+        mock_generate.return_value = "A summary."
+        segments = [
+            {"text": "First segment text here."},
+            {"text": "Second segment text here."},
+            {"text": "Third segment more text."},
+        ]
+        ollama_client.summarize_transcript(segments)
+
+        prompt = mock_generate.call_args[0][0]
+        assert "First segment text here." in prompt
+        assert "Second segment text here." in prompt
+        assert "Third segment more text." in prompt
+
+    @patch("ollama_client.generate")
+    def test_returns_generate_result(self, mock_generate):
+        mock_generate.return_value = "This is a summary.\n- Point one\n- Point two"
+        segments = [
+            {
+                "text": "A sufficiently long segment of text for the minimum length check."
+            },
+        ]
+        result = ollama_client.summarize_transcript(segments)
+        assert result == "This is a summary.\n- Point one\n- Point two"
+
+    @patch("ollama_client.generate")
+    def test_returns_none_when_generate_fails(self, mock_generate):
+        mock_generate.return_value = None
+        segments = [
+            {
+                "text": "A sufficiently long segment of text for the minimum length check."
+            },
+        ]
+        result = ollama_client.summarize_transcript(segments)
+        assert result is None
+
+    @patch("ollama_client.generate")
+    def test_passes_model_override(self, mock_generate):
+        mock_generate.return_value = "ok"
+        segments = [
+            {
+                "text": "A sufficiently long segment of text for the minimum length check."
+            },
+        ]
+        ollama_client.summarize_transcript(segments, model="llama3.1:8b")
+        assert mock_generate.call_args[1]["model"] == "llama3.1:8b"
+
+    @patch("ollama_client.generate")
+    def test_uses_small_model_for_short_text(self, mock_generate):
+        mock_generate.return_value = "ok"
+        # Short text (under _LARGE_MODEL_THRESHOLD)
+        segments = [
+            {
+                "text": "A sufficiently long segment of text for the minimum length check."
+            },
+        ]
+        ollama_client.summarize_transcript(segments)
+        assert mock_generate.call_args[1]["model"] == "qwen3.5:0.8b"
+
+    @patch("ollama_client.generate")
+    def test_uses_large_model_for_long_text(self, mock_generate):
+        mock_generate.return_value = "ok"
+        # Long text (over _LARGE_MODEL_THRESHOLD of 1500 chars)
+        segments = [{"text": "word " * 400}]
+        ollama_client.summarize_transcript(segments)
+        assert mock_generate.call_args[1]["model"] == "qwen3.5:9b"

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -12,6 +12,7 @@ API endpoints (all under /transcripts/):
   GET  /api/transcript/<participant>              - full transcript segments (corrections applied)
   PUT  /api/transcript/<participant>/segment      - edit a segment's text, creates correction
   GET  /api/vtt/<participant>                     - serve transcript as WebVTT
+  GET  /api/summary/<participant>                - AI-generated transcript summary
   GET  /api/corrections                           - list all study-local corrections
   POST /api/corrections                           - add a correction manually
   DELETE /api/corrections/<id>                    - remove a correction
@@ -33,7 +34,9 @@ from typing import Any
 
 from flask import Blueprint, Response, jsonify, request
 
+import config
 import files
+import ollama_client
 import transcripts
 import utils
 
@@ -46,6 +49,10 @@ _worker: transcripts.TranscriptWorker | None = None
 _input_dir: str = ""
 _participants: list[dict[str, Any]] = []
 _manifest_lock = threading.Lock()
+_summary_threads: set[threading.Thread] = set()
+_generating_summaries: set[str] = (
+    set()
+)  # participant IDs with in-flight summary generation
 
 # ---- Blueprint ----
 
@@ -87,6 +94,7 @@ def api_participants() -> FlaskResponse:
                 info["language"] = entry.get("language", "")
                 info["model"] = entry.get("model", "")
                 info["transcribed_at"] = entry.get("transcribed_at", "")
+                info["has_summary"] = bool(entry.get("summary"))
             result.append(info)
 
     # Check for stale artifacts (transcript outdated relative to source)
@@ -232,6 +240,21 @@ def api_vtt(participant: str) -> FlaskResponse:
     )
     vtt_text = transcripts._format_vtt(result)
     return Response(vtt_text, content_type="text/vtt")
+
+
+# ---- AI Summary ----
+
+
+@transcripts_bp.route("/api/summary/<participant>")
+def api_summary(participant: str) -> FlaskResponse:
+    """Return AI-generated summary, generation status, or 404."""
+    with _manifest_lock:
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+    if not entry or not entry.get("summary"):
+        if participant in _generating_summaries:
+            return jsonify({"ok": False, "generating": True})
+        return jsonify({"ok": False}), 404
+    return jsonify({"ok": True, "summary": entry["summary"]})
 
 
 # ---- Corrections ----
@@ -680,14 +703,18 @@ def _persist_manifest() -> None:
 
 def _do_persist() -> None:
     """Persist manifest to disk - caller must hold _manifest_lock."""
-    # Collect completed task results into source_transcripts
+    # Collect completed task results into source_transcripts (merge, not replace,
+    # so that extra keys like "summary" added by other threads are preserved)
     if _worker:
         for task in _worker.get_all_tasks():
             if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get(
                 "result"
             ):
                 pid = task["participant"]
-                _manifest.setdefault("source_transcripts", {})[pid] = task["result"]
+                src = _manifest.setdefault("source_transcripts", {})
+                existing = src.get(pid, {})
+                existing.update(task["result"])
+                src[pid] = existing
         _manifest["tasks"] = _worker.get_all_tasks()
 
     transcripts.save_transcripts_manifest(
@@ -695,6 +722,60 @@ def _do_persist() -> None:
         _manifest.get("corrections", []),
         marks=_manifest.get("marks"),
     )
+
+
+# ---- AI Summary generation ----
+
+
+def _on_task_complete() -> None:
+    """Persist manifest, then trigger summary generation for newly completed participants."""
+    newly_completed: list[str] = []
+    if _worker:
+        for task in _worker.get_all_tasks():
+            if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get(
+                "result"
+            ):
+                pid = task["participant"]
+                with _manifest_lock:
+                    existing = _manifest.get("source_transcripts", {}).get(pid, {})
+                    if not existing.get("summary"):
+                        newly_completed.append(pid)
+
+    _persist_manifest()
+
+    if not config.OLLAMA_SUMMARY_ENABLED:
+        return
+    for pid in newly_completed:
+        _trigger_summary_generation(pid)
+
+
+def _trigger_summary_generation(participant: str) -> None:
+    """Spawn daemon thread to generate AI summary for a participant."""
+
+    def _run() -> None:
+        try:
+            with _manifest_lock:
+                entry = _manifest.get("source_transcripts", {}).get(participant)
+                if not entry or not entry.get("segments"):
+                    return
+                segments = list(entry["segments"])
+            summary = ollama_client.summarize_transcript(segments)
+            if summary:
+                with _manifest_lock:
+                    entry = _manifest.get("source_transcripts", {}).get(participant)
+                    if entry:
+                        entry["summary"] = summary
+                _persist_manifest()
+        except Exception as exc:
+            utils.warning_print(f"Summary generation failed for {participant}: {exc}")
+        finally:
+            _generating_summaries.discard(participant)
+            _summary_threads.discard(t)
+
+    _generating_summaries.add(participant)
+    t = threading.Thread(target=_run, daemon=True, name=f"summary-{participant}")
+    _summary_threads.add(t)
+    t.start()
 
 
 # ---- State initialization ----
@@ -734,6 +815,6 @@ def _init_transcripts_state(
         _participants = utils.discover_participant_videos(study_name)
 
     _worker = transcripts.TranscriptWorker()
-    _worker.on_task_complete = _persist_manifest
+    _worker.on_task_complete = _on_task_complete
     _worker.restore_tasks(_manifest.get("tasks", []))
     _worker.start()


### PR DESCRIPTION
## Summary

Adds local AI summarization of transcripts via Ollama. After transcription completes, a background thread sends the transcript text to a local Ollama model and stores the result in the transcript manifest. A collapsible "AI Summary" section appears between the video player and segment list in the Transcripts UI, showing a paragraph overview and key bullet points.

- New `ollama_client.py` module: centralized Ollama HTTP client with auto-start on connection refused, `<think>` tag stripping for reasoning models, auto model selection based on transcript length, and graceful failure (never crashes)
- Backend: summary generation triggered after transcription via daemon threads, new `/api/summary/<participant>` endpoint with generation-status tracking, manifest persistence uses merge instead of replace to preserve summary field
- Frontend: collapsible summary section with sparkles icon, "Generating summary..." polling state, 3s polling interval while generating
- Config: `OLLAMA_SUMMARY_ENABLED` (default on), `OLLAMA_SUMMARY_MODEL` / `_LARGE`, `OLLAMA_BASE_URL`
- 25 new unit tests covering client, auto-start, think-tag stripping, and model selection

## Test plan
- [ ] Start Ollama, transcribe a participant, verify summary appears after generation
- [ ] Stop Ollama, transcribe — verify no errors, summary section stays hidden
- [ ] Verify collapse toggle persists across participant switches
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` (496 pass)