### PR TITLE
feat: two-column Screenspace bottom with breadcrumb-tab Queue/Results

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1728,7 +1728,7 @@ body {
   box-shadow: var(--shadow-xl);
   padding: var(--space-3) var(--space-5) var(--space-5);
   display: grid;
-  grid-template-columns: 1.2fr 1fr 1fr;
+  grid-template-columns: 1.2fr 1fr;
   gap: var(--space-5);
   flex-shrink: 0;
   margin-bottom: var(--space-5);
@@ -1742,6 +1742,204 @@ body {
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Right pane: tabbed Task Queue + Results */
+
+#rightPane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#rightPaneTabs {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-2);
+}
+
+.rp-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: none;
+  border: none;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  transition: color var(--duration-fast);
+}
+
+.rp-tab:hover {
+  color: var(--color-text);
+}
+
+.rp-tab.active {
+  color: var(--color-text);
+}
+
+.rp-tab-sep {
+  color: var(--color-text-dim);
+  opacity: 0.5;
+  user-select: none;
+  font-size: var(--text-base);
+}
+
+.rp-tab-icon {
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-position: center;
+  flex-shrink: 0;
+}
+
+.rp-tab-icon-queue {
+  mask-image: url("/screenspace/icons/queue-list.svg");
+  -webkit-mask-image: url("/screenspace/icons/queue-list.svg");
+}
+
+.rp-tab-icon-results {
+  mask-image: url("/screenspace/icons/chart-bar.svg");
+  -webkit-mask-image: url("/screenspace/icons/chart-bar.svg");
+}
+
+.rp-tab-chevron {
+  width: 12px;
+  height: 12px;
+  background: currentColor;
+  mask-image: url("/screenspace/icons/chevron-down.svg");
+  -webkit-mask-image: url("/screenspace/icons/chevron-down.svg");
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  opacity: 0;
+  transition: opacity var(--duration-fast), transform var(--duration-fast);
+  flex-shrink: 0;
+}
+
+.rp-tab.active[data-tab="results"] .rp-tab-chevron {
+  opacity: 0.7;
+}
+
+.rp-tab.active[data-tab="results"].switcher-open .rp-tab-chevron {
+  transform: rotate(180deg);
+}
+
+.rp-tab-count,
+.rp-tab-crumb {
+  color: var(--color-text-dim);
+  font-weight: 400;
+  font-size: var(--text-sm);
+}
+
+.rp-tab-crumb:empty {
+  display: none;
+}
+
+.rp-tab-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.rp-tab-actions.hidden {
+  display: none;
+}
+
+.rp-switcher-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  transform: translateX(-50%);
+  min-width: 240px;
+  max-height: 14rem;
+  overflow-y: auto;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-1);
+  z-index: 50;
+}
+
+.rp-switcher-panel.hidden {
+  display: none;
+}
+
+.rp-switcher-empty {
+  padding: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  text-align: center;
+}
+
+.rp-switcher-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  color: var(--color-text);
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+
+.rp-switcher-item:hover {
+  background: var(--color-surface-alt);
+}
+
+.rp-switcher-item.active {
+  background: var(--color-selected);
+}
+
+.rp-switcher-item-badge {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.rp-switcher-item-meta {
+  color: var(--color-text-dim);
+  margin-left: auto;
+}
+
+#rightPaneBody {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rp-tab-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rp-tab-panel.hidden {
+  display: none;
 }
 
 .panel-header {
@@ -2094,25 +2292,101 @@ body {
   color: var(--color-text);
 }
 
-.results-toggle {
-  display: flex;
+/* Compact icon button for right-pane results actions */
+.rp-icon-btn {
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
-  font-size: var(--text-xs);
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
   color: var(--color-text-dim);
+  cursor: pointer;
+  transition: background var(--duration-fast), color var(--duration-fast);
+}
+
+.rp-icon-btn:hover {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-accent);
+}
+
+.rp-icon-btn.active {
+  color: var(--color-accent);
+}
+
+.rp-icon-btn.hidden {
+  display: none;
+}
+
+.rp-icon-btn-icon {
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-position: center;
+  display: inline-block;
+}
+
+.rp-icon-eye {
+  mask-image: url("/screenspace/icons/eye.svg");
+  -webkit-mask-image: url("/screenspace/icons/eye.svg");
+}
+
+.rp-icon-eye-slash {
+  mask-image: url("/screenspace/icons/eye-slash.svg");
+  -webkit-mask-image: url("/screenspace/icons/eye-slash.svg");
+}
+
+.rp-icon-scissors {
+  mask-image: url("/screenspace/icons/scissors.svg");
+  -webkit-mask-image: url("/screenspace/icons/scissors.svg");
+}
+
+/* Certainty slider wrapper */
+.rp-certainty-wrap {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-1);
+}
+
+.rp-certainty-wrap.hidden {
+  display: none;
+}
+
+.rp-certainty-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 34px;
+  height: 4px;
+  background: var(--color-border);
+  border-radius: 2px;
+  cursor: pointer;
+  outline: none;
+}
+
+.rp-certainty-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: none;
   cursor: pointer;
 }
 
-.results-certainty-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  font-size: var(--text-xs);
-  color: var(--color-text-dim);
-}
-
-.results-certainty-slider {
-  width: 60px;
+.rp-certainty-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: none;
+  cursor: pointer;
 }
 
 .result-timestamp {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -158,30 +158,49 @@
         </div>
       </div>
     </section>
-    <div id="taskQueuePanel">
-      <div class="panel-header">
-        <h3>Task Queue <span id="taskCount">(0)</span></h3>
-        <div class="panel-header-actions">
+    <div id="rightPane">
+      <div id="rightPaneTabs">
+        <button class="rp-tab active" data-tab="queue" type="button">
+          <span class="rp-tab-icon rp-tab-icon-queue"></span>
+          <span class="rp-tab-label">Task Queue</span>
+          <span class="rp-tab-count" id="taskCount">(0)</span>
+        </button>
+        <span class="rp-tab-sep">/</span>
+        <button class="rp-tab" data-tab="results" type="button">
+          <span class="rp-tab-icon rp-tab-icon-results"></span>
+          <span class="rp-tab-label">Results</span>
+          <span class="rp-tab-crumb" id="resultsTabCrumb"></span>
+          <span class="rp-tab-chevron"></span>
+        </button>
+        <div class="rp-tab-actions" data-for="queue">
           <button id="taskFilterDoneBtn" class="panel-header-btn task-filter-btn" title="Show completed" data-filter="completed"></button>
           <button id="taskFilterFailedBtn" class="panel-header-btn task-filter-btn" title="Show failed" data-filter="failed"></button>
           <button id="taskQueuePauseBtn" class="panel-header-btn" title="Pause queue"></button>
         </div>
-      </div>
-      <div id="taskList">
-        <div class="panel-empty">No tasks yet. Configure a workflow and click Run.</div>
-      </div>
-    </div>
-    <div id="resultsPanel">
-      <div class="panel-header">
-        <h3>Results <span id="resultCount"></span></h3>
-        <div id="resultsActions" class="hidden">
-          <label id="showExcludedToggle" class="results-toggle"><input type="checkbox" id="showExcludedCb" checked> Show excluded</label>
-          <label id="certaintyCutoffLabel" class="results-certainty-label hidden">Certainty <input type="range" id="certaintyCutoff" min="0" max="100" value="0" step="1" class="results-certainty-slider"><span id="certaintyCutoffVal">0%</span></label>
-          <button id="excludeNonVisibleBtn" class="btn btn-small hidden">Exclude Hidden</button>
+        <div class="rp-tab-actions hidden" data-for="results" id="resultsActions">
+          <div id="certaintyCutoffWrap" class="rp-certainty-wrap hidden">
+            <input type="range" id="certaintyCutoff" min="0" max="100" value="0" step="1" class="rp-certainty-slider">
+          </div>
+          <button id="showExcludedBtn" class="rp-icon-btn active" type="button" aria-label="Show excluded">
+            <span class="rp-icon-btn-icon rp-icon-eye"></span>
+          </button>
+          <button id="excludeNonVisibleBtn" class="rp-icon-btn hidden" type="button" aria-label="Exclude hidden">
+            <span class="rp-icon-btn-icon rp-icon-scissors"></span>
+          </button>
         </div>
+        <div id="resultsSwitcherPanel" class="rp-switcher-panel hidden"></div>
       </div>
-      <div id="resultsList">
-        <div class="panel-empty">Click a completed task to view results.</div>
+      <div id="rightPaneBody">
+        <div id="taskQueuePanel" class="rp-tab-panel">
+          <div id="taskList">
+            <div class="panel-empty">No tasks yet. Configure a workflow and click Run.</div>
+          </div>
+        </div>
+        <div id="resultsPanel" class="rp-tab-panel hidden">
+          <div id="resultsList">
+            <div class="panel-empty">Click a completed task to view results.</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -128,6 +128,8 @@
     videoMuted: false,
     videoPlaybackRate: 1,
     modelViewOpen: false,
+    rightPaneTab: "queue",
+    resultsSwitcherOpen: false,
   };
 
   var _timelineHitRects = [];
@@ -4447,6 +4449,158 @@
     });
   }
 
+  var TOOL_LABELS = {
+    multitool: "Multitool",
+    color: "Color",
+    change: "Change",
+    similarity: "Similarity",
+    text: "Text",
+    numbers: "Numbers",
+    timelapse: "Timelapse",
+    template: "Template",
+    flow: "Flow",
+    scene: "Scene",
+    inactivity: "Inactivity",
+  };
+
+  function selectableTasks() {
+    return state.tasks.filter(function (t) {
+      return t.status === "completed" || t.status === "paused" || t.status === "running";
+    });
+  }
+
+  function setRightPaneTab(tab) {
+    state.rightPaneTab = tab;
+    qsa("#rightPaneTabs .rp-tab").forEach(function (b) {
+      b.classList.toggle("active", b.dataset.tab === tab);
+    });
+    var qp = qs("#taskQueuePanel");
+    var rp = qs("#resultsPanel");
+    if (qp) qp.classList.toggle("hidden", tab !== "queue");
+    if (rp) rp.classList.toggle("hidden", tab !== "results");
+    qsa("#rightPaneTabs .rp-tab-actions").forEach(function (a) {
+      a.classList.toggle("hidden", a.dataset.for !== tab);
+    });
+    closeResultsSwitcher();
+  }
+
+  function updateResultsCrumb() {
+    var crumbEl = qs("#resultsTabCrumb");
+    if (!crumbEl) return;
+    var task = state.selectedTaskId ? findTask(state.selectedTaskId) : null;
+    if (!task) {
+      crumbEl.textContent = "";
+      crumbEl.style.color = "";
+      return;
+    }
+    var sameType = state.tasks
+      .filter(function (t) {
+        return t.type === task.type &&
+          (t.status === "completed" || t.status === "paused" || t.status === "running");
+      });
+    var idx = -1;
+    for (var i = 0; i < sameType.length; i++) {
+      if (sameType[i].id === task.id) { idx = i; break; }
+    }
+    var label = TOOL_LABELS[task.type] || task.type;
+    var ordinal = idx >= 0 ? idx + 1 : 1;
+    var participant = task.participant || "";
+    crumbEl.textContent = ": " + label + " " + ordinal + (participant ? " \u00b7 " + participant : "");
+    crumbEl.style.color = taskTypeColor(task.type);
+  }
+
+  function openResultsSwitcher() {
+    var panel = qs("#resultsSwitcherPanel");
+    if (!panel) return;
+    panel.innerHTML = "";
+    var tasks = selectableTasks();
+    if (tasks.length === 0) {
+      var empty = el("div", "rp-switcher-empty", "No completed tasks yet.");
+      panel.appendChild(empty);
+    } else {
+      var frag = document.createDocumentFragment();
+      tasks.forEach(function (t) {
+        var item = el("button", "rp-switcher-item");
+        item.type = "button";
+        item.dataset.taskId = t.id;
+        if (t.id === state.selectedTaskId) item.classList.add("active");
+        var badge = el("span", "rp-switcher-item-badge");
+        badge.style.background = taskTypeColor(t.type);
+        item.appendChild(badge);
+        var label = TOOL_LABELS[t.type] || t.type;
+        var primary = el("span", null, label + " \u00b7 " + (t.participant || ""));
+        item.appendChild(primary);
+        if (t.region) {
+          var meta = el("span", "rp-switcher-item-meta", t.region);
+          item.appendChild(meta);
+        }
+        item.addEventListener("click", function (e) {
+          e.stopPropagation();
+          var taskId = t.id;
+          closeResultsSwitcher();
+          var task = findTask(taskId);
+          if (!task) return;
+          if (task.participant && task.participant !== state.selectedParticipant) {
+            selectParticipant(task.participant);
+          }
+          state.selectedTaskId = taskId;
+          setRightPaneTab("results");
+          loadAndShowResults(taskId);
+          renderTaskList();
+        });
+        frag.appendChild(item);
+      });
+      panel.appendChild(frag);
+    }
+    var tab = qs('.rp-tab[data-tab="results"]');
+    var tabsEl = qs("#rightPaneTabs");
+    if (tab && tabsEl) {
+      var tabRect = tab.getBoundingClientRect();
+      var tabsRect = tabsEl.getBoundingClientRect();
+      var tabCenter = tabRect.left - tabsRect.left + tabRect.width / 2;
+      panel.style.left = tabCenter + "px";
+      panel.style.transform = "translateX(-50%)";
+    }
+    panel.classList.remove("hidden");
+    state.resultsSwitcherOpen = true;
+    if (tab) tab.classList.add("switcher-open");
+  }
+
+  function closeResultsSwitcher() {
+    var panel = qs("#resultsSwitcherPanel");
+    if (panel) panel.classList.add("hidden");
+    state.resultsSwitcherOpen = false;
+    var tab = qs('.rp-tab[data-tab="results"]');
+    if (tab) tab.classList.remove("switcher-open");
+  }
+
+  function initRightPaneTabs() {
+    qsa("#rightPaneTabs .rp-tab").forEach(function (btn) {
+      btn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        var tab = btn.dataset.tab;
+        if (tab === "queue") {
+          setRightPaneTab("queue");
+          return;
+        }
+        if (tab === "results") {
+          if (state.rightPaneTab === "results" && state.selectedTaskId) {
+            if (state.resultsSwitcherOpen) closeResultsSwitcher();
+            else openResultsSwitcher();
+          } else {
+            setRightPaneTab("results");
+          }
+        }
+      });
+    });
+    document.addEventListener("click", function (e) {
+      if (!state.resultsSwitcherOpen) return;
+      if (e.target.closest("#resultsSwitcherPanel")) return;
+      if (e.target.closest('.rp-tab[data-tab="results"]')) return;
+      closeResultsSwitcher();
+    });
+  }
+
   function initTaskQueue() {
     var taskListEl = qs("#taskList");
 
@@ -4469,6 +4623,7 @@
                 state.selectedTaskId = null;
                 state.selectedTaskResults = null;
                 renderResults();
+                setRightPaneTab("queue");
               }
               renderTaskList();
               renderTimeline();
@@ -4496,11 +4651,14 @@
           renderResults();
           renderTaskList();
           renderTimeline();
+          updateResultsCrumb();
+          setRightPaneTab("queue");
         } else {
           if (task.participant && task.participant !== state.selectedParticipant) {
             selectParticipant(task.participant);
           }
           state.selectedTaskId = taskId;
+          setRightPaneTab("results");
           loadAndShowResults(taskId);
           renderTaskList();
         }
@@ -5025,6 +5183,7 @@
     });
     container.innerHTML = "";
     container.appendChild(frag);
+    updateResultsCrumb();
   }
 
   // ---- SSE (Server-Sent Events) with polling fallback ----
@@ -5170,16 +5329,34 @@
       }
     });
 
-    qs("#showExcludedCb").addEventListener("change", function () {
-      state.showExcluded = this.checked;
+    var showExcludedBtn = qs("#showExcludedBtn");
+    function updateShowExcludedIcon() {
+      var iconSpan = showExcludedBtn.querySelector(".rp-icon-btn-icon");
+      iconSpan.classList.toggle("rp-icon-eye", state.showExcluded);
+      iconSpan.classList.toggle("rp-icon-eye-slash", !state.showExcluded);
+      showExcludedBtn.classList.toggle("active", state.showExcluded);
+    }
+    updateShowExcludedIcon();
+    showExcludedBtn.addEventListener("click", function () {
+      state.showExcluded = !state.showExcluded;
+      updateShowExcludedIcon();
       renderResults();
     });
+    attachHoverTooltip(showExcludedBtn, function () {
+      return state.showExcluded ? "Hiding excluded results is off" : "Hiding excluded results is on";
+    }, { align: "center" });
 
-    qs("#certaintyCutoff").addEventListener("input", function () {
+    var certaintySlider = qs("#certaintyCutoff");
+    certaintySlider.addEventListener("input", function () {
       state.certaintyCutoff = parseInt(this.value, 10) / 100;
-      qs("#certaintyCutoffVal").textContent = this.value + "%";
       renderResults();
     });
+    attachHoverTooltip(certaintySlider, function () {
+      return "Certainty threshold: " + certaintySlider.value + "%";
+    }, { align: "center" });
+
+    var exclBtn = qs("#excludeNonVisibleBtn");
+    attachHoverTooltip(exclBtn, "Exclude results below the certainty threshold", { align: "center" });
 
     qs("#excludeNonVisibleBtn").addEventListener("click", function () {
       var events = state.taskEvents[state.selectedTaskId] || [];
@@ -5221,8 +5398,6 @@
     state.certaintyCutoff = 0;
     var slider = qs("#certaintyCutoff");
     if (slider) slider.value = "0";
-    var valSpan = qs("#certaintyCutoffVal");
-    if (valSpan) valSpan.textContent = "0%";
     apiGet("api/tasks/" + taskId + "/results")
       .then(function (data) {
         if (resultsRequestVersion !== _resultsRequestVersion || state.selectedTaskId !== selectedTaskId) return null;
@@ -5235,13 +5410,14 @@
         state.taskEvents[selectedTaskId] = evData.events || [];
         renderResults();
         renderTaskList();
+        updateResultsCrumb();
       })
       .catch(function () { showToast("Failed to load results"); });
   }
 
   function renderResults() {
     var container = qs("#resultsList");
-    var countEl = qs("#resultCount");
+    var countEl = qs("#resultCount") || { textContent: "" };
     var actionsEl = qs("#resultsActions");
     var results = state.selectedTaskResults;
     var task = state.selectedTaskId ? findTask(state.selectedTaskId) : null;
@@ -5303,9 +5479,9 @@
 
     // Show/hide certainty controls based on whether the tool has confidence scores
     var hasConf = task && { change: 1, similarity: 1, text: 1, template: 1, scene: 1, flow: 1, multitool: 1, inactivity: 1 }[task.type];
-    var certLabel = qs("#certaintyCutoffLabel");
+    var certWrap = qs("#certaintyCutoffWrap");
     var exclBtn = qs("#excludeNonVisibleBtn");
-    if (certLabel) certLabel.classList.toggle("hidden", !hasConf);
+    if (certWrap) certWrap.classList.toggle("hidden", !hasConf);
     if (exclBtn) exclBtn.classList.toggle("hidden", !hasConf);
 
     // Timelapse: single file result
@@ -5348,7 +5524,7 @@
     // For color results (spans), build a consumed-index tracker per timestamp
     var eventTsIndex = {};
 
-    var showToggle = qs("#showExcludedToggle");
+    var showToggle = qs("#showExcludedBtn");
     if (showToggle) showToggle.classList.toggle("hidden", events.length === 0);
 
     var visibleCount = 0;
@@ -5724,6 +5900,7 @@
     initParamTooltips();
     initRunButton();
     initTaskQueue();
+    initRightPaneTabs();
     initPauseButton();
     initTaskFilters();
     initResultsPanel();

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.66"
+VERSIONNUM: str = "0.10.67"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Merge Screenspace's Task Queue and Results columns into a tabbed right pane (`1.2fr / 1fr` grid) so each panel gets full width.
- Results tab title doubles as a breadcrumb (e.g. `Results: Text 1 · P01`, colored by tool) and, when active, opens a quick-switch dropdown centered under the tab.
- Clicking a selectable task auto-switches to Results; deselecting or dismissing returns to Queue.
- Compact the Results-tab actions: icon-only Show excluded (eye/eye-slash) and Exclude hidden (scissors) with hover tooltips, plus a minimal 34px certainty slider with a live-percentage tooltip.

## Test plan
- [ ] `uv run clipgen.py --screenspace -i <dir> -o <dir>` — bottom shows Tools + tabbed right pane; default Queue visible.
- [ ] Run a Text task; click the completed card → Results tab activates, crumb reads e.g. `Results: Text 1 · P01` in the tool color.
- [ ] Click the Results crumb → quick-switch dropdown opens centered under the tab; pick another task to swap.
- [ ] Click Task Queue tab → returns to Queue, `selectedTaskId` preserved.
- [ ] Hover Show excluded / Exclude hidden / Certainty slider → tooltips appear; slider tooltip shows current %.
- [ ] Responsive (<768px) stacks the two columns.