### PR TITLE
fix: convergence tab timeline labels, clustering, drag handle, and baseline parsing

### DIFF
--- a/assets/web/convergence.css
+++ b/assets/web/convergence.css
@@ -1,6 +1,7 @@
 /* Convergence Browser */
 
 #convergencePanel {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: var(--space-2);

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -111,36 +111,52 @@
       }
     }
 
-    // Screenspace events (raw, not clusters)
-    for (var i = 0; i < state.intakeEvents.length; i++) {
-      var ev = state.intakeEvents[i];
+    // Screenspace events (clustered)
+    var ssThresholdEl = qs("#intakeClusterThreshold");
+    var ssThreshold = ssThresholdEl ? (parseInt(ssThresholdEl.value, 10) || 5) : 5;
+    var ssClusters = window._studioClusterIntakeEvents
+      ? window._studioClusterIntakeEvents(state.intakeEvents, ssThreshold)
+      : [];
+    for (var i = 0; i < ssClusters.length; i++) {
+      var cl = ssClusters[i];
+      var clCount = cl.events ? cl.events.length : 1;
       events.push({
-        participant: ev.participant,
-        start: ev.time_in,
-        end: ev.time_out,
+        participant: cl.participant,
+        start: cl.start,
+        end: cl.end,
         source: "screenspace",
-        eventType: ev.event_type || ev.detector || "unknown",
-        label: (ev.event_type || ev.detector || "") + " detection",
-        id: ev.id || ("ss_" + i),
-        rawData: ev,
+        eventType: cl.event_type || cl.detector || "unknown",
+        label: (cl.event_type || cl.detector || "") + " detection"
+          + (clCount > 1 ? " (" + clCount + " events)" : ""),
+        id: "ss_cl_" + i,
+        rawData: cl,
+        clusterCount: clCount,
       });
-      participantSet[ev.participant] = true;
+      participantSet[cl.participant] = true;
     }
 
-    // Transcript marks
-    for (var j = 0; j < state.trIntakeMarks.length; j++) {
-      var mark = state.trIntakeMarks[j];
+    // Transcript marks (clustered)
+    var trThresholdEl = qs("#trIntakeClusterThreshold");
+    var trThreshold = trThresholdEl ? (parseInt(trThresholdEl.value, 10) || 5) : 5;
+    var trClusters = window._studioClusterTranscriptMarks
+      ? window._studioClusterTranscriptMarks(state.trIntakeMarks, trThreshold)
+      : [];
+    for (var j = 0; j < trClusters.length; j++) {
+      var tc = trClusters[j];
+      var tcCount = tc.marks ? tc.marks.length : 1;
       events.push({
-        participant: mark.participant,
-        start: mark.start,
-        end: mark.end,
+        participant: tc.participant,
+        start: tc.start,
+        end: tc.end,
         source: "transcript",
-        eventType: mark.category || "bookmark",
-        label: mark.text || mark.label || "",
-        id: mark.id || mark.segment_id || ("tr_" + j),
-        rawData: mark,
+        eventType: tc.category || "bookmark",
+        label: (tc.label || tc.text || "")
+          + (tcCount > 1 ? " (" + tcCount + " marks)" : ""),
+        id: "tr_cl_" + j,
+        rawData: tc,
+        clusterCount: tcCount,
       });
-      participantSet[mark.participant] = true;
+      participantSet[tc.participant] = true;
     }
 
     // Duration
@@ -467,6 +483,19 @@
 
   var debouncedFilterChange = debounce(onFilterChange, 250);
 
+  // --- Tick Interval (pixel-aware) ---
+
+  function computeConvergenceTickInterval(duration, trackWidthPx) {
+    var labelWidth = duration >= 3600 ? 60 : 40;
+    var minGap = 8;
+    var maxTicks = Math.max(2, Math.floor(trackWidthPx / (labelWidth + minGap)));
+    var candidates = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
+    for (var i = 0; i < candidates.length; i++) {
+      if (duration / candidates[i] <= maxTicks) return candidates[i];
+    }
+    return 3600;
+  }
+
   // --- Rendering ---
 
   function render() {
@@ -508,7 +537,8 @@
     var axisSpacer = el("div", "cv-axis-spacer");
     axis.appendChild(axisSpacer);
     var axisTrack = el("div", "cv-axis-track");
-    var tickInterval = window._studioIntakeComputeTickInterval(cvState.duration);
+    var trackWidthPx = (container.clientWidth || 500) - 52;
+    var tickInterval = computeConvergenceTickInterval(cvState.duration, trackWidthPx);
     for (var t = tickInterval; t <= cvState.duration; t += tickInterval) {
       var tick = el("div", "cv-tick");
       tick.style.left = (t / cvState.duration * 100) + "%";
@@ -596,7 +626,11 @@
           marker.style.left = (mev.start / cvState.duration * 100) + "%";
           marker.style.width = Math.max((mev.end - mev.start) / cvState.duration * 100, 0.3) + "%";
           marker.style.background = getEventTypeColor(mev.source, mev.eventType);
-          marker.title = mev.eventType + " (" + formatTime(mev.start) + ")";
+          var tooltipText = mev.eventType + " (" + formatTime(mev.start) + ")";
+          if (mev.clusterCount && mev.clusterCount > 1) {
+            tooltipText += " [" + mev.clusterCount + " events]";
+          }
+          marker.title = tooltipText;
           if (filteredIdxById[mev.id] !== undefined) marker.dataset.cvIdx = filteredIdxById[mev.id];
           subTrack.appendChild(marker);
         }
@@ -1068,11 +1102,19 @@
       item.desc = event.eventType;
       item.source = "screenspace";
       item.event_type = event.eventType;
-      item.event_ids = [event.rawData.id || event.id];
+      if (event.rawData.events && event.rawData.events.length > 0) {
+        item.event_ids = event.rawData.events.map(function (e) { return e.id; });
+      } else {
+        item.event_ids = [event.rawData.id || event.id];
+      }
     } else if (event.source === "transcript") {
       item.desc = event.eventType || "transcript";
       item.source = "transcript";
-      item.mark_ids = [event.rawData.id || event.rawData.segment_id || event.id];
+      if (event.rawData.marks && event.rawData.marks.length > 0) {
+        item.mark_ids = event.rawData.marks.map(function (m) { return m.id || m.segment_id; });
+      } else {
+        item.mark_ids = [event.rawData.id || event.rawData.segment_id || event.id];
+      }
     } else {
       // Sheet events: use grid item format (no source) so thumbnails route
       // through api/thumbnail and generation through the sheet path
@@ -1186,7 +1228,7 @@
   window.convergenceInit = init;
   window.convergenceResize = debounce(function () {
     if (!cvState.active) return;
-    renderCanvases();
+    render();
   }, 200);
 
   init();

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -48,6 +48,47 @@
     return XREF_BADGES.sheet.color;
   }
 
+  function clockToSeconds(ts) {
+    // Like parseTimestampToSeconds but treats 2-part as HH:MM (clock time)
+    // rather than MM:SS.  Matches Python utils._clock_to_seconds.
+    var parts = ts.split(":");
+    if (parts.length === 3)
+      return parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60 + parseInt(parts[2], 10);
+    if (parts.length === 2)
+      return parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60;
+    return NaN;
+  }
+
+  function parseClockSegments(raw) {
+    // Like _studioParseClipTimestamps but uses clockToSeconds for cells
+    // that contain absolute clock times (when a baseline row exists).
+    var DEFAULT_DUR = 60;
+    var sd = window._studioState && window._studioState.sheetData;
+    if (sd && sd.defaultDuration) DEFAULT_DUR = sd.defaultDuration;
+    var cleaned = raw.toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
+    var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
+    var segments = [];
+    for (var i = 0; i < tokens.length; i++) {
+      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
+      var dashIdx = -1;
+      for (var d = 1; d < tok.length; d++) {
+        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") { dashIdx = d; break; }
+      }
+      if (dashIdx > 0) {
+        var s = clockToSeconds(tok.substring(0, dashIdx));
+        var e = clockToSeconds(tok.substring(dashIdx + 1));
+        if (!isNaN(s) && !isNaN(e))
+          segments.push({ startSeconds: Math.floor(s), duration: Math.max(0, e - s) });
+      } else if (tok.indexOf(":") > 0) {
+        var sec = clockToSeconds(tok);
+        if (!isNaN(sec))
+          segments.push({ startSeconds: Math.floor(sec), duration: DEFAULT_DUR });
+      }
+    }
+    if (segments.length === 0) segments.push({ startSeconds: 0, duration: DEFAULT_DUR });
+    return segments;
+  }
+
   function stddev(nums) {
     if (nums.length < 2) return 0;
     var sum = 0;
@@ -91,8 +132,10 @@
           var pid = participants[p];
           var cell = row.cells[pid];
           if (!cell || !cell.valid) continue;
-          var segs = window._studioParseClipTimestamps(cell.value);
           var baselineOffset = (cvState.baselines && cvState.baselines[pid]) || 0;
+          var segs = baselineOffset
+            ? parseClockSegments(cell.value)
+            : window._studioParseClipTimestamps(cell.value);
           for (var s = 0; s < segs.length; s++) {
             var start = segs[s].startSeconds - baselineOffset;
             var end = start + segs[s].duration;
@@ -1203,20 +1246,9 @@
     }
 
     if (cvState.baselines === null) {
-      // First activation: fetch baselines then recalculate
+      // First activation: fetch baselines (server returns seconds)
       apiGet("api/sheet/baseline").then(function (data) {
-        var parsed = {};
-        if (data.ok && data.baselines) {
-          var keys = Object.keys(data.baselines);
-          for (var i = 0; i < keys.length; i++) {
-            var val = data.baselines[keys[i]];
-            if (val) {
-              var sec = window._studioParseTimestampToSeconds(val);
-              parsed[keys[i]] = isNaN(sec) ? 0 : sec;
-            }
-          }
-        }
-        cvState.baselines = parsed;
+        cvState.baselines = (data.ok && data.baselines) ? data.baselines : {};
         recalculate();
       }).catch(function () {
         cvState.baselines = {};

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -16,6 +16,7 @@
       eventTypes: [],
       minParticipants: 2,
       windowSec: 5,
+      clusterSec: 5,
       timeRange: null,
     },
     dataVersion: 0,
@@ -112,10 +113,9 @@
     }
 
     // Screenspace events (clustered)
-    var ssThresholdEl = qs("#intakeClusterThreshold");
-    var ssThreshold = ssThresholdEl ? (parseInt(ssThresholdEl.value, 10) || 5) : 5;
+    var clusterSec = cvState.filters.clusterSec;
     var ssClusters = window._studioClusterIntakeEvents
-      ? window._studioClusterIntakeEvents(state.intakeEvents, ssThreshold)
+      ? window._studioClusterIntakeEvents(state.intakeEvents, clusterSec)
       : [];
     for (var i = 0; i < ssClusters.length; i++) {
       var cl = ssClusters[i];
@@ -136,10 +136,8 @@
     }
 
     // Transcript marks (clustered)
-    var trThresholdEl = qs("#trIntakeClusterThreshold");
-    var trThreshold = trThresholdEl ? (parseInt(trThresholdEl.value, 10) || 5) : 5;
     var trClusters = window._studioClusterTranscriptMarks
-      ? window._studioClusterTranscriptMarks(state.trIntakeMarks, trThreshold)
+      ? window._studioClusterTranscriptMarks(state.trIntakeMarks, clusterSec)
       : [];
     for (var j = 0; j < trClusters.length; j++) {
       var tc = trClusters[j];
@@ -395,8 +393,24 @@
     winLabel.appendChild(winInput);
     winLabel.appendChild(winSuffix);
 
+    var clusterLabel = el("label", "intake-cluster-label");
+    clusterLabel.textContent = "Cluster ";
+    var clusterInput = document.createElement("input");
+    clusterInput.type = "number";
+    clusterInput.id = "cvClusterThreshold";
+    clusterInput.min = "1";
+    clusterInput.max = "60";
+    clusterInput.value = String(cvState.filters.clusterSec);
+    clusterInput.className = "intake-cluster-input";
+    clusterInput.autocomplete = "off";
+    clusterInput.addEventListener("input", debouncedRecalculate);
+    var clusterSuffix = document.createTextNode("s");
+    clusterLabel.appendChild(clusterInput);
+    clusterLabel.appendChild(clusterSuffix);
+
     controls.appendChild(minLabel);
     controls.appendChild(winLabel);
+    controls.appendChild(clusterLabel);
 
     // --- Filters bar: stream toggles + event type pills ---
     for (var i = 0; i < STREAM_DEFS.length; i++) {
@@ -453,7 +467,13 @@
     var inputs = controls.querySelectorAll("input[type=number]");
     if (inputs[0]) cvState.filters.minParticipants = Math.max(2, parseInt(inputs[0].value, 10) || 2);
     if (inputs[1]) cvState.filters.windowSec = Math.max(1, parseInt(inputs[1].value, 10) || 5);
+    if (inputs[2]) cvState.filters.clusterSec = Math.max(1, parseInt(inputs[2].value, 10) || 5);
   }
+
+  var debouncedRecalculate = debounce(function () {
+    syncFilterInputs();
+    recalculate();
+  }, 250);
 
   function onFilterChange() {
     syncFilterInputs();
@@ -486,9 +506,12 @@
   // --- Tick Interval (pixel-aware) ---
 
   function computeConvergenceTickInterval(duration, trackWidthPx) {
-    var labelWidth = duration >= 3600 ? 60 : 40;
-    var minGap = 8;
-    var maxTicks = Math.max(2, Math.floor(trackWidthPx / (labelWidth + minGap)));
+    // Each tick label is centered on its mark. To prevent overlap the
+    // minimum distance between ticks must be at least one full label
+    // width plus comfortable padding.  10px monospace "H:MM:SS" ≈ 50px,
+    // "M:SS" ≈ 30px; add 30px padding so labels breathe.
+    var slotWidth = duration >= 3600 ? 80 : 60;
+    var maxTicks = Math.max(2, Math.floor(trackWidthPx / slotWidth));
     var candidates = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
     for (var i = 0; i < candidates.length; i++) {
       if (duration / candidates[i] <= maxTicks) return candidates[i];

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -512,11 +512,12 @@
     // "M:SS" ≈ 30px; add 30px padding so labels breathe.
     var slotWidth = duration >= 3600 ? 80 : 60;
     var maxTicks = Math.max(2, Math.floor(trackWidthPx / slotWidth));
-    var candidates = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
+    var candidates = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600,
+      7200, 10800, 21600, 43200];
     for (var i = 0; i < candidates.length; i++) {
       if (duration / candidates[i] <= maxTicks) return candidates[i];
     }
-    return 3600;
+    return 43200;
   }
 
   // --- Rendering ---

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1037,12 +1037,47 @@
     var dragging = false;
     var startY = 0;
     var startOffset = 0;
+    var dragAvailable = 0; // stable available-space snapshot for the drag
+    var dragMaxOff = 0;    // stable upper bound for dividerOffset
 
     function onDown(e) {
       e.preventDefault();
       dragging = true;
       startY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
       startOffset = state.dividerOffset;
+
+      // Snapshot layout values once so they stay stable for the whole drag.
+      // Re-reading bottom.offsetHeight each frame causes oscillation when
+      // the upper panel shrinks and the bottom panel's visible area grows.
+      var header = qs("#studioHeader");
+      var preview = qs("#sheetPreview");
+      var divider = qs("#panelDivider");
+      var bottom = qs("#bottomPanel");
+      if (header && preview && divider && bottom) {
+        var previewHeader = preview.querySelector(".sheet-preview-header");
+        var filterBar = qs("#filterBar");
+        var previewStyle = getComputedStyle(preview);
+        var previewPadTop = parseFloat(previewStyle.paddingTop) || 0;
+        var previewPadBot = parseFloat(previewStyle.paddingBottom) || 0;
+        var phHeight = previewHeader ? previewHeader.offsetHeight : 0;
+        var phStyle = previewHeader ? getComputedStyle(previewHeader) : null;
+        var phMargin = phStyle
+          ? (parseFloat(phStyle.marginTop) || 0) + (parseFloat(phStyle.marginBottom) || 0)
+          : 0;
+        var fbHeight = filterBar && !filterBar.classList.contains("hidden") ? filterBar.offsetHeight : 0;
+        var fbStyle = filterBar && !filterBar.classList.contains("hidden") ? getComputedStyle(filterBar) : null;
+        var fbMargin = fbStyle
+          ? (parseFloat(fbStyle.marginTop) || 0) + (parseFloat(fbStyle.marginBottom) || 0)
+          : 0;
+        var headerRect = header.getBoundingClientRect();
+        var sheetChrome = previewPadTop + phHeight + phMargin + fbHeight + fbMargin + previewPadBot;
+        dragAvailable = window.innerHeight - headerRect.top - headerRect.height
+          - sheetChrome - divider.offsetHeight - bottom.offsetHeight;
+      }
+
+      var MIN_GRID = 100;
+      dragMaxOff = Math.max(0, dragAvailable - MIN_GRID);
+
       handle.classList.add("active");
       document.body.style.cursor = "row-resize";
       document.body.style.userSelect = "none";
@@ -1061,24 +1096,20 @@
       var clientY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
       requestAnimationFrame(function () {
         var delta = startY - clientY;
-        var contentH = 0;
-        if (state.activePreviewTab === "sheet") {
-          var grid = qs("#sheetGrid");
-          var table = grid ? grid.querySelector("table") : null;
-          contentH = table ? table.offsetHeight : 0;
-        } else if (state.activePreviewTab === "intake") {
-          var ip = qs("#intakePanel");
-          contentH = ip ? ip.scrollHeight : 0;
-        } else if (state.activePreviewTab === "transcript-intake") {
-          var tp = qs("#trIntakePanel");
-          contentH = tp ? tp.scrollHeight : 0;
-        } else if (state.activePreviewTab === "convergence") {
-          var cp = qs("#convergencePanel");
-          contentH = cp ? cp.scrollHeight : 0;
-        }
-        var maxOff = Math.max(0, contentH - 100);
-        state.dividerOffset = Math.max(0, Math.min(maxOff, startOffset + delta));
-        computeGridMaxHeight();
+        state.dividerOffset = Math.max(0, Math.min(dragMaxOff, startOffset + delta));
+
+        // Apply maxHeight directly using the stable snapshot
+        var MIN_GRID = 100;
+        var maxH = Math.max(MIN_GRID, dragAvailable - state.dividerOffset) + "px";
+        var grid = qs("#sheetGrid");
+        if (grid) grid.style.maxHeight = maxH;
+        var intakePanel = qs("#intakePanel");
+        if (intakePanel) intakePanel.style.maxHeight = maxH;
+        var trIntakePanel = qs("#trIntakePanel");
+        if (trIntakePanel) trIntakePanel.style.maxHeight = maxH;
+        var convergencePanel = qs("#convergencePanel");
+        if (convergencePanel) convergencePanel.style.maxHeight = maxH;
+
         rafPending = false;
       });
     }
@@ -1089,6 +1120,7 @@
       handle.classList.remove("active");
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
+      computeGridMaxHeight(); // finalize with fresh layout values
     }
 
     document.addEventListener("mouseup", onUp);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1025,6 +1025,10 @@
     grid.style.maxHeight = maxH;
     var intakePanel = qs("#intakePanel");
     if (intakePanel) intakePanel.style.maxHeight = maxH;
+    var trIntakePanel = qs("#trIntakePanel");
+    if (trIntakePanel) trIntakePanel.style.maxHeight = maxH;
+    var convergencePanel = qs("#convergencePanel");
+    if (convergencePanel) convergencePanel.style.maxHeight = maxH;
   }
 
   function initPanelDivider() {
@@ -1057,10 +1061,22 @@
       var clientY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
       requestAnimationFrame(function () {
         var delta = startY - clientY;
-        var grid = qs("#sheetGrid");
-        var table = grid ? grid.querySelector("table") : null;
-        var tableH = table ? table.offsetHeight : 0;
-        var maxOff = Math.max(0, tableH - 100);
+        var contentH = 0;
+        if (state.activePreviewTab === "sheet") {
+          var grid = qs("#sheetGrid");
+          var table = grid ? grid.querySelector("table") : null;
+          contentH = table ? table.offsetHeight : 0;
+        } else if (state.activePreviewTab === "intake") {
+          var ip = qs("#intakePanel");
+          contentH = ip ? ip.scrollHeight : 0;
+        } else if (state.activePreviewTab === "transcript-intake") {
+          var tp = qs("#trIntakePanel");
+          contentH = tp ? tp.scrollHeight : 0;
+        } else if (state.activePreviewTab === "convergence") {
+          var cp = qs("#convergencePanel");
+          contentH = cp ? cp.scrollHeight : 0;
+        }
+        var maxOff = Math.max(0, contentH - 100);
         state.dividerOffset = Math.max(0, Math.min(maxOff, startOffset + delta));
         computeGridMaxHeight();
         rafPending = false;
@@ -4567,4 +4583,6 @@
   window._studioRenderArtifactQueue = renderArtifactQueue;
   window._studioRenderReelQueue = renderReelQueue;
   window._studioSaveQueues = saveQueues;
+  window._studioClusterIntakeEvents = clusterIntakeEvents;
+  window._studioClusterTranscriptMarks = clusterTranscriptMarks;
 })();

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.41"
+VERSIONNUM: str = "0.10.42"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.40"
+VERSIONNUM: str = "0.10.41"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/server.py
+++ b/server.py
@@ -230,9 +230,11 @@ def api_sheet() -> FlaskResponse:
 
 @studio_bp.route("/api/sheet/baseline")
 def api_sheet_baseline() -> FlaskResponse:
-    """Return per-participant baseline timestamps for clock-to-relative conversion.
+    """Return per-participant baseline offsets in seconds for convergence.
 
-    Response: {"ok": true, "baselines": {"P01": "09:12:00", "P02": "", ...}}
+    Response: {"ok": true, "baselines": {"P01": 33120, "P02": 0, ...}}
+    Values are integers (seconds) parsed via _clock_to_seconds which
+    correctly treats "22:00" as HH:MM (22 hours) rather than MM:SS.
     Empty baselines dict when no baseline row exists.
     """
     if _sheet_context is None:
@@ -245,7 +247,7 @@ def api_sheet_baseline() -> FlaskResponse:
     participants = spreadsheet.get_participant_list(
         ctx.header_row, ctx.id_cell, ctx.num_participants
     )
-    baselines: dict[str, str] = {}
+    baselines: dict[str, int] = {}
     for p_idx, pid in enumerate(participants):
         col_idx = ctx.id_cell.col + p_idx
         value = ""
@@ -253,7 +255,7 @@ def api_sheet_baseline() -> FlaskResponse:
             ctx.sheet_data[ctx.baseline_row_idx]
         ):
             value = ctx.sheet_data[ctx.baseline_row_idx][col_idx].strip()
-        baselines[pid] = value
+        baselines[pid] = utils._clock_to_seconds(value) or 0
 
     return jsonify({"ok": True, "baselines": baselines})
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -111,7 +111,7 @@ def test_api_sheet_baseline_with_values(client, monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
-    assert data["baselines"] == {"P01": "09:12:00", "P02": "09:15:30"}
+    assert data["baselines"] == {"P01": 33120, "P02": 33330}
 
 
 def test_api_sheet_baseline_partial(client, monkeypatch):
@@ -134,9 +134,9 @@ def test_api_sheet_baseline_partial(client, monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
-    assert data["baselines"]["P01"] == "09:12:00"
-    assert data["baselines"]["P02"] == ""
-    assert data["baselines"]["P03"] == "09:20:00"
+    assert data["baselines"]["P01"] == 33120
+    assert data["baselines"]["P02"] == 0
+    assert data["baselines"]["P03"] == 33600
 
 
 def test_api_generate_500_when_no_worksheet(client):


### PR DESCRIPTION
## Summary

- **Timeline labels**: Replaced the fixed 12-tick limit with a pixel-aware algorithm that picks intervals based on available track width. Extended tick candidates to support multi-hour timelines (2h, 3h, 6h, 12h intervals). Labels recalculate on window resize.
- **Event clustering**: Screenspace and Transcript events are now clustered in the Convergence tab using the same algorithms as their intake tabs. Added a dedicated "Cluster" threshold input to the convergence controls bar.
- **Drag handle**: Fixed panel resize to work across all tabs (Sheet Preview, Screenspace Intake, Transcript Intake, Convergence). Layout values are snapshotted at drag start to prevent oscillation from `bottom.offsetHeight` feedback. Added `flex: 1` to `#convergencePanel`.
- **Baseline parsing**: Fixed regression where `22:00` baseline times were parsed as 22 minutes instead of 22 hours. The `/api/sheet/baseline` endpoint now returns pre-computed seconds using Python's `_clock_to_seconds`. Added clock-aware `parseClockSegments()` in JS for cell timestamps when baselines are present.

## Test plan
- [ ] Load a spreadsheet with baseline times (e.g. `22:00`) and verify convergence events appear at correct relative positions
- [ ] Check timeline labels are well-spaced and don't overlap, including on multi-hour timelines
- [ ] Adjust the "Cluster" threshold in convergence controls and verify events re-cluster
- [ ] Drag the panel divider in each tab (Sheet, Screenspace, Transcript, Convergence) and verify smooth resizing without reflow