### PR TITLE
feat: double-click Screenspace divider to hide bottom panel

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1735,6 +1735,11 @@ body {
   height: 400px;
   min-height: 120px;
   overflow: hidden;
+  transition:
+    height var(--duration-normal) ease,
+    margin-bottom var(--duration-normal) ease,
+    padding-top var(--duration-normal) ease,
+    padding-bottom var(--duration-normal) ease;
 }
 
 #bottomPanel > * {
@@ -1742,6 +1747,29 @@ body {
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Bottom panel collapse (double-click divider) */
+
+body.bottom-collapsed #bottomPanel {
+  margin-bottom: 0;
+  border-width: 0;
+  min-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+body.bottom-collapsed #panelDivider .divider-handle {
+  width: 24px;
+  background: var(--color-accent);
+}
+
+body.bottom-animating #bottomPanel {
+  box-shadow: none;
+}
+
+body.panel-dragging #bottomPanel {
+  transition: none;
 }
 
 /* Right pane: tabbed Task Queue + Results */

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -102,6 +102,8 @@
     queuePaused: false,
     timelineDragging: false,
     panelHeight: 340,
+    panelHeightBeforeCollapse: 340,
+    bottomCollapsed: false,
     previewMaxWidth: 100,
     taskFilter: null,
     pipetteActive: false,
@@ -5784,11 +5786,13 @@
     var MAX_H = Math.round(window.innerHeight * 0.6);
 
     function onDown(e) {
+      if (state.bottomCollapsed) return;
       e.preventDefault();
       dragging = true;
       startY = e.clientY || (e.touches && e.touches[0].clientY) || 0;
       startHeight = state.panelHeight;
       handle.classList.add("active");
+      document.body.classList.add("panel-dragging");
       document.body.style.cursor = "row-resize";
       document.body.style.userSelect = "none";
     }
@@ -5817,12 +5821,76 @@
       if (!dragging) return;
       dragging = false;
       handle.classList.remove("active");
+      document.body.classList.remove("panel-dragging");
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     }
 
     document.addEventListener("mouseup", onUp);
     document.addEventListener("touchend", onUp);
+
+    handle.addEventListener("dblclick", function (e) {
+      e.preventDefault();
+      toggleBottomPanel();
+    });
+  }
+
+  function toggleBottomPanel() {
+    var panel = qs("#bottomPanel");
+    if (!panel || panel._transitioning) return;
+    panel._transitioning = true;
+
+    if (state.bottomCollapsed) {
+      // --- Restore ---
+      state.bottomCollapsed = false;
+      var maxH = Math.round(window.innerHeight * 0.6);
+      var targetH = Math.min(state.panelHeightBeforeCollapse || 340, maxH);
+
+      document.body.classList.add("bottom-animating");
+      document.body.classList.remove("bottom-collapsed");
+
+      panel.style.height = "0px";
+      panel.offsetHeight; // reflow — pin start frame
+      panel.style.height = targetH + "px";
+
+      onCollapseTransitionEnd(panel, function () {
+        state.panelHeight = targetH;
+        panel._transitioning = false;
+        document.body.classList.remove("bottom-animating");
+      });
+    } else {
+      // --- Collapse ---
+      state.bottomCollapsed = true;
+      state.panelHeightBeforeCollapse = state.panelHeight;
+
+      var currentH = panel.offsetHeight;
+      document.body.classList.add("bottom-animating");
+
+      panel.style.height = currentH + "px";
+      panel.offsetHeight; // reflow
+      document.body.classList.add("bottom-collapsed");
+      panel.style.height = "0px";
+
+      onCollapseTransitionEnd(panel, function () {
+        panel._transitioning = false;
+        document.body.classList.remove("bottom-animating");
+      });
+    }
+  }
+
+  function onCollapseTransitionEnd(el, cb) {
+    var fired = false;
+    function done() {
+      if (fired) return;
+      fired = true;
+      el.removeEventListener("transitionend", handler);
+      cb();
+    }
+    function handler(e) {
+      if (e.target === el && e.propertyName === "height") done();
+    }
+    el.addEventListener("transitionend", handler);
+    setTimeout(done, 400);
   }
 
   // ---- Preview resize ----

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.68"
+VERSIONNUM: str = "0.10.69"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Mirrors the Studio gesture: double-clicking the `#panelDivider` smoothly collapses and restores the Screenspace bottom panel (Workflow + Queue/Results), freeing vertical space for the canvas.
- Collapse animates height, margin-bottom, and padding in sync; `min-height` and padding are overridden under `body.bottom-collapsed` so the panel goes fully to zero (no peeking tab bars).
- Drag uses a `body.panel-dragging` class to suppress the height transition so resize tracks the cursor in real time; `body.bottom-animating` suppresses the panel shadow during collapse/restore to avoid paint jank.
- Drag is blocked while collapsed; a `_transitioning` flag prevents double-click spam mid-animation.

## Test plan
- [ ] `uv run clipgen.py --screenspace -i DIR -o DIR`, open http://127.0.0.1:8089/screenspace/
- [ ] Drag divider — panel tracks the cursor without lag
- [ ] Double-click divider — panel collapses smoothly to 0, tabs fully hidden, divider sits flush
- [ ] Double-click again — panel restores to the pre-collapse height
- [ ] Resize to a custom height, collapse, restore — returns to the custom height, not the default