### PR TITLE
feat: double-click Studio panel divider to collapse/restore bottom panel

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -526,7 +526,7 @@ body {
   justify-content: center;
   flex-shrink: 0;
   user-select: none;
-  transition: background-color var(--duration-fast);
+  transition: background-color var(--duration-fast), margin-bottom var(--duration-normal);
 }
 
 #panelDivider:hover,
@@ -546,6 +546,38 @@ body {
 #panelDivider.active .divider-handle {
   background: var(--color-text-dim);
   width: 48px;
+}
+
+/* Bottom panel collapse (double-click divider) */
+
+body.bottom-collapsed #sheetPreview {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+body.bottom-collapsed #sheetGrid,
+body.bottom-collapsed #intakePanel,
+body.bottom-collapsed #trIntakePanel,
+body.bottom-collapsed #convergencePanel,
+body.bottom-collapsed #metadataPanel {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+body.bottom-collapsed #panelDivider {
+  margin-bottom: var(--space-5);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+body.bottom-collapsed #panelDivider .divider-handle {
+  width: 24px;
+  background: var(--color-accent);
+}
+
+body.bottom-animating #dropAreas,
+body.bottom-animating #reelArea,
+body.bottom-animating #stashedArtifactsArea {
+  box-shadow: none;
 }
 
 #sheetGrid thead th {
@@ -770,6 +802,8 @@ col.col-participant-col {
 #bottomPanel {
   flex-shrink: 0;
   width: 100%;
+  transition: max-height var(--duration-normal) ease;
+  overflow: hidden;
 }
 
 /* Drop areas */

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -16,6 +16,8 @@
     artifactStashes: [],
     settingsData: null,
     dividerOffset: 0,
+    bottomCollapsed: false,
+    dividerOffsetBeforeCollapse: 0,
     activeFunction: "",
     cellExpandHover: true,
     filtersVisible: false,
@@ -994,7 +996,7 @@
 
   // ---- Panel divider (resizable split between sheet preview and bottom panel) ----
 
-  function computeGridMaxHeight() {
+  function computeGridMaxHeight(bottomHeightOverride) {
     var header = qs("#studioHeader");
     var preview = qs("#sheetPreview");
     var divider = qs("#panelDivider");
@@ -1020,8 +1022,9 @@
 
     var headerRect = header.getBoundingClientRect();
     var sheetChrome = previewPadTop + phHeight + phMargin + fbHeight + fbMargin + previewPadBot;
+    var bottomH = bottomHeightOverride !== undefined ? bottomHeightOverride : bottom.offsetHeight;
     var available = window.innerHeight - headerRect.top - headerRect.height
-      - sheetChrome - divider.offsetHeight - bottom.offsetHeight;
+      - sheetChrome - divider.offsetHeight - bottomH;
 
     var MIN_GRID = 100;
     var maxAllowed = Math.max(0, available - MIN_GRID);
@@ -1049,6 +1052,7 @@
     var dragMaxOff = 0;    // stable upper bound for dividerOffset
 
     function onDown(e) {
+      if (state.bottomCollapsed) return;
       e.preventDefault();
       dragging = true;
       startY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
@@ -1133,6 +1137,89 @@
 
     document.addEventListener("mouseup", onUp);
     document.addEventListener("touchend", onUp);
+
+    handle.addEventListener("dblclick", function (e) {
+      e.preventDefault();
+      toggleBottomPanel();
+    });
+  }
+
+  function toggleBottomPanel() {
+    var bottom = qs("#bottomPanel");
+    if (!bottom || bottom._transitioning) return;
+    bottom._transitioning = true;
+    var divider = qs("#panelDivider");
+
+    if (state.bottomCollapsed) {
+      // --- Restore ---
+      state.bottomCollapsed = false;
+      state.dividerOffset = 0;
+
+      // Measure target bottom height (temporarily lift the inline constraint)
+      bottom.style.transition = "none";
+      bottom.style.maxHeight = "none";
+      var targetH = bottom.offsetHeight;
+
+      // Transition divider margin from 20px → 0 alongside the bottom panel grow
+      if (divider) divider.style.marginBottom = "0";
+
+      document.body.classList.add("bottom-animating");
+
+      // Keep bottom-collapsed during animation so flex layout smoothly adjusts
+      bottom.style.maxHeight = "0px";
+      bottom.offsetHeight; // reflow — margin transition starts, bottom at 0
+      bottom.style.transition = "";
+      bottom.style.maxHeight = targetH + "px";
+
+      onCollapseTransitionEnd(bottom, function () {
+        document.body.classList.remove("bottom-collapsed");
+        document.body.classList.remove("bottom-animating");
+        if (divider) divider.style.marginBottom = "";
+        bottom.style.maxHeight = "";
+        bottom._transitioning = false;
+        computeGridMaxHeight();
+      });
+    } else {
+      // --- Collapse ---
+      state.bottomCollapsed = true;
+      state.dividerOffsetBeforeCollapse = state.dividerOffset;
+      state.dividerOffset = 0;
+
+      // Clear grid maxHeight — collapsed CSS flex rules fill the space instead
+      var panels = ["#sheetGrid", "#intakePanel", "#trIntakePanel", "#convergencePanel", "#metadataPanel"];
+      for (var i = 0; i < panels.length; i++) {
+        var p = qs(panels[i]);
+        if (p) p.style.maxHeight = "";
+      }
+
+      document.body.classList.add("bottom-animating");
+      var currentH = bottom.offsetHeight;
+      bottom.style.maxHeight = currentH + "px";
+      document.body.classList.add("bottom-collapsed");
+      bottom.offsetHeight; // reflow
+      bottom.style.maxHeight = "0px";
+
+      onCollapseTransitionEnd(bottom, function () {
+        bottom._transitioning = false;
+        document.body.classList.remove("bottom-animating");
+        computeGridMaxHeight(0);
+      });
+    }
+  }
+
+  function onCollapseTransitionEnd(el, cb) {
+    var fired = false;
+    function done() {
+      if (fired) return;
+      fired = true;
+      el.removeEventListener("transitionend", handler);
+      cb();
+    }
+    function handler(e) {
+      if (e.target === el && e.propertyName === "max-height") done();
+    }
+    el.addEventListener("transitionend", handler);
+    setTimeout(done, 400);
   }
 
   function renderDataRow(row, participants, showSeverity) {


### PR DESCRIPTION
## Summary

- Double-clicking the drag handle between the sheet grid and Artifact/Reel areas collapses the bottom panel with an animated `max-height` transition, giving users full workspace height
- Double-clicking the collapsed handle restores the bottom panel — the flex layout smoothly adjusts as the panel grows back, with the divider margin transitioning in parallel
- Shadows on `#dropAreas`/`#reelArea` are hidden during animation to prevent visual artifacts, and the divider gets rounded bottom corners when collapsed to match the panel styling

## Test plan
- [ ] Double-click handle to collapse — bottom panel animates closed, handle lands at bottom with accent-colored pill and rounded corners
- [ ] Double-click again to restore — bottom panel slides up smoothly, no layout snap
- [ ] Drag handle still works normally when not collapsed
- [ ] Drag is disabled while collapsed (no accidental resize)
- [ ] Rapid double-clicks during animation are ignored
- [ ] Window resize while collapsed keeps correct layout