### PR TITLE
feat: add convergence data collection, algorithm, and timeline rendering

### DIFF
--- a/assets/web/convergence.css
+++ b/assets/web/convergence.css
@@ -56,9 +56,217 @@
   overflow-y: auto;
 }
 
-/* Event type pills container */
+/* Event type pills */
 #cvEventTypePills {
   display: flex;
   gap: 4px;
   flex-wrap: wrap;
+}
+
+.cv-event-type-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 10px;
+  padding: 1px 6px;
+  border: 1px solid var(--det-color, var(--color-border));
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--det-color, var(--color-text-dim));
+  cursor: pointer;
+  font-weight: 600;
+  text-transform: uppercase;
+  transition: background var(--duration-fast), color var(--duration-fast);
+}
+
+.cv-event-type-pill:hover {
+  background: color-mix(in srgb, var(--det-color) 15%, transparent);
+}
+
+.cv-event-type-pill.active {
+  background: var(--det-color);
+  color: #fff;
+}
+
+/* ---- Time Axis ---- */
+
+.cv-time-axis {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-float);
+  height: 20px;
+  background: var(--color-surface-alt);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.cv-tick {
+  position: absolute;
+  top: 0;
+  width: 1px;
+  height: 8px;
+  background: var(--color-border);
+}
+
+.cv-tick-label {
+  position: absolute;
+  top: 9px;
+  left: 50%;
+  transform: translateX(-50%);
+  font: 10px var(--font-mono);
+  color: var(--color-text-dim);
+  white-space: nowrap;
+}
+
+/* ---- Summary Lane ---- */
+
+.cv-summary-lane-wrap {
+  position: sticky;
+  top: 21px;
+  z-index: calc(var(--z-float) - 1);
+  height: 32px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.cv-summary-canvas {
+  display: block;
+  width: 100%;
+  height: 32px;
+}
+
+/* ---- Staleness Banner ---- */
+
+.cv-stale-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-surface-alt);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+}
+
+.cv-stale-banner.hidden {
+  display: none;
+}
+
+.cv-stale-refresh {
+  font-size: var(--text-xs);
+  padding: 2px var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-accent);
+  cursor: pointer;
+}
+
+.cv-stale-refresh:hover {
+  background: var(--color-surface-alt);
+}
+
+/* ---- No Convergence Message ---- */
+
+.cv-no-convergence {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  text-align: center;
+}
+
+/* ---- Participant Rows ---- */
+
+.cv-participant-rows {
+  /* scrolling handled by parent .convergence-timeline-container */
+}
+
+.cv-participant-row {
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.cv-participant-label {
+  width: 52px;
+  flex-shrink: 0;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  padding: var(--space-1);
+  background: var(--color-surface);
+  display: flex;
+  align-items: center;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-dim);
+}
+
+.cv-tracks-container {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+}
+
+/* ---- Sub-tracks ---- */
+
+.cv-sub-track {
+  height: 14px;
+  position: relative;
+  overflow: hidden;
+}
+
+.cv-sub-track + .cv-sub-track {
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 40%, transparent);
+}
+
+/* ---- Row Shading Canvas ---- */
+
+.cv-row-shading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ---- Event Markers ---- */
+
+.cv-event-marker {
+  position: absolute;
+  top: 1px;
+  height: calc(100% - 2px);
+  border-radius: var(--radius-sm);
+  opacity: 0.65;
+  cursor: default;
+  transition: opacity var(--duration-fast);
+  z-index: 1;
+}
+
+.cv-event-marker:hover {
+  opacity: 1;
+}
+
+/* ---- Empty State ---- */
+
+.cv-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  color: var(--color-text-dim);
+  font-size: var(--text-sm);
+  text-align: center;
+  padding: var(--space-3);
+}
+
+/* ---- Reduced Motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .cv-event-marker,
+  .cv-stream-toggle,
+  .cv-event-type-pill {
+    transition: none;
+  }
 }

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -1,4 +1,4 @@
-/* Convergence Browser – Phase 1: Tab shell and filter controls */
+/* Convergence Browser – Phase 1 + Phase 2 */
 
 (function () {
   "use strict";
@@ -21,7 +21,10 @@
     dataVersion: 0,
     duration: 0,
     participants: [],
+    _snapshot: null,
   };
+
+  var _summaryHitRects = [];
 
   // --- Utilities ---
 
@@ -32,6 +35,307 @@
       clearTimeout(timer);
       timer = setTimeout(function () { fn.apply(ctx, args); }, ms);
     };
+  }
+
+  function getState() {
+    return window._studioState;
+  }
+
+  function getEventTypeColor(source, eventType) {
+    if (source === "screenspace") return DETECTOR_COLORS[eventType] || "#888";
+    if (source === "transcript") return (MARK_CATEGORIES[eventType] || {}).color || "#0891b2";
+    return XREF_BADGES.sheet.color;
+  }
+
+  function stddev(nums) {
+    if (nums.length < 2) return 0;
+    var sum = 0;
+    for (var i = 0; i < nums.length; i++) sum += nums[i];
+    var mean = sum / nums.length;
+    var sqSum = 0;
+    for (var j = 0; j < nums.length; j++) sqSum += (nums[j] - mean) * (nums[j] - mean);
+    return Math.sqrt(sqSum / nums.length);
+  }
+
+  function parseAccentColor() {
+    try {
+      var raw = getComputedStyle(document.documentElement).getPropertyValue("--color-accent").trim();
+      if (!raw) return { r: 59, g: 130, b: 246 };
+      if (raw.charAt(0) === "#") {
+        return {
+          r: parseInt(raw.slice(1, 3), 16),
+          g: parseInt(raw.slice(3, 5), 16),
+          b: parseInt(raw.slice(5, 7), 16),
+        };
+      }
+      var m = raw.match(/(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+      if (m) return { r: +m[1], g: +m[2], b: +m[3] };
+    } catch (_) { /* fall through */ }
+    return { r: 59, g: 130, b: 246 };
+  }
+
+  // --- Data Collection ---
+
+  function collectAllEvents() {
+    var state = getState();
+    var events = [];
+    var participantSet = {};
+
+    // Sheet events
+    if (state.sheetData && state.sheetData.rows) {
+      var participants = state.sheetData.participants || [];
+      for (var r = 0; r < state.sheetData.rows.length; r++) {
+        var row = state.sheetData.rows[r];
+        for (var p = 0; p < participants.length; p++) {
+          var pid = participants[p];
+          var cell = row.cells[pid];
+          if (!cell || !cell.valid) continue;
+          var segs = window._studioParseClipTimestamps(cell.value);
+          var baselineOffset = (cvState.baselines && cvState.baselines[pid]) || 0;
+          for (var s = 0; s < segs.length; s++) {
+            var start = segs[s].startSeconds - baselineOffset;
+            var end = start + segs[s].duration;
+            events.push({
+              participant: pid,
+              start: Math.max(0, start),
+              end: Math.max(0, end),
+              source: "sheet",
+              eventType: row.category || "uncategorized",
+              label: row.observation || "",
+              id: "sh_" + row.rowNum + "_" + pid + "_" + s,
+              rawData: row,
+            });
+            participantSet[pid] = true;
+          }
+        }
+      }
+    }
+
+    // Screenspace events (raw, not clusters)
+    for (var i = 0; i < state.intakeEvents.length; i++) {
+      var ev = state.intakeEvents[i];
+      events.push({
+        participant: ev.participant,
+        start: ev.time_in,
+        end: ev.time_out,
+        source: "screenspace",
+        eventType: ev.event_type || ev.detector || "unknown",
+        label: (ev.event_type || ev.detector || "") + " detection",
+        id: ev.id || ("ss_" + i),
+        rawData: ev,
+      });
+      participantSet[ev.participant] = true;
+    }
+
+    // Transcript marks
+    for (var j = 0; j < state.trIntakeMarks.length; j++) {
+      var mark = state.trIntakeMarks[j];
+      events.push({
+        participant: mark.participant,
+        start: mark.start,
+        end: mark.end,
+        source: "transcript",
+        eventType: mark.category || "bookmark",
+        label: mark.text || mark.label || "",
+        id: mark.id || mark.segment_id || ("tr_" + j),
+        rawData: mark,
+      });
+      participantSet[mark.participant] = true;
+    }
+
+    // Duration
+    var maxEnd = 0;
+    for (var k = 0; k < events.length; k++) {
+      if (events[k].end > maxEnd) maxEnd = events[k].end;
+    }
+    cvState.duration = Math.max(maxEnd * 1.05, 60);
+
+    // Participants: spreadsheet order first, then others alphabetically
+    var ordered = [];
+    if (state.sheetData && state.sheetData.participants) {
+      for (var pi = 0; pi < state.sheetData.participants.length; pi++) {
+        ordered.push(state.sheetData.participants[pi]);
+      }
+    }
+    var others = [];
+    var pids = Object.keys(participantSet);
+    for (var qi = 0; qi < pids.length; qi++) {
+      if (ordered.indexOf(pids[qi]) < 0) others.push(pids[qi]);
+    }
+    others.sort();
+    cvState.participants = ordered.concat(others);
+
+    cvState.events = events;
+
+    // Snapshot for staleness detection
+    cvState._snapshot = {
+      ss: state.intakeEvents.length,
+      tr: state.trIntakeMarks.length,
+      sh: state.sheetData ? state.sheetData.rows.length : 0,
+    };
+  }
+
+  // --- Convergence Algorithm ---
+
+  function computeConvergenceZones(events, windowSec, minParticipants) {
+    if (!events.length) return [];
+
+    // Sort by start time
+    var sorted = events.slice().sort(function (a, b) { return a.start - b.start; });
+
+    // For each event, find distinct participants within ±windowSec
+    var qualifying = []; // indices of events that meet threshold
+    for (var i = 0; i < sorted.length; i++) {
+      var center = sorted[i].start;
+      var seen = {};
+      for (var j = 0; j < sorted.length; j++) {
+        if (sorted[j].start > center + windowSec) break;
+        if (sorted[j].end < center - windowSec && sorted[j].start < center - windowSec) continue;
+        // Event j overlaps the window [center - W, center + W]
+        if (sorted[j].start <= center + windowSec && sorted[j].end >= center - windowSec) {
+          seen[sorted[j].participant] = true;
+        }
+      }
+      if (Object.keys(seen).length >= minParticipants) {
+        qualifying.push(i);
+      }
+    }
+
+    if (!qualifying.length) return [];
+
+    // Build zones from consecutive qualifying events
+    var zones = [];
+    var zStart = sorted[qualifying[0]].start;
+    var zEnd = sorted[qualifying[0]].end;
+    var zEvents = [sorted[qualifying[0]]];
+
+    for (var q = 1; q < qualifying.length; q++) {
+      var evt = sorted[qualifying[q]];
+      // Merge if overlapping or within window
+      if (evt.start <= zEnd + windowSec) {
+        zEnd = Math.max(zEnd, evt.end);
+        zEvents.push(evt);
+      } else {
+        zones.push(buildZone(zStart, zEnd, zEvents, windowSec));
+        zStart = evt.start;
+        zEnd = evt.end;
+        zEvents = [evt];
+      }
+    }
+    zones.push(buildZone(zStart, zEnd, zEvents, windowSec));
+
+    return zones;
+  }
+
+  function buildZone(start, end, events, windowSec) {
+    var pSet = {};
+    var starts = [];
+    for (var i = 0; i < events.length; i++) {
+      pSet[events[i].participant] = true;
+      starts.push(events[i].start);
+    }
+    var participants = Object.keys(pSet);
+    var tightness = stddev(starts);
+    var totalP = cvState.participants.length || 1;
+    var strength = (participants.length / totalP) * (1 / (1 + tightness / Math.max(windowSec, 1)));
+    return {
+      start: start,
+      end: end,
+      participantCount: participants.length,
+      participants: participants,
+      events: events,
+      tightness: tightness,
+      strength: strength,
+    };
+  }
+
+  // --- Filter Pipeline ---
+
+  function applyFilters() {
+    var filtered = cvState.events;
+    var streams = cvState.filters.streams;
+    var types = cvState.filters.eventTypes;
+    var range = cvState.filters.timeRange;
+
+    if (streams.length > 0) {
+      filtered = filtered.filter(function (e) { return streams.indexOf(e.source) >= 0; });
+    }
+    if (types.length > 0) {
+      filtered = filtered.filter(function (e) { return types.indexOf(e.eventType) >= 0; });
+    }
+    if (range) {
+      filtered = filtered.filter(function (e) { return e.end >= range.start && e.start <= range.end; });
+    }
+
+    cvState.filteredEvents = filtered;
+    cvState.convergenceZones = computeConvergenceZones(
+      filtered,
+      cvState.filters.windowSec,
+      cvState.filters.minParticipants
+    );
+  }
+
+  function recalculate() {
+    collectAllEvents();
+    populateEventTypePills();
+    applyFilters();
+    render();
+  }
+
+  // --- Event Type Pills ---
+
+  function populateEventTypePills() {
+    var container = qs("#cvEventTypePills");
+    if (!container) return;
+
+    var streams = cvState.filters.streams;
+    var typeMap = {}; // source -> Set<eventType>
+    for (var i = 0; i < cvState.events.length; i++) {
+      var e = cvState.events[i];
+      if (streams.length > 0 && streams.indexOf(e.source) < 0) continue;
+      if (!typeMap[e.source]) typeMap[e.source] = {};
+      typeMap[e.source][e.eventType] = true;
+    }
+
+    var frag = document.createDocumentFragment();
+    var sources = ["sheet", "screenspace", "transcript"];
+    for (var si = 0; si < sources.length; si++) {
+      var src = sources[si];
+      var types = typeMap[src];
+      if (!types) continue;
+      var keys = Object.keys(types).sort();
+      for (var ki = 0; ki < keys.length; ki++) {
+        var type = keys[ki];
+        var pill = document.createElement("button");
+        pill.className = "cv-event-type-pill" +
+          (cvState.filters.eventTypes.indexOf(type) >= 0 ? " active" : "");
+        pill.textContent = type;
+        pill.dataset.eventType = type;
+        pill.style.setProperty("--det-color", getEventTypeColor(src, type));
+        pill.addEventListener("click", (function (t) {
+          return function () { toggleEventType(t); };
+        })(type));
+        frag.appendChild(pill);
+      }
+    }
+
+    container.innerHTML = "";
+    container.appendChild(frag);
+  }
+
+  function toggleEventType(type) {
+    var idx = cvState.filters.eventTypes.indexOf(type);
+    if (idx >= 0) {
+      cvState.filters.eventTypes.splice(idx, 1);
+    } else {
+      cvState.filters.eventTypes.push(type);
+    }
+    // Update pill active states
+    var pills = qsa(".cv-event-type-pill");
+    for (var i = 0; i < pills.length; i++) {
+      pills[i].classList.toggle("active", cvState.filters.eventTypes.indexOf(pills[i].dataset.eventType) >= 0);
+    }
+    onFilterChange();
   }
 
   // --- Filter Controls ---
@@ -120,6 +424,9 @@
       }
     }
 
+    // Clear event type filter when streams change
+    cvState.filters.eventTypes = [];
+    populateEventTypePills();
     onFilterChange();
   }
 
@@ -133,10 +440,256 @@
 
   function onFilterChange() {
     syncFilterInputs();
-    // Phase 2: recalculate convergence zones and re-render
+    applyFilters();
+    render();
   }
 
   var debouncedFilterChange = debounce(onFilterChange, 250);
+
+  // --- Rendering ---
+
+  function render() {
+    renderTimeline();
+    requestAnimationFrame(renderCanvases);
+  }
+
+  function renderTimeline() {
+    var container = qs("#convergenceTimeline");
+    if (!container) return;
+
+    container.innerHTML = "";
+
+    // Empty state
+    if (cvState.events.length === 0) {
+      var empty = el("div", "cv-empty-state");
+      empty.textContent = "No events loaded. Load data from multiple participants to see convergence.";
+      container.appendChild(empty);
+      return;
+    }
+
+    if (cvState.filteredEvents.length === 0) {
+      var emptyFiltered = el("div", "cv-empty-state");
+      emptyFiltered.textContent = "No events match the current filters.";
+      container.appendChild(emptyFiltered);
+      return;
+    }
+
+    var frag = document.createDocumentFragment();
+
+    // Time axis
+    var axis = el("div", "cv-time-axis");
+    var tickInterval = window._studioIntakeComputeTickInterval(cvState.duration);
+    for (var t = tickInterval; t <= cvState.duration; t += tickInterval) {
+      var tick = el("div", "cv-tick");
+      tick.style.left = (t / cvState.duration * 100) + "%";
+      var tickLabel = el("span", "cv-tick-label");
+      tickLabel.textContent = window._studioFormatDuration(t);
+      tick.appendChild(tickLabel);
+      axis.appendChild(tick);
+    }
+    frag.appendChild(axis);
+
+    // Summary lane
+    var summaryWrap = el("div", "cv-summary-lane-wrap");
+    var summaryCanvas = document.createElement("canvas");
+    summaryCanvas.className = "cv-summary-canvas";
+    summaryWrap.appendChild(summaryCanvas);
+    frag.appendChild(summaryWrap);
+
+    // Staleness banner placeholder
+    var staleBanner = el("div", "cv-stale-banner hidden");
+    staleBanner.id = "cvStaleBanner";
+    var staleText = el("span", "");
+    staleText.textContent = "New data available";
+    var staleBtn = document.createElement("button");
+    staleBtn.className = "cv-stale-refresh";
+    staleBtn.textContent = "Refresh";
+    staleBtn.addEventListener("click", function () { recalculate(); });
+    staleBanner.appendChild(staleText);
+    staleBanner.appendChild(staleBtn);
+    frag.appendChild(staleBanner);
+
+    // No convergence message
+    if (cvState.convergenceZones.length === 0 && cvState.filteredEvents.length > 0) {
+      var noZones = el("div", "cv-no-convergence");
+      noZones.textContent = "No convergence detected. Try widening the window or lowering the threshold.";
+      frag.appendChild(noZones);
+    }
+
+    // Participant rows
+    var rowsContainer = el("div", "cv-participant-rows");
+
+    // Index filtered events by participant and source for fast lookup
+    var eventIndex = {}; // pid -> source -> events[]
+    for (var ei = 0; ei < cvState.filteredEvents.length; ei++) {
+      var fe = cvState.filteredEvents[ei];
+      if (!eventIndex[fe.participant]) eventIndex[fe.participant] = {};
+      if (!eventIndex[fe.participant][fe.source]) eventIndex[fe.participant][fe.source] = [];
+      eventIndex[fe.participant][fe.source].push(fe);
+    }
+
+    for (var pi = 0; pi < cvState.participants.length; pi++) {
+      var pid = cvState.participants[pi];
+      var row = el("div", "cv-participant-row");
+
+      var label = el("div", "cv-participant-label");
+      label.textContent = pid;
+      row.appendChild(label);
+
+      var tracks = el("div", "cv-tracks-container");
+
+      // Row shading canvas (behind markers)
+      var rowCanvas = document.createElement("canvas");
+      rowCanvas.className = "cv-row-shading";
+      rowCanvas.dataset.participant = pid;
+      tracks.appendChild(rowCanvas);
+
+      // Sub-tracks
+      var sources = ["sheet", "screenspace", "transcript"];
+      for (var si = 0; si < sources.length; si++) {
+        var src = sources[si];
+        var subTrack = el("div", "cv-sub-track");
+        subTrack.dataset.source = src;
+
+        // Add markers for this participant + source
+        var pEvents = (eventIndex[pid] && eventIndex[pid][src]) || [];
+        for (var mi = 0; mi < pEvents.length; mi++) {
+          var mev = pEvents[mi];
+          var marker = el("div", "cv-event-marker");
+          marker.style.left = (mev.start / cvState.duration * 100) + "%";
+          marker.style.width = Math.max((mev.end - mev.start) / cvState.duration * 100, 0.3) + "%";
+          marker.style.background = getEventTypeColor(mev.source, mev.eventType);
+          marker.title = mev.eventType + " (" + formatTime(mev.start) + ")";
+          subTrack.appendChild(marker);
+        }
+
+        tracks.appendChild(subTrack);
+      }
+
+      row.appendChild(tracks);
+      rowsContainer.appendChild(row);
+    }
+
+    frag.appendChild(rowsContainer);
+    container.appendChild(frag);
+  }
+
+  function renderCanvases() {
+    renderSummaryLane();
+    renderAllRowShading();
+  }
+
+  // --- Summary Lane Canvas ---
+
+  function renderSummaryLane() {
+    var canvas = qs(".cv-summary-canvas");
+    if (!canvas) return;
+    var w = canvas.clientWidth;
+    if (w <= 0) return;
+
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = w * dpr;
+    canvas.height = 32 * dpr;
+    var ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    var cs = getComputedStyle(document.documentElement);
+    var surfaceAlt = cs.getPropertyValue("--color-surface-alt").trim() || "#f1ece4";
+    ctx.fillStyle = surfaceAlt;
+    ctx.fillRect(0, 0, w, 32);
+
+    _summaryHitRects = [];
+    var zones = cvState.convergenceZones;
+    if (!zones.length) return;
+
+    // Normalize strength for alpha mapping
+    var maxStrength = 0;
+    for (var i = 0; i < zones.length; i++) {
+      if (zones[i].strength > maxStrength) maxStrength = zones[i].strength;
+    }
+    if (maxStrength === 0) maxStrength = 1;
+
+    var accent = parseAccentColor();
+
+    for (var zi = 0; zi < zones.length; zi++) {
+      var zone = zones[zi];
+      var x1 = (zone.start / cvState.duration) * w;
+      var x2 = (zone.end / cvState.duration) * w;
+      var zw = Math.max(x2 - x1, 2);
+      var alpha = 0.15 + (zone.strength / maxStrength) * 0.65;
+
+      ctx.fillStyle = "rgba(" + accent.r + "," + accent.g + "," + accent.b + "," + alpha + ")";
+      ctx.fillRect(x1, 0, zw, 32);
+
+      _summaryHitRects.push({ x1: x1, x2: x1 + zw, y: 0, h: 32, zoneIdx: zi });
+    }
+  }
+
+  // --- Per-Participant Row Shading ---
+
+  function renderAllRowShading() {
+    var canvases = qsa(".cv-row-shading");
+    for (var i = 0; i < canvases.length; i++) {
+      renderRowShading(canvases[i], canvases[i].dataset.participant);
+    }
+  }
+
+  function renderRowShading(canvas, participantId) {
+    var w = canvas.clientWidth;
+    var h = canvas.clientHeight;
+    if (w <= 0 || h <= 0) return;
+
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    var ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    var zones = cvState.convergenceZones;
+    if (!zones.length) return;
+
+    var accent = parseAccentColor();
+
+    for (var zi = 0; zi < zones.length; zi++) {
+      var zone = zones[zi];
+      // Check if this participant contributed
+      if (zone.participants.indexOf(participantId) < 0) continue;
+
+      // Count this participant's events in the zone
+      var pCount = 0;
+      for (var ei = 0; ei < zone.events.length; ei++) {
+        if (zone.events[ei].participant === participantId) pCount++;
+      }
+      var ratio = pCount / Math.max(zone.events.length, 1);
+      var alpha = Math.min(ratio * 0.3, 0.15);
+
+      var x1 = (zone.start / cvState.duration) * w;
+      var x2 = (zone.end / cvState.duration) * w;
+      var zw = Math.max(x2 - x1, 2);
+
+      ctx.fillStyle = "rgba(" + accent.r + "," + accent.g + "," + accent.b + "," + alpha + ")";
+      ctx.fillRect(x1, 0, zw, h);
+    }
+  }
+
+  // --- Data Freshness ---
+
+  function checkStaleness() {
+    if (!cvState._snapshot || !cvState.active) return;
+    var state = getState();
+    var stale = (state.intakeEvents.length !== cvState._snapshot.ss) ||
+      (state.trIntakeMarks.length !== cvState._snapshot.tr) ||
+      ((state.sheetData ? state.sheetData.rows.length : 0) !== cvState._snapshot.sh);
+
+    var banner = qs("#cvStaleBanner");
+    if (banner) {
+      if (stale) {
+        banner.classList.remove("hidden");
+      } else {
+        banner.classList.add("hidden");
+      }
+    }
+  }
 
   // --- Lifecycle ---
 
@@ -146,6 +699,30 @@
       buildFilterControls();
       cvState.initialized = true;
     }
+
+    if (cvState.baselines === null) {
+      // First activation: fetch baselines then recalculate
+      apiGet("api/sheet/baseline").then(function (data) {
+        var parsed = {};
+        if (data.ok && data.baselines) {
+          var keys = Object.keys(data.baselines);
+          for (var i = 0; i < keys.length; i++) {
+            var val = data.baselines[keys[i]];
+            if (val) {
+              var sec = window._studioParseTimestampToSeconds(val);
+              parsed[keys[i]] = isNaN(sec) ? 0 : sec;
+            }
+          }
+        }
+        cvState.baselines = parsed;
+        recalculate();
+      }).catch(function () {
+        cvState.baselines = {};
+        recalculate();
+      });
+    } else {
+      checkStaleness();
+    }
   }
 
   function deactivate() {
@@ -153,14 +730,21 @@
   }
 
   function init() {
-    // Phase 2: fetch baselines, collect events
+    document.addEventListener("visibilitychange", function () {
+      if (!document.hidden && cvState.active) {
+        checkStaleness();
+      }
+    });
   }
 
   // --- Window exports ---
   window.convergenceActivate = activate;
   window.convergenceDeactivate = deactivate;
   window.convergenceInit = init;
-  window.convergenceResize = function () { /* Phase 2: resize canvases */ };
+  window.convergenceResize = debounce(function () {
+    if (!cvState.active) return;
+    renderCanvases();
+  }, 200);
 
   init();
 })();

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -4557,4 +4557,10 @@
   });
 
   window._studioState = state;
+  window._studioParseClipTimestamps = parseClipTimestamps;
+  window._studioParseTimestampToSeconds = parseTimestampToSeconds;
+  window._studioHexToRgba = hexToRgba;
+  window._studioIntakeComputeTickInterval = intakeComputeTickInterval;
+  window._studioFormatDuration = formatDuration;
+  window._studioFindOverlappingData = findOverlappingData;
 })();

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.38"
+VERSIONNUM: str = "0.10.39"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/plans/CONVERGENCE-PLAN.md
+++ b/plans/CONVERGENCE-PLAN.md
@@ -462,14 +462,14 @@ Small canvas behind DOM markers per participant row. For each convergence zone, 
 
 #### Verification
 
-- [ ] All participants appear as rows with correct sub-tracks
-- [ ] Sheet events are baseline-adjusted (verify against raw sheet values)
-- [ ] Single-stream filter shows only that stream's markers
-- [ ] Event type filter recalculates convergence for that type
-- [ ] Window slider widens/narrows convergence zones
-- [ ] Min participants threshold shows/hides zones
-- [ ] Summary lane gradient reflects convergence density
-- [ ] "New data available" banner appears after external changes, refresh incorporates them
+- [x] All participants appear as rows with correct sub-tracks
+- [x] Sheet events are baseline-adjusted (verify against raw sheet values)
+- [x] Single-stream filter shows only that stream's markers
+- [x] Event type filter recalculates convergence for that type
+- [x] Window slider widens/narrows convergence zones
+- [x] Min participants threshold shows/hides zones
+- [x] Summary lane gradient reflects convergence density
+- [x] "New data available" banner appears after external changes, refresh incorporates them
 
 ---
 


### PR DESCRIPTION
## Summary

- Collect events from all three data sources (sheet with baseline time normalization, screenspace raw events, transcript marks) into a unified event shape
- Implement sweep-line convergence algorithm that identifies zones where multiple participants have temporally co-occurring events, with configurable window and participant threshold
- Render multi-participant timeline with per-participant rows, three sub-tracks (sheet/screenspace/transcript), percentage-positioned DOM event markers, and dynamic event type filter pills
- Add DPR-aware canvas overlays: summary lane showing convergence density gradient, and per-participant row shading proportional to contribution
- Add data freshness detection with "New data available" refresh banner, and debounced resize handling
- Export bridge functions from studio.js for convergence.js to consume (timestamp parsing, tick intervals, color utilities)

## Test plan
- [ ] Load multi-participant study in Studio, switch to Convergence tab -- timeline renders with all participants
- [ ] Toggle stream filters -- markers and event type pills update correctly
- [ ] Adjust min participants and window sliders -- convergence zones recalculate
- [ ] Verify summary lane gradient appears at convergence points
- [ ] Verify dark mode renders correctly (all colors via CSS custom properties)
- [ ] Add new screenspace events externally, return to tab -- staleness banner appears
- [ ] Run `uv run --extra dev pytest -c tests/pytest.ini` -- all tests pass