### PR TITLE
fix: warm Whisper model on Transcripts pill hover

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -416,6 +416,12 @@
     _modelHintPollTimer = setInterval(poll, 1500);
   }
 
+  function maybeWarmOnPillHover(p, s) {
+    if (state.transcribePrewarm !== "queue_open") return;
+    if (!s || s.status === "completed") return;
+    tryPostTranscriptionWarmup();
+  }
+
   function tryPostTranscriptionWarmup() {
     if (_transcriptionWarmupPosted) return;
     if (state.transcribePrewarm === "off") return;
@@ -1951,6 +1957,9 @@
     if (state.pillOptionsOpen === p.id) {
       wrap.classList.add("pill-wrap--options-open");
     }
+    wrap.addEventListener("mouseenter", function () {
+      maybeWarmOnPillHover(p, s);
+    });
     return wrap;
   }
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.74"
+VERSIONNUM: str = "0.10.75"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -278,7 +278,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "TRANSCRIBE_ENABLED": "Generate transcripts alongside clips using faster-whisper.",
     "TRANSCRIBE_MODEL": "Whisper model size: tiny, base, small, medium, large-v3.",
     "TRANSCRIBE_FORMAT": "Transcript output format: md (Markdown), srt, or vtt.",
-    "TRANSCRIBE_PREWARM": "When the Transcripts page pre-loads the Whisper model: off, queue_open (opening Queue), or page_load (after listing participants).",
+    "TRANSCRIBE_PREWARM": "When the Transcripts page pre-loads the Whisper model: off, queue_open (opening a pill's options pane or hovering a pill that needs transcription), or page_load (after listing participants).",
     "HIGHLIGHTS_REEL_DURATION_SECONDS": "Maximum duration in seconds for the highlights reel time budget.",
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",


### PR DESCRIPTION
## Summary
- Under the default `queue_open` prewarm mode, hovering any pill that's not already `completed` now triggers a Whisper model warm-up. Previously the trigger only fired when the options pane opened (chevron click) — a rarely-used path after the queue sidepanel was replaced by pills, so first transcription paid the full cold-load cost.
- Updated `TRANSCRIBE_PREWARM` settings description to document the new `queue_open` semantics; bumped version to `0.10.75`.

## Test plan
- [ ] On default settings, open Transcripts and hover a non-completed pill — verify `POST /api/transcribe/warmup` fires once and model-status flips to `warming` → `loaded`.
- [ ] Hover only `completed` pills — verify warm-up does not fire.
- [ ] Set `TRANSCRIBE_PREWARM=off` — verify no warm-up on hover.
- [ ] Set `TRANSCRIBE_PREWARM=page_load` — verify warm-up still fires at load and isn't double-posted on hover.
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_transcripts_api.py` passes.
- [x] `uv run ruff check --fix && uv run ruff format && uv run ty check` clean.