### PR TITLE
feat: add citation links to transcript summaries

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -575,6 +575,34 @@ body {
   -webkit-mask-image: url(icons/check.svg);
 }
 
+.summary-action-citations {
+  mask-image: url(icons/hashtag.svg);
+  -webkit-mask-image: url(icons/hashtag.svg);
+}
+
+.citation-link {
+  display: inline;
+  font-size: 0.7em;
+  vertical-align: super;
+  color: var(--color-accent);
+  cursor: pointer;
+  text-decoration: none;
+  margin-left: 1px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.citation-link:hover {
+  text-decoration: underline;
+}
+
+.citations-status {
+  color: var(--color-text-dim);
+  font-style: italic;
+  font-size: var(--text-xs);
+  margin-top: var(--space-2);
+}
+
 .summary-edit-textarea {
   width: 100%;
   min-height: 120px;

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -58,6 +58,9 @@
           <button id="summaryRegenerate" type="button" class="summary-action-btn" title="Regenerate summary" aria-label="Regenerate summary">
             <span class="summary-action-icon summary-action-regenerate"></span>
           </button>
+          <button id="citationsRegenerate" type="button" class="summary-action-btn" title="Regenerate citations" aria-label="Regenerate citations">
+            <span class="summary-action-icon summary-action-citations"></span>
+          </button>
           <button id="summaryCopy" type="button" class="summary-action-btn" title="Copy summary" aria-label="Copy summary">
             <span class="summary-action-icon summary-action-copy"></span>
           </button>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -31,6 +31,8 @@
     summaryCollapsed: false,
     summaryEditing: false,
     summaryText: "",
+    summaryCitations: null,
+    citationsGenerating: false,
   };
 
   // ---- Helpers ----
@@ -361,6 +363,17 @@
       if (data.ok && data.summary) {
         _stopSummaryPoll();
         renderSummary(data.summary);
+        // Handle citations
+        if (data.citations && data.citations.length > 0) {
+          state.summaryCitations = data.citations;
+          state.citationsGenerating = false;
+          renderCitations();
+        } else if (data.citations_generating) {
+          state.summaryCitations = null;
+          state.citationsGenerating = true;
+          renderCitationsStatus();
+          _startCitationsPoll(pid);
+        }
       } else if (data.generating) {
         renderSummaryGenerating();
         _startSummaryPoll(pid);
@@ -384,6 +397,17 @@
         if (data.ok && data.summary) {
           _stopSummaryPoll();
           renderSummary(data.summary);
+          // Summary just arrived — check citation status
+          if (data.citations && data.citations.length > 0) {
+            state.summaryCitations = data.citations;
+            state.citationsGenerating = false;
+            renderCitations();
+          } else if (data.citations_generating) {
+            state.summaryCitations = null;
+            state.citationsGenerating = true;
+            renderCitationsStatus();
+            _startCitationsPoll(pid);
+          }
         } else if (!data.generating) {
           // Generation finished without result — stop polling
           _stopSummaryPoll();
@@ -421,7 +445,7 @@
     var section = qs("#summarySection");
     var content = qs("#summaryContent");
     var lines = text.split("\n");
-    var paragraphs = [];
+    var paragraphSentences = [];
     var bullets = [];
     var inBullets = false;
 
@@ -432,20 +456,34 @@
         inBullets = true;
         bullets.push(escapeHtml(line.substring(2)));
       } else if (!inBullets) {
-        paragraphs.push(escapeHtml(line));
+        // Split paragraph into individual sentences for citation targeting
+        var parts = line.split(/(?<=[.!?])\s+/);
+        for (var k = 0; k < parts.length; k++) {
+          var part = parts[k].trim();
+          if (part) paragraphSentences.push(escapeHtml(part));
+        }
       } else {
         bullets.push(escapeHtml(line));
       }
     }
 
+    // Build HTML with data-cite-index on each sentence/bullet
+    var citeIdx = 0;
     var html = "";
-    if (paragraphs.length > 0) {
-      html += "<p>" + paragraphs.join(" ") + "</p>";
+    if (paragraphSentences.length > 0) {
+      html += "<p>";
+      for (var si = 0; si < paragraphSentences.length; si++) {
+        if (si > 0) html += " ";
+        html += '<span data-cite-index="' + citeIdx + '">' + paragraphSentences[si] + "</span>";
+        citeIdx++;
+      }
+      html += "</p>";
     }
     if (bullets.length > 0) {
       html += "<ul>";
       for (var j = 0; j < bullets.length; j++) {
-        html += "<li>" + bullets[j] + "</li>";
+        html += '<li data-cite-index="' + citeIdx + '">' + bullets[j] + "</li>";
+        citeIdx++;
       }
       html += "</ul>";
     }
@@ -456,15 +494,115 @@
     qs("#summaryToggle").setAttribute("aria-expanded", state.summaryCollapsed ? "false" : "true");
     qs("#summaryActions").classList.remove("hidden");
     _setSummaryEditMode(false);
+
+    // Re-apply citations if already loaded
+    if (state.summaryCitations) {
+      renderCitations();
+    }
   }
 
   function clearSummary() {
     _stopSummaryPoll();
+    _stopCitationsPoll();
     qs("#summarySection").classList.add("hidden");
     qs("#summaryContent").innerHTML = "";
     qs("#summaryActions").classList.add("hidden");
     state.summaryEditing = false;
     state.summaryText = "";
+    state.summaryCitations = null;
+    state.citationsGenerating = false;
+  }
+
+  // ---- Citation rendering (Pass 2) ----
+
+  var _citationsPollTimer = null;
+
+  function renderCitations() {
+    // Remove any existing status text
+    var existing = qs("#summaryContent .citations-status");
+    if (existing) existing.remove();
+
+    // Remove any previously rendered citation links
+    var oldLinks = qs("#summaryContent").querySelectorAll(".citation-link");
+    for (var r = 0; r < oldLinks.length; r++) oldLinks[r].remove();
+
+    if (!state.summaryCitations) return;
+
+    var refNum = 1;
+    for (var i = 0; i < state.summaryCitations.length; i++) {
+      var cite = state.summaryCitations[i];
+      if (!cite.refs || cite.refs.length === 0) continue;
+      var el = qs('#summaryContent [data-cite-index="' + i + '"]');
+      if (!el) continue;
+      for (var j = 0; j < cite.refs.length; j++) {
+        var ref = cite.refs[j];
+        var sup = document.createElement("sup");
+        sup.className = "citation-link";
+        sup.dataset.start = String(ref.start);
+        sup.title = fmtTime(ref.start);
+        sup.textContent = "[" + refNum + "]";
+        (function (startTime) {
+          sup.addEventListener("click", function (e) {
+            e.stopPropagation();
+            seekVideo(startTime);
+          });
+        })(ref.start);
+        el.appendChild(sup);
+        refNum++;
+      }
+    }
+  }
+
+  function renderCitationsStatus() {
+    // Remove any existing status
+    var existing = qs("#summaryContent .citations-status");
+    if (existing) existing.remove();
+
+    var p = document.createElement("p");
+    p.className = "citations-status";
+    p.textContent = "Finding sources\u2026";
+    qs("#summaryContent").appendChild(p);
+  }
+
+  var _CITATIONS_POLL_TIMEOUT = 90000; // stop polling after 90 seconds
+
+  function _startCitationsPoll(pid) {
+    _stopCitationsPoll();
+    var started = Date.now();
+    _citationsPollTimer = setInterval(function () {
+      if (state.selectedParticipant !== pid || Date.now() - started > _CITATIONS_POLL_TIMEOUT) {
+        _stopCitationsPoll();
+        state.citationsGenerating = false;
+        var status = qs("#summaryContent .citations-status");
+        if (status) status.remove();
+        return;
+      }
+      apiGet("api/citations/" + pid).then(function (data) {
+        if (data.ok && data.citations) {
+          _stopCitationsPoll();
+          state.summaryCitations = data.citations;
+          state.citationsGenerating = false;
+          renderCitations();
+        } else if (!data.generating) {
+          _stopCitationsPoll();
+          state.citationsGenerating = false;
+          var status = qs("#summaryContent .citations-status");
+          if (status) status.remove();
+        }
+      }).catch(function () {
+        _stopCitationsPoll();
+        state.citationsGenerating = false;
+        var status = qs("#summaryContent .citations-status");
+        if (status) status.remove();
+      });
+    }, 3000);
+  }
+
+  function _stopCitationsPoll() {
+    if (_citationsPollTimer) {
+      clearInterval(_citationsPollTimer);
+      _citationsPollTimer = null;
+    }
   }
 
   function initSummaryToggle() {
@@ -498,6 +636,9 @@
       var pid = state.selectedParticipant;
       if (!pid) return;
       var previousText = state.summaryText;
+      state.summaryCitations = null;
+      state.citationsGenerating = false;
+      _stopCitationsPoll();
       renderSummaryGenerating();
       apiPost("api/summary/" + pid + "/regenerate", {}).then(function (data) {
         if (data.ok && data.generating) {
@@ -508,6 +649,26 @@
         if (previousText) {
           renderSummary(previousText);
         }
+      });
+    });
+
+    qs("#citationsRegenerate").addEventListener("click", function (e) {
+      e.stopPropagation();
+      var pid = state.selectedParticipant;
+      if (!pid) return;
+      state.summaryCitations = null;
+      state.citationsGenerating = true;
+      renderCitations(); // clear existing links
+      renderCitationsStatus();
+      apiPost("api/citations/" + pid + "/regenerate", {}).then(function (data) {
+        if (data.ok && data.generating) {
+          _startCitationsPoll(pid);
+        }
+      }).catch(function () {
+        showToast("Failed to regenerate citations");
+        state.citationsGenerating = false;
+        var status = qs("#summaryContent .citations-status");
+        if (status) status.remove();
       });
     });
 
@@ -544,6 +705,9 @@
           return;
         }
         apiPut("api/summary/" + pid, { summary: newText }).then(function () {
+          state.summaryCitations = null;
+          state.citationsGenerating = false;
+          _stopCitationsPoll();
           renderSummary(newText);
           showToast("Summary saved");
         }).catch(function () {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.34"
+VERSIONNUM: str = "0.10.35"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -10,6 +10,7 @@ Key functions:
   is_available()            - check Ollama server connectivity
   generate()                - send a prompt and get a text response
   summarize_transcript()    - summarize transcript segments into paragraph + bullets
+  find_citations()          - find supporting transcript segments for each summary sentence
 """
 
 import json
@@ -116,6 +117,7 @@ def generate(
     *,
     model: str | None = None,
     system: str | None = None,
+    think: bool | None = None,
 ) -> str | None:
     """Send a prompt to Ollama and return the generated text.
 
@@ -126,6 +128,8 @@ def generate(
         prompt: The user prompt to send.
         model: Ollama model name. Defaults to config.OLLAMA_SUMMARY_MODEL.
         system: Optional system prompt.
+        think: Explicitly enable/disable thinking mode for reasoning models.
+            When False, the model skips chain-of-thought and responds directly.
 
     Returns the generated text string, or None on any failure.
     """
@@ -137,6 +141,8 @@ def generate(
     }
     if system:
         body["system"] = system
+    if think is not None:
+        body["think"] = think
 
     try:
         return _do_generate(body)
@@ -219,3 +225,193 @@ def summarize_transcript(
     if result:
         utils.verbose_print(f"Summary generated ({len(result)} chars)")
     return result
+
+
+# ---- Citation linking (Pass 2) ----
+
+_CITATION_SYSTEM = (
+    "You match transcript segments to summary claims. "
+    "For each claim, select only the 1-3 most relevant and representative "
+    "segments. Prefer segments that most clearly and directly support the claim. "
+    "Use the exact format shown."
+)
+
+_CITATION_PROMPT = """\
+Claims:
+{claims}
+
+Transcript:
+{transcript}
+
+For each claim, pick the 1-3 BEST supporting timestamps — the clearest, \
+most direct evidence. Do not list every vaguely related segment.
+Format your response exactly as:
+1: 0:45, 1:02
+2: NONE
+Write NONE if no segments clearly support a claim."""
+
+_MAX_REFS_PER_CLAIM = 4  # hard cap enforced during parsing
+
+_CITATION_LINE_RE = re.compile(r"^(\d+)\s*:\s*(.+)$", re.MULTILINE)
+_TIMESTAMP_RE = re.compile(r"(\d{1,2}:\d{2}(?::\d{2})?)")
+
+
+def _split_summary_sentences(summary: str) -> list[str]:
+    """Split summary into individual claims (paragraph sentences + bullets)."""
+    sentences: list[str] = []
+    for line in summary.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("- ") or line.startswith("* "):
+            sentences.append(line[2:].strip())
+            continue
+        # Split paragraph text on sentence boundaries
+        parts = re.split(r"(?<=[.!?])\s+", line)
+        for part in parts:
+            part = part.strip()
+            if part:
+                sentences.append(part)
+    return sentences
+
+
+def _format_segment_chunk(segments: list[dict[str, Any]], offset: int) -> str:
+    """Format a chunk of segments as ``[M:SS] text`` lines for the prompt."""
+    lines: list[str] = []
+    for i, seg in enumerate(segments):
+        start = seg.get("start", 0)
+        ts = utils.seconds_to_timestamp(int(start))
+        text = seg.get("text", "").strip()
+        if text:
+            lines.append(f"[{ts}] {text}")
+    return "\n".join(lines)
+
+
+def _parse_citation_response(
+    response: str,
+    segments: list[dict[str, Any]],
+) -> dict[int, list[dict[str, Any]]]:
+    """Parse model output into ``{claim_index: [ref_dicts]}``.
+
+    Each ref dict has keys ``start``, ``end``, ``segment_index``.
+    Timestamps are matched to the nearest segment by start time.
+    """
+    # Build a lookup of segment start times for matching
+    seg_starts = [seg.get("start", 0.0) for seg in segments]
+
+    result: dict[int, list[dict[str, Any]]] = {}
+    for match in _CITATION_LINE_RE.finditer(response):
+        claim_num = int(match.group(1))
+        claim_idx = claim_num - 1  # 0-based
+        body = match.group(2).strip()
+        if body.upper() == "NONE":
+            continue
+        refs: list[dict[str, Any]] = []
+        for ts_match in _TIMESTAMP_RE.finditer(body):
+            ts_str = ts_match.group(1)
+            ts_seconds = _timestamp_to_seconds(ts_str)
+            if ts_seconds is None:
+                continue
+            # Find closest segment by start time
+            best_idx = _find_closest_segment(ts_seconds, seg_starts)
+            if best_idx is not None:
+                seg = segments[best_idx]
+                refs.append(
+                    {
+                        "start": seg.get("start", 0.0),
+                        "end": seg.get("end", 0.0),
+                        "segment_index": best_idx,
+                    }
+                )
+        if refs:
+            result[claim_idx] = refs
+    return result
+
+
+def _timestamp_to_seconds(ts: str) -> float | None:
+    """Parse ``M:SS`` or ``H:MM:SS`` to seconds."""
+    parts = ts.split(":")
+    try:
+        if len(parts) == 2:
+            return int(parts[0]) * 60 + int(parts[1])
+        if len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+    except ValueError:
+        pass
+    return None
+
+
+def _find_closest_segment(
+    target_seconds: float, seg_starts: list[float], tolerance: float = 5.0
+) -> int | None:
+    """Find the segment index whose start time is closest to *target_seconds*.
+
+    Returns None if the closest segment is more than *tolerance* seconds away.
+    """
+    best_idx: int | None = None
+    best_dist = tolerance + 1
+    for i, start in enumerate(seg_starts):
+        dist = abs(start - target_seconds)
+        if dist < best_dist:
+            best_dist = dist
+            best_idx = i
+    return best_idx
+
+
+_MAX_CITATION_TRANSCRIPT_CHARS = 12000  # generous limit for 9B context window
+
+
+def find_citations(
+    summary: str,
+    segments: list[dict[str, Any]],
+) -> list[dict[str, Any]] | None:
+    """Find supporting transcript segments for each summary sentence (Pass 2).
+
+    Sends the full transcript (truncated if very long) in a single model call
+    to avoid multi-chunk latency.
+
+    Args:
+        summary: The summary text (paragraph + bullets).
+        segments: Full list of transcript segment dicts with start/end/text.
+
+    Returns a list of citation dicts ``[{"sentence", "refs": [...]}]`` ordered
+    by sentence position, or None on failure.
+    """
+    sentences = _split_summary_sentences(summary)
+    if not sentences or not segments:
+        return None
+
+    model = config.OLLAMA_SUMMARY_MODEL_LARGE
+
+    claims_text = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(sentences))
+    transcript_text = _format_segment_chunk(segments, 0)
+
+    # Truncate long transcripts — keep beginning and end
+    if len(transcript_text) > _MAX_CITATION_TRANSCRIPT_CHARS:
+        half = _MAX_CITATION_TRANSCRIPT_CHARS // 2
+        transcript_text = transcript_text[:half] + "\n[...]\n" + transcript_text[-half:]
+
+    utils.verbose_print(
+        f"Finding citations for {len(sentences)} claims "
+        f"({len(transcript_text)} chars transcript) with model {model}"
+    )
+
+    prompt = _CITATION_PROMPT.format(claims=claims_text, transcript=transcript_text)
+    response = generate(prompt, model=model, system=_CITATION_SYSTEM, think=False)
+
+    # Parse refs from the single response
+    parsed: dict[int, list[dict[str, Any]]] = {}
+    if response:
+        parsed = _parse_citation_response(response, segments)
+
+    # Build final citations list, capping refs per claim
+    citations: list[dict[str, Any]] = []
+    for i, sentence in enumerate(sentences):
+        refs = sorted(parsed.get(i, []), key=lambda r: r["start"])
+        citations.append({"sentence": sentence, "refs": refs[:_MAX_REFS_PER_CLAIM]})
+
+    total_refs = sum(len(c["refs"]) for c in citations)
+    utils.verbose_print(
+        f"Citations complete: {total_refs} total refs across {len(citations)} claims"
+    )
+    return citations

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -260,3 +260,156 @@ class TestSummarizeTranscript:
         segments = [{"text": "word " * 1700}]
         ollama_client.summarize_transcript(segments)
         assert mock_generate.call_args[1]["model"] == "qwen3.5:9b"
+
+
+class TestSplitSummarySentences:
+    def test_splits_paragraph_on_sentence_boundaries(self):
+        text = "First sentence. Second sentence. Third sentence."
+        result = ollama_client._split_summary_sentences(text)
+        assert result == ["First sentence.", "Second sentence.", "Third sentence."]
+
+    def test_treats_bullets_as_individual_sentences(self):
+        text = "Overview.\n- Bullet one\n- Bullet two\n* Star bullet"
+        result = ollama_client._split_summary_sentences(text)
+        assert result == ["Overview.", "Bullet one", "Bullet two", "Star bullet"]
+
+    def test_skips_empty_lines(self):
+        text = "First.\n\n- Bullet\n\n"
+        result = ollama_client._split_summary_sentences(text)
+        assert result == ["First.", "Bullet"]
+
+    def test_handles_exclamation_and_question_marks(self):
+        text = "Was it good? It was great! Done."
+        result = ollama_client._split_summary_sentences(text)
+        assert result == ["Was it good?", "It was great!", "Done."]
+
+    def test_returns_empty_for_empty_input(self):
+        assert ollama_client._split_summary_sentences("") == []
+        assert ollama_client._split_summary_sentences("  \n\n  ") == []
+
+
+class TestFormatSegmentChunk:
+    def test_formats_segments_as_timestamped_lines(self):
+        segments = [
+            {"start": 0, "end": 5, "text": "Hello"},
+            {"start": 65, "end": 70, "text": "World"},
+        ]
+        result = ollama_client._format_segment_chunk(segments, 0)
+        assert result == "[0:00] Hello\n[1:05] World"
+
+    def test_skips_segments_with_empty_text(self):
+        segments = [
+            {"start": 0, "end": 5, "text": "Hello"},
+            {"start": 10, "end": 15, "text": ""},
+            {"start": 20, "end": 25, "text": "End"},
+        ]
+        result = ollama_client._format_segment_chunk(segments, 0)
+        assert result == "[0:00] Hello\n[0:20] End"
+
+
+class TestParseCitationResponse:
+    def _make_segments(self, starts):
+        return [{"start": s, "end": s + 5, "text": f"seg at {s}"} for s in starts]
+
+    def test_parses_basic_format(self):
+        segments = self._make_segments([45, 62, 120])
+        response = "1: 0:45, 2:00\n2: NONE\n3: 0:45"
+        result = ollama_client._parse_citation_response(response, segments)
+        # Claim 1 (index 0) matches segments at 45 and 120
+        assert 0 in result
+        assert len(result[0]) == 2
+        assert result[0][0]["segment_index"] == 0  # start=45 (0:45)
+        assert result[0][1]["segment_index"] == 2  # start=120 (2:00)
+        # Claim 2 (index 1) is NONE
+        assert 1 not in result
+        # Claim 3 (index 2) matches segment at 45
+        assert 2 in result
+        assert result[2][0]["segment_index"] == 0
+
+    def test_handles_bracketed_timestamps(self):
+        segments = self._make_segments([45])
+        response = "1: [0:45]"
+        result = ollama_client._parse_citation_response(response, segments)
+        assert 0 in result
+        assert result[0][0]["start"] == 45
+
+    def test_handles_hms_format(self):
+        segments = self._make_segments([3661])
+        response = "1: 1:01:01"
+        result = ollama_client._parse_citation_response(response, segments)
+        assert 0 in result
+        assert result[0][0]["segment_index"] == 0
+
+    def test_ignores_unparseable_lines(self):
+        segments = self._make_segments([10])
+        response = "This is gibberish\n1: 0:10\nmore nonsense"
+        result = ollama_client._parse_citation_response(response, segments)
+        assert 0 in result
+        assert result[0][0]["start"] == 10
+
+    def test_returns_empty_for_all_none(self):
+        segments = self._make_segments([10, 20])
+        response = "1: NONE\n2: NONE"
+        result = ollama_client._parse_citation_response(response, segments)
+        assert result == {}
+
+    def test_rejects_timestamps_beyond_tolerance(self):
+        segments = self._make_segments([100])
+        response = "1: 0:10"  # 10s is 90s away from 100s
+        result = ollama_client._parse_citation_response(response, segments)
+        assert result == {}
+
+
+class TestFindCitations:
+    def test_returns_none_for_empty_summary(self):
+        segments = [{"start": 0, "end": 5, "text": "Hello"}]
+        assert ollama_client.find_citations("", segments) is None
+
+    def test_returns_none_for_empty_segments(self):
+        assert ollama_client.find_citations("A summary.", []) is None
+
+    @patch("ollama_client.generate")
+    def test_always_uses_large_model(self, mock_generate):
+        mock_generate.return_value = "1: NONE"
+        segments = [{"start": 0, "end": 5, "text": "Some text here"}]
+        ollama_client.find_citations("A summary sentence.", segments)
+        assert mock_generate.call_args[1]["model"] == "qwen3.5:9b"
+
+    @patch("ollama_client.generate")
+    def test_returns_citations_on_success(self, mock_generate):
+        mock_generate.return_value = "1: 0:00\n2: 0:10"
+        segments = [
+            {"start": 0, "end": 5, "text": "First part"},
+            {"start": 10, "end": 15, "text": "Second part"},
+        ]
+        summary = "First claim.\n- Bullet claim"
+        result = ollama_client.find_citations(summary, segments)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["sentence"] == "First claim."
+        assert result[0]["refs"][0]["start"] == 0
+        assert result[1]["sentence"] == "Bullet claim"
+        assert result[1]["refs"][0]["start"] == 10
+
+    @patch("ollama_client.generate")
+    def test_returns_empty_refs_when_generate_fails(self, mock_generate):
+        mock_generate.return_value = None
+        segments = [{"start": 0, "end": 5, "text": "Some text"}]
+        result = ollama_client.find_citations("A sentence.", segments)
+        # Returns citations list but with empty refs
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["refs"] == []
+
+    @patch("ollama_client.generate")
+    def test_multiple_refs_per_claim(self, mock_generate):
+        mock_generate.return_value = "1: 0:00, 0:10"
+        segments = [
+            {"start": 0, "end": 5, "text": "Part A"},
+            {"start": 10, "end": 15, "text": "Part B"},
+        ]
+        result = ollama_client.find_citations("A claim.", segments)
+        assert result is not None
+        assert len(result[0]["refs"]) == 2
+        assert result[0]["refs"][0]["start"] == 0
+        assert result[0]["refs"][1]["start"] == 10

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -15,6 +15,8 @@ API endpoints (all under /transcripts/):
   GET  /api/summary/<participant>                - AI-generated transcript summary
   POST /api/summary/<participant>/regenerate    - re-trigger AI summary generation
   PUT  /api/summary/<participant>               - save user-edited summary
+  GET  /api/citations/<participant>             - citation refs for summary sentences
+  POST /api/citations/<participant>/regenerate  - re-trigger citation generation
   GET  /api/corrections                           - list all study-local corrections
   POST /api/corrections                           - add a correction manually
   DELETE /api/corrections/<id>                    - remove a correction
@@ -55,6 +57,10 @@ _summary_threads: set[threading.Thread] = set()
 _generating_summaries: set[str] = (
     set()
 )  # participant IDs with in-flight summary generation
+_citation_threads: set[threading.Thread] = set()
+_generating_citations: set[str] = (
+    set()
+)  # participant IDs with in-flight citation generation
 
 # ---- Blueprint ----
 
@@ -256,7 +262,12 @@ def api_summary(participant: str) -> FlaskResponse:
         if participant in _generating_summaries:
             return jsonify({"ok": False, "generating": True})
         return jsonify({"ok": False}), 404
-    return jsonify({"ok": True, "summary": entry["summary"]})
+    resp: dict[str, Any] = {"ok": True, "summary": entry["summary"]}
+    citations = entry.get("citations")
+    if citations:
+        resp["citations"] = citations
+    resp["citations_generating"] = participant in _generating_citations
+    return jsonify(resp)
 
 
 @transcripts_bp.route("/api/summary/<participant>/regenerate", methods=["POST"])
@@ -272,6 +283,7 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
         return jsonify({"ok": False, "error": "No transcript found"}), 404
     with _manifest_lock:
         entry["summary"] = ""
+        entry.pop("citations", None)
     _persist_manifest()
     _trigger_summary_generation(participant)
     return jsonify({"ok": True, "generating": True})
@@ -288,8 +300,45 @@ def api_summary_save(participant: str) -> FlaskResponse:
         if not entry:
             return jsonify({"ok": False, "error": "Participant not found"}), 404
         entry["summary"] = data["summary"].strip()
+        entry.pop("citations", None)  # invalidate citations on edit
     _persist_manifest()
     return jsonify({"ok": True})
+
+
+# ---- Citations ----
+
+
+@transcripts_bp.route("/api/citations/<participant>")
+def api_citations(participant: str) -> FlaskResponse:
+    """Return citation refs for a participant's summary, or generation status."""
+    with _manifest_lock:
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+    if not entry:
+        return jsonify({"ok": False}), 404
+    citations = entry.get("citations") if entry else None
+    if citations:
+        return jsonify({"ok": True, "citations": citations})
+    if participant in _generating_citations:
+        return jsonify({"ok": False, "generating": True})
+    return jsonify({"ok": False}), 404
+
+
+@transcripts_bp.route("/api/citations/<participant>/regenerate", methods=["POST"])
+def api_citations_regenerate(participant: str) -> FlaskResponse:
+    """Clear existing citations and re-trigger citation generation (Pass 2)."""
+    if not config.OLLAMA_SUMMARY_ENABLED:
+        return jsonify({"ok": False, "error": "Summary generation is disabled"}), 400
+    if participant in _generating_citations:
+        return jsonify({"ok": True, "generating": True})
+    with _manifest_lock:
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+    if not entry or not entry.get("summary") or not entry.get("segments"):
+        return jsonify({"ok": False, "error": "No summary or transcript found"}), 404
+    with _manifest_lock:
+        entry.pop("citations", None)
+    _persist_manifest()
+    _trigger_citation_generation(participant)
+    return jsonify({"ok": True, "generating": True})
 
 
 # ---- Corrections ----
@@ -801,6 +850,8 @@ def _trigger_summary_generation(participant: str) -> None:
                     if entry:
                         entry["summary"] = summary
                 _persist_manifest()
+                # Chain into Pass 2: citation linking
+                _trigger_citation_generation(participant)
         except Exception as exc:
             utils.warning_print(f"Summary generation failed for {participant}: {exc}")
         finally:
@@ -810,6 +861,39 @@ def _trigger_summary_generation(participant: str) -> None:
     _generating_summaries.add(participant)
     t = threading.Thread(target=_run, daemon=True, name=f"summary-{participant}")
     _summary_threads.add(t)
+    t.start()
+
+
+# ---- Citation generation (Pass 2) ----
+
+
+def _trigger_citation_generation(participant: str) -> None:
+    """Spawn daemon thread to find citation refs for a participant's summary."""
+
+    def _run() -> None:
+        try:
+            with _manifest_lock:
+                entry = _manifest.get("source_transcripts", {}).get(participant)
+                if not entry or not entry.get("summary") or not entry.get("segments"):
+                    return
+                summary = entry["summary"]
+                segments = list(entry["segments"])
+            citations = ollama_client.find_citations(summary, segments)
+            if citations is not None:
+                with _manifest_lock:
+                    entry = _manifest.get("source_transcripts", {}).get(participant)
+                    if entry:
+                        entry["citations"] = citations
+                _persist_manifest()
+        except Exception as exc:
+            utils.warning_print(f"Citation generation failed for {participant}: {exc}")
+        finally:
+            _generating_citations.discard(participant)
+            _citation_threads.discard(t)
+
+    _generating_citations.add(participant)
+    t = threading.Thread(target=_run, daemon=True, name=f"citations-{participant}")
+    _citation_threads.add(t)
     t.start()
 
 


### PR DESCRIPTION
## Summary

- After a transcript summary is generated, a second pass automatically runs the 9B model to find 1-3 supporting transcript segments per summary sentence
- Citations render as clickable `[1][2]` superscript footnotes that seek the video to the referenced timestamp
- New `find_citations()` function in `ollama_client.py` with sentence splitting, timestamp parsing, and a hard cap of 4 refs per claim
- Server adds `/api/citations` GET and regenerate endpoints, automatic chaining from summary generation, and citation invalidation on summary edit/regenerate
- Frontend adds citation rendering, a "Finding sources..." status indicator, a dedicated regenerate-citations button (hashtag icon), and a 90-second polling timeout

## Test plan

- [ ] Generate a transcript and verify summary appears, then "Finding sources..." shows, then citation footnotes render
- [ ] Click a citation footnote — video should seek to the referenced timestamp
- [ ] Click "Regenerate citations" button — old citations clear, new ones generate
- [ ] Click "Regenerate summary" — citations clear and re-generate after new summary
- [ ] Edit and save summary — citations are cleared
- [ ] Verify `uv run --extra dev pytest -c tests/pytest.ini` passes (44 ollama_client tests, 520 total)