### PR TITLE
feat: color-code Studio Sheet Preview timestamps by severity + duration

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -715,6 +715,7 @@ col.col-participant-col {
 /* Timestamp cells */
 
 .ts-cell {
+  --ts-intensity: 1;
   cursor: pointer;
   text-align: center;
   font-family: var(--font-mono);
@@ -745,6 +746,31 @@ col.col-participant-col {
 .ts-cell.empty {
   color: var(--color-text-dim);
   cursor: default;
+}
+
+.ts-cell.valid-ts.sev-critical {
+  color: color-mix(in srgb, var(--sev-critical) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-high {
+  color: color-mix(in srgb, var(--sev-high) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-medium {
+  color: color-mix(in srgb, var(--sev-medium) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-low {
+  color: color-mix(in srgb, var(--sev-low) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-na {
+  color: color-mix(in srgb, var(--sev-na) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-positive {
+  color: color-mix(in srgb, var(--sev-positive) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-very-positive {
+  color: color-mix(in srgb, var(--sev-very-positive) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
+}
+.ts-cell.valid-ts.sev-unknown {
+  color: color-mix(in srgb, var(--sev-unknown) calc(var(--ts-intensity) * 100%), var(--color-text-dim));
 }
 
 /* Floating expanded cell overlay */

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -20,6 +20,7 @@
     dividerOffsetBeforeCollapse: 0,
     activeFunction: "",
     cellExpandHover: true,
+    cellColorCoding: true,
     filtersVisible: false,
     filters: {
       categories: [],
@@ -682,6 +683,9 @@
         if (data.cellExpandHover !== undefined) {
           state.cellExpandHover = data.cellExpandHover;
         }
+        if (data.cellColorCoding !== undefined) {
+          state.cellColorCoding = data.cellColorCoding;
+        }
         var tcGroup = qs("#titlecardGroup");
         if (tcGroup && qs("#artifactFormat").value === "clip") {
           tcGroup.classList.remove("hidden");
@@ -1226,6 +1230,21 @@
         td.textContent = cellData.value;
         if (cellData.valid) {
           td.classList.add("valid-ts");
+          if (state.cellColorCoding) {
+            if (row.severity) {
+              var sevCellCls = severityClass(row.severity);
+              if (sevCellCls) td.classList.add(sevCellCls);
+            }
+            var segs = parseClipTimestamps(cellData.value);
+            var totalDur = 0;
+            for (var k = 0; k < segs.length; k++) totalDur += segs[k].duration;
+            var intensity;
+            if (totalDur < 15) intensity = 0.55;
+            else if (totalDur < 45) intensity = 0.7;
+            else if (totalDur < 90) intensity = 0.85;
+            else intensity = 1;
+            td.style.setProperty("--ts-intensity", intensity);
+          }
         } else {
           td.classList.add("has-text");
         }
@@ -3108,6 +3127,14 @@
     var cellExpand = _findSetting("STUDIO_CELL_EXPAND_HOVER");
     if (cellExpand) {
       state.cellExpandHover = !!cellExpand.value;
+    }
+    var cellColor = _findSetting("STUDIO_SHEET_CELL_COLOR_CODING");
+    if (cellColor) {
+      var newVal = !!cellColor.value;
+      if (newVal !== state.cellColorCoding) {
+        state.cellColorCoding = newVal;
+        if (state.sheetData) renderGrid();
+      }
     }
   }
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.86"
+VERSIONNUM: str = "0.10.88"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -136,6 +136,7 @@ STASHES_MANIFEST_FILENAME: str = "reel_stashes.json"
 ARTIFACT_STASHES_MANIFEST_FILENAME: str = "artifact_stashes.json"
 STUDIO_SETTINGS_FILENAME: str = "studio_settings.json"
 STUDIO_CELL_EXPAND_HOVER: bool = True
+STUDIO_SHEET_CELL_COLOR_CODING: bool = True
 GOOGLE_API_MAX_RETRIES: int = 3  # Retries for transient Google API errors (5xx)
 
 # ── Sprite Sheets ────────────────────────────────────────────────────
@@ -282,6 +283,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "HIGHLIGHTS_REEL_DURATION_SECONDS": "Maximum duration in seconds for the highlights reel time budget.",
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
+    "STUDIO_SHEET_CELL_COLOR_CODING": "Color-code timestamp cell text by row severity, with intensity reflecting clip duration.",
     "FILMSTRIP_ENABLED": "Show thumbnail images on timeline markers instead of solid colors (in the HTML viewer).",
     "GALLERY_BUNDLE_ENABLED": "Embed gallery images as base64 data URIs in the HTML file, making it fully self-contained.",
     "CLIP_PARALLEL_WORKERS": "Number of concurrent ffmpeg processes for clip generation. 0 = auto, 1 = sequential.",
@@ -301,6 +303,11 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
         "step": 1,
     },
     "STUDIO_CELL_EXPAND_HOVER": {
+        "tab": "General",
+        "group": "Sheet Preview",
+        "type": "bool",
+    },
+    "STUDIO_SHEET_CELL_COLOR_CODING": {
         "tab": "General",
         "group": "Sheet Preview",
         "type": "bool",

--- a/server.py
+++ b/server.py
@@ -221,6 +221,7 @@ def api_sheet() -> FlaskResponse:
             "titlecardsEnabled": config.TITLECARDS_ENABLED,
             "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
             "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
+            "cellColorCoding": config.STUDIO_SHEET_CELL_COLOR_CODING,
             "defaultDuration": config.DEFAULT_DURATION_SECONDS,
             "participants": participants,
             "rows": rows,


### PR DESCRIPTION
## Summary
- Valid timestamp cells in Studio's Sheet Preview now tint their text with the row's severity hue, using the existing `--sev-*` tokens (light + dark theme covered).
- The tint intensity scales with total parsed clip duration (stepped ramp: `<15s → 0.55`, `<45s → 0.7`, `<90s → 0.85`, `≥90s → 1.0`), mixed via `color-mix` against `--color-text-dim` so short clips fade back and long, severe moments pop.
- Gated by a new `STUDIO_SHEET_CELL_COLOR_CODING` setting (default on) surfaced in the unified settings modal under General → Sheet Preview; toggling it live re-renders the grid, and turning it off restores the pre-existing styling.

## Test plan
- [ ] Open Studio with a sheet that has a Severity column and rows of varied severities + timestamp lengths; verify critical/high/medium/low/positive rows tint correctly and that `"0:10-2:00"` looks noticeably bolder than `"0:10-0:15"`.
- [ ] Confirm rows without severity and invalid-text cells render exactly as before.
- [ ] Toggle the new setting in Settings → General → Sheet Preview and confirm the grid updates live in both directions.
- [ ] Toggle dark mode and confirm all severity tints remain legible on the `.valid-ts` background.
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` passes (585/585 locally).