### PR TITLE
fix: preserve Multitool step params when toggling AND/NOT

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2751,8 +2751,13 @@
           opBtn.addEventListener("click", function (e) {
             e.stopPropagation();
             var s = state.multitoolSteps[capturedIdx];
-            s.logic = (s.logic || "AND").toUpperCase() === "NOT" ? "AND" : "NOT";
-            renderWorkflowParams();
+            var next = (s.logic || "AND").toUpperCase() === "NOT" ? "AND" : "NOT";
+            s.logic = next;
+            opBtn.classList.toggle("is-not", next === "NOT");
+            opBtn.classList.toggle("is-and", next === "AND");
+            opBtn.title = next === "NOT"
+              ? "NOT — frame rejected if this matches (click to switch to AND)"
+              : "AND — frame must also match (click to switch to NOT)";
           });
         })(idx);
         rail.appendChild(opBtn);

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.67"
+VERSIONNUM: str = "0.10.68"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Screenspace Multitool AND/NOT toggle was calling `renderWorkflowParams()`, which rebuilt every step card's DOM and dropped all parameter values (hex color, thresholds, search strings, etc.) that only live in the DOM inputs.
- Toggle the button's `is-and`/`is-not` class and `title` in place instead — backend still reads `state.multitoolSteps[i].logic` at run time, so behaviour is unchanged.
- Bumped `VERSIONNUM` 0.10.67 → 0.10.68.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace.py tests/test_screenspace_api.py` (207 passed)
- [ ] Manual: build a multitool chain, fill in non-default params, toggle AND/NOT and confirm inputs persist and the icon/color/title swap