### PR TITLE
feat: participant pills replace queue sidepanel in transcripts

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -74,23 +74,6 @@ body {
   margin-left: auto;
 }
 
-.participant-label {
-  font-size: var(--text-sm);
-  color: var(--color-text-dim);
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-#participantSelect {
-  font-size: var(--text-sm);
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--color-border);
-  border-radius: calc(var(--radius) - 2px);
-  background: var(--color-surface);
-  color: var(--color-text);
-}
-
 .status-indicator {
   display: inline-block;
   width: 10px;
@@ -908,132 +891,258 @@ body {
   -webkit-mask-repeat: no-repeat;
 }
 
-/* Queue panel */
+/* Participant pills */
 
-#queuePanel {
-  position: fixed;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  width: 340px;
-  background: var(--color-panel-bg);
-  border-left: 1px solid var(--color-panel-border);
-  box-shadow: var(--shadow-lg);
-  z-index: var(--z-float);
-  overflow-y: auto;
+.pill-row {
   display: flex;
-  flex-direction: column;
-}
-
-.panel-header {
-  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
   align-items: center;
-  justify-content: space-between;
-  padding: var(--space-4);
-  border-bottom: 1px solid var(--color-border);
-  flex-shrink: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
 }
 
-.panel-header h3 {
-  font-size: var(--text-base);
+.pill-row-empty {
+  font-size: var(--text-sm);
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+.pill-wrap {
+  position: relative;
+  display: inline-block;
+  flex: 0 0 auto;
+}
+
+.pill {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  user-select: none;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+
+.pill:hover {
+  border-color: var(--color-selected);
+}
+
+.pill > *:not(.pill-progress) {
+  position: relative;
+  z-index: 1;
+}
+
+.pill-progress {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  transition: width 500ms linear;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.pill-id {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.pill--active {
+  border-color: var(--color-selected);
+  background: var(--color-surface-alt);
+  box-shadow: 0 0 0 1px var(--color-selected) inset;
+}
+
+.pill--active .pill-id {
   font-weight: 600;
 }
 
-.panel-header-actions {
-  display: flex;
-  gap: var(--space-2);
+.pill--failed {
+  border-color: color-mix(in srgb, var(--sev-critical) 45%, var(--color-border));
 }
 
-#queueList {
-  flex: 1;
-  overflow-y: auto;
+@keyframes pill-spin {
+  to { transform: rotate(360deg); }
 }
 
-.queue-item {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  padding: var(--space-3) var(--space-4);
-  border-bottom: 1px solid var(--color-border);
+@media (prefers-reduced-motion: reduce) {
+  .pill-trigger--running .pill-trigger-icon--rest { animation: none; }
+  .pill-progress { transition: none; }
 }
 
-.queue-item-header {
-  display: flex;
+/* Trigger — status icon doubles as action button (glyph swaps on hover) */
+.pill-trigger {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+  line-height: 0;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-}
-
-.queue-item-id {
-  font-weight: 500;
-  font-size: var(--text-sm);
-}
-
-.queue-item-status {
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
   color: var(--color-text-dim);
+  transition: color var(--duration-fast);
 }
 
-.queue-item-status.status-completed {
-  color: var(--sev-positive);
+.pill-trigger-icon {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 14px;
+  height: 14px;
+  background-color: currentColor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  transition: opacity var(--duration-fast);
 }
 
-.queue-item-status.status-running {
+.pill-trigger-icon--hover {
+  opacity: 0;
+}
+
+.pill-trigger:hover .pill-trigger-icon--rest,
+.pill-trigger:focus-visible .pill-trigger-icon--rest {
+  opacity: 0;
+}
+
+.pill-trigger:hover .pill-trigger-icon--hover,
+.pill-trigger:focus-visible .pill-trigger-icon--hover {
+  opacity: 1;
+}
+
+.pill-trigger--completed { color: var(--sev-positive); }
+.pill-trigger--queued { color: var(--color-accent); }
+.pill-trigger--running { color: var(--color-accent); }
+.pill-trigger--failed { color: var(--sev-critical); }
+.pill-trigger--idle { color: var(--color-text-dim); }
+
+.pill-trigger--running .pill-trigger-icon--rest {
+  animation: pill-spin 1.2s linear infinite;
+}
+
+.pill-trigger--running:hover,
+.pill-trigger--queued:hover,
+.pill-trigger--running:focus-visible,
+.pill-trigger--queued:focus-visible {
+  color: var(--sev-critical);
+}
+
+.pill-trigger--completed:hover,
+.pill-trigger--completed:focus-visible,
+.pill-trigger--idle:hover,
+.pill-trigger--idle:focus-visible,
+.pill-trigger--failed:hover,
+.pill-trigger--failed:focus-visible {
   color: var(--color-accent);
 }
 
-.queue-item-status.status-failed {
-  color: var(--sev-critical);
-}
-
-.queue-item-status.status-cancelled {
+.pill-chevron {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-color: currentColor;
   color: var(--color-text-dim);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-image: url(icons/chevron-down.svg);
+  -webkit-mask-image: url(icons/chevron-down.svg);
+  transition: transform var(--duration-fast);
 }
 
-.queue-item-cancel {
+.pill-wrap--options-open .pill-chevron {
+  transform: rotate(180deg);
+}
+
+.pill-chevron-btn {
   background: none;
   border: none;
-  color: var(--color-text-dim);
+  padding: 1px;
   cursor: pointer;
-  padding: 0.1rem 0.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-sm);
-  transition: background var(--duration-fast), color var(--duration-fast);
-  font-size: var(--text-sm);
-  line-height: 1;
-  margin-left: auto;
+  flex-shrink: 0;
 }
 
-.queue-item-cancel:hover {
-  background: rgba(220, 38, 38, 0.1);
-  color: var(--sev-critical);
-}
-
-.queue-progress {
-  height: 4px;
+.pill-chevron-btn:hover {
   background: var(--color-surface-alt);
-  border-radius: var(--radius-full);
-  overflow: hidden;
 }
 
-.queue-progress-bar {
-  height: 100%;
-  background: var(--color-accent);
-  border-radius: var(--radius-full);
-  transition: width var(--duration-normal);
-}
-
-.queue-item-action {
-  margin-top: var(--space-1);
-}
-
-.queue-stale-badge {
+.pill-stale-badge {
   display: inline-block;
   font-size: var(--text-xs);
-  color: #f59e0b;
-  padding: 2px 6px;
+  color: var(--sev-high);
+  padding: 1px var(--space-2);
   border: 1px solid currentColor;
   border-radius: var(--radius-sm);
-  margin-left: var(--space-2);
+}
+
+.pill-options {
+  position: fixed;
+  min-width: 220px;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-3);
+  z-index: var(--z-dropdown);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.pill-options-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.pill-options-row > label {
+  color: var(--color-text-dim);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pill-options select {
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  min-width: 110px;
+}
+
+.pill-options-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-1);
 }
 
 /* Modal */

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -12,13 +12,8 @@
     <div id="headerTop">
       <h1>clipgen <span class="frontend-switcher" data-current="transcripts"><span class="frontend-switcher-trigger" tabindex="0" role="button" aria-haspopup="true" aria-expanded="false"><span class="header-light">Transcripts</span><span class="frontend-switcher-chevron" aria-hidden="true"></span></span><span class="frontend-switcher-panel" role="menu" aria-hidden="true"><a class="frontend-switcher-item" href="/studio/" data-frontend="studio" role="menuitem">Studio</a><a class="frontend-switcher-item" href="/insights/" data-frontend="insights" role="menuitem">Insights</a><a class="frontend-switcher-item" href="/screenspace/" data-frontend="screenspace" role="menuitem">Screenspace</a></span></span></h1>
       <div id="headerActions">
-        <label class="participant-label">
-          Source
-          <select id="participantSelect"><option value="">No participants</option></select>
-        </label>
         <span id="trStatusIndicator" class="status-indicator" tabindex="0" role="status" aria-label="Transcription status"></span>
         <span id="trStatusSr" class="sr-only" aria-live="polite"></span>
-        <button id="queueBtn" type="button" class="btn btn-small">Queue</button>
         <button id="correctionsBtn" type="button" class="btn btn-small">Corrections</button>
         <button id="trSettingsBtn" type="button" class="btn btn-small btn-icon" title="AI Model Settings">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
@@ -35,6 +30,9 @@
           <span class="theme-toggle-icon theme-icon-moon"></span>
         </button>
       </div>
+    </div>
+    <div id="participantPills" class="pill-row" role="tablist" aria-label="Participants">
+      <span class="pill-row-empty">No participants</span>
     </div>
     <div id="headerSearch">
       <input id="searchInput" type="text" placeholder="Search across all transcripts..." autocomplete="off">
@@ -88,18 +86,6 @@
       </div>
     </section>
   </main>
-
-  <!-- Transcription queue panel -->
-  <aside id="queuePanel" class="hidden">
-    <div class="panel-header">
-      <h3>Transcription Queue</h3>
-      <div class="panel-header-actions">
-        <button id="transcribeAllBtn" class="btn btn-small">Transcribe All</button>
-        <button id="closeQueueBtn" class="btn btn-small">Close</button>
-      </div>
-    </div>
-    <div id="queueList"></div>
-  </aside>
 
   <!-- Corrections modal -->
   <div id="correctionsModal" class="modal hidden">

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -450,7 +450,7 @@
       if (!data.ok) return;
       state.participants = data.participants;
       state.transcribePrewarm = data.transcribe_prewarm || "queue_open";
-      renderParticipantSelect();
+      renderPills();
 
       if (!needsTranscription()) {
         _transcriptionWarmupPosted = false;
@@ -477,28 +477,10 @@
     });
   }
 
-  function renderParticipantSelect() {
-    var sel = qs("#participantSelect");
-    sel.innerHTML = "";
-    if (state.participants.length === 0) {
-      sel.innerHTML = '<option value="">No participants</option>';
-      return;
-    }
-    state.participants.forEach(function (p) {
-      var opt = document.createElement("option");
-      opt.value = p.id;
-      opt.textContent = p.id + (p.has_transcript ? " \u2713" : "") + (p.has_stale_artifacts ? " \u26a0" : "");
-      sel.appendChild(opt);
-    });
-    if (state.selectedParticipant) {
-      sel.value = state.selectedParticipant;
-    }
-  }
 
   function selectParticipant(pid) {
     state.selectedParticipant = pid;
-    var sel = qs("#participantSelect");
-    sel.value = pid;
+    renderPills();
 
     // Find participant info
     var p = null;
@@ -1841,67 +1823,65 @@
     seekVideo(start);
   }
 
-  // ---- Queue panel ----
+  // ---- Participant pills ----
 
-  function initQueuePanel() {
-    qs("#queueBtn").addEventListener("click", function () {
-      var panel = qs("#queuePanel");
-      panel.classList.toggle("hidden");
-      if (!panel.classList.contains("hidden")) {
-        renderQueue();
-        pollTaskStatus();
-        if (state.transcribePrewarm === "queue_open") {
-          tryPostTranscriptionWarmup();
-        }
-      }
-    });
+  // Icon shown on the trigger by default (left), and on hover (right).
+  // The trigger click always invokes the appropriate action for the status.
+  var PILL_TRIGGER = {
+    idle: { rest: "icons/microphone.svg", hover: "icons/microphone.svg", label: "Transcribe", action: "transcribe" },
+    failed: { rest: "icons/exclamation-triangle.svg", hover: "icons/microphone.svg", label: "Retry transcription", action: "transcribe" },
+    queued: { rest: "icons/clock.svg", hover: "icons/stop-circle.svg", label: "Cancel", action: "cancel" },
+    running: { rest: "icons/arrow-path.svg", hover: "icons/stop-circle.svg", label: "Cancel transcription", action: "cancel" },
+    completed: { rest: "icons/check-circle.svg", hover: "icons/arrow-path.svg", label: "Re-transcribe", action: "retranscribe" }
+  };
 
-    qs("#closeQueueBtn").addEventListener("click", function () {
-      qs("#queuePanel").classList.add("hidden");
-    });
+  var PILL_LANGUAGES = [
+    { code: "", label: "Auto-detect" },
+    { code: "en", label: "English" },
+    { code: "sv", label: "Swedish" },
+    { code: "es", label: "Spanish" },
+    { code: "fr", label: "French" },
+    { code: "de", label: "German" },
+    { code: "it", label: "Italian" },
+    { code: "pt", label: "Portuguese" },
+    { code: "nl", label: "Dutch" },
+    { code: "no", label: "Norwegian" },
+    { code: "da", label: "Danish" },
+    { code: "fi", label: "Finnish" }
+  ];
 
-    qs("#transcribeAllBtn").addEventListener("click", function () {
-      transcribeAll();
-    });
-  }
+  // UI-only state for pills (reset on reload)
+  state.pillOverrides = {};    // pid → { model, language }
+  state.pillOptionsOpen = null; // pid of the pill whose options pane is open
 
-  function queueItemState(p, taskByPid) {
+  function pillState(p, taskByPid) {
     var task = taskByPid[p.id];
-    var status = "not started";
-    var statusClass = "";
+    var status = "idle";
     var progress = 0;
-    var showProgress = false;
     var taskId = null;
 
-    if (p.has_transcript && (!task || task.status === "completed")) {
-      status = "completed";
-      statusClass = "status-completed";
-      progress = 100;
-    } else if (task) {
+    if (task && (task.status === "running" || task.status === "queued")) {
       status = task.status;
       taskId = task.id;
-      if (task.status === "running") {
-        statusClass = "status-running";
-        progress = Math.round(task.progress * 100);
-        showProgress = true;
-      } else if (task.status === "queued") {
-        statusClass = "";
-      } else if (task.status === "failed") {
-        statusClass = "status-failed";
-        status = "failed";
-      } else if (task.status === "cancelled") {
-        statusClass = "status-cancelled";
-      } else if (task.status === "completed") {
-        statusClass = "status-completed";
-        progress = 100;
-      }
+      if (task.status === "running") progress = Math.round((task.progress || 0) * 100);
+    } else if (task && task.status === "failed") {
+      status = "failed";
+      taskId = task.id;
+    } else if (p.has_transcript) {
+      status = "completed";
+      progress = 100;
     }
-    return { status: status, statusClass: statusClass, progress: progress, showProgress: showProgress, taskId: taskId };
+    return { status: status, progress: progress, taskId: taskId };
   }
 
-  function renderQueue() {
-    var container = qs("#queueList");
+  function renderPills() {
+    var container = qs("#participantPills");
     if (!container) return;
+
+    if (state.participants.length === 0) {
+      container.innerHTML = '<span class="pill-row-empty">No participants</span>';
+      return;
+    }
 
     var taskByPid = {};
     state.tasks.forEach(function (t) {
@@ -1910,105 +1890,377 @@
       }
     });
 
-    // Try in-place update when item list and status categories match (avoids layout thrash)
-    var existing = container.querySelectorAll(".queue-item[data-pid]");
+    // In-place patch when structure unchanged (avoids layout thrash + preserves
+    // the open options pane across polling ticks)
+    var existing = container.querySelectorAll(".pill-wrap[data-pid]");
     if (existing.length === state.participants.length) {
       var canPatch = true;
       for (var k = 0; k < state.participants.length; k++) {
-        var s = queueItemState(state.participants[k], taskByPid);
-        if (existing[k].getAttribute("data-pid") !== state.participants[k].id ||
-            existing[k].getAttribute("data-status") !== s.status) {
+        var p0 = state.participants[k];
+        var s0 = pillState(p0, taskByPid);
+        if (existing[k].getAttribute("data-pid") !== p0.id ||
+            existing[k].getAttribute("data-status") !== s0.status ||
+            existing[k].getAttribute("data-active") !== (state.selectedParticipant === p0.id ? "1" : "0")) {
           canPatch = false; break;
         }
       }
       if (canPatch) {
         for (var k = 0; k < state.participants.length; k++) {
-          var item = existing[k];
-          var s = queueItemState(state.participants[k], taskByPid);
-          var statusEl = item.querySelector(".queue-item-status");
-          statusEl.className = "queue-item-status" + (s.statusClass ? " " + s.statusClass : "");
-          statusEl.textContent = s.status + (s.showProgress ? " " + s.progress + "%" : "");
-          var bar = item.querySelector(".queue-progress-bar");
-          if (bar) bar.style.width = s.progress + "%";
+          var wrap = existing[k];
+          var p0 = state.participants[k];
+          var s0 = pillState(p0, taskByPid);
+          var bar = wrap.querySelector(".pill-progress");
+          if (bar) bar.style.width = s0.progress + "%";
         }
         return;
       }
     }
 
-    // Full rebuild when structure changes
-    var html = "";
+    // Full rebuild
+    var openPid = state.pillOptionsOpen;
+    var frag = document.createDocumentFragment();
     state.participants.forEach(function (p) {
-      var s = queueItemState(p, taskByPid);
-      html += '<div class="queue-item" data-pid="' + escapeHtml(p.id) + '" data-status="' + s.status + '">';
-      html += '<div class="queue-item-header">';
-      html += '<span class="queue-item-id">' + escapeHtml(p.id) + '</span>';
-      html += '<span class="queue-item-status ' + s.statusClass + '">' + s.status + (s.showProgress ? " " + s.progress + "%" : "") + '</span>';
-      if (s.taskId && (s.status === "running" || s.status === "queued")) {
-        html += '<button class="queue-item-cancel" data-cancel-task="' + escapeHtml(s.taskId) + '" title="Cancel">&times;</button>';
+      frag.appendChild(buildPillWrap(p, taskByPid));
+    });
+    container.innerHTML = "";
+    container.appendChild(frag);
+    // The pane is mounted on <body>, not inside the rebuilt wrap — reposition
+    // it to the new wrap's rect, or tear it down if the pill disappeared.
+    if (openPid !== null) {
+      var newWrap = _findPillWrap(openPid);
+      var floating = document.querySelector("body > .pill-options");
+      if (newWrap && floating) {
+        _positionPillOptions(floating, newWrap);
+      } else {
+        closePillOptions();
       }
-      html += '</div>';
+    }
+  }
 
-      if (s.showProgress || s.progress === 100) {
-        html += '<div class="queue-progress"><div class="queue-progress-bar" style="width:' + s.progress + '%"></div></div>';
-      }
+  function buildPillWrap(p, taskByPid) {
+    var s = pillState(p, taskByPid);
+    var wrap = document.createElement("div");
+    var isActive = state.selectedParticipant === p.id;
+    wrap.className = "pill-wrap";
+    wrap.setAttribute("data-pid", p.id);
+    wrap.setAttribute("data-status", s.status);
+    wrap.setAttribute("data-active", isActive ? "1" : "0");
+    wrap.appendChild(buildPill(p, s, isActive));
+    if (state.pillOptionsOpen === p.id) {
+      wrap.classList.add("pill-wrap--options-open");
+    }
+    return wrap;
+  }
 
-      if (!p.has_transcript && (!taskByPid[p.id] || taskByPid[p.id].status === "failed" || taskByPid[p.id].status === "cancelled")) {
-        html += '<div class="queue-item-action"><button class="btn btn-small" data-transcribe="' + escapeHtml(p.id) + '">Transcribe</button></div>';
-      } else if (p.has_transcript && (!taskByPid[p.id] || taskByPid[p.id].status === "completed")) {
-        html += '<div class="queue-item-action"><button class="btn btn-small" data-retranscribe="' + escapeHtml(p.id) + '">Re-transcribe</button>';
-        if (p.has_stale_artifacts) {
-          html += '<span class="queue-stale-badge">artifacts outdated</span>';
+  function buildPill(p, s, isActive) {
+    var pill = document.createElement("div");
+    var classes = ["pill", "pill--" + s.status];
+    if (isActive) classes.push("pill--active");
+    pill.className = classes.join(" ");
+    pill.setAttribute("role", "tab");
+    pill.setAttribute("aria-selected", isActive ? "true" : "false");
+
+    // Progress fill (background layer)
+    var prog = document.createElement("div");
+    prog.className = "pill-progress";
+    prog.style.width = s.progress + "%";
+    pill.appendChild(prog);
+
+    // Trigger — status icon doubles as action button (hover swaps the glyph)
+    pill.appendChild(buildPillTrigger(p, s));
+
+    var idSpan = document.createElement("span");
+    idSpan.className = "pill-id";
+    idSpan.textContent = p.id;
+    pill.appendChild(idSpan);
+
+    // Stale badge (inline)
+    if (p.has_stale_artifacts) {
+      var stale = document.createElement("span");
+      stale.className = "pill-stale-badge";
+      stale.textContent = "stale";
+      stale.title = "Artifacts built from an older transcript";
+      pill.appendChild(stale);
+    }
+
+    // Chevron for options pane
+    var chevBtn = document.createElement("button");
+    chevBtn.type = "button";
+    chevBtn.className = "pill-chevron-btn";
+    chevBtn.setAttribute("aria-label", "Transcription options");
+    chevBtn.setAttribute("aria-expanded", state.pillOptionsOpen === p.id ? "true" : "false");
+    var chev = document.createElement("span");
+    chev.className = "pill-chevron";
+    chevBtn.appendChild(chev);
+    chevBtn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      togglePillOptions(p.id);
+    });
+    pill.appendChild(chevBtn);
+
+    // Clicking the pill body (not its buttons) selects the participant
+    pill.addEventListener("click", function () {
+      if (p.id !== state.selectedParticipant) selectParticipant(p.id);
+    });
+
+    return pill;
+  }
+
+  function buildPillTrigger(p, s) {
+    var cfg = PILL_TRIGGER[s.status] || PILL_TRIGGER.idle;
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "pill-trigger pill-trigger--" + s.status;
+    btn.setAttribute("aria-label", cfg.label);
+    btn.setAttribute("title", cfg.label);
+
+    // Two stacked icons; CSS hides one and shows the other on hover/focus.
+    var rest = document.createElement("span");
+    rest.className = "pill-trigger-icon pill-trigger-icon--rest";
+    rest.style.maskImage = "url(" + cfg.rest + ")";
+    rest.style.webkitMaskImage = "url(" + cfg.rest + ")";
+    btn.appendChild(rest);
+
+    var hover = document.createElement("span");
+    hover.className = "pill-trigger-icon pill-trigger-icon--hover";
+    hover.style.maskImage = "url(" + cfg.hover + ")";
+    hover.style.webkitMaskImage = "url(" + cfg.hover + ")";
+    btn.appendChild(hover);
+
+    btn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      if (cfg.action === "cancel") {
+        if (s.taskId) {
+          apiDelete("api/transcribe/" + s.taskId).then(function () { pollTaskStatus(); });
         }
-        html += '</div>';
+      } else if (cfg.action === "retranscribe") {
+        startTranscribe(p.id, true);
+      } else {
+        startTranscribe(p.id, false);
       }
-
-      html += '</div>';
     });
+    return btn;
+  }
 
-    container.innerHTML = html;
+  function buildPillOptions(p, s) {
+    var pane = document.createElement("div");
+    pane.className = "pill-options";
+    pane.addEventListener("click", function (e) { e.stopPropagation(); });
 
-    // Attach event listeners
-    var transcribeBtns = container.querySelectorAll("[data-transcribe]");
-    for (var i = 0; i < transcribeBtns.length; i++) {
-      transcribeBtns[i].addEventListener("click", function () {
-        var pid = this.getAttribute("data-transcribe");
-        transcribeParticipants([pid], false);
+    var ov = state.pillOverrides[p.id] || {};
+
+    // Model row
+    var modelRow = document.createElement("div");
+    modelRow.className = "pill-options-row";
+    var modelLabel = document.createElement("label");
+    modelLabel.textContent = "Model";
+    var modelSelect = document.createElement("select");
+    modelSelect.innerHTML = '<option value="">Loading…</option>';
+    _trFetchModels().then(function (data) {
+      var models = (data && data.whisper && data.whisper.models) || [];
+      if (models.length === 0) {
+        modelSelect.innerHTML = '<option value="">Default</option>';
+        return;
+      }
+      var defaultName = "";
+      var opts = '<option value="">Default</option>';
+      models.forEach(function (m) {
+        if (m.selected) defaultName = m.name;
+        opts += '<option value="' + escapeHtml(m.name) + '">' + escapeHtml(m.name) + '</option>';
+      });
+      modelSelect.innerHTML = opts;
+      modelSelect.options[0].textContent = "Default (" + (defaultName || "base") + ")";
+      modelSelect.value = ov.model || "";
+    });
+    modelSelect.addEventListener("change", function () {
+      _setOverride(p.id, "model", this.value);
+    });
+    modelRow.appendChild(modelLabel);
+    modelRow.appendChild(modelSelect);
+    pane.appendChild(modelRow);
+
+    // Language row
+    var langRow = document.createElement("div");
+    langRow.className = "pill-options-row";
+    var langLabel = document.createElement("label");
+    langLabel.textContent = "Language";
+    var langSelect = document.createElement("select");
+    var lh = "";
+    for (var i = 0; i < PILL_LANGUAGES.length; i++) {
+      var L = PILL_LANGUAGES[i];
+      lh += '<option value="' + escapeHtml(L.code) + '">' + escapeHtml(L.label) + '</option>';
+    }
+    langSelect.innerHTML = lh;
+    langSelect.value = ov.language || "";
+    langSelect.addEventListener("change", function () {
+      _setOverride(p.id, "language", this.value);
+    });
+    langRow.appendChild(langLabel);
+    langRow.appendChild(langSelect);
+    pane.appendChild(langRow);
+
+    // Footer: transcribe / re-transcribe
+    var footer = document.createElement("div");
+    footer.className = "pill-options-footer";
+    var runBtn = document.createElement("button");
+    runBtn.type = "button";
+    runBtn.className = "btn btn-small";
+    if (p.has_transcript && s.status !== "running" && s.status !== "queued") {
+      runBtn.textContent = "Re-transcribe";
+      runBtn.addEventListener("click", function () {
+        closePillOptions();
+        startTranscribe(p.id, true);
+      });
+    } else if (s.status === "running" || s.status === "queued") {
+      runBtn.textContent = "Cancel";
+      runBtn.className = "btn btn-small";
+      runBtn.addEventListener("click", function () {
+        if (s.taskId) {
+          apiDelete("api/transcribe/" + s.taskId).then(function () { pollTaskStatus(); });
+        }
+        closePillOptions();
+      });
+    } else {
+      runBtn.textContent = "Transcribe";
+      runBtn.addEventListener("click", function () {
+        closePillOptions();
+        startTranscribe(p.id, false);
       });
     }
+    footer.appendChild(runBtn);
+    pane.appendChild(footer);
 
-    var retranscribeBtns = container.querySelectorAll("[data-retranscribe]");
-    for (var j = 0; j < retranscribeBtns.length; j++) {
-      retranscribeBtns[j].addEventListener("click", function () {
-        var pid = this.getAttribute("data-retranscribe");
-        transcribeParticipants([pid], true);
-      });
+    return pane;
+  }
+
+  function _setOverride(pid, key, value) {
+    if (!state.pillOverrides[pid]) state.pillOverrides[pid] = {};
+    if (value) state.pillOverrides[pid][key] = value;
+    else delete state.pillOverrides[pid][key];
+  }
+
+  function _findPillWrap(pid) {
+    var container = qs("#participantPills");
+    if (!container) return null;
+    var wraps = container.querySelectorAll(".pill-wrap[data-pid]");
+    for (var i = 0; i < wraps.length; i++) {
+      if (wraps[i].getAttribute("data-pid") === pid) return wraps[i];
     }
+    return null;
+  }
 
-    var cancelBtns = container.querySelectorAll("[data-cancel-task]");
-    for (var c = 0; c < cancelBtns.length; c++) {
-      cancelBtns[c].addEventListener("click", function () {
-        var taskId = this.getAttribute("data-cancel-task");
-        apiDelete("api/transcribe/" + taskId).then(function () {
-          pollTaskStatus();
-        });
-      });
+  function _positionPillOptions(pane, wrap) {
+    var rect = wrap.getBoundingClientRect();
+    pane.style.top = rect.bottom + 4 + "px";
+    pane.style.left = rect.left + "px";
+  }
+
+  function _closeOpenPaneInDom() {
+    if (state.pillOptionsOpen === null) return;
+    var wrap = _findPillWrap(state.pillOptionsOpen);
+    if (wrap) {
+      wrap.classList.remove("pill-wrap--options-open");
+      var chev = wrap.querySelector(".pill-chevron-btn");
+      if (chev) chev.setAttribute("aria-expanded", "false");
+    }
+    var floating = document.querySelector("body > .pill-options");
+    if (floating) floating.remove();
+    if (state.pillOptionsReposition) {
+      window.removeEventListener("resize", state.pillOptionsReposition);
+      window.removeEventListener("scroll", state.pillOptionsReposition, true);
+      state.pillOptionsReposition = null;
+    }
+    state.pillOptionsOpen = null;
+  }
+
+  function togglePillOptions(pid) {
+    // Close whichever pane is currently open (possibly same pill → toggle off)
+    var wasOpen = state.pillOptionsOpen === pid;
+    _closeOpenPaneInDom();
+    if (wasOpen) return;
+
+    var wrap = _findPillWrap(pid);
+    if (!wrap) return;
+    var p = null;
+    for (var i = 0; i < state.participants.length; i++) {
+      if (state.participants[i].id === pid) { p = state.participants[i]; break; }
+    }
+    if (!p) return;
+    var taskByPid = {};
+    state.tasks.forEach(function (t) {
+      if (!taskByPid[t.participant] || t.created_at > taskByPid[t.participant].created_at) {
+        taskByPid[t.participant] = t;
+      }
+    });
+    var s = pillState(p, taskByPid);
+
+    // Mount the pane on <body> (not inside #participantPills) so it escapes the
+    // pill row's overflow clipping and renders above the search bar.
+    var pane = buildPillOptions(p, s);
+    pane.setAttribute("data-pid", pid);
+    document.body.appendChild(pane);
+    _positionPillOptions(pane, wrap);
+
+    wrap.classList.add("pill-wrap--options-open");
+    var chev = wrap.querySelector(".pill-chevron-btn");
+    if (chev) chev.setAttribute("aria-expanded", "true");
+    state.pillOptionsOpen = pid;
+
+    var reposition = function () {
+      var w = _findPillWrap(pid);
+      var floating = document.querySelector("body > .pill-options[data-pid='" + pid + "']");
+      if (w && floating) _positionPillOptions(floating, w);
+    };
+    state.pillOptionsReposition = reposition;
+    window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
+
+    if (state.transcribePrewarm === "queue_open") {
+      tryPostTranscriptionWarmup();
     }
   }
 
-  function transcribeAll() {
-    var pids = [];
-    state.participants.forEach(function (p) {
-      if (p.has_video && !p.has_transcript) pids.push(p.id);
-    });
-    if (pids.length === 0) {
-      showToast("All participants already transcribed");
-      return;
-    }
-    transcribeParticipants(pids, false);
+  function closePillOptions() {
+    _closeOpenPaneInDom();
   }
 
-  function transcribeParticipants(pids, force) {
-    apiPost("api/transcribe", { participants: pids, force: force }).then(function (data) {
+  function initPillOutsideClick() {
+    document.addEventListener("click", function (e) {
+      if (state.pillOptionsOpen === null) return;
+      var wrap = _findPillWrap(state.pillOptionsOpen);
+      if (wrap && wrap.contains(e.target)) return;
+      var floating = document.querySelector("body > .pill-options");
+      if (floating && floating.contains(e.target)) return;
+      closePillOptions();
+    });
+  }
+
+  function initPillWheelScroll() {
+    var el = qs("#participantPills");
+    if (!el) return;
+    el.addEventListener("wheel", function (e) {
+      if (el.scrollWidth > el.clientWidth) {
+        e.preventDefault();
+        el.scrollLeft += e.deltaY;
+      }
+    }, { passive: false });
+  }
+
+  function startTranscribe(pid, force) {
+    var overrides = {};
+    var ov = state.pillOverrides[pid];
+    if (ov && (ov.model || ov.language)) {
+      overrides[pid] = {};
+      if (ov.model) overrides[pid].model = ov.model;
+      if (ov.language) overrides[pid].language = ov.language;
+    }
+    transcribeParticipants([pid], force, overrides);
+  }
+
+  function transcribeParticipants(pids, force, overrides) {
+    var body = { participants: pids, force: force };
+    if (overrides && Object.keys(overrides).length > 0) body.overrides = overrides;
+    apiPost("api/transcribe", body).then(function (data) {
       if (!data.ok) {
         showToast("Failed to enqueue transcription");
         return;
@@ -2099,10 +2351,7 @@
       }
       _hadActiveTranscriptionLastPoll = hasActive;
 
-      // Update queue panel if visible
-      if (!qs("#queuePanel").classList.contains("hidden")) {
-        renderQueue();
-      }
+      renderPills();
     });
   }
 
@@ -2495,7 +2744,8 @@
     checkNavLinks();
     initFrontendSwitcher();
     initSearch();
-    initQueuePanel();
+    initPillOutsideClick();
+    initPillWheelScroll();
     initCorrectionsModal();
     initVideoSync();
     initSummaryToggle();
@@ -2511,11 +2761,6 @@
         pollTaskStatus();
         startXrefPolling();
       }
-    });
-
-    // Participant select handler
-    qs("#participantSelect").addEventListener("change", function () {
-      if (this.value) selectParticipant(this.value);
     });
 
     // Load initial data

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.67"
+VERSIONNUM: str = "0.10.72"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1,10 +1,13 @@
 """Smoke tests for Transcripts Flask API (prewarm + model status)."""
 
+from typing import cast
+
 import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
 import config  # noqa: E402
+import transcripts  # noqa: E402
 import transcripts_server  # noqa: E402
 import viewer  # noqa: E402
 
@@ -80,3 +83,57 @@ def test_warmup_already_loaded_in_debugging(tr_client, monkeypatch):
     data = resp.get_json()
     assert data["ok"] is True
     assert data.get("already_loaded") is True
+
+
+def test_transcribe_applies_per_participant_overrides(tr_client, monkeypatch):
+    """POST /api/transcribe threads {model, language} overrides onto the task."""
+
+    captured: list[dict] = []
+
+    class _StubWorker:
+        def enqueue(self, task):
+            captured.append(task)
+
+    transcripts_server._participants = [
+        {"id": "P01", "video_path": "/tmp/P01.mp4", "has_video": True}
+    ]
+    transcripts_server._worker = cast("transcripts.TranscriptWorker", _StubWorker())
+
+    resp = tr_client.post(
+        "/transcripts/api/transcribe",
+        json={
+            "participants": ["P01"],
+            "force": True,
+            "overrides": {"P01": {"model": "tiny", "language": "sv"}},
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(captured) == 1
+    assert captured[0]["model"] == "tiny"
+    assert captured[0]["language"] == "sv"
+
+
+def test_transcribe_without_overrides_defaults_to_none(tr_client):
+    """Missing overrides → task uses None (worker falls back to config defaults)."""
+
+    captured: list[dict] = []
+
+    class _StubWorker:
+        def enqueue(self, task):
+            captured.append(task)
+
+    transcripts_server._participants = [
+        {"id": "P01", "video_path": "/tmp/P01.mp4", "has_video": True}
+    ]
+    transcripts_server._worker = cast("transcripts.TranscriptWorker", _StubWorker())
+
+    resp = tr_client.post(
+        "/transcripts/api/transcribe",
+        json={"participants": ["P01"], "force": True},
+    )
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    assert captured[0]["model"] is None
+    assert captured[0]["language"] is None

--- a/transcripts.py
+++ b/transcripts.py
@@ -10,8 +10,9 @@ Data types (defined below):
   ManifestSegment   – TypedDict: id (str), start, end, text — enriched segment for manifest storage
 
 Key functions:
-  transcribe_video(path, *, language, initial_prompt, context_keywords)
-    → TranscriptResult; context_keywords are appended to the initial prompt
+  transcribe_video(path, *, model_name, language, initial_prompt, context_keywords)
+    → TranscriptResult; context_keywords are appended to the initial prompt;
+      model_name overrides config.TRANSCRIBE_MODEL for one call
   filter_segments(result, start_sec, end_sec, *, offset_to_zero)
     → TranscriptResult for a clip's time range; offset_to_zero=True shifts to clip-relative times
   write_transcript(result, output_path, *, fmt)
@@ -133,11 +134,15 @@ def warmup_transcription_model() -> bool:
     return _load_model() is not None
 
 
-def _load_model() -> Any:
-    """Lazy-load the WhisperModel, caching it for reuse (thread-safe)."""
+def _load_model(model_name: str | None = None) -> Any:
+    """Lazy-load the WhisperModel, caching it for reuse (thread-safe).
+
+    When *model_name* is None, uses ``config.TRANSCRIBE_MODEL``. Passing a
+    different name swaps the cached model.
+    """
     global _cached_model, _cached_model_name  # noqa: PLW0603
 
-    model_name = config.TRANSCRIBE_MODEL
+    model_name = model_name or config.TRANSCRIBE_MODEL
     if _cached_model is not None and _cached_model_name == model_name:
         return _cached_model
 
@@ -168,6 +173,7 @@ def _load_model() -> Any:
 def transcribe_video(
     video_path: str,
     *,
+    model_name: str | None = None,
     language: str | None = None,
     initial_prompt: str | None = None,
     context_keywords: list[str] | None = None,
@@ -177,6 +183,8 @@ def transcribe_video(
 
     Args:
         video_path: Path to the video file.
+        model_name: Whisper model size override (e.g. "tiny", "large-v3").
+            None uses ``config.TRANSCRIBE_MODEL``.
         language: Language code (e.g. "en"). None = auto-detect.
         initial_prompt: Override the default initial prompt.
         context_keywords: Extra keywords to append to the prompt.
@@ -187,15 +195,16 @@ def transcribe_video(
     Returns:
         TranscriptResult with segments, or None on failure.
     """
+    resolved_model = model_name or config.TRANSCRIBE_MODEL
     if config.DEBUGGING:
         return TranscriptResult(
             segments=[],
             language=language or "en",
             source_file=str(video_path),
-            model=config.TRANSCRIBE_MODEL,
+            model=resolved_model,
         )
 
-    model = _load_model()
+    model = _load_model(resolved_model)
     if model is None:
         return None
 
@@ -227,7 +236,7 @@ def transcribe_video(
             segments=segments,
             language=detected_lang,
             source_file=str(video_path),
-            model=config.TRANSCRIBE_MODEL,
+            model=resolved_model,
         )
     except _TranscriptionCancelled:
         raise
@@ -649,12 +658,25 @@ class _TranscriptionCancelled(Exception):
     """Raised inside the on_segment callback to abort a running transcription."""
 
 
-def create_transcript_task(participant: str, video_path: str) -> dict[str, Any]:
-    """Create a new transcription task dict ready to enqueue."""
+def create_transcript_task(
+    participant: str,
+    video_path: str,
+    *,
+    model: str | None = None,
+    language: str | None = None,
+) -> dict[str, Any]:
+    """Create a new transcription task dict ready to enqueue.
+
+    *model* and *language* are optional per-participant overrides; when None,
+    the worker falls back to ``config.TRANSCRIBE_MODEL`` and whisper
+    auto-detect respectively.
+    """
     return {
         "id": f"tr_{uuid.uuid4().hex[:8]}",
         "participant": participant,
         "video_path": video_path,
+        "model": model,
+        "language": language,
         "status": TASK_STATUS_QUEUED,
         "progress": 0.0,
         "partial_segments": [],
@@ -806,6 +828,8 @@ class TranscriptWorker:
         try:
             result = transcribe_video(
                 video_path,
+                model_name=task.get("model"),
+                language=task.get("language"),
                 context_keywords=context_kw,
                 on_segment=_on_seg,
             )

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -776,6 +776,7 @@ def api_transcribe() -> FlaskResponse:
 
     participant_ids = data.get("participants", [])
     force = data.get("force", False)
+    overrides = data.get("overrides") or {}
 
     if not participant_ids:
         return jsonify({"ok": False, "error": "No participants specified"}), 400
@@ -795,7 +796,15 @@ def api_transcribe() -> FlaskResponse:
             if not force and pid in src and src[pid].get("segments"):
                 continue
 
-            task = transcripts.create_transcript_task(pid, p["video_path"])
+            o = overrides.get(pid) or {}
+            model_override = o.get("model") or None
+            language_override = o.get("language") or None
+            task = transcripts.create_transcript_task(
+                pid,
+                p["video_path"],
+                model=model_override,
+                language=language_override,
+            )
             if _worker:
                 _worker.enqueue(task)
             enqueued.append(


### PR DESCRIPTION
## Summary
- Replaces the 340px queue sidepanel and participant `<select>` with a horizontally-scrollable row of pills in the transcripts header. Each pill is the active-source selector, shows status via an icon that doubles as an action button (hover swaps to transcribe/cancel/retranscribe), animates its background as a progress bar, and has a chevron that folds out a per-participant options pane.
- Per-participant `model` + `language` overrides thread from the pane through `POST /api/transcribe` → `create_transcript_task` → `transcribe_video`'s new `model_name` kwarg. Overrides are ephemeral (reset on reload); the manifest still records only the model actually used.
- Options pane mounts on `<body>` with `position: fixed` so it escapes the pill row's overflow clipping and renders above the search bar.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 581 passed, including new coverage that overrides thread onto the task and default to `None` when omitted
- [x] `uv run ruff check --fix && uv run ruff format` — clean
- [x] `uv run ty check` — clean
- [ ] Manual smoke with `uv run clipgen.py --transcripts -i <dir>` across 3+ participants: pill selection, hover-swap trigger glyph, progress fill, chevron options pane (model + language + re-transcribe), horizontal wheel scroll, pane repositioning on scroll/resize, outside-click dismissal