### PR TITLE
Prompt for Excel fallback when Google auth fails

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -459,11 +459,13 @@ def get_runtime_working_dir() -> str:
 # ---- Google authentication ----
 
 
-def authenticate_google() -> Any:
+def authenticate_google() -> Any | None:
     """Authenticate with Google Sheets API.
 
     Returns:
-        Google client connection object
+        Google client connection object on success, or None if authentication
+        failed. Callers are responsible for deciding whether to fall back to a
+        local Excel file or exit.
     """
     import gspread
 
@@ -472,7 +474,7 @@ def authenticate_google() -> Any:
         gspread_client = gspread.oauth(credentials_filename="credentials.json")
         utils.debug_print("Login successful!")
         return gspread_client
-    except gspread.exceptions.GSpreadException as e:
+    except (gspread.exceptions.GSpreadException, FileNotFoundError, OSError) as e:
         utils.error_print(
             "Could not authenticate with Google.",
             [
@@ -486,7 +488,7 @@ def authenticate_google() -> Any:
                 "  4. For OAuth flow, delete any existing token files and re-authenticate",
             ],
         )
-        sys.exit(1)
+        return None
 
 
 # ---- Worksheet selection ----
@@ -1487,12 +1489,34 @@ def main() -> None:
         import google_api
 
         gspread_client = authenticate_google()
-        doc_list = google_api.get_all_spreadsheets(gspread_client)
+        if gspread_client is None:
+            # Auth failed. CLI mode or an explicit -s argument can't recover
+            # interactively — point the user at the Excel option and exit.
+            if cli_mode or getattr(args, "spreadsheet", None):
+                utils.error_print(
+                    "Google authentication failed.",
+                    [
+                        "Use -s path/to/file.xlsx to work with a local Excel file instead.",
+                    ],
+                )
+                sys.exit(1)
+            # Interactive mode: fall through with gspread_client=None; the
+            # while loop below will prompt for an Excel file instead.
+        else:
+            doc_list = google_api.get_all_spreadsheets(gspread_client)
 
     # Outer loop so 'top' can return to spreadsheet selection
     while True:
         try:
-            worksheet = select_worksheet(gspread_client, doc_list, args, cli_mode)
+            if gspread_client is None and not getattr(args, "spreadsheet", None):
+                import excel_io
+
+                worksheet = excel_io.prompt_for_excel_fallback()
+                if worksheet is None:
+                    sys.exit(0)
+                utils.standard_print("Using local Excel file.")
+            else:
+                worksheet = select_worksheet(gspread_client, doc_list, args, cli_mode)
 
             if getattr(args, "studio", False):
                 import server

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.61"
+VERSIONNUM: str = "0.10.62"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/excel_io.py
+++ b/excel_io.py
@@ -171,3 +171,85 @@ def select_excel_file() -> ExcelSheetAdapter | None:
             if Path(p).name == choice:
                 return open_excel_workbook(p)
         utils.info_print(f'No file named "{choice}". Enter an index or exact filename.')
+
+
+def _print_credentials_help() -> None:
+    """Print troubleshooting steps for setting up Google credentials."""
+    utils.info_print(
+        "Google Sheets access requires a 'credentials.json' file in the working directory."
+    )
+    utils.info_print(f"Working directory: {Path.cwd()}")
+    utils.info_print("Troubleshooting steps:")
+    utils.info_print("  1. Ensure 'credentials.json' exists in the working directory")
+    utils.info_print("  2. Verify the credentials file is valid JSON")
+    utils.info_print(
+        "  3. Check that the service account has access to Google Sheets API"
+    )
+    utils.info_print(
+        "  4. For OAuth flow, delete any existing token files and re-authenticate"
+    )
+
+
+def prompt_for_excel_fallback() -> ExcelSheetAdapter | None:
+    """Offer an Excel fallback when Google auth fails.
+
+    Lists .xlsx files in cwd and also accepts a pasted path, 'help' for
+    credentials troubleshooting, or an empty input to cancel. Returns the
+    opened ExcelSheetAdapter, or None if the user cancelled.
+    """
+    utils.info_print(
+        "No Google credentials available — you can work with a local Excel file instead."
+    )
+    paths = list_excel_in_cwd()
+    if paths:
+        utils.info_print("Excel files in current directory:")
+        for i, p in enumerate(paths, 1):
+            utils.info_print(f"  {i}. {Path(p).name}")
+    else:
+        utils.info_print("(No .xlsx files found in the current directory.)")
+
+    while True:
+        choice = utils.read_user_input(
+            "\nEnter an index, filename, path to a .xlsx file, "
+            "'help' for credentials setup tips, or Enter to cancel:\n>> "
+        ).strip()
+        if not choice:
+            return None
+        if choice.lower() == "help":
+            _print_credentials_help()
+            continue
+        if choice.isdigit() and paths:
+            idx = int(choice)
+            if 1 <= idx <= len(paths):
+                adapter = open_excel_workbook(paths[idx - 1])
+                if adapter is not None:
+                    return adapter
+                continue
+            utils.info_print(
+                f"Invalid index. Enter a number between 1 and {len(paths)}."
+            )
+            continue
+        # Exact filename match inside cwd.
+        matched = False
+        for p in paths:
+            if Path(p).name == choice:
+                adapter = open_excel_workbook(p)
+                if adapter is not None:
+                    return adapter
+                matched = True
+                break
+        if matched:
+            continue
+        # Treat as a path (absolute or relative to cwd).
+        candidate = Path(choice).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        if candidate.suffix.lower() != ".xlsx":
+            utils.info_print(
+                "Path must end in .xlsx. Try again, or press Enter to cancel."
+            )
+            continue
+        adapter = open_excel_workbook(str(candidate))
+        if adapter is not None:
+            return adapter
+        # open_excel_workbook already printed the error; loop for retry.

--- a/tests/test_google_and_excel_adapters.py
+++ b/tests/test_google_and_excel_adapters.py
@@ -77,3 +77,63 @@ def test_excel_sheet_adapter_basic_access(tmp_path, monkeypatch):
     row2 = adapter.row_values(2)
     assert "P01" in row2
     assert adapter.col_count >= 5
+
+
+def _make_workbook(path):
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = "ID"
+    wb.save(path)
+    wb.close()
+
+
+def test_prompt_for_excel_fallback_picks_by_index(tmp_path, monkeypatch):
+    wb_path = tmp_path / "alpha.xlsx"
+    _make_workbook(wb_path)
+    monkeypatch.chdir(tmp_path)
+
+    inputs = iter(["1"])
+    monkeypatch.setattr(excel_io.utils, "read_user_input", lambda _prompt: next(inputs))
+
+    adapter = excel_io.prompt_for_excel_fallback()
+    assert adapter is not None
+    assert adapter.spreadsheet.title == "alpha"
+
+
+def test_prompt_for_excel_fallback_accepts_path(tmp_path, monkeypatch):
+    # No .xlsx in cwd — user pastes an absolute path.
+    cwd = tmp_path / "empty"
+    cwd.mkdir()
+    elsewhere = tmp_path / "data" / "other.xlsx"
+    elsewhere.parent.mkdir()
+    _make_workbook(elsewhere)
+    monkeypatch.chdir(cwd)
+
+    inputs = iter([str(elsewhere)])
+    monkeypatch.setattr(excel_io.utils, "read_user_input", lambda _prompt: next(inputs))
+
+    adapter = excel_io.prompt_for_excel_fallback()
+    assert adapter is not None
+    assert adapter.spreadsheet.title == "other"
+
+
+def test_prompt_for_excel_fallback_cancel_returns_none(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    inputs = iter([""])
+    monkeypatch.setattr(excel_io.utils, "read_user_input", lambda _prompt: next(inputs))
+
+    assert excel_io.prompt_for_excel_fallback() is None
+
+
+def test_prompt_for_excel_fallback_help_then_cancel(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    inputs = iter(["help", ""])
+    monkeypatch.setattr(excel_io.utils, "read_user_input", lambda _prompt: next(inputs))
+
+    # 'help' should not exit the loop; subsequent empty input cancels.
+    assert excel_io.prompt_for_excel_fallback() is None


### PR DESCRIPTION
## Summary
- `authenticate_google()` returns `None` on failure instead of `sys.exit(1)`, and the exception catch now covers `FileNotFoundError`/`OSError` (common when `credentials.json` is missing).
- Interactive sessions without credentials now hit a new `excel_io.prompt_for_excel_fallback()` that lists `.xlsx` files in the working directory and also accepts a pasted path, `help` for credentials troubleshooting, or Enter to cancel.
- CLI mode or an explicit `-s` argument still exits on auth failure, but with a clearer hint pointing at `-s path/to/file.xlsx`; version bumped to 0.10.62 and four smoke tests cover the new prompt.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` (576 passing)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check`
- [ ] Manual: rename `credentials.json`, run `uv run clipgen.py` in a dir with an `.xlsx` — confirm fallback prompt opens the file
- [ ] Manual: same, but paste an absolute path to an `.xlsx` outside cwd
- [ ] Manual: `uv run clipgen.py -b` without credentials — confirm clear error + exit 1