### PR TITLE
refactor: frontend JS cleanup + Studio drag-handle fix for Metadata

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -46,7 +46,7 @@
   }
 
   function clockToSeconds(ts) {
-    // Like parseTimestampToSeconds but treats 2-part as HH:MM (clock time)
+    // Like utils.parseTimestamp but treats 2-part as HH:MM (clock time)
     // rather than MM:SS.  Matches Python utils._clock_to_seconds.
     var parts = ts.split(":");
     if (parts.length === 3)
@@ -113,20 +113,6 @@
     return { r: 59, g: 130, b: 246 };
   }
 
-  // --- Tooltip Positioning ---
-
-  function cvPositionTooltip(tooltipEl, anchorRect) {
-    var ttW = tooltipEl.offsetWidth;
-    var ttH = tooltipEl.offsetHeight;
-    var left = anchorRect.left + anchorRect.width / 2 - ttW / 2;
-    var top = anchorRect.top - ttH - 6;
-    if (top < 4) top = anchorRect.bottom + 6;
-    if (left < 4) left = 4;
-    if (left + ttW > window.innerWidth - 4) left = window.innerWidth - ttW - 4;
-    tooltipEl.style.left = left + "px";
-    tooltipEl.style.top = top + "px";
-  }
-
   // --- Frame Preview ---
 
   function cvFrameUrl(source, participant, startSec) {
@@ -166,6 +152,7 @@
     } else if (!cached) {
       _cvFrameCache[url] = "loading";
       img.src = "";
+      // TODO: utils.apiGet returns JSON; needs an apiGetBlob helper to migrate.
       fetch(url)
         .then(function (r) {
           if (!r.ok) throw new Error("status " + r.status);
@@ -187,7 +174,7 @@
 
     lbl.textContent = event.participant + " \u00b7 " + formatTime(event.start);
     preview.classList.remove("hidden");
-    cvPositionTooltip(preview, markerEl.getBoundingClientRect());
+    positionTooltipAnchored(preview, markerEl.getBoundingClientRect());
   }
 
   function cvHideFramePreview() {
@@ -860,7 +847,7 @@
               + " \u00b7 " + zone.events.length + " event"
               + (zone.events.length !== 1 ? "s" : "");
             tip.classList.remove("hidden");
-            cvPositionTooltip(tip, {
+            positionTooltipAnchored(tip, {
               left: e.clientX - 4, top: rect.top,
               width: 8, height: rect.height, bottom: rect.bottom,
             });
@@ -1505,7 +1492,6 @@
   // --- Window exports ---
   window.convergenceActivate = activate;
   window.convergenceDeactivate = deactivate;
-  window.convergenceInit = init;
   window.convergenceResize = debounce(function () {
     if (!cvState.active) return;
     render();

--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -79,12 +79,15 @@
       overlay.textContent = a.timestamp_formatted || formatTime(a.timestamp);
       card.appendChild(overlay);
 
-      card.addEventListener("click", (function (idx) {
-        return function () { openLightbox(idx); };
-      })(i));
-
       grid.appendChild(card);
     }
+
+    grid.addEventListener("click", function (e) {
+      var card = e.target.closest(".gallery-card");
+      if (!card) return;
+      var idx = parseInt(card.getAttribute("data-index"), 10);
+      if (!isNaN(idx)) openLightbox(idx);
+    });
   }
 
   // ---- Lightbox ----

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -64,12 +64,8 @@
 
   function loadData() {
     Promise.all([
-      fetch("api/artifacts").then(function (r) {
-        return r.json();
-      }),
-      fetch("api/insights").then(function (r) {
-        return r.json();
-      }),
+      apiGet("api/artifacts"),
+      apiGet("api/insights"),
     ]).then(function (results) {
       state.artifacts = results[0].artifacts || [];
       state.insights = results[1].insights || [];
@@ -544,6 +540,7 @@
   function loadAudioBuffer(filePath) {
     if (_audioBuffers[filePath]) return Promise.resolve(_audioBuffers[filePath]);
     if (_audioLoading[filePath]) return _audioLoading[filePath];
+    // TODO: returns arrayBuffer (audio), not JSON. apiGet doesn't cover non-JSON responses.
     _audioLoading[filePath] = fetch("media/" + encodeURIComponent(filePath))
       .then(function (r) { return r.arrayBuffer(); })
       .then(function (buf) { return getAudioContext().decodeAudioData(buf); })
@@ -765,14 +762,7 @@
   }
 
   function createNewInsight() {
-    fetch("api/insights", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Untitled insight" }),
-    })
-      .then(function (r) {
-        return r.json();
-      })
+    apiPost("api/insights", { title: "Untitled insight" })
       .then(function (data) {
         if (data.ok) {
           state.insights.push(data.insight);
@@ -786,10 +776,7 @@
 
   function deleteInsight(insightId) {
     if (!confirm("Delete this insight? This cannot be undone.")) return;
-    fetch("api/insights/" + insightId, { method: "DELETE" })
-      .then(function (r) {
-        return r.json();
-      })
+    apiDelete("api/insights/" + insightId)
       .then(function (data) {
         if (data.ok) {
           state.insights = state.insights.filter(function (ins) {
@@ -831,13 +818,7 @@
         }
       }
       if (!insight) return Promise.resolve();
-      return fetch("api/insights/" + id, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(insight),
-      }).then(function (r) {
-        return r.json();
-      });
+      return apiPut("api/insights/" + id, insight);
     });
     Promise.all(promises).then(function () {
       state.dirtyIds = {};
@@ -855,14 +836,7 @@
       }
     }
     if (!insight) return;
-    fetch("api/insights/" + insightId, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(insight),
-    })
-      .then(function (r) {
-        return r.json();
-      })
+    apiPut("api/insights/" + insightId, insight)
       .then(function () {
         delete state.dirtyIds[insightId];
         updateDirtyUI();
@@ -872,10 +846,7 @@
 
   function discardAll() {
     if (!confirm("Discard all unsaved changes?")) return;
-    fetch("api/insights")
-      .then(function (r) {
-        return r.json();
-      })
+    apiGet("api/insights")
       .then(function (data) {
         state.insights = data.insights || [];
         state.dirtyIds = {};
@@ -1250,9 +1221,9 @@
       rafPending = true;
       var clientX = e.clientX;
       requestAnimationFrame(function () {
-        var panelLeft = sidebar.parentElement.getBoundingClientRect().left;
-        var maxW = sidebar.parentElement.offsetWidth * 0.6;
-        var w = Math.max(280, Math.min(maxW, clientX - panelLeft));
+        var parentRect = sidebar.parentElement.getBoundingClientRect();
+        var maxW = parentRect.width * 0.6;
+        var w = Math.max(280, Math.min(maxW, clientX - parentRect.left));
         sidebar.style.width = w + "px";
         rafPending = false;
       });
@@ -1363,10 +1334,7 @@
     qs("#generateViewerBtn").addEventListener("click", function () {
       this.disabled = true;
       var btn = this;
-      fetch("api/generate-viewer", { method: "POST" })
-        .then(function (r) {
-          return r.json();
-        })
+      apiPost("api/generate-viewer", {})
         .then(function (data) {
           btn.disabled = false;
           if (data.ok) {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -66,6 +66,11 @@
   var TIMELINE_CANVAS_HEIGHT = 64;
 
   var _paletteDocListeners = null;
+  // Cached HSV hidden inputs for the single-tool color picker. Populated by
+  // renderColorParams() when the panel is built; reused by setTargetColor,
+  // updateColorPreview, _collectPreviewParams, etc. so they don't re-query
+  // the DOM on every drag tick. Null when no color tool panel is active.
+  var _colorHiddenInputs = null;
 
   var REGION_COLORS = [
     "#3b82f6", "#ef4444", "#22c55e", "#f59e0b",
@@ -182,19 +187,6 @@
     var m = Math.floor(secs / 60);
     var s = secs % 60;
     return m + ":" + (s < 10 ? "0" : "") + s.toFixed(1);
-  }
-
-  function parseTimestampInput(str) {
-    str = (str || "").trim();
-    var parts = str.split(":");
-    if (parts.length === 3) return (+parts[0]) * 3600 + (+parts[1]) * 60 + (+parts[2]);
-    if (parts.length === 2) return (+parts[0]) * 60 + (+parts[1]);
-    var n = parseFloat(str);
-    return isNaN(n) ? null : n;
-  }
-
-  function clamp(val, min, max) {
-    return Math.max(min, Math.min(max, val));
   }
 
   function regionColorForIndex(i) {
@@ -738,7 +730,7 @@
     var input = qs("#timestampInput");
 
     input.addEventListener("change", function () {
-      var ts = parseTimestampInput(input.value);
+      var ts = parseTimestamp(input.value);
       if (ts !== null && state.videoInfo) {
         ts = clamp(ts, 0, state.videoInfo.duration || 0);
         loadFrame(ts);
@@ -2963,6 +2955,7 @@
     pickerGroup.appendChild(hiddenH);
     pickerGroup.appendChild(hiddenS);
     pickerGroup.appendChild(hiddenV);
+    _colorHiddenInputs = { h: hiddenH, s: hiddenS, v: hiddenV, hex: hexInput };
 
     container.appendChild(pickerGroup);
 
@@ -2974,7 +2967,7 @@
       var y = clamp(e.clientY - rect.top, 0, rect.height);
       var h = Math.round((x / rect.width) * 180);
       var s = Math.round((1 - y / rect.height) * 255);
-      var curV = parseFloat(qs("#paramColorV").value) || 0;
+      var curV = parseFloat(hiddenV.value) || 0;
       setTargetColor(h, s, curV);
     }
     palette.addEventListener("mousedown", function (e) {
@@ -2987,8 +2980,8 @@
       var rect = bright.getBoundingClientRect();
       var x = clamp(e.clientX - rect.left, 0, rect.width);
       var v = Math.round((x / rect.width) * 255);
-      var curH = parseFloat(qs("#paramColorH").value) || 0;
-      var curS = parseFloat(qs("#paramColorS").value) || 0;
+      var curH = parseFloat(hiddenH.value) || 0;
+      var curS = parseFloat(hiddenS.value) || 0;
       setTargetColor(curH, curS, v);
     }
     bright.addEventListener("mousedown", function (e) {
@@ -3014,10 +3007,9 @@
       var rgb = hexToRgb(hexInput.value);
       if (rgb) {
         var hsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
-        var hEl = qs("#paramColorH"), sEl = qs("#paramColorS"), vEl = qs("#paramColorV");
-        if (hEl) hEl.value = hsv.h;
-        if (sEl) sEl.value = hsv.s;
-        if (vEl) vEl.value = hsv.v;
+        hiddenH.value = hsv.h;
+        hiddenS.value = hsv.s;
+        hiddenV.value = hsv.v;
         updateColorPreview();
         renderColorPalette();
         renderBrightnessStrip();
@@ -3297,6 +3289,7 @@
   function renderWorkflowParams() {
     var container = qs("#workflowParams");
     container.innerHTML = "";
+    _colorHiddenInputs = null;
     hideToolInfoTooltip(true);
     _toolInfoPinned = false;
     var intervalSlot = qs("#workflowIntervalSlot");
@@ -3464,10 +3457,10 @@
   function _collectPreviewParams(tool) {
     var out = {};
     if (tool === "color") {
-      var hEl = qs("#paramColorH"), sEl = qs("#paramColorS"), vEl = qs("#paramColorV");
-      if (hEl) out.h = hEl.value;
-      if (sEl) out.s = sEl.value;
-      if (vEl) out.v = vEl.value;
+      var c = _colorHiddenInputs;
+      if (c) {
+        out.h = c.h.value; out.s = c.s.value; out.v = c.v.value;
+      }
     } else if (tool === "change") {
       var n = qs("#paramChangeNoise");
       if (n) out.noise = n.value;
@@ -3561,6 +3554,7 @@
 
     var useTemplatePost = tool === "template" && state.uploadedTemplate && state.uploadedTemplate.data;
     if (useTemplatePost) {
+      // TODO: utils.apiPost returns JSON; needs an apiPostBlob helper to migrate.
       fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -3670,11 +3664,9 @@
 
   function updateColorPreview() {
     var preview = qs("#colorPreview");
-    if (!preview) return;
-    var h = parseFloat((qs("#paramColorH") || {}).value) || 0;
-    var s = parseFloat((qs("#paramColorS") || {}).value) || 0;
-    var v = parseFloat((qs("#paramColorV") || {}).value) || 0;
-    var rgb = hsvToRgb(h, s, v);
+    var c = _colorHiddenInputs;
+    if (!preview || !c) return;
+    var rgb = hsvToRgb(parseFloat(c.h.value) || 0, parseFloat(c.s.value) || 0, parseFloat(c.v.value) || 0);
     preview.style.background = rgbToHex(rgb.r, rgb.g, rgb.b);
   }
 
@@ -3682,13 +3674,12 @@
     h = clamp(Math.round(h), 0, 180);
     s = clamp(Math.round(s), 0, 255);
     v = clamp(Math.round(v), 0, 255);
-    var hEl = qs("#paramColorH"), sEl = qs("#paramColorS"), vEl = qs("#paramColorV");
-    if (hEl) hEl.value = h;
-    if (sEl) sEl.value = s;
-    if (vEl) vEl.value = v;
-    var rgb = hsvToRgb(h, s, v);
-    var hexEl = qs("#paramColorHex");
-    if (hexEl) hexEl.value = rgbToHex(rgb.r, rgb.g, rgb.b);
+    var c = _colorHiddenInputs;
+    if (c) {
+      c.h.value = h; c.s.value = s; c.v.value = v;
+      var rgb = hsvToRgb(h, s, v);
+      c.hex.value = rgbToHex(rgb.r, rgb.g, rgb.b);
+    }
     updateColorPreview();
     renderColorPalette();
     renderBrightnessStrip();
@@ -3728,7 +3719,10 @@
     ctx.fillRect(0, 0, w, h);
 
     // Black overlay for brightness
-    var curV = parseFloat((qs("#paramColorV") || {}).value) || 0;
+    var c = _colorHiddenInputs;
+    var curH = c ? parseFloat(c.h.value) || 0 : 0;
+    var curS = c ? parseFloat(c.s.value) || 0 : 0;
+    var curV = c ? parseFloat(c.v.value) || 0 : 0;
     var darkness = 1 - curV / 255;
     if (darkness > 0) {
       ctx.fillStyle = "rgba(0,0,0," + darkness + ")";
@@ -3736,8 +3730,6 @@
     }
 
     // Current position
-    var curH = parseFloat((qs("#paramColorH") || {}).value) || 0;
-    var curS = parseFloat((qs("#paramColorS") || {}).value) || 0;
     var cx = (curH / 180) * w;
     var cy = (1 - curS / 255) * h;
 
@@ -3777,8 +3769,10 @@
     var size = sizeCanvasToDisplay(canvas);
     var w = size.w, h = size.h, dpr = size.dpr;
     var ctx = canvas.getContext("2d");
-    var curH = parseFloat((qs("#paramColorH") || {}).value) || 0;
-    var curS = parseFloat((qs("#paramColorS") || {}).value) || 0;
+    var c = _colorHiddenInputs;
+    var curH = c ? parseFloat(c.h.value) || 0 : 0;
+    var curS = c ? parseFloat(c.s.value) || 0 : 0;
+    var curV = c ? parseFloat(c.v.value) || 0 : 0;
 
     // Gradient from black (left) to fully saturated color (right)
     var fullRgb = hsvToRgb(curH, curS, 255);
@@ -3789,7 +3783,6 @@
     ctx.fillRect(0, 0, w, h);
 
     // Position indicator
-    var curV = parseFloat((qs("#paramColorV") || {}).value) || 0;
     var ix = (curV / 255) * w;
     var r = 4 * dpr;
     ctx.beginPath();
@@ -6006,6 +5999,7 @@
         // Preload frame 0 for all participants (instant first-frame display)
         state.participants.forEach(function (p) {
           var url = frameUrl(p.id, 0);
+          // TODO: fire-and-forget blob preload; needs apiGetBlob helper to migrate.
           fetch(url)
             .then(function (r) { return r.blob(); })
             .then(function (blob) { _preloadedFrames[p.id] = URL.createObjectURL(blob); })

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -155,19 +155,6 @@
     if (td) td.classList.add("header-highlight");
   }
 
-  function parseTimestampToSeconds(ts) {
-    var parts = ts.split(":");
-    if (parts.length === 3)
-      return (
-        parseInt(parts[0], 10) * 3600 +
-        parseInt(parts[1], 10) * 60 +
-        parseInt(parts[2], 10)
-      );
-    if (parts.length === 2)
-      return parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
-    return NaN;
-  }
-
   function parseClipTimestamps(raw) {
     var DEFAULT_DUR = (state.sheetData && state.sheetData.defaultDuration) || 60;
     var cleaned = raw
@@ -188,14 +175,14 @@
         }
       }
       if (dashIdx > 0) {
-        var s = parseTimestampToSeconds(tok.substring(0, dashIdx));
-        var e = parseTimestampToSeconds(tok.substring(dashIdx + 1));
-        if (!isNaN(s) && !isNaN(e)) {
+        var s = parseTimestamp(tok.substring(0, dashIdx));
+        var e = parseTimestamp(tok.substring(dashIdx + 1));
+        if (s !== null && e !== null) {
           segments.push({ startSeconds: Math.floor(s), duration: Math.max(0, e - s) });
         }
       } else if (tok.indexOf(":") > 0) {
-        var sec = parseTimestampToSeconds(tok);
-        if (!isNaN(sec)) {
+        var sec = parseTimestamp(tok);
+        if (sec !== null) {
           segments.push({ startSeconds: Math.floor(sec), duration: DEFAULT_DUR });
         }
       }
@@ -259,18 +246,6 @@
     }
 
     return result;
-  }
-
-  function positionTooltip(tooltipEl, anchorRect) {
-    var ttW = tooltipEl.offsetWidth;
-    var ttH = tooltipEl.offsetHeight;
-    var left = anchorRect.left + anchorRect.width / 2 - ttW / 2;
-    var top = anchorRect.top - ttH - 6;
-    if (top < 4) top = anchorRect.bottom + 6;
-    if (left < 4) left = 4;
-    if (left + ttW > window.innerWidth - 4) left = window.innerWidth - ttW - 4;
-    tooltipEl.style.left = left + "px";
-    tooltipEl.style.top = top + "px";
   }
 
   function intakeComputeTickInterval(visLen) {
@@ -679,11 +654,7 @@
   // ---- Data loading ----
 
   function loadSheetData() {
-    fetch("api/sheet")
-      .then(function (r) {
-        if (!r.ok) throw new Error("Server error " + r.status);
-        return r.json();
-      })
+    apiGet("api/sheet")
       .then(function (data) {
         if (!data.ok) {
           qs("#sheetLoading").textContent =
@@ -736,6 +707,7 @@
     var svg = btn.querySelector("svg");
     if (svg) svg.style.animation = "spin 0.7s linear infinite";
 
+    // TODO: no r.ok check; migrating to apiPost would add throw on HTTP error.
     fetch("api/sheet/refresh", { method: "POST" })
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -755,6 +727,7 @@
   }
 
   function loadManifestState() {
+    // TODO: no r.ok check; migrating to apiGet would add throw on HTTP error.
     fetch("api/manifest")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -989,6 +962,24 @@
 
   // ---- Panel divider (resizable split between sheet preview and bottom panel) ----
 
+  // Tab panels whose height tracks the divider. Keep in sync with the markup in studio.html;
+  // every preview tab that shares the upper pane must appear here so the drag/collapse/resize
+  // code paths apply the same maxHeight to each.
+  var UPPER_PANE_PANELS = [
+    "#sheetGrid",
+    "#intakePanel",
+    "#trIntakePanel",
+    "#convergencePanel",
+    "#metadataPanel",
+  ];
+
+  function applyUpperPaneMaxHeight(value) {
+    for (var i = 0; i < UPPER_PANE_PANELS.length; i++) {
+      var p = qs(UPPER_PANE_PANELS[i]);
+      if (p) p.style.maxHeight = value;
+    }
+  }
+
   function computeGridMaxHeight(bottomHeightOverride) {
     var header = qs("#studioHeader");
     var preview = qs("#sheetPreview");
@@ -1024,15 +1015,7 @@
     state.dividerOffset = Math.min(state.dividerOffset, maxAllowed);
 
     var maxH = Math.max(MIN_GRID, available - state.dividerOffset) + "px";
-    grid.style.maxHeight = maxH;
-    var intakePanel = qs("#intakePanel");
-    if (intakePanel) intakePanel.style.maxHeight = maxH;
-    var trIntakePanel = qs("#trIntakePanel");
-    if (trIntakePanel) trIntakePanel.style.maxHeight = maxH;
-    var convergencePanel = qs("#convergencePanel");
-    if (convergencePanel) convergencePanel.style.maxHeight = maxH;
-    var metadataPanel = qs("#metadataPanel");
-    if (metadataPanel) metadataPanel.style.maxHeight = maxH;
+    applyUpperPaneMaxHeight(maxH);
   }
 
   function initPanelDivider() {
@@ -1106,14 +1089,7 @@
         // Apply maxHeight directly using the stable snapshot
         var MIN_GRID = 100;
         var maxH = Math.max(MIN_GRID, dragAvailable - state.dividerOffset) + "px";
-        var grid = qs("#sheetGrid");
-        if (grid) grid.style.maxHeight = maxH;
-        var intakePanel = qs("#intakePanel");
-        if (intakePanel) intakePanel.style.maxHeight = maxH;
-        var trIntakePanel = qs("#trIntakePanel");
-        if (trIntakePanel) trIntakePanel.style.maxHeight = maxH;
-        var convergencePanel = qs("#convergencePanel");
-        if (convergencePanel) convergencePanel.style.maxHeight = maxH;
+        applyUpperPaneMaxHeight(maxH);
 
         rafPending = false;
       });
@@ -1179,11 +1155,7 @@
       state.dividerOffset = 0;
 
       // Clear grid maxHeight — collapsed CSS flex rules fill the space instead
-      var panels = ["#sheetGrid", "#intakePanel", "#trIntakePanel", "#convergencePanel", "#metadataPanel"];
-      for (var i = 0; i < panels.length; i++) {
-        var p = qs(panels[i]);
-        if (p) p.style.maxHeight = "";
-      }
+      applyUpperPaneMaxHeight("");
 
       document.body.classList.add("bottom-animating");
       var currentH = bottom.offsetHeight;
@@ -1965,6 +1937,7 @@
   // ---- Stashed reels ----
 
   function loadStashes() {
+    // TODO: no r.ok check; migrating to apiGet would surface HTTP errors via the catch.
     fetch("api/stashes")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -2061,6 +2034,7 @@
 
     var items = state.reelQueue.slice();
     var totalDuration = computeReelDuration(items);
+    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
     fetch("api/stashes", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -2090,6 +2064,7 @@
   }
 
   function deleteStash(stashId, endpoint, stateArray, renderFn) {
+    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
     fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -2129,6 +2104,7 @@
       });
       parent.replaceChild(span, input);
 
+      // TODO: fire-and-forget; needs custom shape, no migration to apiPost.
       fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2150,6 +2126,7 @@
 
   function createStashViaAPI(endpoint, items, onSuccess) {
     var totalDuration = computeReelDuration(items);
+    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
     fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -2165,6 +2142,7 @@
   // ---- Stashed artifacts ----
 
   function loadArtifactStashes() {
+    // TODO: no r.ok check; migrating to apiGet would surface HTTP errors via the catch.
     fetch("api/artifact-stashes")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -2248,6 +2226,7 @@
 
     var items = state.artifactQueue.slice();
     var totalDuration = computeReelDuration(items);
+    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
     fetch("api/artifact-stashes", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -2374,6 +2353,7 @@
     qs("#statusDismiss").addEventListener("click", hideOverlay);
     qs("#statusOpen").addEventListener("click", function () {
       if (_lastViewerFile) {
+        // TODO: fire-and-forget with no response handling; no clean migration to apiPost.
         fetch("api/open-viewer", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -2559,6 +2539,8 @@
         if (tcDur) genBody.titlecard_duration = parseInt(tcDur.value, 10) || 2;
       }
 
+      // TODO: streaming NDJSON response — not a JSON body. apiPost doesn't apply;
+      // manual fetch is required to get a reader and parse line-delimited progress events.
       fetch("api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2608,6 +2590,8 @@
         };
       });
 
+      // TODO: skips r.ok check — success is signaled by data.ok from server. Migrating to apiPost
+      // would add an r.ok throw that this handler doesn't currently trigger.
       fetch("api/generate-intake", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2646,6 +2630,7 @@
 
   function onCancelReel() {
     qs("#cancelReelBtn").classList.add("hidden");
+    // TODO: fire-and-forget POST with no body; apiPost would send JSON.stringify(undefined).
     fetch("api/reel/cancel", { method: "POST" });
   }
 
@@ -2709,15 +2694,7 @@
       setCardQueued(reelCards[i]);
     }
 
-    fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(reelBody),
-    })
-      .then(function (r) {
-        if (!r.ok) throw new Error("Server error " + r.status);
-        return r.json();
-      })
+    apiPost(endpoint, reelBody)
       .then(function (data) {
         state.generating = false;
         setTitleSpinner("reelSpinner", false);
@@ -2765,15 +2742,7 @@
 
     showOverlay("Building timeline viewer...");
 
-    fetch("api/viewer", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    })
-      .then(function (r) {
-        if (!r.ok) throw new Error("Server error " + r.status);
-        return r.json();
-      })
+    apiPost("api/viewer", {})
       .then(function (data) {
         state.generating = false;
         if (data.ok) {
@@ -2825,15 +2794,7 @@
       showOverlay("Building timeline viewer\u2026");
     }
 
-    fetch("api/timeline-viewer", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    })
-      .then(function (r) {
-        if (!r.ok) throw new Error("Server error " + r.status);
-        return r.json();
-      })
+    apiPost("api/timeline-viewer", body)
       .then(function (data) {
         state.generating = false;
         if (data.ok) {
@@ -2885,15 +2846,7 @@
     state.generating = true;
     showOverlay("Finding best clips (" + duration + "s budget)...");
 
-    fetch("api/highlights-preview", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ highlights_duration: duration }),
-    })
-      .then(function (r) {
-        if (!r.ok) throw new Error("Server error " + r.status);
-        return r.json();
-      })
+    apiPost("api/highlights-preview", { highlights_duration: duration })
       .then(function (data) {
         state.generating = false;
         if (data.ok && data.clips && data.clips.length > 0) {
@@ -2971,15 +2924,7 @@
     state.generating = true;
     showOverlay("Generating gallery viewer for " + participant + "...");
 
-    fetch("api/gallery", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participant: participant, format: format, interval: interval, bundle: bundle }),
-    })
-      .then(function (r) {
-        if (!r.ok) throw new Error("Server error " + r.status);
-        return r.json();
-      })
+    apiPost("api/gallery", { participant: participant, format: format, interval: interval, bundle: bundle })
       .then(function (data) {
         state.generating = false;
         if (data.ok) {
@@ -3137,6 +3082,7 @@
   function _fetchModels() {
     if (_modelsCache) return Promise.resolve(_modelsCache);
     if (_modelsCachePromise) return _modelsCachePromise;
+    // TODO: skips r.ok; cross-mode URL (../api/...) — apiGet would migrate if it accepts absolute paths.
     _modelsCachePromise = fetch("../api/models")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -3202,6 +3148,7 @@
 
   function loadSettings() {
     qs("#settingsContent").textContent = "Loading settings\u2026";
+    // TODO: skips r.ok check — handler reacts only to data.ok. apiGet would throw on non-2xx.
     fetch("api/settings")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -3373,6 +3320,8 @@
     var statusEl = qs("#settingsSaveStatus");
     if (statusEl) statusEl.textContent = "Saving\u2026";
 
+    // TODO: skips r.ok — "Save failed" is shown when data.ok is false; apiPut would convert
+    // non-2xx into a catch branch that also shows the same message, but changes status-code semantics.
     fetch("api/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -3401,6 +3350,8 @@
     }
     renderSettings();
 
+    // TODO: skips r.ok; response payload is ignored beyond success path. Migrating to apiPut
+    // would surface non-2xx via .catch — currently any failure is silently swallowed.
     fetch("api/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -3452,6 +3403,7 @@
       TITLECARD_DURATION_SECONDS: parseInt(dur.value, 10) || 2,
     };
 
+    // TODO: skips r.ok; only reacts to data.ok. Silent on HTTP failure — apiPut would expose it via .catch.
     fetch("api/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -3500,6 +3452,8 @@
   }
 
   function checkNavLinks() {
+    // TODO: skips r.ok; a failed request silently leaves tabs hidden. apiGet would catch but
+    // the current code already swallows errors via the .catch below.
     fetch("../api/status")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -3550,6 +3504,7 @@
       if (!item.img.parentNode) continue;
       _ssThumbActive++;
       (function (entry) {
+        // TODO: returns a blob (image), not JSON. apiGet doesn't cover blob responses.
         fetch(entry.url)
           .then(function (r) {
             if (!r.ok) throw new Error("status " + r.status);
@@ -3669,11 +3624,7 @@
   }
 
   function pollIntakeEvents() {
-    fetch("../screenspace/api/events?excluded=false")
-      .then(function (r) {
-        if (!r.ok) throw new Error("status " + r.status);
-        return r.json();
-      })
+    apiGet("../screenspace/api/events?excluded=false")
       .then(function (data) {
         if (!data.ok) return;
         var events = data.events || [];
@@ -4001,6 +3952,8 @@
 
   function intakeDismissCluster(cluster) {
     var ids = cluster.events.map(function (e) { return e.id; });
+    // TODO: response body ignored; apiPut would parse JSON unnecessarily. Refactor if a
+    // fire-and-forget apiPutVoid helper is added.
     fetch("../screenspace/api/events/bulk-exclude", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -4097,7 +4050,7 @@
         if (tooltipText) {
           trTooltip.textContent = tooltipText;
           trTooltip.classList.remove("hidden");
-          positionTooltip(trTooltip, card.getBoundingClientRect());
+          positionTooltipAnchored(trTooltip, card.getBoundingClientRect());
         } else {
           trTooltip.classList.add("hidden");
         }
@@ -4227,6 +4180,7 @@
   };
 
   function pollTranscriptIntakeMarks() {
+    // TODO: skips r.ok; migrating to apiGet would catch HTTP errors currently silently swallowed.
     fetch("../transcripts/api/marks")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -4237,12 +4191,14 @@
 
         // If "Show all" is enabled, also fetch all segments as unmark items
         if (state.trIntakeShowAll) {
+          // TODO: skips r.ok (same pattern).
           fetch("../transcripts/api/participants")
             .then(function (r2) { return r2.json(); })
             .then(function (pData) {
               if (!pData.ok) return;
               var transcribed = pData.participants.filter(function (p) { return p.has_transcript; });
               var promises = transcribed.map(function (p) {
+                // TODO: skips r.ok (same pattern).
                 return fetch("../transcripts/api/transcript/" + p.id).then(function (r3) { return r3.json(); });
               });
               Promise.all(promises).then(function (results) {
@@ -4616,6 +4572,7 @@
       if (!cluster) return;
       var ids = cluster.marks.map(function (m) { return m.id; }).filter(Boolean);
       if (!ids.length) return;
+      // TODO: DELETE with a JSON body — apiDelete takes no body, so this custom fetch stays.
       fetch("../transcripts/api/marks/" + ids[0], {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
@@ -4640,7 +4597,7 @@
         if (fullText) {
           trTooltip.textContent = fullText;
           trTooltip.classList.remove("hidden");
-          positionTooltip(trTooltip, card.getBoundingClientRect());
+          positionTooltipAnchored(trTooltip, card.getBoundingClientRect());
         } else {
           trTooltip.classList.add("hidden");
         }
@@ -4855,15 +4812,12 @@
 
   window._studioState = state;
   window._studioParseClipTimestamps = parseClipTimestamps;
-  window._studioParseTimestampToSeconds = parseTimestampToSeconds;
   window._studioHexToRgba = hexToRgba;
-  window._studioIntakeComputeTickInterval = intakeComputeTickInterval;
   window._studioFormatDuration = formatDuration;
   window._studioFindOverlappingData = findOverlappingData;
   window._studioBuildXrefBadges = buildXrefBadges;
   window._studioRenderArtifactQueue = renderArtifactQueue;
   window._studioRenderReelQueue = renderReelQueue;
-  window._studioSaveQueues = saveQueues;
   window._studioClusterIntakeEvents = clusterIntakeEvents;
   window._studioClusterTranscriptMarks = clusterTranscriptMarks;
   window._studioROW_FUNCTIONS = ROW_FUNCTIONS;

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -3,7 +3,6 @@
 
   var SEARCH_DEBOUNCE = 300;
 
-  var fmtTime = formatTime;
   var SS_DETECTOR_COLORS = DETECTOR_COLORS;
 
   var state = {
@@ -54,6 +53,7 @@
   // ---- Nav links ----
 
   function checkNavLinks() {
+    // TODO: skips r.ok; silent on HTTP errors.
     fetch("../api/status").then(function (r) { return r.json(); }).then(function (data) {
       if (data.screenspace || data.studio) {
         state.xrefEligible = true;
@@ -78,6 +78,7 @@
   }
 
   function loadCrossRefData() {
+    // TODO: skips r.ok; silent on HTTP errors (polling every 30s, so caller tolerates it).
     fetch("../screenspace/api/events?excluded=false")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -90,6 +91,7 @@
       })
       .catch(function () {});
 
+    // TODO: skips r.ok (same pattern).
     fetch("../studio/api/sheet")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -753,7 +755,7 @@
         var sup = document.createElement("sup");
         sup.className = "citation-link";
         sup.dataset.start = String(ref.start);
-        sup.title = fmtTime(ref.start);
+        sup.title = formatTime(ref.start);
         sup.textContent = "[" + refNum + "]";
         (function (startTime) {
           sup.addEventListener("click", function (e) {
@@ -960,7 +962,7 @@
 
       html += '<div class="segment-row' + activeClass + correctedClass + '" data-index="' + i + '" data-start="' + seg.start + '">';
       html += '<span class="' + markClass + '" data-segment-id="' + escapeHtml(seg.id) + '"' + markStyle + markLabel + '></span>';
-      html += '<span class="segment-timestamp">' + fmtTime(seg.start);
+      html += '<span class="segment-timestamp">' + formatTime(seg.start);
       // Cross-reference badges in gutter (inside timestamp, positioned at right edge)
       if (state.tooltipsEnabled) {
         var xref = findOverlapsForSearch(state.selectedParticipant, seg.start, seg.end);
@@ -1026,7 +1028,7 @@
     var markStyle = cachedColor ? ' style="background:' + cachedColor + '"' : "";
     var html = '<div class="segment-row segment-streaming" data-index="' + i + '" data-start="' + seg.start + '">';
     html += '<span class="' + markClass + '" data-segment-id="' + escapeHtml(segId) + '"' + markStyle + '></span>';
-    html += '<span class="segment-timestamp">' + fmtTime(seg.start) + '</span>';
+    html += '<span class="segment-timestamp">' + formatTime(seg.start) + '</span>';
     html += '<span class="segment-text">' + escapeHtml(seg.text) + '</span>';
     html += '<span class="segment-copy" title="Copy text"><span class="segment-copy-icon"></span></span>';
     html += '</div>';
@@ -1764,7 +1766,7 @@
       groups[pid].forEach(function (r) {
         var xref = findOverlapsForSearch(r.participant, r.start, r.end);
         html += '<div class="search-result-row" data-participant="' + escapeHtml(r.participant) + '" data-start="' + r.start + '">';
-        html += '<span class="search-result-time">' + fmtTime(r.start) + '</span>';
+        html += '<span class="search-result-time">' + formatTime(r.start) + '</span>';
         html += '<span class="search-result-text">' + highlightQuery(r.text, state.searchQuery) + '</span>';
         if (state.tooltipsEnabled && xref.screenspaceEvents.length > 0) {
           var seen = {};
@@ -2475,6 +2477,7 @@
   function _trFetchModels() {
     if (_trModelsCache) return Promise.resolve(_trModelsCache);
     if (_trModelsCachePromise) return _trModelsCachePromise;
+    // TODO: skips r.ok; cross-mode URL. apiGet would work if it accepts relative paths.
     _trModelsCachePromise = fetch("../api/models")
       .then(function (r) { return r.json(); })
       .then(function (data) {
@@ -2550,6 +2553,8 @@
       if (s.value !== s.default) payload[s.name] = s.value;
     }
     var statusEl = qs("#trSettingsSaveStatus");
+    // TODO: skips r.ok; "Error" is set from data.ok only. apiPut would route HTTP errors
+    // into .catch (currently also sets "Error"), so semantics are equivalent but less explicit.
     fetch("../api/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -2694,6 +2699,7 @@
   }
 
   function _trLoadSettings() {
+    // TODO: skips r.ok; silent on HTTP errors.
     fetch("../api/settings")
       .then(function (r) { return r.json(); })
       .then(function (data) {

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -80,6 +80,47 @@ var truncate = function (str, max) {
   return str.length > max ? str.slice(0, max) + "\u2026" : str;
 };
 
+// Parse "HH:MM:SS", "MM:SS", or a bare float to seconds. Returns null on failure.
+var parseTimestamp = function (str) {
+  str = (str == null ? "" : String(str)).trim();
+  if (!str) return null;
+  var parts = str.split(":");
+  if (parts.length === 3) {
+    var h = parseFloat(parts[0]), m = parseFloat(parts[1]), s = parseFloat(parts[2]);
+    if (isNaN(h) || isNaN(m) || isNaN(s)) return null;
+    return h * 3600 + m * 60 + s;
+  }
+  if (parts.length === 2) {
+    var m2 = parseFloat(parts[0]), s2 = parseFloat(parts[1]);
+    if (isNaN(m2) || isNaN(s2)) return null;
+    return m2 * 60 + s2;
+  }
+  var n = parseFloat(str);
+  return isNaN(n) ? null : n;
+};
+
+// ---- Math ----
+
+var clamp = function (val, min, max) {
+  return Math.max(min, Math.min(max, val));
+};
+
+// ---- Tooltip positioning ----
+
+// Position a tooltip element centered above an anchor rect, flipping below
+// if there's no room above and clamping to the viewport horizontally.
+var positionTooltipAnchored = function (tooltipEl, anchorRect) {
+  var ttW = tooltipEl.offsetWidth;
+  var ttH = tooltipEl.offsetHeight;
+  var left = anchorRect.left + anchorRect.width / 2 - ttW / 2;
+  var top = anchorRect.top - ttH - 6;
+  if (top < 4) top = anchorRect.bottom + 6;
+  if (left < 4) left = 4;
+  if (left + ttW > window.innerWidth - 4) left = window.innerWidth - ttW - 4;
+  tooltipEl.style.left = left + "px";
+  tooltipEl.style.top = top + "px";
+};
+
 // ---- Debounce / escaping / color / toast (shared across Studio tabs + web UIs) ----
 
 var debounce = function (fn, ms) {

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -44,8 +44,6 @@
 
   // ---- Helpers ----
 
-  var severityClassForLabel = severityClass;
-
   var SEVERITY_SORT = {
     "sev-critical": -4,
     "sev-high": -3,
@@ -68,7 +66,7 @@
     var parts = ["artifact-marker", markerTypeClass(a.type)];
     var sev = (a.severity || "").trim();
     if (sev) {
-      parts.push(severityClassForLabel(sev));
+      parts.push(severityClass(sev));
     }
     return parts.join(" ");
   }
@@ -83,8 +81,8 @@
       labels.push(s);
     });
     labels.sort(function (a, b) {
-      var ca = severityClassForLabel(a);
-      var cb = severityClassForLabel(b);
+      var ca = severityClass(a);
+      var cb = severityClass(b);
       var na = SEVERITY_SORT.hasOwnProperty(ca) ? SEVERITY_SORT[ca] : 999;
       var nb = SEVERITY_SORT.hasOwnProperty(cb) ? SEVERITY_SORT[cb] : 999;
       if (na !== nb) return na - nb;
@@ -103,7 +101,7 @@
     }
     pillEl.classList.remove("hidden");
     pillEl.textContent = sev;
-    pillEl.className = "detail-badge detail-severity " + severityClassForLabel(sev);
+    pillEl.className = "detail-badge detail-severity " + severityClass(sev);
   }
 
   // ---- Clip thumbnails ----
@@ -752,7 +750,7 @@
     leg.appendChild(prefix);
     labels.forEach(function (lab) {
       var wrap = el("span", "severity-legend-item");
-      var sw = el("span", "legend-severity-swatch " + severityClassForLabel(lab));
+      var sw = el("span", "legend-severity-swatch " + severityClass(lab));
       wrap.appendChild(sw);
       wrap.appendChild(document.createTextNode(lab));
       leg.appendChild(wrap);
@@ -908,7 +906,7 @@
     var items = artifacts.map(function (a) {
       var s = a.start || 0;
       var e = a.end || a.start || 0;
-      var cls = severityClassForLabel(a.severity);
+      var cls = severityClass(a.severity);
       var sevVal = cls && SEVERITY_SORT.hasOwnProperty(cls) ? SEVERITY_SORT[cls] : 999;
       return { id: a.id, duration: e - s, start: s, sevVal: sevVal };
     });
@@ -1120,8 +1118,8 @@
         else if (ae) r = 1;
         else if (be) r = -1;
         else {
-          var ca = severityClassForLabel(a.severity);
-          var cb = severityClassForLabel(b.severity);
+          var ca = severityClass(a.severity);
+          var cb = severityClass(b.severity);
           var na = SEVERITY_SORT.hasOwnProperty(ca) ? SEVERITY_SORT[ca] : 999;
           var nb = SEVERITY_SORT.hasOwnProperty(cb) ? SEVERITY_SORT[cb] : 999;
           if (dir === "desc") r = na - nb;
@@ -1329,7 +1327,7 @@
       badges.appendChild(el("span", "badge badge-" + markerTypeClass(a.type), a.type || "clip"));
       if (a.category) badges.appendChild(el("span", "badge badge-category", a.category));
       var sev = (a.severity || "").trim();
-      if (sev) badges.appendChild(el("span", "badge badge-severity " + severityClassForLabel(sev), sev));
+      if (sev) badges.appendChild(el("span", "badge badge-severity " + severityClass(sev), sev));
       meta.appendChild(badges);
       meta.appendChild(el("div", "artifact-desc", a.description || "(no description)"));
       meta.appendChild(el("div", "artifact-time",

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.73"
+VERSIONNUM: str = "0.10.74"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Dedupe helpers into `utils.js` (`clamp`, `parseTimestamp`, `positionTooltipAnchored`); migrate callers across screenspace/studio/convergence/viewer/transcripts; drop dead aliases and orphaned `window.*` exports.
- Small perf wins: cache HSV selectors (screenspace), cache sidebar parent rect + combine reorder reads (insights-builder), simplify gallery IIFE.
- Migrate full-ceremony `fetch` calls to `apiGet/apiPost/apiPut/apiDelete`; annotate the rest (streaming NDJSON, blob/arrayBuffer, no-`r.ok`, fire-and-forget, DELETE-with-body) with TODOs so the divergent shapes are visible for future work.
- Fix Studio bottom-divider drag in the Metadata tab: `#metadataPanel` was missing from `onMove`'s live `maxHeight` loop, so it only resized on mouseup; panel list is now a single `UPPER_PANE_PANELS` constant with an `applyUpperPaneMaxHeight` helper used by drag, compute, and collapse paths.

## Test plan
- [ ] Drag the Studio bottom divider while on each preview tab (Sheet Preview, Intake, Transcript Intake, Convergence, Metadata) — all should resize live.
- [ ] Double-click divider and re-expand — panels rebind cleanly with no stuck `max-height`.
- [ ] Smoke-test Studio reel/viewer/gallery/highlights generation (migrated fetches).
- [ ] Smoke-test Insights create/delete/save/discard + viewer generation (migrated fetches).
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` → 581 passed.