### PR TITLE
fix: resolve doubled output directory in screenspace intake clips

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.33"
+VERSIONNUM: str = "0.10.34"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/server.py
+++ b/server.py
@@ -296,7 +296,6 @@ def _generate_intake_clips(
     the video was missing or ffmpeg failed) plus an ``"_error"`` string so
     callers can report per-item results without duplicating the loop.
     """
-    output_dir = Path(utils.get_effective_output_dir())
     results: list[dict[str, Any]] = []
 
     for item in items:

--- a/server.py
+++ b/server.py
@@ -322,8 +322,7 @@ def _generate_intake_clips(
             if study
             else f"intake_{span_hash}{config.FILEFORMAT}"
         )
-        out_path = str(output_dir / out_name)
-        out_path = files.get_unique_filename(out_path)
+        out_path = files.get_unique_filename(out_name)
 
         start_str = utils.seconds_to_timestamp(int(round(start)))
         end_str = utils.seconds_to_timestamp(int(round(end)))
@@ -1243,7 +1242,7 @@ def api_reel_direct() -> FlaskResponse:
             reel_study = _sheet_context.study_name if _sheet_context else ""
             reel_base = f"{reel_study} intake reel" if reel_study else "intake_reel"
             reel_name = files.get_unique_filename(
-                str(output_dir / f"{reel_base}{config.FILEFORMAT}")
+                f"{reel_base}{config.FILEFORMAT}"
             )
             ok = video.concatenate_clips(clip_paths, reel_name, reencode_on_fail=True)
 

--- a/server.py
+++ b/server.py
@@ -1240,9 +1240,7 @@ def api_reel_direct() -> FlaskResponse:
 
             reel_study = _sheet_context.study_name if _sheet_context else ""
             reel_base = f"{reel_study} intake reel" if reel_study else "intake_reel"
-            reel_name = files.get_unique_filename(
-                f"{reel_base}{config.FILEFORMAT}"
-            )
+            reel_name = files.get_unique_filename(f"{reel_base}{config.FILEFORMAT}")
             ok = video.concatenate_clips(clip_paths, reel_name, reencode_on_fail=True)
 
             if ok:


### PR DESCRIPTION
## Summary
- Screenspace intake clip generation always failed because the output path was doubled (`output/output/filename.mp4`)
- Two call sites in `server.py` prepended `output_dir` before passing to `files.get_unique_filename()`, which internally resolves the output directory again via `resolve_output_path()`
- Removed the redundant `output_dir /` prefix to match every other caller in the codebase

## Test plan
- [x] All existing tests pass
- [ ] Launch `--studio`, generate clips from Screenspace intake sources, confirm output paths are correct