### PR TITLE
feat: NOT operator for Screenspace Multitool

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1229,6 +1229,72 @@ body {
   display: none;
 }
 
+.multitool-operator-row {
+  display: flex;
+  align-items: center;
+}
+
+.multitool-operator-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-left: var(--space-3);
+}
+
+.multitool-operator-line {
+  width: 2px;
+  height: var(--space-2);
+  background: var(--color-border);
+}
+
+.multitool-operator-btn {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text-dim);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--duration-fast),
+              border-color var(--duration-fast),
+              background var(--duration-fast);
+}
+
+.multitool-operator-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-accent);
+  background: var(--color-surface-hover);
+}
+
+.multitool-operator-btn.is-not {
+  color: var(--sev-high);
+  border-color: var(--sev-high);
+}
+
+.multitool-operator-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-color: currentColor;
+  -webkit-mask-image: url("/screenspace/icons/plus.svg");
+          mask-image: url("/screenspace/icons/plus.svg");
+  -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+          mask-size: contain;
+  -webkit-mask-position: center;
+          mask-position: center;
+}
+
+.multitool-operator-btn.is-not .multitool-operator-icon {
+  -webkit-mask-image: url("/screenspace/icons/no-symbol.svg");
+          mask-image: url("/screenspace/icons/no-symbol.svg");
+}
+
 .multitool-add-row {
   display: flex;
   align-items: center;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2686,7 +2686,7 @@
     var allowed = MULTITOOL_ALLOWED_TYPES.some(function (t) { return t.value === type; });
     if (!allowed) return null;
     var params = task.parameters || {};
-    var step = { type: type, collapsed: false };
+    var step = { type: type, collapsed: false, logic: "AND" };
     if (task.region) step.region = task.region;
     if (params.reference_timestamp !== undefined) step._refTs = params.reference_timestamp;
     if (params.scene_references) step._scenes = params.scene_references.map(function (ref) {
@@ -2733,6 +2733,31 @@
   function renderMultitoolParams(container) {
     var stepsDiv = el("div", "multitool-steps");
     state.multitoolSteps.forEach(function (step, idx) {
+      if (idx > 0) {
+        var opRow = el("div", "multitool-operator-row");
+        var rail = el("div", "multitool-operator-rail");
+        rail.appendChild(el("div", "multitool-operator-line"));
+        var opBtn = el("button", "multitool-operator-btn");
+        opBtn.type = "button";
+        var current = (step.logic || "AND").toUpperCase();
+        opBtn.classList.add(current === "NOT" ? "is-not" : "is-and");
+        opBtn.title = current === "NOT"
+          ? "NOT — frame rejected if this matches (click to switch to AND)"
+          : "AND — frame must also match (click to switch to NOT)";
+        opBtn.appendChild(el("span", "multitool-operator-icon"));
+        (function (capturedIdx) {
+          opBtn.addEventListener("click", function (e) {
+            e.stopPropagation();
+            var s = state.multitoolSteps[capturedIdx];
+            s.logic = (s.logic || "AND").toUpperCase() === "NOT" ? "AND" : "NOT";
+            renderWorkflowParams();
+          });
+        })(idx);
+        rail.appendChild(opBtn);
+        rail.appendChild(el("div", "multitool-operator-line"));
+        opRow.appendChild(rail);
+        stepsDiv.appendChild(opRow);
+      }
       var card = el("div", "multitool-step");
       card.dataset.stepIdx = String(idx);
       var header = el("div", "multitool-step-header");
@@ -2865,7 +2890,7 @@
     var addBtn = el("button", "btn btn-small", "+ Add Step");
     addBtn.addEventListener("click", function () {
       var chosen = sel.value;
-      state.multitoolSteps.push({ type: chosen, collapsed: false });
+      state.multitoolSteps.push({ type: chosen, collapsed: false, logic: "AND" });
       renderWorkflowParams();
       updateRunButton();
     });
@@ -3999,6 +4024,9 @@
         var stepP = gatherMultitoolStepParams(state.multitoolSteps[i].type, i);
         if (stepP === null) return null;
         stepP.type = state.multitoolSteps[i].type;
+        if (i > 0) {
+          stepP.logic = (state.multitoolSteps[i].logic || "AND").toUpperCase();
+        }
         params.steps.push(stepP);
       }
       params.interval = parseFloat((qs("#paramMultitoolInterval") || {}).value) || 1.0;
@@ -4707,6 +4735,7 @@
       var mtParams = task.parameters || {};
       state.multitoolSteps = (mtParams.steps || []).map(function (s) {
         var step = { type: s.type, collapsed: true };
+        step.logic = (s.logic || "AND").toUpperCase();
         if (s.region) step.region = s.region;
         if (s.reference_timestamp !== undefined) step._refTs = s.reference_timestamp;
         if (s.scene_references) step._scenes = s.scene_references.map(function (ref) {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.65"
+VERSIONNUM: str = "0.10.66"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace.py
+++ b/screenspace.py
@@ -2078,26 +2078,37 @@ def scan_multitool(
             return False
 
         step_results: list[dict[str, Any]] = []
+        chain_ok = True
         for i, step in enumerate(steps):
             passed, rd = check_frame_for_tool(
                 frame, prev_frame[0], step_regions[i], step["type"], step
             )
-            if not passed or rd is None:
-                break
-            step_results.append(rd)
+            logic = (step.get("logic") or "AND").upper() if i > 0 else "AND"
+            if logic == "NOT":
+                if passed:
+                    chain_ok = False
+                    break
+                step_results.append({"negated": True, "type": step["type"]})
+            else:
+                if not passed or rd is None:
+                    chain_ok = False
+                    break
+                step_results.append(rd)
 
         prev_frame[0] = frame
 
-        if len(step_results) == len(steps):
-            confidences = [
-                _extract_confidence(steps[i]["type"], sr)
-                for i, sr in enumerate(step_results)
-            ]
+        if chain_ok and len(step_results) == len(steps):
+            confidences = []
+            for i, sr in enumerate(step_results):
+                logic = (steps[i].get("logic") or "AND").upper() if i > 0 else "AND"
+                if logic == "NOT":
+                    continue
+                confidences.append(_extract_confidence(steps[i]["type"], sr))
             rd = {
                 "timestamp": round(ts, 2),
                 "tool_types": tool_types,
                 "steps": step_results,
-                "min_confidence": round(min(confidences), 4),
+                "min_confidence": round(min(confidences), 4) if confidences else 1.0,
             }
             results.append(rd)
             if on_result:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -759,6 +759,11 @@ def _validate_task_request(
                 return jsonify(
                     {"ok": False, "error": f"Step {i}: invalid type '{stype}'"}
                 ), 400
+            logic = step_v.get("logic")
+            if logic is not None and logic not in ("AND", "NOT"):
+                return jsonify(
+                    {"ok": False, "error": f"Step {i}: logic must be 'AND' or 'NOT'"}
+                ), 400
 
     # Build combined region lookup dict (active + stashes)
     all_known_regions: dict[str, Any] = dict(_manifest.get("regions", {}))

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1242,6 +1242,70 @@ class TestScanMultitool:
                 steps=[{"type": "color"}],
             )
 
+    @staticmethod
+    def _setup_stubs(monkeypatch, check_fn):
+        monkeypatch.setattr(screenspace, "_probe_video_meta", lambda _p: (30.0, 10.0))
+
+        def fake_scan(
+            video_path,
+            interval_seconds,
+            callback,
+            *,
+            start_seconds=0.0,
+            end_seconds=None,
+            fps=0.0,
+            duration=0.0,
+            fast_opts=None,
+        ):
+            frame = np.zeros((10, 10, 3), dtype=np.uint8)
+            callback(1.0, frame)
+
+        monkeypatch.setattr(screenspace, "scan_video_full_frames", fake_scan)
+        monkeypatch.setattr(screenspace, "check_frame_for_tool", check_fn)
+
+    def test_not_operator_rejects_when_negated_match(self, monkeypatch):
+        def check(frame, prev, region, ttype, step):
+            return True, {"_confidence": 0.9}
+
+        self._setup_stubs(monkeypatch, check)
+        results = screenspace.scan_multitool(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            steps=[{"type": "color"}, {"type": "change", "logic": "NOT"}],
+        )
+        assert results == []
+
+    def test_not_operator_passes_when_negated_misses(self, monkeypatch):
+        def check(frame, prev, region, ttype, step):
+            if ttype == "color":
+                return True, {"_confidence": 0.8}
+            return False, None
+
+        self._setup_stubs(monkeypatch, check)
+        results = screenspace.scan_multitool(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            steps=[{"type": "color"}, {"type": "change", "logic": "NOT"}],
+        )
+        assert len(results) == 1
+        assert results[0]["steps"][1] == {"negated": True, "type": "change"}
+        assert results[0]["min_confidence"] == 0.8
+
+    def test_and_default_when_logic_missing(self, monkeypatch):
+        def check(frame, prev, region, ttype, step):
+            if ttype == "color":
+                return True, {"_confidence": 0.7}
+            return True, {"magnitude": 0.5}
+
+        self._setup_stubs(monkeypatch, check)
+        results = screenspace.scan_multitool(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            steps=[{"type": "color"}, {"type": "change"}],
+        )
+        assert len(results) == 1
+        assert results[0]["min_confidence"] == 0.5
+
 
 # ---------------------------------------------------------------------------
 # Fast Scan mode

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -837,6 +837,27 @@ def test_create_multitool_task_invalid_step_type(client):
     assert "invalid type" in data["error"]
 
 
+def test_create_multitool_task_invalid_step_logic(client):
+    _create_region(client, "healthbar")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "multitool",
+            "participant": "P01",
+            "region": "healthbar",
+            "parameters": {
+                "steps": [
+                    {"type": "color", "region": "healthbar"},
+                    {"type": "change", "region": "healthbar", "logic": "MAYBE"},
+                ]
+            },
+        },
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "logic must be" in data["error"]
+
+
 def test_create_multitool_task_no_steps(client):
     _create_region(client, "healthbar")
     resp = client.post(


### PR DESCRIPTION
## Summary
- Adds a per-pair AND/NOT toggle between chained tool cards in the Screenspace Multitool. NOT rejects the frame if the underlying tool matches above threshold; tools still run sequentially, so mixing AND and NOT in one chain (e.g. `A AND B NOT C`) works as expected.
- Frontend: icon-only circular button rendered in a left-side rail between cards, flanked by short vertical connector lines to visualize the logical flow; toggles `plus.svg` ↔ `no-symbol.svg` on click and persists through save/reload.
- Backend: `scan_multitool` branches on each step's `logic` field (default `"AND"`, first step ignored); negated steps record a `{"negated": True, "type": …}` placeholder and are excluded from `min_confidence`. Validator rejects `logic` values other than `"AND"` / `"NOT"`.

## Test plan
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` (full suite green locally, including new multitool cases)
- [ ] Launch `uv run clipgen.py --screenspace -i DIR -o DIR`, build `Color → Change → Template`, toggle middle operator to NOT, run on a clip and confirm frames where Change matches are excluded
- [ ] Reload the task and verify NOT state persists in `screenspace_manifest.json`