### PR TITLE
feat: share theme and tooltip settings across all web UIs

### DIFF
--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -4,58 +4,6 @@
 
   var data = window.CLIPGEN_DATA || null;
   var state = { artifacts: [], lightboxIndex: -1 };
-  var THEME_STORAGE_KEY = "clipgen-gallery-theme";
-
-  // ---- Theme ----
-
-  function initThemeToggle() {
-    applyStoredThemePreference();
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.addEventListener("click", function () { toggleThemePreference(); });
-  }
-
-  function applyStoredThemePreference() {
-    var stored = null;
-    try { stored = window.localStorage.getItem(THEME_STORAGE_KEY); } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    } else {
-      root.removeAttribute("data-theme");
-    }
-    updateThemeToggleButton(stored);
-  }
-
-  function toggleThemePreference() {
-    var root = document.documentElement;
-    var current = root.getAttribute("data-theme");
-    var next;
-    if (current === "dark") next = "light";
-    else if (current === "light") next = "dark";
-    else {
-      try {
-        next = window.matchMedia("(prefers-color-scheme: dark)").matches ? "light" : "dark";
-      } catch (_) { next = "dark"; }
-    }
-    root.setAttribute("data-theme", next);
-    try { window.localStorage.setItem(THEME_STORAGE_KEY, next); } catch (_) {}
-    updateThemeToggleButton(next);
-  }
-
-  function updateThemeToggleButton(explicitTheme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    var effective = explicitTheme;
-    if (effective !== "light" && effective !== "dark") {
-      try {
-        effective = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      } catch (_) { effective = "light"; }
-    }
-    btn.setAttribute("data-theme", effective);
-    btn.setAttribute("aria-pressed", effective === "dark" ? "true" : "false");
-  }
-
   // ---- Init ----
 
   document.addEventListener("DOMContentLoaded", function () {

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -3,7 +3,6 @@
 (function () {
   "use strict";
 
-  var THEME_STORAGE_KEY = "clipgen-insights-theme";
   var SIDEBAR_WIDTH_KEY = "clipgen-insights-sidebar-width";
   var SEVERITY_OPTIONS = [
     "",
@@ -69,72 +68,6 @@
     t._timer = setTimeout(function () {
       t.classList.add("hidden");
     }, 3000);
-  }
-
-  // ---- Theme ----
-
-  function initThemeToggle() {
-    applyStoredTheme();
-    var btn = qs("#themeToggle");
-    if (btn)
-      btn.addEventListener("click", function () {
-        toggleTheme();
-      });
-  }
-
-  function applyStoredTheme() {
-    var stored = null;
-    try {
-      stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    } else {
-      root.removeAttribute("data-theme");
-    }
-    updateThemeButton(stored);
-  }
-
-  function toggleTheme() {
-    var root = document.documentElement;
-    var current = root.getAttribute("data-theme");
-    var next;
-    if (current === "dark") next = "light";
-    else if (current === "light") next = "dark";
-    else {
-      try {
-        next =
-          window.matchMedia &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "light"
-            : "dark";
-      } catch (_) {
-        next = "dark";
-      }
-    }
-    root.setAttribute("data-theme", next);
-    try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, next);
-    } catch (_) {}
-    updateThemeButton(next);
-  }
-
-  function updateThemeButton(explicitTheme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    var effective = explicitTheme;
-    if (effective !== "light" && effective !== "dark") {
-      var prefersDark = false;
-      try {
-        prefersDark =
-          window.matchMedia &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      effective = prefersDark ? "dark" : "light";
-    }
-    btn.setAttribute("data-theme", effective);
-    btn.setAttribute("aria-pressed", effective === "dark" ? "true" : "false");
   }
 
   // ---- Data loading ----

--- a/assets/web/insights-viewer.js
+++ b/assets/web/insights-viewer.js
@@ -3,8 +3,6 @@
 (function () {
   "use strict";
 
-  var THEME_STORAGE_KEY = "clipgen-insights-viewer-theme";
-
   var data = null;
   var artifactMap = {};
 
@@ -15,62 +13,6 @@
     var b = (insight.behaviors || {}).artifacts || [];
     var i = (insight.impacts || {}).artifacts || [];
     return c.length + b.length + i.length;
-  }
-
-  // ---- Theme ----
-
-  function initThemeToggle() {
-    var stored = null;
-    try {
-      stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    }
-    updateThemeButton(stored);
-
-    var btn = qs("#themeToggle");
-    if (btn)
-      btn.addEventListener("click", function () {
-        var current = root.getAttribute("data-theme");
-        var next;
-        if (current === "dark") next = "light";
-        else if (current === "light") next = "dark";
-        else {
-          try {
-            next =
-              window.matchMedia &&
-              window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "light"
-                : "dark";
-          } catch (_) {
-            next = "dark";
-          }
-        }
-        root.setAttribute("data-theme", next);
-        try {
-          window.localStorage.setItem(THEME_STORAGE_KEY, next);
-        } catch (_) {}
-        updateThemeButton(next);
-      });
-  }
-
-  function updateThemeButton(explicitTheme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    var effective = explicitTheme;
-    if (effective !== "light" && effective !== "dark") {
-      var prefersDark = false;
-      try {
-        prefersDark =
-          window.matchMedia &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      effective = prefersDark ? "dark" : "light";
-    }
-    btn.setAttribute("data-theme", effective);
-    btn.setAttribute("aria-pressed", effective === "dark" ? "true" : "false");
   }
 
   // ---- Render index ----

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3,7 +3,6 @@
 (function () {
   "use strict";
 
-  var THEME_STORAGE_KEY = "clipgen-screenspace-theme";
   var FRAME_STEP = 1.0;
 
   var TASK_COLORS = DETECTOR_COLORS;
@@ -225,58 +224,6 @@
 
   function videoStreamUrl(pid) {
     return "api/video/stream/" + encodeURIComponent(pid);
-  }
-
-  // ---- Theme toggle (matches Studio) ----
-
-  function initThemeToggle() {
-    applyStoredThemePreference();
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.addEventListener("click", function () {
-      toggleThemePreference();
-    });
-  }
-
-  function applyStoredThemePreference() {
-    var stored = null;
-    try { stored = window.localStorage.getItem(THEME_STORAGE_KEY); } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    } else {
-      root.removeAttribute("data-theme");
-    }
-    updateThemeToggleButton(stored);
-  }
-
-  function toggleThemePreference() {
-    var root = document.documentElement;
-    var current = root.getAttribute("data-theme");
-    var next;
-    if (current === "dark") {
-      next = "light";
-    } else if (current === "light") {
-      next = "dark";
-    } else {
-      var prefersDark = false;
-      try {
-        prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      next = prefersDark ? "light" : "dark";
-    }
-    root.setAttribute("data-theme", next);
-    try { window.localStorage.setItem(THEME_STORAGE_KEY, next); } catch (_) {}
-    updateThemeToggleButton(next);
-    refreshThemeColors();
-    renderTimeline();
-  }
-
-  function updateThemeToggleButton(theme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.setAttribute("data-theme", theme || "");
-    btn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
   }
 
   // ---- Nav links ----
@@ -5267,7 +5214,7 @@
   // ---- Init ----
 
   document.addEventListener("DOMContentLoaded", function () {
-    initThemeToggle();
+    initThemeToggle(function () { refreshThemeColors(); renderTimeline(); });
     initFrameControls();
     initVideoPlayback();
     initRegionDrawing();

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3,7 +3,6 @@
 (function () {
   "use strict";
 
-  var THEME_STORAGE_KEY = "clipgen-studio-theme";
   var QUEUE_STORAGE_KEY = "clipgen-studio-queues";
 
   var state = {
@@ -644,62 +643,6 @@
       setTimeout(sizeTrIntakeCanvas, 0);
     }
     computeGridMaxHeight();
-  }
-
-  // ---- Theme ----
-
-  function initThemeToggle() {
-    applyStoredThemePreference();
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.addEventListener("click", function () {
-      toggleThemePreference();
-    });
-  }
-
-  function applyStoredThemePreference() {
-    var stored = null;
-    try {
-      stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    } else {
-      root.removeAttribute("data-theme");
-    }
-    updateThemeToggleButton(stored);
-  }
-
-  function toggleThemePreference() {
-    var root = document.documentElement;
-    var current = root.getAttribute("data-theme");
-    var next;
-    if (current === "dark") {
-      next = "light";
-    } else if (current === "light") {
-      next = "dark";
-    } else {
-      var prefersDark = false;
-      try {
-        prefersDark =
-          window.matchMedia &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      next = prefersDark ? "light" : "dark";
-    }
-    root.setAttribute("data-theme", next);
-    try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, next);
-    } catch (_) {}
-    updateThemeToggleButton(next);
-  }
-
-  function updateThemeToggleButton(theme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.setAttribute("data-theme", theme || "");
-    btn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
   }
 
   // ---- Queue persistence (sessionStorage) ----
@@ -4514,11 +4457,14 @@
   }
 
   function initTooltipToggle() {
+    state.trIntakeTooltipsEnabled = getStoredTooltipPref();
     var btn = qs("#tooltipToggle");
     if (!btn) return;
+    btn.setAttribute("aria-pressed", state.trIntakeTooltipsEnabled ? "true" : "false");
     btn.addEventListener("click", function () {
       state.trIntakeTooltipsEnabled = !state.trIntakeTooltipsEnabled;
       btn.setAttribute("aria-pressed", state.trIntakeTooltipsEnabled ? "true" : "false");
+      setStoredTooltipPref(state.trIntakeTooltipsEnabled);
       if (!state.trIntakeTooltipsEnabled) {
         var tt = qs("#trIntakeTooltip");
         if (tt) tt.classList.add("hidden");

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1,7 +1,6 @@
 (function () {
   "use strict";
 
-  var THEME_STORAGE_KEY = "clipgen-transcripts-theme";
   var SEARCH_DEBOUNCE = 300;
 
   var fmtTime = formatTime;
@@ -50,56 +49,6 @@
     el.classList.remove("hidden");
     clearTimeout(el._timer);
     el._timer = setTimeout(function () { el.classList.add("hidden"); }, 2500);
-  }
-
-  // ---- Theme toggle ----
-
-  function initThemeToggle() {
-    applyStoredThemePreference();
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.addEventListener("click", function () {
-      toggleThemePreference();
-    });
-  }
-
-  function applyStoredThemePreference() {
-    var stored = null;
-    try { stored = window.localStorage.getItem(THEME_STORAGE_KEY); } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    } else {
-      root.removeAttribute("data-theme");
-    }
-    updateThemeToggleButton(stored);
-  }
-
-  function toggleThemePreference() {
-    var root = document.documentElement;
-    var current = root.getAttribute("data-theme");
-    var next;
-    if (current === "dark") {
-      next = "light";
-    } else if (current === "light") {
-      next = "dark";
-    } else {
-      var prefersDark = false;
-      try {
-        prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      next = prefersDark ? "light" : "dark";
-    }
-    root.setAttribute("data-theme", next);
-    try { window.localStorage.setItem(THEME_STORAGE_KEY, next); } catch (_) {}
-    updateThemeToggleButton(next);
-  }
-
-  function updateThemeToggleButton(theme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.setAttribute("data-theme", theme || "");
-    btn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
   }
 
   // ---- Nav links ----
@@ -1897,11 +1846,14 @@
   }
 
   function initTooltipToggle() {
+    state.tooltipsEnabled = getStoredTooltipPref();
     var btn = qs("#tooltipToggle");
     if (!btn) return;
+    btn.setAttribute("aria-pressed", state.tooltipsEnabled ? "true" : "false");
     btn.addEventListener("click", function () {
       state.tooltipsEnabled = !state.tooltipsEnabled;
       btn.setAttribute("aria-pressed", state.tooltipsEnabled ? "true" : "false");
+      setStoredTooltipPref(state.tooltipsEnabled);
       if (state.searchResults) renderSearchResults(state.searchResults);
       if (state.segments.length > 0) renderSegments();
     });

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -146,3 +146,105 @@ var DETECTOR_COLORS = (function () {
     return fallback;
   }
 })();
+
+// ---- Shared settings (localStorage) ----
+
+var THEME_STORAGE_KEY = "clipgen-theme";
+var TOOLTIP_STORAGE_KEY = "clipgen-tooltips";
+
+// Old per-UI theme keys — checked on every page load so stragglers are migrated.
+var _THEME_OLD_KEYS = [
+  "clipgen-studio-theme", "clipgen-screenspace-theme",
+  "clipgen-insights-theme", "clipgen-insights-viewer-theme",
+  "clipgen-gallery-theme", "clipgen-viewer-theme", "clipgen-transcripts-theme",
+];
+
+var _migrateThemeKey = function () {
+  try {
+    var shared = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (!shared) {
+      for (var i = 0; i < _THEME_OLD_KEYS.length; i++) {
+        var val = window.localStorage.getItem(_THEME_OLD_KEYS[i]);
+        if (val === "light" || val === "dark") {
+          window.localStorage.setItem(THEME_STORAGE_KEY, val);
+          break;
+        }
+      }
+    }
+    for (var j = 0; j < _THEME_OLD_KEYS.length; j++) {
+      window.localStorage.removeItem(_THEME_OLD_KEYS[j]);
+    }
+  } catch (_) {}
+};
+
+var applyStoredThemePreference = function () {
+  _migrateThemeKey();
+  var stored = null;
+  try { stored = window.localStorage.getItem(THEME_STORAGE_KEY); } catch (_) {}
+  var root = document.documentElement;
+  if (stored === "light" || stored === "dark") {
+    root.setAttribute("data-theme", stored);
+  } else {
+    root.removeAttribute("data-theme");
+  }
+  updateThemeToggleButton(stored);
+};
+
+var toggleThemePreference = function () {
+  var root = document.documentElement;
+  var current = root.getAttribute("data-theme");
+  var next;
+  if (current === "dark") {
+    next = "light";
+  } else if (current === "light") {
+    next = "dark";
+  } else {
+    var prefersDark = false;
+    try {
+      prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    } catch (_) {}
+    next = prefersDark ? "light" : "dark";
+  }
+  root.setAttribute("data-theme", next);
+  try { window.localStorage.setItem(THEME_STORAGE_KEY, next); } catch (_) {}
+  updateThemeToggleButton(next);
+};
+
+var updateThemeToggleButton = function (explicitTheme) {
+  var btn = qs("#themeToggle");
+  if (!btn) return;
+  var effective = explicitTheme;
+  if (effective !== "light" && effective !== "dark") {
+    var prefersDark = false;
+    try {
+      prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    } catch (_) {}
+    effective = prefersDark ? "dark" : "light";
+  }
+  btn.setAttribute("data-theme", effective);
+  btn.setAttribute("aria-pressed", effective === "dark" ? "true" : "false");
+};
+
+var initThemeToggle = function (onToggle) {
+  applyStoredThemePreference();
+  var btn = qs("#themeToggle");
+  if (!btn) return;
+  btn.addEventListener("click", function () {
+    toggleThemePreference();
+    if (onToggle) onToggle();
+  });
+};
+
+var getStoredTooltipPref = function () {
+  try {
+    var v = window.localStorage.getItem(TOOLTIP_STORAGE_KEY);
+    if (v === "false") return false;
+  } catch (_) {}
+  return true;
+};
+
+var setStoredTooltipPref = function (enabled) {
+  try {
+    window.localStorage.setItem(TOOLTIP_STORAGE_KEY, enabled ? "true" : "false");
+  } catch (_) {}
+};

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -584,8 +584,6 @@
 
   // ---- Initialization ----
 
-  var THEME_STORAGE_KEY = "clipgen-viewer-theme";
-
   document.addEventListener("DOMContentLoaded", function () {
     initThemeToggle();
 
@@ -634,70 +632,6 @@
     initFilmstripToggle();
     if (_filmstripEnabled) applyFilmstripMode();
   });
-
-  function initThemeToggle() {
-    applyStoredThemePreference();
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    btn.addEventListener("click", function () {
-      toggleThemePreference();
-    });
-  }
-
-  function applyStoredThemePreference() {
-    var stored = null;
-    try {
-      stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    } catch (_) {}
-    var root = document.documentElement;
-    if (stored === "light" || stored === "dark") {
-      root.setAttribute("data-theme", stored);
-    } else {
-      root.removeAttribute("data-theme");
-    }
-    updateThemeToggleButton(stored);
-  }
-
-  function toggleThemePreference() {
-    var root = document.documentElement;
-    var current = root.getAttribute("data-theme");
-    var next;
-    if (current === "dark") {
-      next = "light";
-    } else if (current === "light") {
-      next = "dark";
-    } else {
-      var prefersDark = false;
-      try {
-        prefersDark =
-          window.matchMedia &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      next = prefersDark ? "light" : "dark";
-    }
-    root.setAttribute("data-theme", next);
-    try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, next);
-    } catch (_) {}
-    updateThemeToggleButton(next);
-  }
-
-  function updateThemeToggleButton(explicitTheme) {
-    var btn = qs("#themeToggle");
-    if (!btn) return;
-    var effective = explicitTheme;
-    if (effective !== "light" && effective !== "dark") {
-      var prefersDark = false;
-      try {
-        prefersDark =
-          window.matchMedia &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches;
-      } catch (_) {}
-      effective = prefersDark ? "dark" : "light";
-    }
-    btn.setAttribute("data-theme", effective);
-    btn.setAttribute("aria-pressed", effective === "dark" ? "true" : "false");
-  }
 
   function derivePresentTypes(artifacts) {
     var found = {};

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.35"
+VERSIONNUM: str = "0.10.36"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Moves dark mode toggle functions and tooltip persistence helpers from 7 individual UI scripts into the shared `utils.js`, using a single `clipgen-theme` localStorage key instead of per-UI keys (`clipgen-studio-theme`, `clipgen-transcripts-theme`, etc.)
- Adds shared `clipgen-tooltips` localStorage key so the cross-ref tooltip toggle in Transcripts and Studio persists and carries between UIs
- Old per-UI theme keys are automatically migrated on first page load and cleaned up
- Screenspace's post-toggle canvas refresh is handled via an optional `onToggle` callback parameter on the shared `initThemeToggle`

## Test plan

- [ ] Start combined server, toggle dark mode in one UI, navigate to another — theme should carry over
- [ ] Toggle tooltips off in Transcripts, navigate to Studio — tooltips should remain off
- [ ] Manually set an old per-UI key in devtools (e.g. `clipgen-studio-theme=dark`), reload — should migrate to shared key
- [ ] Verify Screenspace canvas re-renders correctly after theme toggle
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` — 519 tests pass