### PR TITLE
refactor: single Ollama model path for summaries and citations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -238,7 +238,7 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         "--ollama-model",
         type=str,
         metavar="MODEL",
-        help="Ollama model name for transcript summaries (sets both small and large model, e.g. gemma3:4b)",
+        help="Ollama model for transcript summaries and citations (e.g. gemma3:4b)",
     )
 
     paths = parser.add_argument_group("spreadsheet & directories")
@@ -1324,7 +1324,6 @@ def _apply_config_overrides(args: Any, cli_mode: bool) -> CliModeArgs:
         config.TRANSCRIBE_MODEL = args.whisper_model
     if getattr(args, "ollama_model", None):
         config.OLLAMA_SUMMARY_MODEL = args.ollama_model
-        config.OLLAMA_SUMMARY_MODEL_LARGE = args.ollama_model
 
     return parse_cli_mode_args(args)
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.61"
+VERSIONNUM: str = "0.10.62"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -252,8 +252,7 @@ TRANSCRIBE_PREWARM: str = "queue_open"
 
 # ── Ollama (Local AI) ───────────────────────────────────────────────
 OLLAMA_SUMMARY_ENABLED: bool = True  # auto-generate transcript summaries via Ollama
-OLLAMA_SUMMARY_MODEL: str = "qwen3.5:0.8b"  # model for short transcripts
-OLLAMA_SUMMARY_MODEL_LARGE: str = "qwen3.5:9b"  # model for longer transcripts
+OLLAMA_SUMMARY_MODEL: str = "qwen3.5:9b"  # model for transcript summaries and citations
 OLLAMA_BASE_URL: str = "http://localhost:11434"  # Ollama server address
 
 # ── Rich Output ──────────────────────────────────────────────────────
@@ -287,8 +286,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "GALLERY_BUNDLE_ENABLED": "Embed gallery images as base64 data URIs in the HTML file, making it fully self-contained.",
     "CLIP_PARALLEL_WORKERS": "Number of concurrent ffmpeg processes for clip generation. 0 = auto, 1 = sequential.",
     "OLLAMA_SUMMARY_ENABLED": "Auto-generate AI summaries of transcripts using a local Ollama model.",
-    "OLLAMA_SUMMARY_MODEL": "Ollama model for short transcripts (fast, small).",
-    "OLLAMA_SUMMARY_MODEL_LARGE": "Ollama model for longer transcripts (slower, more capable).",
+    "OLLAMA_SUMMARY_MODEL": "Ollama model used for transcript summaries and citation linking.",
     "OLLAMA_BASE_URL": "Base URL of the local Ollama server.",
 }
 
@@ -353,11 +351,6 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
     },
     "OLLAMA_SUMMARY_ENABLED": {"group": "AI Summary", "type": "bool"},
     "OLLAMA_SUMMARY_MODEL": {
-        "group": "AI Summary",
-        "type": "model_select",
-        "provider": "ollama",
-    },
-    "OLLAMA_SUMMARY_MODEL_LARGE": {
         "group": "AI Summary",
         "type": "model_select",
         "provider": "ollama",

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -293,15 +293,12 @@ def test_whisper_model_applies_to_config(monkeypatch):
     config.TRANSCRIBE_MODEL = original
 
 
-def test_ollama_model_applies_to_both_config(monkeypatch):
+def test_ollama_model_applies_to_config(monkeypatch):
     import config
 
-    orig_small = config.OLLAMA_SUMMARY_MODEL
-    orig_large = config.OLLAMA_SUMMARY_MODEL_LARGE
+    original = config.OLLAMA_SUMMARY_MODEL
     monkeypatch.setattr("sys.argv", ["clipgen.py", "--ollama-model", "gemma3:4b"])
     args = cli.parse_arguments()
     cli._apply_config_overrides(args, cli_mode=True)
     assert config.OLLAMA_SUMMARY_MODEL == "gemma3:4b"
-    assert config.OLLAMA_SUMMARY_MODEL_LARGE == "gemma3:4b"
-    config.OLLAMA_SUMMARY_MODEL = orig_small
-    config.OLLAMA_SUMMARY_MODEL_LARGE = orig_large
+    config.OLLAMA_SUMMARY_MODEL = original

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -157,7 +157,7 @@ class TestGenerate:
         call_args = mock_urlopen.call_args
         req = call_args[0][0]
         body = json.loads(req.data.decode("utf-8"))
-        assert body["model"] == "qwen3.5:0.8b"
+        assert body["model"] == "qwen3.5:9b"
 
     @patch("ollama_client.urllib.request.urlopen")
     def test_uses_custom_model(self, mock_urlopen):

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1100,7 +1100,7 @@ def test_api_settings_includes_provider_field(client):
     resp = client.get("/studio/api/settings")
     data = resp.get_json()
     model_settings = [s for s in data["settings"] if s["type"] == "model_select"]
-    assert len(model_settings) >= 3  # TRANSCRIBE_MODEL + 2 OLLAMA models
+    assert len(model_settings) >= 2  # TRANSCRIBE_MODEL + OLLAMA_SUMMARY_MODEL
     for s in model_settings:
         assert "provider" in s
         assert s["provider"] in ("whisper", "ollama")

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -115,21 +115,13 @@ class TestSummarizeTranscript:
         assert mock_generate.call_args[1]["model"] == "llama3.1:8b"
 
     @patch("thinking_agents.ollama_client.generate")
-    def test_uses_small_model_for_short_text(self, mock_generate):
+    def test_uses_default_model_when_no_override(self, mock_generate):
         mock_generate.return_value = "ok"
         segments = [
             {
                 "text": "A sufficiently long segment of text for the minimum length check."
             },
         ]
-        thinking_agents.summarize_transcript(segments)
-        assert mock_generate.call_args[1]["model"] == "qwen3.5:0.8b"
-
-    @patch("thinking_agents.ollama_client.generate")
-    def test_uses_large_model_for_long_text(self, mock_generate):
-        mock_generate.return_value = "ok"
-        # Long text (over _LARGE_MODEL_THRESHOLD of 8000 chars)
-        segments = [{"text": "word " * 1700}]
         thinking_agents.summarize_transcript(segments)
         assert mock_generate.call_args[1]["model"] == "qwen3.5:9b"
 
@@ -241,7 +233,7 @@ class TestFindCitations:
         assert thinking_agents.find_citations("A summary.", []) is None
 
     @patch("thinking_agents.ollama_client.generate")
-    def test_always_uses_large_model(self, mock_generate):
+    def test_uses_default_model(self, mock_generate):
         mock_generate.return_value = "1: NONE"
         segments = [{"start": 0, "end": 5, "text": "Some text here"}]
         thinking_agents.find_citations("A summary sentence.", segments)

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -77,7 +77,6 @@ Transcript:
 {text}"""
 
 _MIN_TEXT_LENGTH = 50  # skip summarization for very short transcripts
-_LARGE_MODEL_THRESHOLD = 8000  # chars — use the larger model above this
 _MAX_TRANSCRIPT_CHARS = 6000  # truncate long transcripts to fit context window
 
 
@@ -97,19 +96,15 @@ def summarize_transcript(
 ) -> str | None:
     """Summarize transcript segments into a paragraph + bullet points.
 
-    Automatically selects between ``OLLAMA_SUMMARY_MODEL`` (short transcripts)
-    and ``OLLAMA_SUMMARY_MODEL_LARGE`` (long transcripts) unless an explicit
-    model override is provided.
+    Uses ``config.OLLAMA_SUMMARY_MODEL`` unless an explicit model override is
+    provided.
     """
     text = " ".join(seg.get("text", "").strip() for seg in segments).strip()
     if len(text) < _MIN_TEXT_LENGTH:
         return None
 
     if model is None:
-        if len(text) > _LARGE_MODEL_THRESHOLD:
-            model = config.OLLAMA_SUMMARY_MODEL_LARGE
-        else:
-            model = config.OLLAMA_SUMMARY_MODEL
+        model = config.OLLAMA_SUMMARY_MODEL
 
     text = _truncate_middle(text, _MAX_TRANSCRIPT_CHARS)
 
@@ -155,7 +150,7 @@ Format your response exactly as:
 Write NONE if no segments clearly support a claim."""
 
 _MAX_REFS_PER_CLAIM = 4  # hard cap enforced during parsing
-_MAX_CITATION_TRANSCRIPT_CHARS = 12000  # generous limit for 9B context window
+_MAX_CITATION_TRANSCRIPT_CHARS = 12000  # generous context-window limit
 
 _CITATION_LINE_RE = re.compile(r"^(\d+)\s*:\s*(.+)$", re.MULTILINE)
 _TIMESTAMP_RE = re.compile(r"(\d{1,2}:\d{2}(?::\d{2})?)")
@@ -268,7 +263,7 @@ def find_citations(
     if not sentences or not segments:
         return None
 
-    model = config.OLLAMA_SUMMARY_MODEL_LARGE
+    model = config.OLLAMA_SUMMARY_MODEL
 
     claims_text = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(sentences))
     transcript_text = _truncate_middle(


### PR DESCRIPTION
## Summary
- Drop the short/long auto-selection heuristic in `thinking_agents.py`; the small `qwen3.5:0.8b` branch was unreliable, so both summary and citation agents now use `config.OLLAMA_SUMMARY_MODEL` (user-picked in the Transcripts settings UI).
- Remove `OLLAMA_SUMMARY_MODEL_LARGE` (constant, description, `STUDIO_SETTINGS` entry), bump the default `OLLAMA_SUMMARY_MODEL` to `qwen3.5:9b`, simplify `--ollama-model` to set the single var, and bump `VERSIONNUM` to `0.10.62`.
- Update affected tests: collapse the short/long branching tests, rename the citations test, and fix two pre-existing assertions that depended on the removed defaults.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 571 passed
- [x] `uv run ruff check` and `uv run ruff format --check` clean
- [ ] Manual: open the Transcripts settings popover and confirm only one Ollama model dropdown appears; regenerate a summary + citations