### PR TITLE
feat: add regenerate, copy, and edit buttons to transcript summary

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -518,6 +518,82 @@ body {
   font-style: italic;
 }
 
+.summary-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.summary-actions + .summary-toggle-btn {
+  margin-left: 0;
+}
+
+.summary-action-btn {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+}
+
+.summary-action-btn:hover {
+  background: var(--color-surface-alt);
+}
+
+.summary-action-icon {
+  width: 14px;
+  height: 14px;
+  background: var(--color-text-dim);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+}
+
+.summary-action-regenerate {
+  mask-image: url(icons/arrow-path.svg);
+  -webkit-mask-image: url(icons/arrow-path.svg);
+}
+
+.summary-action-copy {
+  mask-image: url(icons/clipboard-document.svg);
+  -webkit-mask-image: url(icons/clipboard-document.svg);
+}
+
+.summary-action-edit {
+  mask-image: url(icons/pencil-square.svg);
+  -webkit-mask-image: url(icons/pencil-square.svg);
+}
+
+.summary-action-save {
+  mask-image: url(icons/check.svg);
+  -webkit-mask-image: url(icons/check.svg);
+}
+
+.summary-edit-textarea {
+  width: 100%;
+  min-height: 120px;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  font-family: inherit;
+  resize: vertical;
+}
+
+.summary-edit-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
 /* Transcript segments */
 
 #transcriptSection {

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -54,6 +54,17 @@
       <div id="summaryHeader">
         <span class="summary-icon"></span>
         <span class="summary-title">Summary</span>
+        <div id="summaryActions" class="summary-actions hidden">
+          <button id="summaryRegenerate" type="button" class="summary-action-btn" title="Regenerate summary" aria-label="Regenerate summary">
+            <span class="summary-action-icon summary-action-regenerate"></span>
+          </button>
+          <button id="summaryCopy" type="button" class="summary-action-btn" title="Copy summary" aria-label="Copy summary">
+            <span class="summary-action-icon summary-action-copy"></span>
+          </button>
+          <button id="summaryEdit" type="button" class="summary-action-btn" title="Edit summary" aria-label="Edit summary">
+            <span class="summary-action-icon summary-action-edit"></span>
+          </button>
+        </div>
         <button id="summaryToggle" type="button" class="summary-toggle-btn" aria-label="Toggle summary" aria-expanded="true">
           <span class="summary-chevron"></span>
         </button>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -29,6 +29,8 @@
     xrefPollTimer: null,
     tooltipsEnabled: true,
     summaryCollapsed: false,
+    summaryEditing: false,
+    summaryText: "",
   };
 
   // ---- Helpers ----
@@ -408,9 +410,14 @@
     section.classList.remove("hidden");
     section.classList.toggle("collapsed", state.summaryCollapsed);
     qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
+    qs("#summaryActions").classList.add("hidden");
+    state.summaryEditing = false;
+    state.summaryText = "";
   }
 
   function renderSummary(text) {
+    state.summaryText = text;
+    state.summaryEditing = false;
     var section = qs("#summarySection");
     var content = qs("#summaryContent");
     var lines = text.split("\n");
@@ -447,12 +454,17 @@
     section.classList.remove("hidden");
     section.classList.toggle("collapsed", state.summaryCollapsed);
     qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
+    qs("#summaryActions").classList.remove("hidden");
+    _setSummaryEditMode(false);
   }
 
   function clearSummary() {
     _stopSummaryPoll();
     qs("#summarySection").classList.add("hidden");
     qs("#summaryContent").innerHTML = "";
+    qs("#summaryActions").classList.add("hidden");
+    state.summaryEditing = false;
+    state.summaryText = "";
   }
 
   function initSummaryToggle() {
@@ -461,6 +473,83 @@
       state.summaryCollapsed = !state.summaryCollapsed;
       section.classList.toggle("collapsed", state.summaryCollapsed);
       qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
+    });
+  }
+
+  function _setSummaryEditMode(editing) {
+    var btn = qs("#summaryEdit");
+    var icon = btn.querySelector(".summary-action-icon");
+    if (editing) {
+      icon.classList.remove("summary-action-edit");
+      icon.classList.add("summary-action-save");
+      btn.title = "Save summary";
+      btn.setAttribute("aria-label", "Save summary");
+    } else {
+      icon.classList.remove("summary-action-save");
+      icon.classList.add("summary-action-edit");
+      btn.title = "Edit summary";
+      btn.setAttribute("aria-label", "Edit summary");
+    }
+  }
+
+  function initSummaryActions() {
+    qs("#summaryRegenerate").addEventListener("click", function (e) {
+      e.stopPropagation();
+      var pid = state.selectedParticipant;
+      if (!pid) return;
+      var previousText = state.summaryText;
+      renderSummaryGenerating();
+      apiPost("api/summary/" + pid + "/regenerate", {}).then(function (data) {
+        if (data.ok && data.generating) {
+          _startSummaryPoll(pid);
+        }
+      }).catch(function () {
+        showToast("Failed to regenerate summary");
+        if (previousText) {
+          renderSummary(previousText);
+        }
+      });
+    });
+
+    qs("#summaryCopy").addEventListener("click", function (e) {
+      e.stopPropagation();
+      var text = state.summaryEditing
+        ? qs("#summaryContent textarea").value
+        : state.summaryText;
+      if (!text) return;
+      navigator.clipboard.writeText(text).then(function () {
+        showToast("Summary copied");
+      });
+    });
+
+    qs("#summaryEdit").addEventListener("click", function (e) {
+      e.stopPropagation();
+      var pid = state.selectedParticipant;
+      if (!pid) return;
+      if (!state.summaryEditing) {
+        var ta = document.createElement("textarea");
+        ta.className = "summary-edit-textarea";
+        ta.value = state.summaryText;
+        ta.autocomplete = "off";
+        ta.addEventListener("click", function (ev) { ev.stopPropagation(); });
+        qs("#summaryContent").innerHTML = "";
+        qs("#summaryContent").appendChild(ta);
+        ta.focus();
+        state.summaryEditing = true;
+        _setSummaryEditMode(true);
+      } else {
+        var newText = qs("#summaryContent textarea").value.trim();
+        if (!newText) {
+          showToast("Summary cannot be empty");
+          return;
+        }
+        apiPut("api/summary/" + pid, { summary: newText }).then(function () {
+          renderSummary(newText);
+          showToast("Summary saved");
+        }).catch(function () {
+          showToast("Failed to save summary");
+        });
+      }
     });
   }
 
@@ -1665,6 +1754,7 @@
     initCorrectionsModal();
     initVideoSync();
     initSummaryToggle();
+    initSummaryActions();
 
     // Pause polling when tab is hidden; resume when visible
     document.addEventListener("visibilitychange", function () {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.32"
+VERSIONNUM: str = "0.10.33"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -13,6 +13,8 @@ API endpoints (all under /transcripts/):
   PUT  /api/transcript/<participant>/segment      - edit a segment's text, creates correction
   GET  /api/vtt/<participant>                     - serve transcript as WebVTT
   GET  /api/summary/<participant>                - AI-generated transcript summary
+  POST /api/summary/<participant>/regenerate    - re-trigger AI summary generation
+  PUT  /api/summary/<participant>               - save user-edited summary
   GET  /api/corrections                           - list all study-local corrections
   POST /api/corrections                           - add a correction manually
   DELETE /api/corrections/<id>                    - remove a correction
@@ -255,6 +257,39 @@ def api_summary(participant: str) -> FlaskResponse:
             return jsonify({"ok": False, "generating": True})
         return jsonify({"ok": False}), 404
     return jsonify({"ok": True, "summary": entry["summary"]})
+
+
+@transcripts_bp.route("/api/summary/<participant>/regenerate", methods=["POST"])
+def api_summary_regenerate(participant: str) -> FlaskResponse:
+    """Clear existing summary and re-trigger AI generation."""
+    if not config.OLLAMA_SUMMARY_ENABLED:
+        return jsonify({"ok": False, "error": "Summary generation is disabled"}), 400
+    if participant in _generating_summaries:
+        return jsonify({"ok": True, "generating": True})
+    with _manifest_lock:
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+    if not entry or not entry.get("segments"):
+        return jsonify({"ok": False, "error": "No transcript found"}), 404
+    with _manifest_lock:
+        entry["summary"] = ""
+    _persist_manifest()
+    _trigger_summary_generation(participant)
+    return jsonify({"ok": True, "generating": True})
+
+
+@transcripts_bp.route("/api/summary/<participant>", methods=["PUT"])
+def api_summary_save(participant: str) -> FlaskResponse:
+    """Save a user-edited summary for a participant."""
+    data = request.get_json(silent=True)
+    if not data or not data.get("summary", "").strip():
+        return jsonify({"ok": False, "error": "Summary text is required"}), 400
+    with _manifest_lock:
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+        if not entry:
+            return jsonify({"ok": False, "error": "Participant not found"}), 404
+        entry["summary"] = data["summary"].strip()
+    _persist_manifest()
+    return jsonify({"ok": True})
 
 
 # ---- Corrections ----


### PR DESCRIPTION
## Summary
- Adds three action buttons (Regenerate, Copy, Edit/Save) to the AI summary header on the Transcripts page
- Regenerate clears the existing summary and re-triggers Ollama generation via a new `POST /api/summary/<pid>/regenerate` endpoint
- Copy writes the summary text to the clipboard with toast feedback
- Edit/Save toggles inline textarea editing; saves persist to the manifest via a new `PUT /api/summary/<pid>` endpoint, and are overwritten on regeneration

## Test plan
- [ ] Verify summary loads normally and action buttons appear
- [ ] Click Copy and confirm clipboard contains summary text
- [ ] Click Edit, modify text, click Save — verify rendered summary updates and toast shown
- [ ] Click Regenerate — verify generating state, polling, and new summary replaces previous text
- [ ] Confirm collapse toggle still works and button clicks don't trigger collapse
- [ ] Switch participants during edit mode — verify state resets