### PR TITLE
feat: add local AI model settings for Whisper and Ollama

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1937,6 +1937,31 @@ html[data-theme="dark"] .filter-cat-btn {
   font-size: var(--text-sm);
 }
 
+.settings-model-dropdown {
+  min-width: 14rem;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+}
+
+.settings-model-dropdown:disabled {
+  opacity: 0.5;
+}
+
+.settings-control input[type="text"] {
+  width: 14rem;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+}
+
 .settings-toggle {
   position: relative;
   width: 36px;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3043,6 +3043,66 @@
 
   // ---- Settings ----
 
+  var _modelsCache = null;
+  var _modelsCachePromise = null;
+
+  function _fetchModels() {
+    if (_modelsCache) return Promise.resolve(_modelsCache);
+    if (_modelsCachePromise) return _modelsCachePromise;
+    _modelsCachePromise = fetch("../api/models")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) _modelsCache = data;
+        return data;
+      })
+      .catch(function () { return null; });
+    return _modelsCachePromise;
+  }
+
+  function _formatSize(mb) {
+    if (mb >= 1024) return (mb / 1024).toFixed(1) + " GB";
+    return mb + " MB";
+  }
+
+  function _loadModelsForSelect(sel, provider, currentValue) {
+    _fetchModels().then(function (data) {
+      if (!data || !data.ok) { sel.disabled = false; return; }
+
+      var models = [];
+      if (provider === "whisper") {
+        models = (data.whisper && data.whisper.models) || [];
+      } else if (provider === "ollama") {
+        models = (data.ollama && data.ollama.models) || [];
+      }
+
+      sel.innerHTML = "";
+      var hasCurrentValue = false;
+      for (var i = 0; i < models.length; i++) {
+        var m = models[i];
+        var opt = document.createElement("option");
+        opt.value = m.name;
+        var label = m.name;
+        if (m.size_mb) label += " (" + _formatSize(m.size_mb) + ")";
+        if (m.parameter_size) label += " \u00B7 " + m.parameter_size;
+        if (m.description) label += " \u2014 " + m.description;
+        opt.textContent = label;
+        if (m.name === currentValue) {
+          opt.selected = true;
+          hasCurrentValue = true;
+        }
+        sel.appendChild(opt);
+      }
+      if (!hasCurrentValue && currentValue) {
+        var custom = document.createElement("option");
+        custom.value = currentValue;
+        custom.textContent = currentValue + " (current)";
+        custom.selected = true;
+        sel.insertBefore(custom, sel.firstChild);
+      }
+      sel.disabled = false;
+    });
+  }
+
   function openSettings() {
     qs("#settingsOverlay").classList.remove("hidden");
     loadSettings();
@@ -3138,6 +3198,36 @@
         scheduleSaveSettings();
       });
       controlDiv.appendChild(sel);
+    } else if (s.type === "model_select") {
+      var msel = document.createElement("select");
+      msel.className = "settings-model-dropdown";
+      var curOpt = document.createElement("option");
+      curOpt.value = s.value;
+      curOpt.textContent = s.value;
+      curOpt.selected = true;
+      msel.appendChild(curOpt);
+      msel.disabled = true;
+      msel.addEventListener("change", function () {
+        var setting = findSetting(settingName);
+        if (setting) setting.value = this.value;
+        updateSettingChanged(settingName);
+        scheduleSaveSettings();
+      });
+      controlDiv.appendChild(msel);
+      _loadModelsForSelect(msel, s.provider, s.value);
+    } else if (s.type === "str") {
+      var txtInput = document.createElement("input");
+      txtInput.type = "text";
+      txtInput.autocomplete = "off";
+      txtInput.value = s.value || "";
+      txtInput.placeholder = String(s.default || "");
+      txtInput.addEventListener("change", function () {
+        var setting = findSetting(settingName);
+        if (setting) setting.value = this.value;
+        updateSettingChanged(settingName);
+        scheduleSaveSettings();
+      });
+      controlDiv.appendChild(txtInput);
     } else {
       var input = document.createElement("input");
       input.type = "number";

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1140,6 +1140,129 @@ body {
   background: rgba(239, 68, 68, 0.1);
 }
 
+/* Settings Popover */
+
+.tr-settings-popover {
+  position: fixed;
+  top: 56px;
+  right: var(--space-4);
+  width: 360px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-dropdown, 1200);
+  display: flex;
+  flex-direction: column;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.tr-settings-popover.hidden { display: none; }
+
+.tr-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tr-settings-title {
+  font-weight: 600;
+  font-size: var(--text-sm);
+}
+
+.tr-settings-footer {
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border);
+  min-height: 28px;
+}
+
+.tr-settings-group-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-dim);
+  padding: var(--space-3) var(--space-4) var(--space-1);
+}
+
+.tr-settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+}
+
+.tr-settings-row.settings-changed {
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.tr-settings-label {
+  flex: 1;
+  min-width: 0;
+}
+
+.tr-settings-label-name {
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.tr-settings-label-desc {
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  margin-top: 1px;
+}
+
+.tr-settings-control select {
+  min-width: 10rem;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+}
+
+.tr-settings-control select:disabled {
+  opacity: 0.5;
+}
+
+.tr-settings-control input[type="checkbox"] {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--color-border);
+  border-radius: var(--radius-lg);
+  outline: none;
+  cursor: pointer;
+  transition: background var(--duration-fast);
+}
+
+.tr-settings-control input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  transition: transform var(--duration-fast);
+}
+
+.tr-settings-control input[type="checkbox"]:checked {
+  background: var(--color-accent);
+}
+
+.tr-settings-control input[type="checkbox"]:checked::after {
+  transform: translateX(16px);
+}
+
 /* Toast */
 
 .toast {

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -22,6 +22,11 @@
         <span id="transcriptStatus" class="transcript-status"></span>
         <button id="queueBtn" type="button" class="btn btn-small">Queue</button>
         <button id="correctionsBtn" type="button" class="btn btn-small">Corrections</button>
+        <button id="trSettingsBtn" type="button" class="btn btn-small btn-icon" title="AI Model Settings">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M6.45498 1.45025C6.48054 1.19465 6.69562 1 6.9525 1H9.04751C9.30438 1 9.51947 1.19465 9.54503 1.45025L9.73077 3.30766C10.2693 3.50637 10.7642 3.79513 11.1973 4.15568L12.9001 3.38721C13.1342 3.28155 13.4103 3.37049 13.5387 3.59295L14.5863 5.40728C14.7147 5.62975 14.6537 5.91334 14.4451 6.06327L12.9286 7.15339C12.9756 7.42858 13 7.71143 13 8C13 8.28864 12.9755 8.57157 12.9286 8.84682L14.4451 9.93696C14.6537 10.0869 14.7147 10.3705 14.5863 10.5929L13.5387 12.4073C13.4103 12.6297 13.1342 12.7187 12.9001 12.613L11.1971 11.8445C10.7641 12.205 10.2692 12.4937 9.73077 12.6923L9.54503 14.5498C9.51947 14.8054 9.30439 15 9.04751 15H6.9525C6.69562 15 6.48054 14.8054 6.45498 14.5498L6.26924 12.6923C5.73071 12.4936 5.23579 12.2049 4.80275 11.8443L3.09994 12.6128C2.86581 12.7185 2.58969 12.6295 2.46126 12.4071L1.41375 10.5927C1.28531 10.3703 1.34634 10.0867 1.55492 9.93673L3.07138 8.84661C3.02445 8.57142 3 8.28857 3 8C3 7.71136 3.02446 7.42843 3.07142 7.15318L1.55492 6.06304C1.34634 5.9131 1.28531 5.62951 1.41375 5.40705L2.46126 3.59272C2.58969 3.37025 2.8658 3.28131 3.09994 3.38698L4.80293 4.15552C5.23593 3.79505 5.73079 3.50634 6.26924 3.30766L6.45498 1.45025ZM6.27751 9.01699L6.25615 8.98C6.09305 8.69039 6 8.35606 6 8C6 6.89543 6.89543 6 8 6C8.73327 6 9.37437 6.39461 9.72253 6.98306L9.74383 7.01995C9.90695 7.30957 10 7.64392 10 8C10 9.10457 9.10457 10 8 10C7.26676 10 6.62567 9.60541 6.27751 9.01699Z"/>
+          </svg>
+        </button>
         <button id="tooltipToggle" type="button" aria-label="Toggle cross-reference tooltips" aria-pressed="true" title="Toggle cross-reference tooltips">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M1 8.74053C1 9.72321 1.71341 10.5653 2.68906 10.6827C3.5937 10.7915 4.50678 10.8729 5.42746 10.926C5.78969 10.9469 6.11506 11.1572 6.27733 11.4817L7.32918 13.5854C7.45622 13.8395 7.71592 14 8 14C8.28408 14 8.54378 13.8395 8.67082 13.5854L9.72265 11.4817C9.88492 11.1572 10.2103 10.9469 10.5725 10.9261C11.4932 10.873 12.4063 10.7916 13.3109 10.6828C14.2866 10.5654 15 9.72332 15 8.74062V4.25938C15 3.27668 14.2866 2.43458 13.3109 2.3172C11.57 2.10777 9.79777 2 8.00039 2C6.20273 2 4.43025 2.10781 2.68906 2.3173C1.71341 2.43469 1 3.27679 1 4.25947V8.74053ZM4 5.25C4 4.83579 4.33579 4.5 4.75 4.5H11.25C11.6642 4.5 12 4.83579 12 5.25C12 5.66421 11.6642 6 11.25 6H4.75C4.33579 6 4 5.66421 4 5.25ZM4.75 7C4.33579 7 4 7.33579 4 7.75C4 8.16421 4.33579 8.5 4.75 8.5H7.25C7.66421 8.5 8 8.16421 8 7.75C8 7.33579 7.66421 7 7.25 7H4.75Z"/>
@@ -120,6 +125,17 @@
     <div class="mark-popover-categories"></div>
     <input class="mark-popover-label" type="text" placeholder="Label (optional)" autocomplete="off">
     <button class="mark-popover-remove btn btn-small">Remove</button>
+  </div>
+
+  <div id="trSettingsPopover" class="tr-settings-popover hidden">
+    <div class="tr-settings-header">
+      <span class="tr-settings-title">AI Models</span>
+      <button id="trSettingsClose" type="button" class="btn btn-small">Close</button>
+    </div>
+    <div id="trSettingsContent"></div>
+    <div class="tr-settings-footer">
+      <span id="trSettingsSaveStatus" class="settings-save-status"></span>
+    </div>
   </div>
 
   <div id="toast" class="toast hidden"></div>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1859,6 +1859,278 @@
     });
   }
 
+  // ---- Settings Popover ----
+
+  var _trModelsCache = null;
+  var _trModelsCachePromise = null;
+  var _trSettingsData = null;
+  var _trSettingsSaveTimer = null;
+
+  var TR_SETTINGS_GROUPS = ["Transcription", "AI Summary"];
+
+  function _trFetchModels() {
+    if (_trModelsCache) return Promise.resolve(_trModelsCache);
+    if (_trModelsCachePromise) return _trModelsCachePromise;
+    _trModelsCachePromise = fetch("../api/models")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) _trModelsCache = data;
+        return data;
+      })
+      .catch(function () { return null; });
+    return _trModelsCachePromise;
+  }
+
+  function _trFormatSize(mb) {
+    if (mb >= 1024) return (mb / 1024).toFixed(1) + " GB";
+    return mb + " MB";
+  }
+
+  function _trLoadModelsForSelect(sel, provider, currentValue) {
+    _trFetchModels().then(function (data) {
+      if (!data || !data.ok) { sel.disabled = false; return; }
+
+      var models = [];
+      if (provider === "whisper") {
+        models = (data.whisper && data.whisper.models) || [];
+      } else if (provider === "ollama") {
+        models = (data.ollama && data.ollama.models) || [];
+      }
+
+      sel.innerHTML = "";
+      var hasCurrentValue = false;
+      for (var i = 0; i < models.length; i++) {
+        var m = models[i];
+        var opt = document.createElement("option");
+        opt.value = m.name;
+        var label = m.name;
+        if (m.size_mb) label += " (" + _trFormatSize(m.size_mb) + ")";
+        if (m.parameter_size) label += " \u00B7 " + m.parameter_size;
+        if (m.description) label += " \u2014 " + m.description;
+        opt.textContent = label;
+        if (m.name === currentValue) {
+          opt.selected = true;
+          hasCurrentValue = true;
+        }
+        sel.appendChild(opt);
+      }
+      if (!hasCurrentValue && currentValue) {
+        var custom = document.createElement("option");
+        custom.value = currentValue;
+        custom.textContent = currentValue + " (current)";
+        custom.selected = true;
+        sel.insertBefore(custom, sel.firstChild);
+      }
+      sel.disabled = false;
+    });
+  }
+
+  function _trFindSetting(name) {
+    if (!_trSettingsData) return null;
+    for (var i = 0; i < _trSettingsData.length; i++) {
+      if (_trSettingsData[i].name === name) return _trSettingsData[i];
+    }
+    return null;
+  }
+
+  function _trScheduleSave() {
+    if (_trSettingsSaveTimer) clearTimeout(_trSettingsSaveTimer);
+    _trSettingsSaveTimer = setTimeout(_trSaveSettings, 400);
+  }
+
+  function _trSaveSettings() {
+    if (!_trSettingsData) return;
+    var payload = {};
+    for (var i = 0; i < _trSettingsData.length; i++) {
+      var s = _trSettingsData[i];
+      if (s.value !== s.default) payload[s.name] = s.value;
+    }
+    var statusEl = qs("#trSettingsSaveStatus");
+    fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: payload }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (statusEl) {
+          statusEl.textContent = data.ok ? "Saved" : "Error";
+          setTimeout(function () { statusEl.textContent = ""; }, 1500);
+        }
+      })
+      .catch(function () {
+        if (statusEl) statusEl.textContent = "Error";
+      });
+  }
+
+  function _trUpdateChanged(settingName) {
+    var row = qs('.tr-settings-row[data-setting="' + settingName + '"]');
+    if (!row) return;
+    var s = _trFindSetting(settingName);
+    if (!s) return;
+    if (s.value !== s.default) {
+      row.classList.add("settings-changed");
+    } else {
+      row.classList.remove("settings-changed");
+    }
+  }
+
+  function _trBuildRow(s) {
+    var row = document.createElement("div");
+    row.className = "tr-settings-row";
+    if (s.value !== s.default) row.classList.add("settings-changed");
+    row.setAttribute("data-setting", s.name);
+
+    var labelDiv = document.createElement("div");
+    labelDiv.className = "tr-settings-label";
+    var nameEl = document.createElement("div");
+    nameEl.className = "tr-settings-label-name";
+    nameEl.textContent = s.name
+      .replace(/_/g, " ").toLowerCase()
+      .replace(/\b\w/g, function (c) { return c.toUpperCase(); })
+      .replace(/Mb$/i, "(MB)").replace(/Seconds$/i, "(s)");
+    var descEl = document.createElement("div");
+    descEl.className = "tr-settings-label-desc";
+    descEl.textContent = s.description;
+    labelDiv.appendChild(nameEl);
+    labelDiv.appendChild(descEl);
+
+    var controlDiv = document.createElement("div");
+    controlDiv.className = "tr-settings-control";
+    var settingName = s.name;
+
+    if (s.type === "bool") {
+      var toggle = document.createElement("input");
+      toggle.type = "checkbox";
+      toggle.checked = !!s.value;
+      toggle.addEventListener("change", function () {
+        var setting = _trFindSetting(settingName);
+        if (setting) setting.value = this.checked;
+        _trUpdateChanged(settingName);
+        _trScheduleSave();
+      });
+      controlDiv.appendChild(toggle);
+    } else if (s.type === "select" && s.options) {
+      var sel = document.createElement("select");
+      for (var oi = 0; oi < s.options.length; oi++) {
+        var opt = document.createElement("option");
+        opt.value = s.options[oi];
+        opt.textContent = s.options[oi];
+        if (s.options[oi] === s.value) opt.selected = true;
+        sel.appendChild(opt);
+      }
+      sel.addEventListener("change", function () {
+        var setting = _trFindSetting(settingName);
+        if (setting) setting.value = this.value;
+        _trUpdateChanged(settingName);
+        _trScheduleSave();
+      });
+      controlDiv.appendChild(sel);
+    } else if (s.type === "model_select") {
+      var msel = document.createElement("select");
+      var curOpt = document.createElement("option");
+      curOpt.value = s.value;
+      curOpt.textContent = s.value;
+      curOpt.selected = true;
+      msel.appendChild(curOpt);
+      msel.disabled = true;
+      msel.addEventListener("change", function () {
+        var setting = _trFindSetting(settingName);
+        if (setting) setting.value = this.value;
+        _trUpdateChanged(settingName);
+        _trScheduleSave();
+      });
+      controlDiv.appendChild(msel);
+      _trLoadModelsForSelect(msel, s.provider, s.value);
+    } else if (s.type === "str") {
+      var txtInput = document.createElement("input");
+      txtInput.type = "text";
+      txtInput.autocomplete = "off";
+      txtInput.value = s.value || "";
+      txtInput.placeholder = String(s.default || "");
+      txtInput.addEventListener("change", function () {
+        var setting = _trFindSetting(settingName);
+        if (setting) setting.value = this.value;
+        _trUpdateChanged(settingName);
+        _trScheduleSave();
+      });
+      controlDiv.appendChild(txtInput);
+    }
+
+    row.appendChild(labelDiv);
+    row.appendChild(controlDiv);
+    return row;
+  }
+
+  function _trRenderSettings() {
+    var container = qs("#trSettingsContent");
+    if (!container || !_trSettingsData) return;
+    container.innerHTML = "";
+
+    var groups = {};
+    for (var i = 0; i < _trSettingsData.length; i++) {
+      var s = _trSettingsData[i];
+      if (TR_SETTINGS_GROUPS.indexOf(s.group) === -1) continue;
+      if (!groups[s.group]) groups[s.group] = [];
+      groups[s.group].push(s);
+    }
+
+    for (var gi = 0; gi < TR_SETTINGS_GROUPS.length; gi++) {
+      var groupName = TR_SETTINGS_GROUPS[gi];
+      if (!groups[groupName]) continue;
+      var header = document.createElement("div");
+      header.className = "tr-settings-group-label";
+      header.textContent = groupName;
+      container.appendChild(header);
+      var items = groups[groupName];
+      for (var si = 0; si < items.length; si++) {
+        container.appendChild(_trBuildRow(items[si]));
+      }
+    }
+  }
+
+  function _trLoadSettings() {
+    fetch("../api/settings")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.ok) return;
+        _trSettingsData = data.settings;
+        _trRenderSettings();
+      })
+      .catch(function () {});
+  }
+
+  function initTranscriptSettings() {
+    var btn = qs("#trSettingsBtn");
+    var popover = qs("#trSettingsPopover");
+    var closeBtn = qs("#trSettingsClose");
+    if (!btn || !popover) return;
+
+    btn.addEventListener("click", function () {
+      var isOpen = !popover.classList.contains("hidden");
+      if (isOpen) {
+        popover.classList.add("hidden");
+      } else {
+        popover.classList.remove("hidden");
+        _trModelsCache = null;
+        _trModelsCachePromise = null;
+        _trLoadSettings();
+      }
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener("click", function () {
+        popover.classList.add("hidden");
+      });
+    }
+
+    document.addEventListener("click", function (e) {
+      if (popover.classList.contains("hidden")) return;
+      if (popover.contains(e.target) || btn.contains(e.target)) return;
+      popover.classList.add("hidden");
+    });
+  }
+
   // ---- Boot ----
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -1871,6 +2143,7 @@
     initVideoSync();
     initSummaryToggle();
     initSummaryActions();
+    initTranscriptSettings();
 
     // Pause polling when tab is hidden; resume when visible
     document.addEventListener("visibilitychange", function () {

--- a/cli.py
+++ b/cli.py
@@ -225,6 +225,21 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         default=None,
         help="Pre-transcribe source videos. No IDs = all participants. Specify IDs to transcribe specific participants (e.g., P01 P03).",
     )
+    transcription.add_argument(
+        "--whisper-model",
+        type=str,
+        choices=["tiny", "base", "small", "medium", "large-v3"],
+        metavar="MODEL",
+        help="Whisper model for transcription: tiny, base, small, medium, large-v3 (default: base)",
+    )
+
+    ai_opts = parser.add_argument_group("AI models")
+    ai_opts.add_argument(
+        "--ollama-model",
+        type=str,
+        metavar="MODEL",
+        help="Ollama model name for transcript summaries (sets both small and large model, e.g. gemma3:4b)",
+    )
 
     paths = parser.add_argument_group("spreadsheet & directories")
     paths.add_argument(
@@ -1305,6 +1320,11 @@ def _apply_config_overrides(args: Any, cli_mode: bool) -> CliModeArgs:
         config.TRANSCRIBE_ENABLED = True
     if getattr(args, "transcript_format", None):
         config.TRANSCRIBE_FORMAT = args.transcript_format
+    if getattr(args, "whisper_model", None):
+        config.TRANSCRIBE_MODEL = args.whisper_model
+    if getattr(args, "ollama_model", None):
+        config.OLLAMA_SUMMARY_MODEL = args.ollama_model
+        config.OLLAMA_SUMMARY_MODEL_LARGE = args.ollama_model
 
     return parse_cli_mode_args(args)
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.43"
+VERSIONNUM: str = "0.10.44"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -329,8 +329,27 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
         "step": 1,
     },
     "STUDIO_CELL_EXPAND_HOVER": {"group": "Sheet Preview", "type": "bool"},
+    "TRANSCRIBE_ENABLED": {"group": "Transcription", "type": "bool"},
+    "TRANSCRIBE_MODEL": {
+        "group": "Transcription",
+        "type": "model_select",
+        "provider": "whisper",
+    },
+    "TRANSCRIBE_FORMAT": {
+        "group": "Transcription",
+        "type": "select",
+        "options": ["md", "srt", "vtt"],
+    },
     "OLLAMA_SUMMARY_ENABLED": {"group": "AI Summary", "type": "bool"},
-    "OLLAMA_SUMMARY_MODEL": {"group": "AI Summary", "type": "str"},
-    "OLLAMA_SUMMARY_MODEL_LARGE": {"group": "AI Summary", "type": "str"},
+    "OLLAMA_SUMMARY_MODEL": {
+        "group": "AI Summary",
+        "type": "model_select",
+        "provider": "ollama",
+    },
+    "OLLAMA_SUMMARY_MODEL_LARGE": {
+        "group": "AI Summary",
+        "type": "model_select",
+        "provider": "ollama",
+    },
     "OLLAMA_BASE_URL": {"group": "AI Summary", "type": "str"},
 }

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -48,6 +48,34 @@ def is_available() -> bool:
         return False
 
 
+def list_models() -> list[dict[str, Any]] | None:
+    """List installed Ollama models with metadata.
+
+    Calls GET /api/tags on the Ollama server and parses the response into a
+    list of dicts with keys: name, size_bytes, parameter_size, quantization,
+    family.  Returns None on any failure (server unreachable, bad JSON, etc.).
+    """
+    try:
+        req = urllib.request.Request(f"{config.OLLAMA_BASE_URL}/api/tags")
+        with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            models = []
+            for m in data.get("models", []):
+                details = m.get("details", {})
+                models.append(
+                    {
+                        "name": m.get("name", ""),
+                        "size_bytes": m.get("size", 0),
+                        "parameter_size": details.get("parameter_size", ""),
+                        "quantization": details.get("quantization_level", ""),
+                        "family": details.get("family", ""),
+                    }
+                )
+            return models
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
 def _is_connection_refused(exc: Exception) -> bool:
     """Check whether an exception indicates connection refused (server not running)."""
     if isinstance(exc, urllib.error.URLError) and isinstance(

--- a/server.py
+++ b/server.py
@@ -1125,6 +1125,7 @@ def api_settings_get() -> FlaskResponse:
                 "options": meta.get("options"),
                 "min": meta.get("min"),
                 "step": meta.get("step"),
+                "provider": meta.get("provider"),
             }
         )
     return jsonify({"ok": True, "settings": settings})
@@ -1415,6 +1416,112 @@ def start_combined_server(
                 "insights": True,
                 "screenspace": True,
                 "transcripts": True,
+            }
+        )
+
+    # ---- Shared settings (available from any page) ----
+
+    # Load persisted settings unconditionally so Transcripts/Screenspace can
+    # read and write model preferences even when Studio is not active.
+    if not has_studio:
+        _load_studio_settings()
+
+    @combined.route("/api/settings", methods=["GET"])
+    def combined_settings_get() -> FlaskResponse:
+        settings = []
+        for name, meta in config.STUDIO_SETTINGS.items():
+            settings.append(
+                {
+                    "name": name,
+                    "value": getattr(config, name),
+                    "default": _settings_defaults.get(name),
+                    "description": config.SETTINGS_DESCRIPTIONS.get(name, ""),
+                    "group": meta.get("group", ""),
+                    "type": meta.get("type", "str"),
+                    "options": meta.get("options"),
+                    "min": meta.get("min"),
+                    "step": meta.get("step"),
+                    "provider": meta.get("provider"),
+                }
+            )
+        return jsonify({"ok": True, "settings": settings})
+
+    @combined.route("/api/settings", methods=["PUT"])
+    def combined_settings_put() -> FlaskResponse:
+        data = request.get_json(silent=True) or {}
+        settings_data = data.get("settings")
+        if not isinstance(settings_data, dict):
+            return jsonify({"ok": False, "error": "Invalid settings payload"}), 400
+
+        applied: dict[str, Any] = {}
+        for name, value in settings_data.items():
+            if name not in config.STUDIO_SETTINGS:
+                continue
+            default = _settings_defaults.get(name)
+            expected_type = type(default) if default is not None else str
+            try:
+                if expected_type is bool:
+                    coerced = (
+                        value
+                        if isinstance(value, bool)
+                        else str(value).lower() in ("true", "1", "yes", "on")
+                    )
+                elif expected_type is int:
+                    coerced = int(value)
+                elif expected_type is float:
+                    coerced = float(value)
+                else:
+                    coerced = str(value)
+            except (ValueError, TypeError):
+                continue
+            setattr(config, name, coerced)
+            applied[name] = coerced
+
+        _save_studio_settings(applied)
+        return jsonify({"ok": True, "applied": applied})
+
+    # ---- Model discovery ----
+
+    @combined.route("/api/models")
+    def api_models() -> Response:
+        import ollama_client
+        import transcripts
+
+        whisper_models = [
+            {
+                "name": m["name"],
+                "size_mb": m["size_mb"],
+                "description": m["description"],
+                "selected": m["name"] == config.TRANSCRIBE_MODEL,
+            }
+            for m in transcripts.WHISPER_MODELS
+        ]
+
+        ollama_models: list[dict[str, Any]] = []
+        ollama_available = False
+        raw = ollama_client.list_models()
+        if raw is not None:
+            ollama_available = True
+            for m in raw:
+                size_mb = round(m["size_bytes"] / (1024 * 1024))
+                ollama_models.append(
+                    {
+                        "name": m["name"],
+                        "size_mb": size_mb,
+                        "parameter_size": m["parameter_size"],
+                        "family": m["family"],
+                    }
+                )
+
+        return jsonify(
+            {
+                "ok": True,
+                "whisper": {"models": whisper_models},
+                "ollama": {
+                    "available": ollama_available,
+                    "models": ollama_models,
+                    "base_url": config.OLLAMA_BASE_URL,
+                },
             }
         )
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -262,3 +262,46 @@ def test_pre_transcribe_with_ids(monkeypatch):
     monkeypatch.setattr("sys.argv", ["clipgen.py", "--pre-transcribe", "P01", "P03"])
     args = cli.parse_arguments()
     assert args.pre_transcribe == ["P01", "P03"]
+
+
+def test_whisper_model_flag_parses(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--whisper-model", "medium"])
+    args = cli.parse_arguments()
+    assert args.whisper_model == "medium"
+
+
+def test_whisper_model_flag_rejects_invalid(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--whisper-model", "huge"])
+    with pytest.raises(SystemExit):
+        cli.parse_arguments()
+
+
+def test_ollama_model_flag_parses(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--ollama-model", "gemma3:4b"])
+    args = cli.parse_arguments()
+    assert args.ollama_model == "gemma3:4b"
+
+
+def test_whisper_model_applies_to_config(monkeypatch):
+    import config
+
+    original = config.TRANSCRIBE_MODEL
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--whisper-model", "small"])
+    args = cli.parse_arguments()
+    cli._apply_config_overrides(args, cli_mode=True)
+    assert config.TRANSCRIBE_MODEL == "small"
+    config.TRANSCRIBE_MODEL = original
+
+
+def test_ollama_model_applies_to_both_config(monkeypatch):
+    import config
+
+    orig_small = config.OLLAMA_SUMMARY_MODEL
+    orig_large = config.OLLAMA_SUMMARY_MODEL_LARGE
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--ollama-model", "gemma3:4b"])
+    args = cli.parse_arguments()
+    cli._apply_config_overrides(args, cli_mode=True)
+    assert config.OLLAMA_SUMMARY_MODEL == "gemma3:4b"
+    assert config.OLLAMA_SUMMARY_MODEL_LARGE == "gemma3:4b"
+    config.OLLAMA_SUMMARY_MODEL = orig_small
+    config.OLLAMA_SUMMARY_MODEL_LARGE = orig_large

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -27,6 +27,61 @@ class TestIsAvailable:
         assert ollama_client.is_available() is False
 
 
+class TestListModels:
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_models_on_success(self, mock_urlopen):
+        response_data = json.dumps(
+            {
+                "models": [
+                    {
+                        "name": "qwen3.5:0.8b",
+                        "size": 531490688,
+                        "details": {
+                            "parameter_size": "0.8B",
+                            "quantization_level": "Q4_K_M",
+                            "family": "qwen3.5",
+                        },
+                    },
+                    {
+                        "name": "gemma3:4b",
+                        "size": 2100000000,
+                        "details": {
+                            "parameter_size": "4B",
+                            "quantization_level": "Q4_0",
+                            "family": "gemma3",
+                        },
+                    },
+                ]
+            }
+        ).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        result = ollama_client.list_models()
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["name"] == "qwen3.5:0.8b"
+        assert result[0]["size_bytes"] == 531490688
+        assert result[0]["parameter_size"] == "0.8B"
+        assert result[0]["family"] == "qwen3.5"
+        assert result[1]["name"] == "gemma3:4b"
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_none_on_connection_error(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        assert ollama_client.list_models() is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_returns_empty_list_for_no_models(self, mock_urlopen):
+        response_data = json.dumps({"models": []}).encode("utf-8")
+        mock_resp = io.BytesIO(response_data)
+        mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        result = ollama_client.list_models()
+        assert result is not None
+        assert len(result) == 0
+
+
 class TestGenerate:
     @patch("ollama_client.urllib.request.urlopen")
     def test_returns_response_text_on_success(self, mock_urlopen):

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1084,6 +1084,27 @@ def test_api_settings_get(client):
         assert "type" in s
 
 
+def test_api_settings_includes_transcription_settings(client):
+    """GET /api/settings includes new Transcription group settings."""
+    resp = client.get("/studio/api/settings")
+    data = resp.get_json()
+    names = {s["name"] for s in data["settings"]}
+    assert "TRANSCRIBE_ENABLED" in names
+    assert "TRANSCRIBE_MODEL" in names
+    assert "TRANSCRIBE_FORMAT" in names
+
+
+def test_api_settings_includes_provider_field(client):
+    """model_select settings include a provider field."""
+    resp = client.get("/studio/api/settings")
+    data = resp.get_json()
+    model_settings = [s for s in data["settings"] if s["type"] == "model_select"]
+    assert len(model_settings) >= 3  # TRANSCRIBE_MODEL + 2 OLLAMA models
+    for s in model_settings:
+        assert "provider" in s
+        assert s["provider"] in ("whisper", "ollama")
+
+
 def test_api_settings_put_applies_values(client, monkeypatch):
     """PUT /api/settings applies values to config and returns applied dict."""
     import config

--- a/transcripts.py
+++ b/transcripts.py
@@ -85,6 +85,19 @@ MARK_CATEGORIES: dict[str, dict[str, str]] = {
     "bookmark": {"label": "Bookmark", "color": "#0891b2"},
 }
 
+# Known faster-whisper model variants with approximate download sizes.
+WHISPER_MODELS: list[dict[str, Any]] = [
+    {"name": "tiny", "size_mb": 40, "description": "Fastest, least accurate"},
+    {"name": "base", "size_mb": 140, "description": "Fast, good for short segments"},
+    {"name": "small", "size_mb": 500, "description": "Balanced speed and accuracy"},
+    {"name": "medium", "size_mb": 1500, "description": "Slower, more accurate"},
+    {
+        "name": "large-v3",
+        "size_mb": 2900,
+        "description": "Best accuracy, requires significant RAM",
+    },
+]
+
 
 # ---------------------------------------------------------------------------
 # Module-level model cache


### PR DESCRIPTION
## Summary

Adds user-configurable model selection for Whisper (transcription) and Ollama (summarization) across CLI, Studio, and Transcripts. Ollama models are discovered dynamically via the local server API; Whisper models use a static metadata list. Both display size and parameter info to help users choose.

- **Backend**: `list_models()` in ollama_client, `WHISPER_MODELS` constant in transcripts, new `/api/models` endpoint, settings endpoints moved to combined app so they work without Studio
- **CLI**: `--whisper-model` (tiny/base/small/medium/large-v3) and `--ollama-model` (sets both small and large) flags
- **Studio**: New `model_select` dropdown type in settings with async model fetching, plus `str` type for text inputs
- **Transcripts**: Gear button in header opens a compact "AI Models" popover for Transcription and AI Summary settings

## Test plan

- [ ] `uv run --extra dev pytest -c tests/pytest.ini` — 533 tests pass
- [ ] Verify `--whisper-model` and `--ollama-model` appear in `--help`
- [ ] Open Studio settings — Transcription group visible with model dropdown
- [ ] Open Transcripts — gear button opens popover with model dropdowns populated from Ollama
- [ ] With Ollama stopped, dropdowns show current value as fallback