### PR TITLE
feat: manual run/stop controls for Transcription, Summary, Citations in pill dropdown

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1182,6 +1182,28 @@ body {
   margin-top: var(--space-1);
 }
 
+.pill-options-agents {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}
+
+.pill-agent-btn {
+  min-width: 72px;
+}
+
+.pill-agent-btn--stop {
+  border-color: var(--sev-high);
+  color: var(--sev-high);
+}
+
+.pill-agent-btn--stop:hover:not(:disabled) {
+  background: var(--sev-high);
+  color: #fff;
+}
+
 /* Modal */
 
 .modal {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1947,16 +1947,33 @@
     container.innerHTML = "";
     container.appendChild(frag);
     // The pane is mounted on <body>, not inside the rebuilt wrap — reposition
-    // it to the new wrap's rect, or tear it down if the pill disappeared.
+    // it to the new wrap's rect and re-render its contents so the agent rows
+    // reflect the latest state. Tear it down if the pill disappeared.
     if (openPid !== null) {
       var newWrap = _findPillWrap(openPid);
       var floating = document.querySelector("body > .pill-options");
       if (newWrap && floating) {
-        _positionPillOptions(floating, newWrap);
+        _refreshPillOptionsContent(openPid, taskByPid);
+        var refreshed = document.querySelector("body > .pill-options[data-pid='" + openPid + "']");
+        if (refreshed) _positionPillOptions(refreshed, newWrap);
       } else {
         closePillOptions();
       }
     }
+  }
+
+  function _refreshPillOptionsContent(pid, taskByPid) {
+    var floating = document.querySelector("body > .pill-options[data-pid='" + pid + "']");
+    if (!floating) return;
+    var p = null;
+    for (var i = 0; i < state.participants.length; i++) {
+      if (state.participants[i].id === pid) { p = state.participants[i]; break; }
+    }
+    if (!p) return;
+    var s = pillState(p, taskByPid);
+    var fresh = buildPillOptions(p, s);
+    fresh.setAttribute("data-pid", pid);
+    floating.parentNode.replaceChild(fresh, floating);
   }
 
   function buildPillWrap(p, taskByPid) {
@@ -2163,38 +2180,139 @@
     langRow.appendChild(langSelect);
     pane.appendChild(langRow);
 
-    // Footer: transcribe / re-transcribe
-    var footer = document.createElement("div");
-    footer.className = "pill-options-footer";
-    var runBtn = document.createElement("button");
-    runBtn.type = "button";
-    runBtn.className = "btn btn-small";
-    if (p.has_transcript && s.status !== "running" && s.status !== "queued") {
-      runBtn.textContent = "Re-transcribe";
-      runBtn.addEventListener("click", function () {
-        closePillOptions();
-        startTranscribe(p.id, true);
-      });
-    } else if (s.status === "running" || s.status === "queued") {
-      runBtn.textContent = "Cancel";
-      runBtn.className = "btn btn-small";
-      runBtn.addEventListener("click", function () {
+    // Agent rows — manual run / re-run / stop controls with dependency gating.
+    // Order: Transcription → Summary → Citations. Summary requires
+    // transcription; citations requires summary. Re-running summary cascades
+    // to citations server-side (see transcripts_server.py).
+    pane.appendChild(buildPillAgentsSection(p, s));
+
+    return pane;
+  }
+
+  function buildPillAgentsSection(p, s) {
+    var section = document.createElement("div");
+    section.className = "pill-options-agents";
+
+    // 1. Transcription
+    section.appendChild(buildAgentRow({
+      pid: p.id,
+      label: "Transcription",
+      agent: "transcription",
+      depMet: true,
+      agentState: s.agents.transcription,
+      hasResult: !!p.has_transcript,
+      cascadeWarning: !!(p.agents && (p.agents.summary === "done" || p.agents.citations === "done")),
+      onStart: function () { startTranscribe(p.id, !!p.has_transcript); },
+      onStop: function () {
         if (s.taskId) {
           apiDelete("api/transcribe/" + s.taskId).then(function () { pollTaskStatus(); });
         }
-        closePillOptions();
-      });
-    } else {
-      runBtn.textContent = "Transcribe";
-      runBtn.addEventListener("click", function () {
-        closePillOptions();
-        startTranscribe(p.id, false);
-      });
-    }
-    footer.appendChild(runBtn);
-    pane.appendChild(footer);
+      },
+    }));
 
-    return pane;
+    // 2. Summary
+    section.appendChild(buildAgentRow({
+      pid: p.id,
+      label: "Summary",
+      agent: "summary",
+      depLabel: "transcription",
+      depMet: s.agents.transcription === "done",
+      agentState: s.agents.summary,
+      hasResult: !!(p.agents && p.agents.summary === "done"),
+      cascadeWarning: !!(p.agents && p.agents.citations === "done"),
+      onStart: function () {
+        apiPost("api/summary/" + p.id + "/regenerate", {}).catch(function () {
+          showToast("Failed to start summary");
+        });
+      },
+      onStop: function () {
+        apiPost("api/summary/" + p.id + "/stop", {}).catch(function () {
+          showToast("Failed to stop summary");
+        });
+      },
+    }));
+
+    // 3. Citations
+    section.appendChild(buildAgentRow({
+      pid: p.id,
+      label: "Citations",
+      agent: "citations",
+      depLabel: "summary",
+      depMet: s.agents.summary === "done",
+      agentState: s.agents.citations,
+      hasResult: !!(p.agents && p.agents.citations === "done"),
+      cascadeWarning: false,
+      onStart: function () {
+        apiPost("api/citations/" + p.id + "/regenerate", {}).catch(function () {
+          showToast("Failed to start citations");
+        });
+      },
+      onStop: function () {
+        apiPost("api/citations/" + p.id + "/stop", {}).catch(function () {
+          showToast("Failed to stop citations");
+        });
+      },
+    }));
+
+    return section;
+  }
+
+  function buildAgentRow(opts) {
+    var row = document.createElement("div");
+    row.className = "pill-options-row pill-options-agent-row";
+    row.setAttribute("data-agent", opts.agent);
+
+    var label = document.createElement("label");
+    label.textContent = opts.label;
+    row.appendChild(label);
+
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-small pill-agent-btn";
+
+    var running = opts.agentState === "running";
+    var mode = "start"; // start | stop | disabled
+    var title = "";
+
+    if (running) {
+      btn.textContent = "Stop";
+      btn.classList.add("pill-agent-btn--stop");
+      mode = "stop";
+    } else if (!opts.depMet) {
+      btn.textContent = "Run";
+      mode = "disabled";
+      title = "Requires " + opts.depLabel + " to finish first";
+    } else if (opts.hasResult) {
+      btn.textContent = "Re-run";
+      if (opts.cascadeWarning) {
+        title = opts.agent === "transcription"
+          ? "Re-transcribing invalidates Summary and Citations"
+          : "Re-running will also re-run Citations";
+      }
+    } else {
+      btn.textContent = "Run";
+    }
+
+    if (mode === "disabled") btn.setAttribute("disabled", "disabled");
+    if (title) btn.title = title;
+
+    btn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      if (btn.hasAttribute("disabled")) return;
+      // Optimistic UI swap; the next poll re-renders via _refreshPillOptionsContent.
+      if (mode === "stop") {
+        btn.textContent = "Stopping\u2026";
+        btn.setAttribute("disabled", "disabled");
+        opts.onStop();
+      } else {
+        btn.textContent = "Starting\u2026";
+        btn.setAttribute("disabled", "disabled");
+        opts.onStart();
+      }
+    });
+
+    row.appendChild(btn);
+    return row;
   }
 
   function _setOverride(pid, key, value) {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.83"
+VERSIONNUM: str = "0.10.85"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -14,9 +14,11 @@ API endpoints (all under /transcripts/):
   GET  /api/vtt/<participant>                     - serve transcript as WebVTT
   GET  /api/summary/<participant>                - AI-generated transcript summary
   POST /api/summary/<participant>/regenerate    - re-trigger AI summary generation
+  POST /api/summary/<participant>/stop          - flag in-flight summary for discard
   PUT  /api/summary/<participant>               - save user-edited summary
   GET  /api/citations/<participant>             - citation refs for summary sentences
   POST /api/citations/<participant>/regenerate  - re-trigger citation generation
+  POST /api/citations/<participant>/stop        - flag in-flight citations for discard
   GET  /api/corrections                           - list all study-local corrections
   POST /api/corrections                           - add a correction manually
   DELETE /api/corrections/<id>                    - remove a correction
@@ -64,6 +66,13 @@ _agent_threads: dict[str, set[threading.Thread]] = {
     a["key"]: set() for a in thinking_agents.AGENTS
 }
 _agent_in_flight: dict[str, set[str]] = {
+    a["key"]: set() for a in thinking_agents.AGENTS
+}
+# Participants flagged for cancellation. The Ollama call still runs to
+# completion in its daemon thread; when it returns, _run_agent discards the
+# result and skips the chain advance. Lets the UI flip to idle instantly
+# without needing a cancel-aware HTTP layer (see plan: discard-on-return).
+_agent_cancel_requested: dict[str, set[str]] = {
     a["key"]: set() for a in thinking_agents.AGENTS
 }
 
@@ -320,9 +329,11 @@ def api_summary(participant: str) -> FlaskResponse:
 
 @transcripts_bp.route("/api/summary/<participant>/regenerate", methods=["POST"])
 def api_summary_regenerate(participant: str) -> FlaskResponse:
-    """Clear existing summary and re-trigger AI generation."""
-    if not config.OLLAMA_SUMMARY_ENABLED:
-        return jsonify({"ok": False, "error": "Summary generation is disabled"}), 400
+    """Clear existing summary and re-trigger AI generation.
+
+    Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False
+    so the frontend's per-participant controls can force a run.
+    """
     if _is_generating(participant, "summary"):
         return jsonify({"ok": True, "generating": True})
     with _manifest_lock:
@@ -333,8 +344,22 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
         entry["summary"] = ""
         entry.pop("citations", None)
     _persist_manifest()
-    _run_agent_chain(participant)
+    _run_agent_chain(participant, force=True)
     return jsonify({"ok": True, "generating": True})
+
+
+@transcripts_bp.route("/api/summary/<participant>/stop", methods=["POST"])
+def api_summary_stop(participant: str) -> FlaskResponse:
+    """Flag an in-flight summary run for cancellation (discard-on-return).
+
+    The Ollama call keeps running in the background, but its result is thrown
+    away when it returns. The UI sees idle immediately.
+    """
+    if not _is_generating(participant, "summary"):
+        return jsonify({"ok": True, "running": False})
+    _agent_cancel_requested["summary"].add(participant)
+    _agent_in_flight["summary"].discard(participant)
+    return jsonify({"ok": True, "running": False})
 
 
 @transcripts_bp.route("/api/summary/<participant>", methods=["PUT"])
@@ -373,9 +398,10 @@ def api_citations(participant: str) -> FlaskResponse:
 
 @transcripts_bp.route("/api/citations/<participant>/regenerate", methods=["POST"])
 def api_citations_regenerate(participant: str) -> FlaskResponse:
-    """Clear existing citations and re-trigger citation generation (Pass 2)."""
-    if not config.OLLAMA_SUMMARY_ENABLED:
-        return jsonify({"ok": False, "error": "Summary generation is disabled"}), 400
+    """Clear existing citations and re-trigger citation generation (Pass 2).
+
+    Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False.
+    """
     if _is_generating(participant, "citations"):
         return jsonify({"ok": True, "generating": True})
     with _manifest_lock:
@@ -385,8 +411,18 @@ def api_citations_regenerate(participant: str) -> FlaskResponse:
     with _manifest_lock:
         entry.pop("citations", None)
     _persist_manifest()
-    _run_agent("citations", participant)
+    _run_agent("citations", participant, force=True)
     return jsonify({"ok": True, "generating": True})
+
+
+@transcripts_bp.route("/api/citations/<participant>/stop", methods=["POST"])
+def api_citations_stop(participant: str) -> FlaskResponse:
+    """Flag an in-flight citations run for cancellation (discard-on-return)."""
+    if not _is_generating(participant, "citations"):
+        return jsonify({"ok": True, "running": False})
+    _agent_cancel_requested["citations"].add(participant)
+    _agent_in_flight["citations"].discard(participant)
+    return jsonify({"ok": True, "running": False})
 
 
 # ---- Corrections ----
@@ -962,11 +998,13 @@ def _agent_dependencies_met(
     return True
 
 
-def _next_eligible_agent(participant: str) -> thinking_agents.Agent | None:
+def _next_eligible_agent(
+    participant: str, force: bool = False
+) -> thinking_agents.Agent | None:
     """Find the first agent that should run next for *participant*.
 
     An agent is eligible when:
-      - it is enabled,
+      - it is enabled (unless *force* is True — manual triggers bypass this),
       - its result is not already on the entry,
       - all of its dependencies are satisfied,
       - it is not already running for this participant.
@@ -976,7 +1014,7 @@ def _next_eligible_agent(participant: str) -> thinking_agents.Agent | None:
         if not entry or not entry.get("segments"):
             return None
         for agent in thinking_agents.AGENTS:
-            if not _agent_enabled(agent):
+            if not force and not _agent_enabled(agent):
                 continue
             if entry.get(agent["manifest_field"]):
                 continue
@@ -988,17 +1026,18 @@ def _next_eligible_agent(participant: str) -> thinking_agents.Agent | None:
     return None
 
 
-def _run_agent(agent_key: str, participant: str) -> None:
+def _run_agent(agent_key: str, participant: str, force: bool = False) -> None:
     """Spawn a daemon thread to run a single agent for *participant*.
 
     On success, the agent's result is written to the manifest and the chain
     advances to the next eligible agent. Guards against double-spawning via
-    ``_agent_in_flight``.
+    ``_agent_in_flight``. Pass *force* to bypass the config enabled check
+    (used by manual triggers from the UI).
     """
     agent = thinking_agents.get_agent(agent_key)
     if agent is None:
         return
-    if not _agent_enabled(agent):
+    if not force and not _agent_enabled(agent):
         return
     if _is_generating(participant, agent_key):
         return
@@ -1013,20 +1052,27 @@ def _run_agent(agent_key: str, participant: str) -> None:
                 # during the (potentially slow) model call.
                 snapshot = dict(entry)
             result = agent["run"](snapshot)
+            # Discard-on-return: if the UI asked to stop while the model was
+            # running, throw away the result and do not advance the chain.
+            if participant in _agent_cancel_requested[agent_key]:
+                return
             if result is not None:
                 with _manifest_lock:
                     entry = _manifest.get("source_transcripts", {}).get(participant)
                     if entry is not None:
                         entry[agent["manifest_field"]] = result
                 _persist_manifest()
-                # Chain into the next eligible agent (e.g. summary → citations)
-                _run_agent_chain(participant)
+                # Chain into the next eligible agent (e.g. summary → citations).
+                # Propagate *force* so a manual run cascades through disabled
+                # downstream agents too.
+                _run_agent_chain(participant, force=force)
         except Exception as exc:
             utils.warning_print(
                 f"{agent_key} generation failed for {participant}: {exc}"
             )
         finally:
             _agent_in_flight[agent_key].discard(participant)
+            _agent_cancel_requested[agent_key].discard(participant)
             _agent_threads[agent_key].discard(t)
 
     _agent_in_flight[agent_key].add(participant)
@@ -1039,15 +1085,16 @@ def _run_agent(agent_key: str, participant: str) -> None:
     t.start()
 
 
-def _run_agent_chain(participant: str) -> None:
+def _run_agent_chain(participant: str, force: bool = False) -> None:
     """Advance the thinking-agent chain for *participant* by one step.
 
     Starts the first eligible agent (if any). When that agent completes,
-    ``_run_agent`` re-enters this function to start the next step.
+    ``_run_agent`` re-enters this function to start the next step. Pass
+    *force* to bypass config enable checks for manual/UI-triggered runs.
     """
-    agent = _next_eligible_agent(participant)
+    agent = _next_eligible_agent(participant, force=force)
     if agent is not None:
-        _run_agent(agent["key"], participant)
+        _run_agent(agent["key"], participant, force=force)
 
 
 # ---- State initialization ----


### PR DESCRIPTION
## Summary
- Adds Transcription, Summary, and Citations rows to the Transcripts pill dropdown, each with Run / Re-run / Stop. Dependencies are enforced in the UI (Summary needs Transcription, Citations needs Summary) and the pane re-renders on each poll.
- Backend: relaxes the `OLLAMA_SUMMARY_ENABLED` guard on regenerate endpoints (with a `force` flag threaded through the agent chain) so manual triggers work even when auto-run is off and a manual Summary still cascades to Citations.
- New `POST /api/summary/<pid>/stop` and `POST /api/citations/<pid>/stop` endpoints using discard-on-return: the Ollama call keeps running in the background, but the result is dropped and the chain advance is skipped, so the UI flips to idle instantly.

## Test plan
- [ ] With auto-run on, transcribe a participant and confirm Summary then Citations run; each row shows Running → Re-run.
- [ ] Open the pill dropdown before transcription finishes; confirm Summary and Citations are disabled until their dependency is `done`.
- [ ] Click Summary "Re-run" on a fully-processed participant; confirm citations are cleared and re-run automatically.
- [ ] Set `OLLAMA_SUMMARY_ENABLED = False`, restart, transcribe a participant; confirm neither agent runs automatically, then manually trigger Summary from the dropdown and confirm it runs and cascades to Citations.
- [ ] Click Stop during Summary and during Citations; confirm the UI flips to idle immediately and no result is written.