### PR TITLE
style: unify all Screenspace slider styling

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1370,7 +1370,6 @@ body {
 
 .param-control input[type="range"] {
   width: 80px;
-  accent-color: var(--color-accent);
 }
 
 .param-control input[type="number"],
@@ -2386,10 +2385,15 @@ body.panel-dragging #bottomPanel {
   display: none;
 }
 
-.rp-certainty-slider {
+/* Shared slider styling — used by all Screenspace range inputs.
+   Per-variant widths live with each slider's own rule
+   (.rp-certainty-slider = 34px, .scene-ref-thresh = 60px,
+   .param-control input[type="range"] = 80px). */
+.rp-certainty-slider,
+.param-control input[type="range"],
+.scene-ref-thresh {
   -webkit-appearance: none;
   appearance: none;
-  width: 34px;
   height: 4px;
   background: var(--color-border);
   border-radius: 2px;
@@ -2397,7 +2401,13 @@ body.panel-dragging #bottomPanel {
   outline: none;
 }
 
-.rp-certainty-slider::-webkit-slider-thumb {
+.rp-certainty-slider {
+  width: 34px;
+}
+
+.rp-certainty-slider::-webkit-slider-thumb,
+.param-control input[type="range"]::-webkit-slider-thumb,
+.scene-ref-thresh::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   width: 12px;
@@ -2406,15 +2416,37 @@ body.panel-dragging #bottomPanel {
   background: var(--color-accent);
   border: none;
   cursor: pointer;
+  transition: box-shadow var(--duration-fast) ease;
 }
 
-.rp-certainty-slider::-moz-range-thumb {
+.rp-certainty-slider::-moz-range-thumb,
+.param-control input[type="range"]::-moz-range-thumb,
+.scene-ref-thresh::-moz-range-thumb {
   width: 12px;
   height: 12px;
   border-radius: 50%;
   background: var(--color-accent);
   border: none;
   cursor: pointer;
+  transition: box-shadow var(--duration-fast) ease;
+}
+
+.rp-certainty-slider:hover::-webkit-slider-thumb,
+.param-control input[type="range"]:hover::-webkit-slider-thumb,
+.scene-ref-thresh:hover::-webkit-slider-thumb,
+.rp-certainty-slider:focus-visible::-webkit-slider-thumb,
+.param-control input[type="range"]:focus-visible::-webkit-slider-thumb,
+.scene-ref-thresh:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 25%, transparent);
+}
+
+.rp-certainty-slider:hover::-moz-range-thumb,
+.param-control input[type="range"]:hover::-moz-range-thumb,
+.scene-ref-thresh:hover::-moz-range-thumb,
+.rp-certainty-slider:focus-visible::-moz-range-thumb,
+.param-control input[type="range"]:focus-visible::-moz-range-thumb,
+.scene-ref-thresh:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 25%, transparent);
 }
 
 .result-timestamp {


### PR DESCRIPTION
## Summary
- Extracts the Results-tab certainty slider's look (4px track, 12px accent-colored circular thumb) into a shared rule set covering tool-panel parameter sliders and multitool scene-reference threshold sliders.
- Per-variant widths (34 / 60 / 80 px) are preserved; removes the now-redundant native \`accent-color\` from param sliders.
- Adds a subtle hover / focus-visible ring on the thumb for a11y.

## Test plan
- [ ] Results tab certainty slider looks identical to before
- [ ] Tool-panel sliders (Color Tolerance, Similarity, Text Fuzzy, Template Threshold + Scale, Change Threshold + Noise, Flow Magnitude, Inactivity Sensitivity) now match that style
- [ ] Multitool scene-reference threshold slider matches
- [ ] Keyboard-tab onto a slider shows a focus ring on the thumb
- [ ] \`.param-value\` readouts still update while dragging