### PR TITLE
feat: add Screenspace Model view preview pane

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1074,6 +1074,99 @@ body {
   overflow-y: auto;
 }
 
+/* Model view panel (preview of preprocessed input per tool) */
+
+.model-view-panel {
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-2);
+  padding-top: var(--space-1);
+  flex-shrink: 0;
+}
+
+.model-view-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: 100%;
+  padding: var(--space-1) var(--space-2);
+  background: transparent;
+  border: none;
+  color: var(--color-text-dim);
+  font-size: var(--text-xs);
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.model-view-toggle:hover {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
+.model-view-icon {
+  width: 14px;
+  height: 14px;
+  background-color: currentColor;
+  mask-image: url("/screenspace/icons/eye.svg");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-image: url("/screenspace/icons/eye.svg");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  flex-shrink: 0;
+}
+
+.model-view-panel.collapsed .model-view-icon {
+  mask-image: url("/screenspace/icons/eye-slash.svg");
+  -webkit-mask-image: url("/screenspace/icons/eye-slash.svg");
+}
+
+.model-view-label {
+  font-weight: 600;
+}
+
+.model-view-hint {
+  margin-left: auto;
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.model-view-body {
+  margin-top: var(--space-1);
+  padding: var(--space-2);
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.model-view-body.hidden {
+  display: none;
+}
+
+.model-view-meta {
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+}
+
+#modelViewImage {
+  max-width: 100%;
+  max-height: 220px;
+  align-self: flex-start;
+  image-rendering: pixelated;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+}
+
+#modelViewImage:not([src]),
+#modelViewImage[src=""] {
+  display: none;
+}
+
 /* Multitool step list */
 
 .multitool-steps {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -147,6 +147,17 @@
       </div>
       <div id="workflowBody">
         <div id="workflowParams"></div>
+        <div id="modelViewPanel" class="model-view-panel collapsed">
+          <button id="modelViewToggle" class="model-view-toggle" type="button" aria-expanded="false">
+            <span class="model-view-icon"></span>
+            <span class="model-view-label">Model view</span>
+            <span class="model-view-hint">what the CV model sees</span>
+          </button>
+          <div id="modelViewBody" class="model-view-body hidden">
+            <div id="modelViewMeta" class="model-view-meta">Select a region to preview.</div>
+            <img id="modelViewImage" alt="Preprocessed preview" />
+          </div>
+        </div>
       </div>
     </section>
     <div id="taskQueuePanel">

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -121,6 +121,7 @@
     hoveredResultSceneName: null,
     videoPlaying: false,
     videoMuted: false,
+    modelViewOpen: false,
   };
 
   var _timelineHitRects = [];
@@ -704,6 +705,7 @@
       updateVideoButtons();
     }
     seekPlayhead(timestamp);
+    refreshModelView({ debounce: true });
     if (state.frameLoading) {
       _pendingFrameTs = timestamp;
       return;
@@ -1317,6 +1319,7 @@
     });
     renderRunRegionPicker();
     updateRegionChipsOverflow();
+    refreshModelView({ debounce: true });
   }
 
   function updateRegionChipsOverflow() {
@@ -3175,6 +3178,7 @@
     if (scanBtn && scanBtn._updateScanState) scanBtn._updateScanState();
 
     updateRunButton();
+    refreshModelView();
   }
 
   function addParamRow(container, label, control, valueDisplayId) {
@@ -3192,10 +3196,166 @@
         if (state.activeWorkflow === "color" && control.id && control.id.startsWith("paramColor")) {
           updateColorPreview();
         }
+        refreshModelView({ debounce: true });
+      });
+    } else {
+      control.addEventListener("input", function () {
+        refreshModelView({ debounce: true });
       });
     }
     row.appendChild(ctrl);
     container.appendChild(row);
+  }
+
+  // ---- Model view (preprocessed preview) ----
+
+  var _modelViewGen = 0;
+  var _modelViewTimer = 0;
+
+  var MODEL_VIEW_META = {
+    color: "Downscaled region (≤64 px) with mean HSV vs. target swatch.",
+    change: "Gray-blur + abs-diff + thresholded mask (prev = 1 s earlier).",
+    similarity: "Gray-blurred region (≤256 px); reference appears once captured.",
+    text: "Grayscale region fed to OCR.",
+    numbers: "Grayscale region fed to OCR.",
+    timelapse: "Region crop — FFmpeg encodes this unmodified.",
+    template: "Gray-blurred frame, template, and normalized match heatmap.",
+    flow: "Prev + current gray frames with dense optical-flow vectors.",
+    scene: "Region (≤128 px), Canny edges, and 8-bin hue histogram.",
+    inactivity: "Region and pHash bit grid (white = 1, black = 0).",
+    multitool: "Preview of the first tool step.",
+  };
+
+  function initModelView() {
+    var btn = qs("#modelViewToggle");
+    if (btn) btn.addEventListener("click", toggleModelView);
+  }
+
+  function toggleModelView() {
+    state.modelViewOpen = !state.modelViewOpen;
+    var panel = qs("#modelViewPanel");
+    var body = qs("#modelViewBody");
+    var btn = qs("#modelViewToggle");
+    if (state.modelViewOpen) {
+      panel.classList.remove("collapsed");
+      body.classList.remove("hidden");
+      btn.setAttribute("aria-expanded", "true");
+      refreshModelView();
+    } else {
+      panel.classList.add("collapsed");
+      body.classList.add("hidden");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  }
+
+  function refreshModelView(opts) {
+    if (!state.modelViewOpen) return;
+    if (_modelViewTimer) {
+      clearTimeout(_modelViewTimer);
+      _modelViewTimer = 0;
+    }
+    if (opts && opts.debounce) {
+      _modelViewTimer = setTimeout(_doRefreshModelView, 150);
+    } else {
+      _doRefreshModelView();
+    }
+  }
+
+  function _normalizedRegionString() {
+    if (state.pendingRegion) {
+      var p = state.pendingRegion;
+      var c = qs("#overlayCanvas");
+      if (!c.width || !c.height) return null;
+      return [p.x / c.width, p.y / c.height, p.w / c.width, p.h / c.height]
+        .map(function (v) { return Number(v).toFixed(6); })
+        .join(",");
+    }
+    if (state.activeRegion && state.regions[state.activeRegion]) {
+      var r = state.regions[state.activeRegion];
+      if (r.source_width) {
+        return [r.x, r.y, r.w, r.h]
+          .map(function (v) { return Number(v).toFixed(6); })
+          .join(",");
+      }
+      var canvas = qs("#overlayCanvas");
+      if (!canvas.width || !canvas.height) return null;
+      return [r.x / canvas.width, r.y / canvas.height, r.w / canvas.width, r.h / canvas.height]
+        .map(function (v) { return Number(v).toFixed(6); })
+        .join(",");
+    }
+    return null;
+  }
+
+  function _collectPreviewParams(tool) {
+    var out = {};
+    if (tool === "color") {
+      var hEl = qs("#paramColorH"), sEl = qs("#paramColorS"), vEl = qs("#paramColorV");
+      if (hEl) out.h = hEl.value;
+      if (sEl) out.s = sEl.value;
+      if (vEl) out.v = vEl.value;
+    } else if (tool === "change") {
+      var n = qs("#paramChangeNoise");
+      if (n) out.noise = n.value;
+    } else if (tool === "flow") {
+      var m = qs("#paramFlowMag");
+      if (m) out.magnitude = m.value;
+    }
+    return out;
+  }
+
+  function _doRefreshModelView() {
+    var gen = ++_modelViewGen;
+    var meta = qs("#modelViewMeta");
+    var img = qs("#modelViewImage");
+    if (!meta || !img) return;
+
+    if (!state.selectedParticipant) {
+      meta.textContent = "Select a participant to preview.";
+      img.removeAttribute("src");
+      return;
+    }
+
+    var tool = state.activeWorkflow;
+    var regionStr = _normalizedRegionString();
+    var fullFrameTools = { template: true };
+    if (!fullFrameTools[tool] && !regionStr) {
+      meta.textContent = "Select or draw a region to preview.";
+      img.removeAttribute("src");
+      return;
+    }
+
+    var params = _collectPreviewParams(tool);
+    var qsParts = ["tool=" + encodeURIComponent(tool)];
+    if (regionStr) qsParts.push("region=" + regionStr);
+    if (tool === "change" || tool === "flow") {
+      var prevTs = Math.max(0, (state.currentTimestamp || 0) - 1);
+      qsParts.push("prev=" + prevTs.toFixed(3));
+    }
+    if (tool === "similarity" && state.referenceTimestamp != null) {
+      qsParts.push("ref=" + Number(state.referenceTimestamp).toFixed(3));
+    }
+    Object.keys(params).forEach(function (k) {
+      qsParts.push(encodeURIComponent(k) + "=" + encodeURIComponent(params[k]));
+    });
+    qsParts.push("_=" + gen);
+
+    var ts = Number(state.currentTimestamp || 0).toFixed(3);
+    var url = "api/preview/" + encodeURIComponent(state.selectedParticipant)
+      + "/" + ts + "?" + qsParts.join("&");
+
+    meta.textContent = "Loading preview…";
+    var tmp = new Image();
+    tmp.onload = function () {
+      if (gen !== _modelViewGen) return;
+      img.src = tmp.src;
+      meta.textContent = MODEL_VIEW_META[tool] || "";
+    };
+    tmp.onerror = function () {
+      if (gen !== _modelViewGen) return;
+      meta.textContent = "Preview unavailable.";
+      img.removeAttribute("src");
+    };
+    tmp.src = url;
   }
 
   function rangeInput(id, min, max, value, step) {
@@ -5323,6 +5483,7 @@
     initRegionDrawing();
     initTimeline();
     initWorkflowTabs();
+    initModelView();
     initParamTooltips();
     initRunButton();
     initTaskQueue();

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.47"
+VERSIONNUM: str = "0.10.48"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -1,0 +1,532 @@
+# -*- coding: utf-8 -*-
+"""Preprocessing preview generation for the Screenspace "Model view" pane.
+
+Given a frame (and optionally a prev_frame / reference_frame / template_image),
+a region, a tool type, and the tool's parameters, returns a composite BGR image
+showing what that tool's CV pipeline actually operates on — grayscale crops,
+diff masks, edge maps, flow vectors, pHash bit grids, etc.
+
+The produced image is always a single ``numpy.ndarray`` of shape (H, W, 3) in
+BGR uint8, suitable for ``cv2.imencode('.png', img)``.
+
+Entry point: :func:`build_preview`.
+"""
+
+from typing import Any
+
+import cv2
+import numpy as np
+
+import config
+import screenspace
+
+
+# Max width (px) of the composite preview image.  Kept modest: the UI pane is
+# small and generating larger images just wastes bandwidth.
+_MAX_WIDTH = 512
+_PANEL_GAP = 6
+_LABEL_HEIGHT = 16
+
+
+def build_preview(
+    frame: "np.ndarray",
+    prev_frame: "np.ndarray | None",
+    region: dict[str, int] | None,
+    tool: str,
+    params: dict[str, Any],
+) -> "np.ndarray":
+    """Build a BGR preview image for the given tool and frame."""
+    if tool == "color":
+        return _preview_color(frame, region, params)
+    if tool == "change":
+        return _preview_change(frame, prev_frame, region, params)
+    if tool == "similarity":
+        return _preview_similarity(frame, region, params)
+    if tool in ("text", "numbers"):
+        return _preview_text_numbers(frame, region, params)
+    if tool == "timelapse":
+        return _preview_timelapse(frame, region)
+    if tool == "template":
+        return _preview_template(frame, params)
+    if tool == "flow":
+        return _preview_flow(frame, prev_frame, region, params)
+    if tool == "scene":
+        return _preview_scene(frame, region, params)
+    if tool == "inactivity":
+        return _preview_inactivity(frame, region)
+    if tool == "multitool":
+        steps = params.get("steps") or []
+        if steps:
+            step = steps[0]
+            return build_preview(
+                frame,
+                prev_frame,
+                region,
+                step.get("type", ""),
+                step.get("parameters") or {},
+            )
+        return _placeholder("Add a step to see its preview")
+    return _placeholder(f"Unknown tool: {tool}")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _placeholder(message: str, w: int = 320, h: int = 120) -> "np.ndarray":
+    """Return a dark panel with a centered message — used for empty states."""
+    img = np.full((h, w, 3), 32, dtype=np.uint8)
+    cv2.putText(
+        img,
+        message,
+        (12, h // 2),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.5,
+        (200, 200, 200),
+        1,
+        cv2.LINE_AA,
+    )
+    return img
+
+
+def _gray_to_bgr(gray: "np.ndarray") -> "np.ndarray":
+    if gray.ndim == 3:
+        return gray
+    return cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
+
+
+def _fit_width(img: "np.ndarray", target_w: int) -> "np.ndarray":
+    """Upscale/downscale preserving aspect so width == target_w."""
+    h, w = img.shape[:2]
+    if w == target_w:
+        return img
+    scale = target_w / float(w)
+    new_h = max(1, int(round(h * scale)))
+    interp = cv2.INTER_AREA if scale < 1.0 else cv2.INTER_NEAREST
+    return cv2.resize(img, (target_w, new_h), interpolation=interp)
+
+
+def _label_panel(img: "np.ndarray", label: str) -> "np.ndarray":
+    """Stack a small label strip above an image."""
+    img = _gray_to_bgr(img)
+    h, w = img.shape[:2]
+    strip = np.full((_LABEL_HEIGHT, w, 3), 24, dtype=np.uint8)
+    cv2.putText(
+        strip,
+        label,
+        (4, 12),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.38,
+        (210, 210, 210),
+        1,
+        cv2.LINE_AA,
+    )
+    return np.vstack([strip, img])
+
+
+def _hstack_panels(panels: list["np.ndarray"]) -> "np.ndarray":
+    """Horizontally stack equal-height panels with a small gap between them."""
+    if not panels:
+        return _placeholder("No preview")
+    target_h = max(p.shape[0] for p in panels)
+    resized = []
+    for p in panels:
+        h, w = p.shape[:2]
+        if h != target_h:
+            scale = target_h / float(h)
+            new_w = max(1, int(round(w * scale)))
+            p = cv2.resize(
+                _gray_to_bgr(p), (new_w, target_h), interpolation=cv2.INTER_AREA
+            )
+        else:
+            p = _gray_to_bgr(p)
+        resized.append(p)
+    gap = np.full((target_h, _PANEL_GAP, 3), 16, dtype=np.uint8)
+    out = resized[0]
+    for p in resized[1:]:
+        out = np.hstack([out, gap, p])
+    return out
+
+
+def _clip_region_pixels(
+    frame: "np.ndarray", region: dict[str, int] | None
+) -> "np.ndarray | None":
+    if region is None:
+        return None
+    pixels = screenspace.extract_region(frame, region)
+    if pixels.size == 0:
+        return None
+    return pixels
+
+
+# ---------------------------------------------------------------------------
+# Per-tool previews
+# ---------------------------------------------------------------------------
+
+
+def _preview_color(
+    frame: "np.ndarray",
+    region: dict[str, int] | None,
+    params: dict[str, Any],
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+
+    # Downscaled crop (mirrors average_color_hsv's ≤64 resize)
+    h, w = pixels.shape[:2]
+    if h > 64 or w > 64:
+        down = cv2.resize(
+            pixels, (min(w, 64), min(h, 64)), interpolation=cv2.INTER_AREA
+        )
+    else:
+        down = pixels.copy()
+    mean_hsv = screenspace.average_color_hsv(pixels)
+
+    # Target swatch from params (falls back to computed mean)
+    tgt_h = float(params.get("h", mean_hsv["h"]))
+    tgt_s = float(params.get("s", mean_hsv["s"]))
+    tgt_v = float(params.get("v", mean_hsv["v"]))
+    tgt_bgr = cv2.cvtColor(
+        np.array([[[int(tgt_h), int(tgt_s), int(tgt_v)]]], dtype=np.uint8),
+        cv2.COLOR_HSV2BGR,
+    )[0, 0]
+    mean_bgr = cv2.cvtColor(
+        np.array(
+            [[[int(mean_hsv["h"]), int(mean_hsv["s"]), int(mean_hsv["v"])]]],
+            dtype=np.uint8,
+        ),
+        cv2.COLOR_HSV2BGR,
+    )[0, 0]
+
+    swatch_h = 80
+    mean_swatch = np.full((swatch_h, 80, 3), mean_bgr, dtype=np.uint8)
+    target_swatch = np.full((swatch_h, 80, 3), tgt_bgr, dtype=np.uint8)
+
+    crop_panel = _label_panel(_fit_width(down, 120), "region (≤64 px)")
+    mean_panel = _label_panel(
+        mean_swatch,
+        f"mean HSV {int(mean_hsv['h'])},{int(mean_hsv['s'])},{int(mean_hsv['v'])}",
+    )
+    target_panel = _label_panel(
+        target_swatch, f"target {int(tgt_h)},{int(tgt_s)},{int(tgt_v)}"
+    )
+    return _hstack_panels([crop_panel, mean_panel, target_panel])
+
+
+def _preview_change(
+    frame: "np.ndarray",
+    prev_frame: "np.ndarray | None",
+    region: dict[str, int] | None,
+    params: dict[str, Any],
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+    k = config.SCREENSPACE_BLUR_KERNEL
+    curr_blur = cv2.GaussianBlur(pixels, (k, k), 0)
+    curr_gray = cv2.cvtColor(curr_blur, cv2.COLOR_BGR2GRAY)
+
+    if prev_frame is None:
+        panel = _label_panel(_fit_width(curr_gray, 200), "gray-blur (no prev)")
+        return panel
+
+    prev_pixels = _clip_region_pixels(prev_frame, region)
+    if prev_pixels is None or prev_pixels.shape[:2] != pixels.shape[:2]:
+        panel = _label_panel(_fit_width(curr_gray, 200), "gray-blur (no prev)")
+        return panel
+
+    prev_blur = cv2.GaussianBlur(prev_pixels, (k, k), 0)
+    prev_gray = cv2.cvtColor(prev_blur, cv2.COLOR_BGR2GRAY)
+
+    noise = int(params.get("noise_threshold", config.SCREENSPACE_NOISE_THRESHOLD))
+    diff = cv2.absdiff(prev_gray, curr_gray)
+    _, mask = cv2.threshold(diff, noise, 255, cv2.THRESH_BINARY)
+    mk = config.SCREENSPACE_MORPH_KERNEL
+    mask_clean = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((mk, mk), np.uint8))
+
+    ratio = (
+        float(np.count_nonzero(mask_clean)) / float(mask_clean.size)
+        if mask_clean.size
+        else 0.0
+    )
+
+    return _hstack_panels(
+        [
+            _label_panel(_fit_width(curr_gray, 160), "gray-blur"),
+            _label_panel(_fit_width(diff, 160), "abs-diff"),
+            _label_panel(_fit_width(mask_clean, 160), f"mask (ratio {ratio:.3f})"),
+        ]
+    )
+
+
+def _preview_similarity(
+    frame: "np.ndarray",
+    region: dict[str, int] | None,
+    params: dict[str, Any],
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+
+    max_dim = 256
+    h, w = pixels.shape[:2]
+    if h > max_dim or w > max_dim:
+        scale = max_dim / max(h, w)
+        pixels_small = cv2.resize(
+            pixels,
+            (int(w * scale), int(h * scale)),
+            interpolation=cv2.INTER_AREA,
+        )
+    else:
+        pixels_small = pixels
+    k = config.SCREENSPACE_BLUR_KERNEL
+    curr_gray = cv2.cvtColor(
+        cv2.GaussianBlur(pixels_small, (k, k), 0), cv2.COLOR_BGR2GRAY
+    )
+
+    ref_frame = params.get("reference_frame")
+    panels = [_label_panel(_fit_width(curr_gray, 200), "current gray (≤256)")]
+    if isinstance(ref_frame, np.ndarray) and ref_frame.size > 0:
+        rh, rw = ref_frame.shape[:2]
+        if rh > max_dim or rw > max_dim:
+            rs = max_dim / max(rh, rw)
+            ref_small = cv2.resize(
+                ref_frame,
+                (int(rw * rs), int(rh * rs)),
+                interpolation=cv2.INTER_AREA,
+            )
+        else:
+            ref_small = ref_frame
+        ref_gray = cv2.cvtColor(
+            cv2.GaussianBlur(ref_small, (k, k), 0), cv2.COLOR_BGR2GRAY
+        )
+        panels.append(_label_panel(_fit_width(ref_gray, 200), "reference gray"))
+    return _hstack_panels(panels)
+
+
+def _preview_text_numbers(
+    frame: "np.ndarray",
+    region: dict[str, int] | None,
+    params: dict[str, Any],
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+    gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+    return _label_panel(_fit_width(gray, 300), "OCR input (gray)")
+
+
+def _preview_timelapse(
+    frame: "np.ndarray",
+    region: dict[str, int] | None,
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+    return _label_panel(_fit_width(pixels, 300), "region crop (no preprocessing)")
+
+
+def _preview_template(
+    frame: "np.ndarray",
+    params: dict[str, Any],
+) -> "np.ndarray":
+    k = config.SCREENSPACE_BLUR_KERNEL
+    frame_gray = cv2.cvtColor(cv2.GaussianBlur(frame, (k, k), 0), cv2.COLOR_BGR2GRAY)
+    panels = [_label_panel(_fit_width(frame_gray, 240), "frame gray-blur")]
+
+    template = params.get("template_image")
+    if isinstance(template, np.ndarray) and template.size > 0:
+        tmpl_gray = cv2.cvtColor(
+            cv2.GaussianBlur(template, (k, k), 0), cv2.COLOR_BGR2GRAY
+        )
+        panels.append(_label_panel(_fit_width(tmpl_gray, 120), "template"))
+
+        # Match heatmap (only when template fits inside the frame)
+        if (
+            tmpl_gray.shape[0] <= frame_gray.shape[0]
+            and tmpl_gray.shape[1] <= frame_gray.shape[1]
+            and float(np.std(tmpl_gray)) >= 1e-6
+        ):
+            mask = params.get("template_mask")
+            gray_mask = None
+            if isinstance(mask, np.ndarray) and mask.size > 0:
+                gray_mask = cv2.GaussianBlur(mask, (k, k), 0)
+            result = cv2.matchTemplate(
+                frame_gray, tmpl_gray, cv2.TM_CCOEFF_NORMED, mask=gray_mask
+            )
+            result = np.nan_to_num(result, nan=0.0, posinf=1.0, neginf=-1.0)
+            norm = np.empty_like(result)
+            cv2.normalize(result, norm, 0, 255, cv2.NORM_MINMAX)
+            heat = cv2.applyColorMap(norm.astype(np.uint8), cv2.COLORMAP_JET)
+            panels.append(_label_panel(_fit_width(heat, 240), "match heatmap"))
+    else:
+        panels.append(_label_panel(_placeholder("no template", 120, 80), "template"))
+    return _hstack_panels(panels)
+
+
+def _preview_flow(
+    frame: "np.ndarray",
+    prev_frame: "np.ndarray | None",
+    region: dict[str, int] | None,
+    params: dict[str, Any],
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+    curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+
+    if prev_frame is None:
+        return _label_panel(_fit_width(curr_gray, 200), "current gray (no prev)")
+    prev_pixels = _clip_region_pixels(prev_frame, region)
+    if prev_pixels is None or prev_pixels.shape[:2] != pixels.shape[:2]:
+        return _label_panel(_fit_width(curr_gray, 200), "current gray (no prev)")
+    prev_gray = cv2.cvtColor(prev_pixels, cv2.COLOR_BGR2GRAY)
+
+    max_dim = 256
+    h, w = prev_gray.shape[:2]
+    if h > max_dim or w > max_dim:
+        scale = max_dim / max(h, w)
+        new_w, new_h = int(w * scale), int(h * scale)
+        prev_r = cv2.resize(prev_gray, (new_w, new_h), interpolation=cv2.INTER_AREA)
+        curr_r = cv2.resize(curr_gray, (new_w, new_h), interpolation=cv2.INTER_AREA)
+    else:
+        prev_r, curr_r = prev_gray, curr_gray
+
+    flow_out = np.zeros((*prev_r.shape[:2], 2), dtype=np.float32)
+    flow = cv2.calcOpticalFlowFarneback(
+        prev_r, curr_r, flow_out, config.SCREENSPACE_FLOW_PYR_SCALE, 3, 15, 3, 5, 1.2, 0
+    )
+    mag, _ = cv2.cartToPolar(flow[..., 0], flow[..., 1], angleInDegrees=True)
+
+    # Draw flow arrows on the current-frame panel
+    vis = cv2.cvtColor(curr_r, cv2.COLOR_GRAY2BGR)
+    grid_size = config.SCREENSPACE_FLOW_GRID_SIZE
+    gh, gw = mag.shape[:2]
+    step_y = max(1, gh // grid_size)
+    step_x = max(1, gw // grid_size)
+    min_mag = config.SCREENSPACE_FLOW_GRID_MIN_MAG
+    for gy in range(0, gh, step_y):
+        for gx in range(0, gw, step_x):
+            cy = gy + step_y // 2
+            cx = gx + step_x // 2
+            if cy >= gh or cx >= gw:
+                continue
+            fx, fy = float(flow[cy, cx, 0]), float(flow[cy, cx, 1])
+            m = float(np.sqrt(fx * fx + fy * fy))
+            if m < min_mag:
+                continue
+            scale = 4.0
+            end = (int(cx + fx * scale), int(cy + fy * scale))
+            cv2.arrowedLine(vis, (cx, cy), end, (40, 220, 40), 1, tipLength=0.3)
+
+    mean_mag = float(np.mean(mag))
+    thresh = float(
+        params.get("magnitude_threshold", config.SCREENSPACE_FLOW_MAGNITUDE_THRESHOLD)
+    )
+    return _hstack_panels(
+        [
+            _label_panel(_fit_width(prev_gray, 160), "prev gray"),
+            _label_panel(
+                _fit_width(vis, 160),
+                f"flow vectors (mean {mean_mag:.2f}, thr {thresh:.2f})",
+            ),
+        ]
+    )
+
+
+def _preview_scene(
+    frame: "np.ndarray",
+    region: dict[str, int] | None,
+    params: dict[str, Any],  # noqa: ARG001 — reserved for future scene-ref overlays
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+
+    max_dim = 128
+    h, w = pixels.shape[:2]
+    if h > max_dim or w > max_dim:
+        scale = max_dim / max(h, w)
+        pixels_small = cv2.resize(
+            pixels,
+            (int(w * scale), int(h * scale)),
+            interpolation=cv2.INTER_AREA,
+        )
+    else:
+        pixels_small = pixels
+
+    gray = cv2.cvtColor(pixels_small, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 100, 200)
+    edge_density = (
+        float(np.count_nonzero(edges)) / float(edges.size) if edges.size else 0.0
+    )
+
+    # 8-bin hue histogram strip
+    hsv = cv2.cvtColor(pixels_small, cv2.COLOR_BGR2HSV)
+    hist = cv2.calcHist([hsv], [0], None, [8], [0, 180]).flatten()
+    hist = hist / (hist.max() + 1e-6)
+    bar_w, bar_h = 24, 80
+    strip = np.full((bar_h, bar_w * len(hist), 3), 20, dtype=np.uint8)
+    for i, v in enumerate(hist):
+        hue_deg = int((i + 0.5) * (180.0 / len(hist)))
+        bgr = cv2.cvtColor(
+            np.array([[[hue_deg, 200, 220]]], dtype=np.uint8), cv2.COLOR_HSV2BGR
+        )[0, 0]
+        h_px = max(1, int(v * (bar_h - 4)))
+        cv2.rectangle(
+            strip,
+            (i * bar_w + 2, bar_h - h_px),
+            ((i + 1) * bar_w - 2, bar_h - 1),
+            (int(bgr[0]), int(bgr[1]), int(bgr[2])),
+            -1,
+        )
+
+    return _hstack_panels(
+        [
+            _label_panel(_fit_width(pixels_small, 160), "region (≤128)"),
+            _label_panel(_fit_width(edges, 160), f"Canny edges ({edge_density:.2%})"),
+            _label_panel(_fit_width(strip, 160), "hue histogram (8 bins)"),
+        ]
+    )
+
+
+def _preview_inactivity(
+    frame: "np.ndarray",
+    region: dict[str, int] | None,
+) -> "np.ndarray":
+    pixels = _clip_region_pixels(frame, region)
+    if pixels is None:
+        return _placeholder("Select a region to preview")
+
+    ph = screenspace.compute_phash(pixels)
+    # imagehash.ImageHash exposes .hash as a 2D bool ndarray (typically 8×8 for phash)
+    bits = np.asarray(ph.hash, dtype=np.uint8) * 255
+    # Upscale to a visible grid
+    cell = 16
+    grid = np.kron(bits, np.ones((cell, cell), dtype=np.uint8))
+    grid_bgr = cv2.cvtColor(grid, cv2.COLOR_GRAY2BGR)
+    # Draw gridlines for readability
+    n = bits.shape[0]
+    for i in range(1, n):
+        cv2.line(grid_bgr, (i * cell, 0), (i * cell, n * cell), (60, 60, 60), 1)
+        cv2.line(grid_bgr, (0, i * cell), (n * cell, i * cell), (60, 60, 60), 1)
+
+    return _hstack_panels(
+        [
+            _label_panel(_fit_width(pixels, 160), "region"),
+            _label_panel(_fit_width(grid_bgr, 160), f"pHash bits ({n}×{n})"),
+        ]
+    )
+
+
+def encode_png(img: "np.ndarray") -> bytes:
+    """Encode a BGR image as PNG bytes — convenience for the Flask route."""
+    # Cap overall width so the UI pane never has to scale huge images down.
+    if img.shape[1] > _MAX_WIDTH:
+        img = _fit_width(img, _MAX_WIDTH)
+    ok, buf = cv2.imencode(".png", img)
+    if not ok:
+        return b""
+    return buf.tobytes()

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -10,6 +10,7 @@ API endpoints (all under /screenspace/):
   GET  /media/<filename>                    – serve artifact media files
   GET  /api/participants                    – list discovered participant videos
   GET  /api/video/frame/<participant>/<ts>  – extract a JPEG frame at timestamp
+  GET  /api/preview/<participant>/<ts>      – PNG of the active tool's preprocessed view
   GET  /api/video/info/<participant>        – video metadata (duration, resolution, fps)
   GET  /api/video/stream/<participant>     – stream source video (mp4, range-aware)
   GET  /api/regions                         – list regions
@@ -209,6 +210,130 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
         jpeg_bytes,
         mimetype="image/jpeg",
         headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@screenspace_bp.route("/api/preview/<participant>/<timestamp>")
+def api_preview(participant: str, timestamp: str) -> FlaskResponse:
+    """Render what the selected tool's CV pipeline sees at ``timestamp``.
+
+    Returns a PNG composite image (grayscale crop, diff mask, edge map, flow
+    vectors, pHash bit grid, etc.) tailored to the active tool.  Optional query
+    params:
+
+      tool=<name>          one of the 11 screenspace tool types
+      region=x,y,w,h       normalized 0–1 region coordinates (required for most tools)
+      prev=<seconds>       prior timestamp for change/flow (defaults to ts-1s)
+      ref=<seconds>        reference timestamp for similarity (full-frame region crop)
+      noise=<int>          change tool's noise_threshold override
+      h,s,v=<int>          color tool's target HSV override
+      magnitude=<float>    flow tool's magnitude threshold override
+    """
+    import screenspace_preview
+
+    try:
+        ts = float(timestamp)
+    except (ValueError, TypeError):
+        return jsonify({"ok": False, "error": "Invalid timestamp"}), 400
+
+    video_path = _find_participant_video(participant)
+    if video_path is None:
+        return jsonify(
+            {"ok": False, "error": f"No video for participant {participant}"}
+        ), 404
+
+    tool = (request.args.get("tool") or "").strip() or "color"
+    if tool not in _VALID_TASK_TYPES:
+        return jsonify({"ok": False, "error": f"Unknown tool: {tool}"}), 400
+
+    frame = video.extract_frame_at_timestamp(video_path, ts)
+    if frame is None:
+        return jsonify({"ok": False, "error": "Could not read frame"}), 400
+    frame_h, frame_w = frame.shape[:2]
+
+    region_coords: dict[str, int] | None = None
+    region_str = request.args.get("region", "").strip()
+    if region_str:
+        parts = region_str.split(",")
+        if len(parts) == 4:
+            try:
+                rx, ry, rw, rh = (float(p) for p in parts)
+            except ValueError:
+                return jsonify({"ok": False, "error": "Invalid region"}), 400
+            region_coords = {
+                "x": int(round(rx * frame_w)),
+                "y": int(round(ry * frame_h)),
+                "w": int(round(rw * frame_w)),
+                "h": int(round(rh * frame_h)),
+            }
+
+    # Prev frame for tools that consume a temporal pair
+    prev_frame = None
+    if tool in ("change", "flow"):
+        prev_ts_raw = request.args.get("prev")
+        if prev_ts_raw is not None:
+            try:
+                prev_ts = float(prev_ts_raw)
+            except ValueError:
+                prev_ts = max(0.0, ts - 1.0)
+        else:
+            prev_ts = max(0.0, ts - 1.0)
+        if prev_ts < ts:
+            prev_frame = video.extract_frame_at_timestamp(video_path, prev_ts)
+
+    # Build params dict for the preview (subset of task parameters)
+    params: dict[str, Any] = {}
+    if tool == "color":
+        for key in ("h", "s", "v"):
+            raw = request.args.get(key)
+            if raw is not None:
+                try:
+                    params[key] = float(raw)
+                except ValueError:
+                    pass
+    elif tool == "change":
+        raw = request.args.get("noise")
+        if raw is not None:
+            try:
+                params["noise_threshold"] = int(float(raw))
+            except ValueError:
+                pass
+    elif tool == "flow":
+        raw = request.args.get("magnitude")
+        if raw is not None:
+            try:
+                params["magnitude_threshold"] = float(raw)
+            except ValueError:
+                pass
+    elif tool == "similarity":
+        ref_ts_raw = request.args.get("ref")
+        if ref_ts_raw is not None and region_coords is not None:
+            try:
+                ref_ts = float(ref_ts_raw)
+            except ValueError:
+                ref_ts = None  # type: ignore[assignment]
+            if ref_ts is not None:
+                ref_frame = video.extract_frame_at_timestamp(video_path, ref_ts)
+                if ref_frame is not None:
+                    import screenspace as _ss
+
+                    params["reference_frame"] = _ss.extract_region(
+                        ref_frame, region_coords
+                    )
+
+    img = screenspace_preview.build_preview(
+        frame, prev_frame, region_coords, tool, params
+    )
+    if img is None or getattr(img, "size", 0) == 0:
+        return jsonify({"ok": False, "error": "Could not build preview"}), 500
+
+    png_bytes = screenspace_preview.encode_png(img)
+    if not png_bytes:
+        return jsonify({"ok": False, "error": "Could not encode preview"}), 500
+    return Response(
+        png_bytes,
+        mimetype="image/png",
+        headers={"Cache-Control": "no-cache"},
     )
 
 

--- a/tests/test_screenspace_preview.py
+++ b/tests/test_screenspace_preview.py
@@ -1,0 +1,106 @@
+"""Smoke tests for the Screenspace Model View preview builder.
+
+Verifies that :func:`screenspace_preview.build_preview` returns a
+PNG-encodable BGR array for every supported tool type, given a synthetic
+frame and region.
+"""
+
+import cv2
+import numpy as np
+import pytest
+
+import screenspace_preview
+
+
+@pytest.fixture
+def synthetic_frame() -> np.ndarray:
+    """A 320x240 BGR frame with a varying gradient plus a contrasting patch."""
+    frame = np.zeros((240, 320, 3), dtype=np.uint8)
+    for y in range(240):
+        frame[y, :, 0] = y % 256  # blue gradient
+    for x in range(320):
+        frame[:, x, 1] = x % 256  # green gradient
+    frame[50:110, 80:180] = (20, 200, 220)  # distinct patch
+    return frame
+
+
+@pytest.fixture
+def prev_frame() -> np.ndarray:
+    """A slightly different frame so change/flow produce non-trivial output."""
+    frame = np.zeros((240, 320, 3), dtype=np.uint8)
+    for y in range(240):
+        frame[y, :, 0] = (y + 5) % 256
+    for x in range(320):
+        frame[:, x, 1] = (x + 5) % 256
+    frame[60:120, 90:190] = (30, 190, 210)
+    return frame
+
+
+@pytest.fixture
+def region() -> dict[str, int]:
+    return {"x": 60, "y": 40, "w": 120, "h": 80}
+
+
+ALL_TOOLS = [
+    "color",
+    "change",
+    "similarity",
+    "text",
+    "numbers",
+    "timelapse",
+    "template",
+    "flow",
+    "scene",
+    "inactivity",
+]
+
+
+@pytest.mark.parametrize("tool", ALL_TOOLS)
+def test_build_preview_returns_encodable_image(
+    synthetic_frame: np.ndarray,
+    prev_frame: np.ndarray,
+    region: dict[str, int],
+    tool: str,
+) -> None:
+    """Every tool produces a non-empty BGR image that PNG-encodes successfully."""
+    params: dict = {}
+    if tool == "template":
+        params["template_image"] = synthetic_frame[50:110, 80:180].copy()
+
+    img = screenspace_preview.build_preview(
+        synthetic_frame, prev_frame, region, tool, params
+    )
+    assert isinstance(img, np.ndarray)
+    assert img.ndim == 3 and img.shape[2] == 3
+    assert img.dtype == np.uint8
+    assert img.size > 0
+
+    png_bytes = screenspace_preview.encode_png(img)
+    assert png_bytes and len(png_bytes) > 50
+    # Re-decode round-trip to confirm well-formed PNG.
+    decoded = cv2.imdecode(np.frombuffer(png_bytes, dtype=np.uint8), cv2.IMREAD_COLOR)
+    assert decoded is not None
+    assert decoded.shape[2] == 3
+
+
+def test_missing_region_returns_placeholder(synthetic_frame: np.ndarray) -> None:
+    """Tools that need a region degrade gracefully when none is supplied."""
+    img = screenspace_preview.build_preview(synthetic_frame, None, None, "change", {})
+    assert isinstance(img, np.ndarray)
+    assert img.size > 0
+
+
+def test_multitool_previews_first_step(
+    synthetic_frame: np.ndarray, region: dict[str, int]
+) -> None:
+    """Multitool forwards to its first step's preview."""
+    params = {"steps": [{"type": "scene", "parameters": {}}]}
+    img = screenspace_preview.build_preview(
+        synthetic_frame, None, region, "multitool", params
+    )
+    assert img.size > 0
+
+
+def test_unknown_tool_returns_placeholder(synthetic_frame: np.ndarray) -> None:
+    img = screenspace_preview.build_preview(synthetic_frame, None, None, "bogus", {})
+    assert img.size > 0


### PR DESCRIPTION
## Summary
Adds a collapsible **Model view** panel in the Screenspace tool area that shows what each CV tool actually sees before running — grayscale crops, diff masks, edge maps, optical-flow vectors, pHash bit grids, and more — updated live as region, timestamp, and parameters change. A new `screenspace_preview.build_preview()` dispatches per tool and a new `/api/preview/<participant>/<ts>` route returns a PNG composite. All 11 tool types are covered with graceful fallbacks for non-visualizable intermediates (e.g. a swatch + numeric readout for `color`).

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 555 pass (13 new smoke tests)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean
- [ ] Manual: open each tool tab, draw a region, toggle Model view, and confirm the preview updates on param/timestamp/region changes