### PR TITLE
chore: add Conductor setup/run shell scripts

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Run clipgen Studio against ~/Projects/clipgen with the 'clipgen-test' sheet.
+# macOS only for now.
+set -e
+
+case "$(uname -s)" in
+Darwin) ;;
+*)
+  echo "Unsupported OS: run.sh is macOS-only for now." >&2
+  exit 1
+  ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+exec uv run clipgen.py -i "$HOME/Projects/clipgen/" -s "clipgen-test" --studio "$@"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Sync the current worktree's Python venv via uv.
+# macOS only for now.
+set -e
+
+case "$(uname -s)" in
+Darwin) ;;
+*)
+  echo "Unsupported OS: setup.sh is macOS-only for now." >&2
+  exit 1
+  ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+uv sync
+echo "Venv ready at $REPO_ROOT/.venv"


### PR DESCRIPTION
## Summary

- `scripts/setup.sh` runs `uv sync` in the current worktree, producing a local `.venv` (fast thanks to uv's global wheel cache).
- `scripts/run.sh` launches clipgen Studio against `~/Projects/clipgen` with the `clipgen-test` sheet, passing through any extra args.
- Both are macOS-only for now, follow the style of `scripts/install-ffmpeg-ollama.sh`, and resolve paths relative to the script so they work in any Conductor worktree.

## Test plan

- [x] `./scripts/setup.sh` creates `.venv` in the worktree
- [x] `./scripts/run.sh` launches Studio at http://127.0.0.1:8089 and serves the UI