### PR TITLE
style: align Transcripts intake filter pills with Screenspace

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2278,7 +2278,3 @@ html[data-theme="dark"] .log-panel {
   width: 10px;
   height: 10px;
 }
-
-.tr-intake-filter-cat {
-  font-size: var(--text-xs);
-}

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.88"
+VERSIONNUM: str = "0.10.89"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Drop the `.tr-intake-filter-cat` font-size override so transcript category pills inherit the 10px base from `.intake-filter-det`, matching Screenspace intake pills exactly (padding, margins, border, hover/active states already shared).
- No icons added to transcript tags (intentional).
- Bump `VERSIONNUM` to `0.10.89`.

## Test plan
- [ ] Open Studio, switch between the Screenspace and Transcripts intake tabs, and confirm the filter pills render with matching size, padding, and spacing.