### PR TITLE
perf: optimize Screenspace thumbnail loading in Studio

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1647,20 +1647,22 @@
 
       var thumb = el("div", "queue-card-thumb");
       var img = document.createElement("img");
-      img.src = isIntake
-        ? ("../screenspace/api/video/frame/" + encodeURIComponent(item.participant) + "/" + segStart)
-        : ("api/thumbnail/" + encodeURIComponent(item.participant) + "/" + segStart);
-      img.loading = "lazy";
       img.alt = "";
       img.draggable = false;
-      (function (cardEl, thumbEl) {
-        img.addEventListener("error", function () {
-          this.remove();
-          thumbEl.appendChild(el("span", "", "\u2715"));
-          cardEl.classList.add("queue-card-error");
-        });
-      })(card, thumb);
       thumb.appendChild(img);
+      if (isIntake) {
+        ssObserveThumb(card, img, thumb, item.participant, segStart);
+      } else {
+        img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + segStart;
+        img.loading = "lazy";
+        (function (cardEl, thumbEl) {
+          img.addEventListener("error", function () {
+            this.remove();
+            thumbEl.appendChild(el("span", "", "\u2715"));
+            cardEl.classList.add("queue-card-error");
+          });
+        })(card, thumb);
+      }
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
       if (isIntake) {
         var ssBadge = el("span", "queue-card-source-badge");
@@ -1757,20 +1759,22 @@
 
       var thumb = el("div", "queue-card-thumb");
       var img = document.createElement("img");
-      img.src = isIntake
-        ? ("../screenspace/api/video/frame/" + encodeURIComponent(item.participant) + "/" + segStart)
-        : ("api/thumbnail/" + encodeURIComponent(item.participant) + "/" + segStart);
-      img.loading = "lazy";
       img.alt = "";
       img.draggable = false;
-      (function (cardEl, thumbEl) {
-        img.addEventListener("error", function () {
-          this.remove();
-          thumbEl.appendChild(el("span", "", "\u2715"));
-          cardEl.classList.add("queue-card-error");
-        });
-      })(card, thumb);
       thumb.appendChild(img);
+      if (isIntake) {
+        ssObserveThumb(card, img, thumb, item.participant, segStart);
+      } else {
+        img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + segStart;
+        img.loading = "lazy";
+        (function (cardEl, thumbEl) {
+          img.addEventListener("error", function () {
+            this.remove();
+            thumbEl.appendChild(el("span", "", "\u2715"));
+            cardEl.classList.add("queue-card-error");
+          });
+        })(card, thumb);
+      }
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
       if (isIntake) {
         var ssBadge = el("span", "queue-card-source-badge");
@@ -3311,6 +3315,93 @@
     inactivity: "pause-circle",
   };
 
+  // ---- Screenspace thumbnail queue (throttled + cached) ----
+
+  var _ssThumbQueue = [];
+  var _ssThumbActive = 0;
+  var _SS_THUMB_MAX = 3;
+  var _ssThumbCache = {}; // url -> objectURL | "error"
+
+  function ssThumbUrl(participant, timestamp) {
+    return "../screenspace/api/video/frame/" + encodeURIComponent(participant) + "/" + timestamp + "?w=200";
+  }
+
+  function ssProcessQueue() {
+    while (_ssThumbActive < _SS_THUMB_MAX && _ssThumbQueue.length) {
+      var item = _ssThumbQueue.shift();
+      if (!item.img.parentNode) continue;
+      _ssThumbActive++;
+      (function (entry) {
+        fetch(entry.url)
+          .then(function (r) {
+            if (!r.ok) throw new Error("status " + r.status);
+            return r.blob();
+          })
+          .then(function (blob) {
+            var objUrl = URL.createObjectURL(blob);
+            _ssThumbCache[entry.url] = objUrl;
+            if (entry.img.parentNode) entry.img.src = objUrl;
+          })
+          .catch(function () {
+            _ssThumbCache[entry.url] = "error";
+            if (entry.img.parentNode) {
+              entry.img.remove();
+              entry.thumbEl.appendChild(el("span", "", "\u2715"));
+              entry.cardEl.classList.add("queue-card-error");
+            }
+          })
+          .then(function () {
+            _ssThumbActive--;
+            ssProcessQueue();
+          });
+      })(item);
+    }
+  }
+
+  function ssEnqueueThumb(img, cardEl, thumbEl, participant, timestamp) {
+    var url = ssThumbUrl(participant, timestamp);
+    var cached = _ssThumbCache[url];
+    if (cached && cached !== "error") { img.src = cached; return; }
+    if (cached === "error") {
+      img.remove();
+      thumbEl.appendChild(el("span", "", "\u2715"));
+      cardEl.classList.add("queue-card-error");
+      return;
+    }
+    _ssThumbQueue.push({ img: img, cardEl: cardEl, thumbEl: thumbEl, url: url });
+    ssProcessQueue();
+  }
+
+  var _ssThumbObservers = {};
+
+  function ssGetObserver(root) {
+    var key = root ? (root.id || "anon") : "viewport";
+    if (_ssThumbObservers[key]) return _ssThumbObservers[key];
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        obs.unobserve(entry.target);
+        var d = entry.target.dataset;
+        var imgEl = entry.target.querySelector(".queue-card-thumb img");
+        var tEl = entry.target.querySelector(".queue-card-thumb");
+        if (imgEl && tEl) ssEnqueueThumb(imgEl, entry.target, tEl, d.ssThumbPid, d.ssThumbTs);
+      });
+    }, { root: root || null, rootMargin: "200px 0px" });
+    _ssThumbObservers[key] = obs;
+    return obs;
+  }
+
+  function ssObserveThumb(card, img, thumbEl, participant, timestamp) {
+    card.dataset.ssThumbPid = participant;
+    card.dataset.ssThumbTs = timestamp;
+    var scrollParent = card.closest(".intake-cards-grid") || card.closest("#artifactsList") || card.closest("#reelList");
+    ssGetObserver(scrollParent).observe(card);
+  }
+
+  function ssClearPending() {
+    _ssThumbQueue = [];
+  }
+
   function clusterIntakeEvents(events, thresholdSec) {
     if (!events.length) return [];
     var sorted = events.slice().sort(function (a, b) {
@@ -3590,6 +3681,7 @@
   }
 
   function renderIntake(hasNew) {
+    ssClearPending();
     var container = qs("#intakeCards");
     var addAllBtn = qs("#intakeAddAllBtn");
     var reelAllBtn = qs("#intakeReelAllBtn");
@@ -3629,18 +3721,10 @@
 
       var thumb = el("div", "queue-card-thumb");
       var img = document.createElement("img");
-      img.src = "../screenspace/api/video/frame/" + encodeURIComponent(c.participant) + "/" + c.start;
-      img.loading = "lazy";
       img.alt = "";
       img.draggable = false;
-      (function (cardEl, thumbEl) {
-        img.addEventListener("error", function () {
-          this.remove();
-          thumbEl.appendChild(el("span", "", "\u2715"));
-          cardEl.classList.add("queue-card-error");
-        });
-      })(card, thumb);
       thumb.appendChild(img);
+      ssObserveThumb(card, img, thumb, c.participant, c.start);
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
 
       var detDot = el("span", "intake-card-det-dot");
@@ -4029,6 +4113,7 @@
   }
 
   function renderTranscriptIntake() {
+    ssClearPending();
     var filtered = filteredTranscriptIntakeClusters();
     var container = qs("#trIntakeCards");
     var addAllBtn = qs("#trIntakeAddAllBtn");
@@ -4069,18 +4154,10 @@
 
       var segDuration = Math.max(0, c.end - c.start);
       var img = document.createElement("img");
-      img.src = "../screenspace/api/video/frame/" + encodeURIComponent(c.participant) + "/" + c.start;
-      img.loading = "lazy";
       img.alt = "";
       img.draggable = false;
-      (function (cardEl, thumbEl) {
-        img.addEventListener("error", function () {
-          this.remove();
-          thumbEl.appendChild(el("span", "", "\u2715"));
-          cardEl.classList.add("queue-card-error");
-        });
-      })(card, thumb);
       thumb.appendChild(img);
+      ssObserveThumb(card, img, thumb, c.participant, c.start);
 
       var catColor = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
       var dot = document.createElement("span");

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.40"
+VERSIONNUM: str = "0.10.41"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -93,6 +93,7 @@ _worker: "screenspace.ScreenspaceWorker | None" = None
 _output_dir: str = ""
 _participants: list[dict[str, Any]] = []
 _video_metadata_cache: dict[str, dict[str, Any]] = {}
+_frame_cache: dict[tuple[str, float, int], bytes] = {}
 
 # ---- SSE (Server-Sent Events) client registry ----
 
@@ -160,7 +161,12 @@ def _find_participant_video(participant_id: str) -> str | None:
 
 @screenspace_bp.route("/api/video/frame/<participant>/<timestamp>")
 def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
-    """Extract and return a single JPEG frame at the given timestamp."""
+    """Extract and return a single JPEG frame at the given timestamp.
+
+    Optional query parameter ``w`` requests a scaled-down thumbnail
+    (e.g. ``?w=200`` for a 200 px-wide JPEG).  Without ``w`` the frame
+    is returned at full resolution.  Results are cached in-memory.
+    """
     try:
         ts = float(timestamp)
     except (ValueError, TypeError):
@@ -172,17 +178,37 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
             {"ok": False, "error": f"No video for participant {participant}"}
         ), 404
 
-    frame = video.extract_frame_at_timestamp(video_path, ts)
-    if frame is None:
-        return jsonify({"ok": False, "error": "Could not read frame at timestamp"}), 400
+    width = request.args.get("w", 0, type=int)
+    cache_key = (video_path, round(ts, 2), width)
+    cached = _frame_cache.get(cache_key)
+    if cached is not None:
+        return Response(
+            cached,
+            mimetype="image/jpeg",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
 
-    import cv2
+    if width > 0:
+        jpeg_bytes = video.extract_thumbnail_bytes(video_path, int(ts), width=width)
+    else:
+        frame = video.extract_frame_at_timestamp(video_path, ts)
+        if frame is None:
+            return jsonify(
+                {"ok": False, "error": "Could not read frame at timestamp"}
+            ), 400
+        import cv2
 
-    _, jpeg = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
+        _, jpeg = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
+        jpeg_bytes = jpeg.tobytes()
+
+    if jpeg_bytes is None:
+        return jsonify({"ok": False, "error": "Could not extract frame"}), 400
+
+    _frame_cache[cache_key] = jpeg_bytes
     return Response(
-        jpeg.tobytes(),
+        jpeg_bytes,
         mimetype="image/jpeg",
-        headers={"Cache-Control": "public, max-age=60"},
+        headers={"Cache-Control": "public, max-age=86400"},
     )
 
 

--- a/server.py
+++ b/server.py
@@ -1422,4 +1422,4 @@ def start_combined_server(
     utils.info_print(f"clipgen server running at http://127.0.0.1:{port}")
     webbrowser.open(url)
 
-    combined.run(host="127.0.0.1", port=port, debug=False)
+    combined.run(host="127.0.0.1", port=port, debug=False, threaded=True)


### PR DESCRIPTION
## Summary

- Enable `threaded=True` on Flask server so thumbnail ffmpeg extractions no longer block other API requests (e.g. Convergence table data)
- Add server-side `_frame_cache` and `?w=` thumbnail mode to the Screenspace frame route — when Studio requests thumbnails it now gets ~10KB scaled JPEGs instead of ~200KB full-resolution frames
- Replace eager `img.src` assignment with IntersectionObserver + throttled fetch queue (max 3 concurrent) and a client-side blob URL cache, so only visible cards trigger requests and re-renders are instant
- Increase Screenspace frame `Cache-Control` from 60s to 86400s to match Studio thumbnails

## Test plan

- [ ] Start Studio with `--studio` and a spreadsheet with Screenspace events
- [ ] Open DevTools Network tab — confirm Convergence tab loads immediately, not blocked by thumbnail requests
- [ ] Switch to Screenspace intake tab — thumbnails load progressively (max 3 concurrent), each ~5-15KB
- [ ] Confirm thumbnail responses have `Cache-Control: max-age=86400`
- [ ] Switch away from intake and back — thumbnails appear instantly from blob cache
- [ ] Verify `uv run --extra dev pytest -c tests/pytest.ini` passes (523 tests)