### PR TITLE
feat: show OS-specific install instructions when Ollama is missing

### DIFF
--- a/ollama_client.py
+++ b/ollama_client.py
@@ -15,7 +15,9 @@ Key functions:
 
 import json
 import re
+import shutil
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -87,11 +89,44 @@ def _is_connection_refused(exc: Exception) -> bool:
     return False
 
 
+def _ollama_install_guidance_lines() -> list[str]:
+    """Return actionable install guidance based on the current platform."""
+    platform_specific = []
+    if sys.platform == "darwin":
+        platform_specific = [
+            "macOS: install with Homebrew: brew install ollama",
+        ]
+    elif sys.platform.startswith("linux"):
+        platform_specific = [
+            "Linux: curl -fsSL https://ollama.com/install.sh | sh",
+        ]
+    elif sys.platform.startswith("win"):
+        platform_specific = [
+            "Windows: winget install Ollama.Ollama",
+        ]
+    else:
+        platform_specific = [
+            "Download from: https://ollama.com/download",
+        ]
+
+    return platform_specific + [
+        "Then verify in a new terminal:",
+        "  ollama --version",
+    ]
+
+
 def _start_server() -> bool:
     """Attempt to start ``ollama serve`` and wait for it to become available.
 
     Returns True if the server is responding after startup, False otherwise.
     """
+    if shutil.which("ollama") is None:
+        utils.warning_print(
+            "Ollama is not installed.",
+            details=_ollama_install_guidance_lines(),
+        )
+        return False
+
     utils.info_print("Starting Ollama server...")
     try:
         subprocess.Popen(
@@ -99,9 +134,6 @@ def _start_server() -> bool:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-    except FileNotFoundError:
-        utils.warning_print("Ollama binary not found — is Ollama installed?")
-        return False
     except OSError as exc:
         utils.warning_print(f"Failed to start Ollama: {exc}")
         return False

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -223,20 +223,32 @@ class TestAutoStartServer:
         assert result is None
         mock_start.assert_not_called()
 
+    @patch("ollama_client.shutil.which", return_value="/usr/local/bin/ollama")
     @patch("ollama_client.subprocess.Popen")
     @patch("ollama_client.is_available")
-    def test_start_server_polls_until_available(self, mock_avail, mock_popen):
+    def test_start_server_polls_until_available(
+        self, mock_avail, mock_popen, mock_which
+    ):
         """_start_server polls is_available until it returns True."""
         mock_avail.side_effect = [False, False, True]
         assert ollama_client._start_server() is True
         assert mock_avail.call_count == 3
         mock_popen.assert_called_once()
 
-    @patch("ollama_client.subprocess.Popen")
-    def test_start_server_returns_false_when_binary_missing(self, mock_popen):
+    @patch("ollama_client.shutil.which", return_value=None)
+    def test_start_server_returns_false_when_binary_missing(self, mock_which):
         """_start_server returns False when ollama is not installed."""
-        mock_popen.side_effect = FileNotFoundError("ollama not found")
         assert ollama_client._start_server() is False
+
+    @patch("ollama_client.shutil.which", return_value=None)
+    @patch("ollama_client.utils.warning_print")
+    def test_start_server_shows_install_guidance(self, mock_warn, mock_which):
+        """_start_server shows install guidance when ollama is not in PATH."""
+        ollama_client._start_server()
+        mock_warn.assert_called_once()
+        assert "not installed" in mock_warn.call_args[0][0].lower()
+        details = mock_warn.call_args[1]["details"]
+        assert any("ollama --version" in line for line in details)
 
 
 class TestSummarizeTranscript:


### PR DESCRIPTION
## Summary
- When `_start_server()` detects Ollama is not in PATH (via `shutil.which`), it now shows copy-pastable, OS-specific install commands (macOS/brew, Linux/curl installer, Windows/winget) with a verification step
- Replaces the previous generic "Ollama binary not found — is Ollama installed?" message
- Follows the existing `_ffmpeg_install_guidance_lines()` pattern from `video.py`

## Test plan
- [x] Existing `_start_server` tests updated to use `shutil.which` patches
- [x] New test verifies install guidance is shown with details when binary is missing
- [x] All 48 ollama_client tests pass
- [x] ty type check passes