### PR TITLE
feat: status light in transcripts header + shared tooltip helper

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -985,42 +985,6 @@ body {
   background: var(--color-warning, #f59e0b);
 }
 
-.scan-toggle-tooltip {
-  position: fixed;
-  padding: var(--space-1) var(--space-3);
-  background: var(--color-text);
-  color: var(--color-bg);
-  font-size: var(--text-xs);
-  font-weight: 400;
-  white-space: pre-line;
-  border-radius: var(--radius-sm);
-  pointer-events: none;
-  z-index: var(--z-float);
-  transform: translateX(-50%);
-  opacity: 0;
-  transition: opacity var(--duration-fast);
-}
-
-.scan-toggle-tooltip.visible {
-  opacity: 1;
-}
-
-.param-label-tooltip {
-  position: fixed;
-  padding: var(--space-1) var(--space-3);
-  background: var(--color-text);
-  color: var(--color-bg);
-  font-size: var(--text-xs);
-  font-weight: 400;
-  white-space: nowrap;
-  border-radius: var(--radius-sm);
-  pointer-events: none;
-  z-index: var(--z-float);
-  opacity: 0;
-  transition: opacity var(--duration-fast);
-}
-.param-label-tooltip.visible { opacity: 1; }
-
 .task-fast-badge {
   display: inline-flex;
   align-items: center;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -554,29 +554,20 @@
     icon.style.webkitMaskImage = url;
     btn.appendChild(icon);
 
-    var tip = el("div", "scan-toggle-tooltip");
-    document.body.appendChild(tip);
-
     function updateState() {
       var isFast = state.scanMode === "fast";
       btn.classList.toggle("active", isFast);
-      var label = isFast ? "Fast scan enabled" : "Enable fast scan";
-      var desc = FAST_SCAN_DESCRIPTIONS[state.activeWorkflow];
-      if (desc) label += "\n" + desc;
-      tip.textContent = label;
     }
     updateState();
     btn._updateScanState = updateState;
 
-    btn.addEventListener("mouseenter", function () {
-      var r = btn.getBoundingClientRect();
-      tip.style.left = (r.left + r.width / 2) + "px";
-      tip.style.top = (r.top - tip.offsetHeight - 6) + "px";
-      tip.classList.add("visible");
-    });
-    btn.addEventListener("mouseleave", function () {
-      tip.classList.remove("visible");
-    });
+    attachHoverTooltip(btn, function () {
+      var isFast = state.scanMode === "fast";
+      var label = isFast ? "Fast scan enabled" : "Enable fast scan";
+      var desc = FAST_SCAN_DESCRIPTIONS[state.activeWorkflow];
+      if (desc) label += "\n" + desc;
+      return label;
+    }, { align: "center", multiline: true });
 
     btn.addEventListener("click", function () {
       state.scanMode = state.scanMode === "fast" ? "normal" : "fast";
@@ -587,11 +578,10 @@
   }
 
   function initParamTooltips() {
-    var tip = el("div", "param-label-tooltip");
-    document.body.appendChild(tip);
-
     var container = qs("#workflowParams");
     if (!container) return;
+
+    var tooltip = createTooltip({ align: "center" });
 
     function getToolType(labelEl) {
       var stepCard = labelEl.closest(".multitool-step");
@@ -618,20 +608,12 @@
       var text = label.textContent.trim();
       var desc = getDescription(text, getToolType(label));
       if (!desc) return;
-
-      tip.textContent = desc;
-      var r = label.getBoundingClientRect();
-      tip.style.left = (r.left + r.width / 2) + "px";
-      tip.style.transform = "translateX(-50%)";
-      // Position above; flip below if clipped
-      var above = r.top - tip.offsetHeight - 6;
-      tip.style.top = (above < 0 ? r.bottom + 6 : above) + "px";
-      tip.classList.add("visible");
+      tooltip.show(label, desc);
     }, true);
 
     container.addEventListener("mouseleave", function (e) {
       if (e.target.closest && e.target.closest(".param-label")) {
-        tip.classList.remove("visible");
+        tooltip.hide();
       }
     }, true);
   }

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -236,3 +236,37 @@ html[data-theme="dark"] {
   -webkit-mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
+
+/* ---- Components ---- */
+
+/* Visually-hidden text (keeps content in the a11y tree) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Shared dark-pill hover tooltip. Pair with createTooltip/attachHoverTooltip in utils.js. */
+.cg-tooltip {
+  position: fixed;
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-text);
+  color: var(--color-bg);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  white-space: nowrap;
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  z-index: var(--z-float);
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+.cg-tooltip.is-visible { opacity: 1; }
+.cg-tooltip--centered { transform: translateX(-50%); }
+.cg-tooltip--multiline { white-space: pre-line; }

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -106,18 +106,31 @@ body {
   color: var(--color-text);
 }
 
-.transcript-status {
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
-  color: var(--color-text-dim);
+.status-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-text-dim);
+  cursor: default;
+  transition: background var(--duration-fast);
 }
-
-.tr-model-hint {
-  font-size: var(--text-xs);
-  color: var(--color-text-dim);
-  max-width: 14rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.status-indicator:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.status-indicator--ready { background: var(--sev-very-positive); }
+.status-indicator--error { background: var(--sev-critical); }
+.status-indicator--working {
+  background: #a855f7;
+  animation: status-pulse 1s ease-in-out infinite;
+}
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .status-indicator--working { animation: none; }
 }
 
 /* Buttons */
@@ -1026,10 +1039,6 @@ body {
 
 .queue-item-action {
   margin-top: var(--space-1);
-}
-
-.transcript-stale {
-  color: #f59e0b;
 }
 
 .queue-stale-badge {

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -19,8 +19,8 @@
           Source
           <select id="participantSelect"><option value="">No participants</option></select>
         </label>
-        <span id="transcriptStatus" class="transcript-status"></span>
-        <span id="trModelHint" class="tr-model-hint hidden" aria-live="polite"></span>
+        <span id="trStatusIndicator" class="status-indicator" tabindex="0" role="status" aria-label="Transcription status"></span>
+        <span id="trStatusSr" class="sr-only" aria-live="polite"></span>
         <button id="queueBtn" type="button" class="btn btn-small">Queue</button>
         <button id="correctionsBtn" type="button" class="btn btn-small">Corrections</button>
         <button id="trSettingsBtn" type="button" class="btn btn-small btn-icon" title="AI Model Settings">

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -35,11 +35,14 @@
     summaryCitations: null,
     citationsGenerating: false,
     transcribePrewarm: "queue_open",
+    modelStatus: null,
+    modelFailSince: 0,
   };
 
   var _transcriptionWarmupPosted = false;
   var _modelHintPollTimer = null;
   var _hadActiveTranscriptionLastPoll = false;
+  var MODEL_FAIL_GRACE_MS = 10000;
 
   // ---- Helpers (showToast: 2500ms hide; shared default in utils.js is 3000ms) ----
 
@@ -245,39 +248,131 @@
     return false;
   }
 
-  function hasActiveTranscriptionTasks() {
-    for (var i = 0; i < state.tasks.length; i++) {
-      var st = state.tasks[i].status;
-      if (st === "queued" || st === "running") return true;
+  function applyTranscriptionModelHint(data) {
+    if (!data || !data.ok) return;
+    state.modelStatus = data;
+    // Track how long we've been in an apparent "failed to load" state, so
+    // the indicator doesn't flash red on cold load before the first response.
+    var looksFailed = !data.loaded && !data.warming && data.prewarm !== "off";
+    if (looksFailed) {
+      if (state.modelFailSince === 0) state.modelFailSince = Date.now();
+    } else {
+      state.modelFailSince = 0;
     }
-    return false;
+    updateStatusIndicator();
   }
 
-  function applyTranscriptionModelHint(data) {
-    var el = qs("#trModelHint");
-    if (!el || !data || !data.ok) return;
-    if (hasActiveTranscriptionTasks()) {
-      el.textContent = "";
-      el.classList.add("hidden");
-      return;
+  // ---- Status indicator ----
+
+  function _taskForSelectedParticipant() {
+    var pid = state.selectedParticipant;
+    if (!pid) return null;
+    var latest = null;
+    for (var i = 0; i < state.tasks.length; i++) {
+      var t = state.tasks[i];
+      if (t.participant !== pid) continue;
+      // Priority: running > queued > failed > completed/cancelled > stale
+      if (!latest) { latest = t; continue; }
+      var order = { running: 5, queued: 4, failed: 3, completed: 2, cancelled: 1 };
+      if ((order[t.status] || 0) > (order[latest.status] || 0)) latest = t;
     }
-    if (data.prewarm === "off") {
-      el.textContent = "";
-      el.classList.add("hidden");
-      return;
+    return latest;
+  }
+
+  function _selectedParticipantRow() {
+    var pid = state.selectedParticipant;
+    if (!pid) return null;
+    for (var i = 0; i < state.participants.length; i++) {
+      if (state.participants[i].id === pid) return state.participants[i];
     }
-    if (data.loaded) {
-      el.textContent = "Transcription model ready";
-      el.classList.remove("hidden");
-      return;
+    return null;
+  }
+
+  function _modelLine() {
+    var ms = state.modelStatus;
+    if (!ms) return "Model: loading\u2026";
+    if (ms.loaded) return "Model: ready" + (ms.model ? " \u00B7 " + ms.model : "");
+    if (ms.warming) return "Model: loading\u2026";
+    if (ms.prewarm === "off") return "Model: idle (loads on demand)";
+    if (state.modelFailSince && Date.now() - state.modelFailSince >= MODEL_FAIL_GRACE_MS) {
+      return "Model: failed to load";
     }
-    if (data.warming) {
-      el.textContent = "Transcription model loading\u2026";
-      el.classList.remove("hidden");
-      return;
+    return "Model: not loaded";
+  }
+
+  function _modelHasFailed() {
+    var ms = state.modelStatus;
+    if (!ms) return false;
+    if (ms.loaded || ms.warming) return false;
+    if (ms.prewarm === "off") return false;
+    return state.modelFailSince > 0 && Date.now() - state.modelFailSince >= MODEL_FAIL_GRACE_MS;
+  }
+
+  function computeIndicatorState() {
+    var pid = state.selectedParticipant;
+    var task = _taskForSelectedParticipant();
+    var row = _selectedParticipantRow();
+    var cls = "status-indicator--ready";
+    var taskLine;
+
+    if (!pid) {
+      taskLine = "No participant selected";
+    } else if (task && task.status === "running") {
+      cls = "status-indicator--working";
+      var pct = Math.round((task.progress || 0) * 100);
+      taskLine = pid + ": transcribing\u2026 " + pct + "%";
+    } else if (task && task.status === "queued") {
+      cls = "status-indicator--working";
+      taskLine = pid + ": queued";
+    } else if (task && task.status === "failed") {
+      cls = "status-indicator--error";
+      taskLine = pid + ": transcription failed" + (task.error ? " (" + task.error + ")" : "");
+    } else if (row && row.has_transcript) {
+      taskLine = pid + ": " + (row.segment_count || 0) + " segments";
+      if (row.has_stale_artifacts) taskLine += " \u00B7 artifacts outdated";
+    } else if (row && row.has_video) {
+      taskLine = pid + ": not transcribed";
+    } else {
+      taskLine = pid + ": no source video";
     }
-    el.textContent = "";
-    el.classList.add("hidden");
+
+    // Model failure overrides non-task-active states (keep working class if a
+    // task is currently running — the user can see the task is progressing).
+    if (cls !== "status-indicator--working" && _modelHasFailed()) {
+      cls = "status-indicator--error";
+    }
+
+    var lines = [_modelLine(), taskLine];
+    var ariaLabel;
+    if (cls === "status-indicator--working") ariaLabel = taskLine;
+    else if (cls === "status-indicator--error") ariaLabel = lines.join(" \u2014 ");
+    else ariaLabel = "Ready \u2014 " + taskLine;
+
+    return { cls: cls, ariaLabel: ariaLabel, lines: lines };
+  }
+
+  function updateStatusIndicator() {
+    var indicator = qs("#trStatusIndicator");
+    if (!indicator) return;
+    var s = computeIndicatorState();
+    indicator.classList.remove(
+      "status-indicator--ready",
+      "status-indicator--error",
+      "status-indicator--working"
+    );
+    indicator.classList.add(s.cls);
+    indicator.setAttribute("aria-label", s.ariaLabel);
+    var sr = qs("#trStatusSr");
+    if (sr) sr.textContent = s.lines.join(" \u2014 ");
+  }
+
+  function initStatusIndicatorTooltip() {
+    var indicator = qs("#trStatusIndicator");
+    if (!indicator) return;
+    attachHoverTooltip(indicator, function () {
+      return computeIndicatorState().lines.join("\n");
+    }, { multiline: true, align: "center" });
+    updateStatusIndicator();
   }
 
   function refreshTranscriptionModelHintOnce() {
@@ -443,32 +538,14 @@
       videoEmpty.classList.remove("hidden");
     }
 
-    // Update status
-    var statusEl = qs("#transcriptStatus");
     var taskForPid = null;
     state.tasks.forEach(function (t) {
       if (t.participant === pid && (t.status === "running" || t.status === "queued")) {
         taskForPid = t;
       }
     });
-    if (p.has_transcript) {
-      statusEl.textContent = p.segment_count + " segments";
-      if (p.has_stale_artifacts) {
-        statusEl.textContent += " \u2022 artifacts outdated";
-        statusEl.classList.add("transcript-stale");
-      } else {
-        statusEl.classList.remove("transcript-stale");
-      }
-    } else if (taskForPid && taskForPid.status === "running") {
-      statusEl.textContent = "transcribing\u2026 " + Math.round((taskForPid.progress || 0) * 100) + "%";
-      statusEl.classList.remove("transcript-stale");
-    } else if (taskForPid && taskForPid.status === "queued") {
-      statusEl.textContent = "queued";
-      statusEl.classList.remove("transcript-stale");
-    } else {
-      statusEl.textContent = "not transcribed";
-      statusEl.classList.remove("transcript-stale");
-    }
+
+    updateStatusIndicator();
 
     // Load transcript
     if (p.has_transcript) {
@@ -1966,6 +2043,11 @@
       if (!data.ok) return;
       state.tasks = data.tasks;
 
+      // Re-render the status circle immediately so completed tasks reflect
+      // before the async loadParticipants()/loadTranscript() chain resolves.
+      // This is what keeps the indicator from freezing at "95%".
+      updateStatusIndicator();
+
       // Stream partial segments for the selected participant's running task
       var selectedRunningTask = null;
       if (state.selectedParticipant) {
@@ -1979,9 +2061,6 @@
         renderPartialSegments(selectedRunningTask.partial_segments, selectedRunningTask.progress);
         state.streamingParticipant = state.selectedParticipant;
         _loadStreamingMarks(state.selectedParticipant);
-        // Update status text
-        var statusEl = qs("#transcriptStatus");
-        if (statusEl) statusEl.textContent = "transcribing\u2026 " + Math.round(selectedRunningTask.progress * 100) + "%";
       } else if (state.streamingParticipant) {
         state.streamingParticipant = null;
       }
@@ -2007,6 +2086,7 @@
             loadTranscript(state.selectedParticipant);
             loadSummary(state.selectedParticipant);
           }
+          updateStatusIndicator();
         });
       }
 
@@ -2017,14 +2097,8 @@
         _refreshedCompletedPids = {};
       }
 
-      var hintEl = qs("#trModelHint");
-      if (hintEl) {
-        if (hasActive) {
-          hintEl.textContent = "";
-          hintEl.classList.add("hidden");
-        } else if (_hadActiveTranscriptionLastPoll) {
-          refreshTranscriptionModelHintOnce();
-        }
+      if (!hasActive && _hadActiveTranscriptionLastPoll) {
+        refreshTranscriptionModelHintOnce();
       }
       _hadActiveTranscriptionLastPoll = hasActive;
 
@@ -2420,6 +2494,7 @@
   document.addEventListener("DOMContentLoaded", function () {
     initThemeToggle();
     initTooltipToggle();
+    initStatusIndicatorTooltip();
     checkNavLinks();
     initSearch();
     initQueuePanel();

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -20,6 +20,47 @@ var el = function (tag, cls, text) {
   return e;
 };
 
+// ---- Hover tooltips (dark pill, pairs with .cg-tooltip in tokens.css) ----
+
+var createTooltip = function (opts) {
+  opts = opts || {};
+  var cls = "cg-tooltip";
+  if (opts.multiline) cls += " cg-tooltip--multiline";
+  if (opts.align === "center") cls += " cg-tooltip--centered";
+  var tip = document.createElement("div");
+  tip.className = cls;
+  document.body.appendChild(tip);
+  return {
+    el: tip,
+    show: function (anchor, text) {
+      tip.textContent = text || "";
+      var r = anchor.getBoundingClientRect();
+      // Set text before measuring so offsetHeight reflects final size.
+      var x = opts.align === "center" ? r.left + r.width / 2 : r.left;
+      var above = r.top - tip.offsetHeight - 6;
+      tip.style.left = x + "px";
+      tip.style.top = (above < 0 ? r.bottom + 6 : above) + "px";
+      tip.classList.add("is-visible");
+    },
+    hide: function () {
+      tip.classList.remove("is-visible");
+    },
+  };
+};
+
+var attachHoverTooltip = function (anchor, getText, opts) {
+  var t = createTooltip(opts);
+  var show = function () {
+    var text = typeof getText === "function" ? getText() : getText;
+    if (text) t.show(anchor, text);
+  };
+  anchor.addEventListener("mouseenter", show);
+  anchor.addEventListener("focus", show);
+  anchor.addEventListener("mouseleave", t.hide);
+  anchor.addEventListener("blur", t.hide);
+  return t;
+};
+
 // ---- Formatting ----
 
 var pad2 = function (n) { return n < 10 ? "0" + n : "" + n; };

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.62"
+VERSIONNUM: str = "0.10.63"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Replace the two text-based status indicators in the transcripts header with a single colored circle (green = ready/transcribed, red = model/task failed, purple pulsing = running/queued), scoped to the selected participant. Full model + task status is surfaced in a hover tooltip.
- Extract the dark-pill tooltip pattern from Screenspace into a shared `.cg-tooltip` component (`tokens.css`) with `createTooltip` / `attachHoverTooltip` helpers (`utils.js`); rewire Screenspace's fast-scan and param-label tooltips onto it and delete the duplicate CSS. The shared helper also fires on keyboard focus.
- Fix the bug where the header froze at "transcribing… 95%" after a task completed: `pollTaskStatus` now updates the indicator immediately when `state.tasks` changes, so the circle flips purple→green within one poll tick without waiting on the async `loadParticipants()` chain.
- Bump `VERSIONNUM` to 0.10.63.

## Test plan

- [ ] `uv run --extra dev pytest -c tests/pytest.ini` — 575 tests pass
- [ ] `uv run ruff check` / `uv run ruff format --check` — clean
- [ ] Open `/transcripts/`, queue a transcription, confirm the circle turns purple-pulsing, ticks through % in the tooltip, and flips to green within one 3s poll of completion (no 95% freeze)
- [ ] Hover and tab-focus the circle — tooltip shows model + task lines in both cases
- [ ] Open `/screenspace/` — fast-scan toggle and param-label hovers still show the same dark-pill tooltip
- [ ] Enable `prefers-reduced-motion` — purple circle stops pulsing