### PR TITLE
fix: apply baseline to Sheet Preview timestamp parsing

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -45,46 +45,6 @@
     return XREF_BADGES.sheet.color;
   }
 
-  function clockToSeconds(ts) {
-    // Like utils.parseTimestamp but treats 2-part as HH:MM (clock time)
-    // rather than MM:SS.  Matches Python utils._clock_to_seconds.
-    var parts = ts.split(":");
-    if (parts.length === 3)
-      return parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60 + parseInt(parts[2], 10);
-    if (parts.length === 2)
-      return parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60;
-    return NaN;
-  }
-
-  function parseClockSegments(raw) {
-    // Like _studioParseClipTimestamps but uses clockToSeconds for cells
-    // that contain absolute clock times (when a baseline row exists).
-    var DEFAULT_DUR = 60;
-    var sd = window._studioState && window._studioState.sheetData;
-    if (sd && sd.defaultDuration) DEFAULT_DUR = sd.defaultDuration;
-    var cleaned = raw.toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
-    var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
-    var segments = [];
-    for (var i = 0; i < tokens.length; i++) {
-      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
-      var dashIdx = -1;
-      for (var d = 1; d < tok.length; d++) {
-        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") { dashIdx = d; break; }
-      }
-      if (dashIdx > 0) {
-        var s = clockToSeconds(tok.substring(0, dashIdx));
-        var e = clockToSeconds(tok.substring(dashIdx + 1));
-        if (!isNaN(s) && !isNaN(e))
-          segments.push({ startSeconds: Math.floor(s), duration: Math.max(0, e - s) });
-      } else if (tok.indexOf(":") > 0) {
-        var sec = clockToSeconds(tok);
-        if (!isNaN(sec))
-          segments.push({ startSeconds: Math.floor(sec), duration: DEFAULT_DUR });
-      }
-    }
-    if (segments.length === 0) segments.push({ startSeconds: 0, duration: DEFAULT_DUR });
-    return segments;
-  }
 
   function stddev(nums) {
     if (nums.length < 2) return 0;
@@ -229,11 +189,10 @@
           var cell = row.cells[pid];
           if (!cell || !cell.valid) continue;
           var baselineOffset = (cvState.baselines && cvState.baselines[pid]) || 0;
-          var segs = baselineOffset
-            ? parseClockSegments(cell.value)
-            : window._studioParseClipTimestamps(cell.value);
+          var defaultDur = (state.sheetData && state.sheetData.defaultDuration) || 60;
+          var segs = parseClipSegmentsForCell(cell.value, baselineOffset, defaultDur);
           for (var s = 0; s < segs.length; s++) {
-            var start = segs[s].startSeconds - baselineOffset;
+            var start = segs[s].startSeconds;
             var end = start + segs[s].duration;
             events.push({
               participant: pid,
@@ -1377,7 +1336,9 @@
         ? rawRow.cells[event.participant].value : "";
       var parts = event.id.split("_");
       var segIdx = parseInt(parts[parts.length - 1]) || 0;
-      var segs = window._studioParseClipTimestamps(cellValue);
+      var defaultDur2 = (state.sheetData && state.sheetData.defaultDuration) || 60;
+      var baselineOffset2 = (cvState.baselines && cvState.baselines[event.participant]) || 0;
+      var segs = parseClipSegmentsForCell(cellValue, baselineOffset2, defaultDur2);
       item.row = rawRow.rowNum;
       item.desc = rawRow.observation || event.label || event.eventType;
       item.timestamp = cellValue;

--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -45,52 +45,8 @@
     return (state.sheetData && state.sheetData.study) || "study";
   }
 
-  // Baseline-aware timestamp parsing (matches convergence.js pattern)
-  function clockToSeconds(ts) {
-    var parts = ts.split(":");
-    if (parts.length === 3)
-      return parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60 + parseInt(parts[2], 10);
-    if (parts.length === 2)
-      return parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60;
-    return NaN;
-  }
-
-  function parseClockSegments(raw) {
-    var DEFAULT_DUR = (state.sheetData && state.sheetData.defaultDuration) || 60;
-    var cleaned = raw.toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
-    var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
-    var segments = [];
-    for (var i = 0; i < tokens.length; i++) {
-      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
-      var dashIdx = -1;
-      for (var d = 1; d < tok.length; d++) {
-        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") { dashIdx = d; break; }
-      }
-      if (dashIdx > 0) {
-        var s = clockToSeconds(tok.substring(0, dashIdx));
-        var e = clockToSeconds(tok.substring(dashIdx + 1));
-        if (!isNaN(s) && !isNaN(e))
-          segments.push({ startSeconds: Math.floor(s), duration: Math.max(0, e - s) });
-      } else if (tok.indexOf(":") > 0) {
-        var sec = clockToSeconds(tok);
-        if (!isNaN(sec))
-          segments.push({ startSeconds: Math.floor(sec), duration: DEFAULT_DUR });
-      }
-    }
-    return segments;
-  }
-
   function parseSheetTimestamps(cellValue, participant) {
-    var baselineOffset = (mdState.baselines && mdState.baselines[participant]) || 0;
-    var segs = baselineOffset
-      ? parseClockSegments(cellValue)
-      : parseClipTimestamps(cellValue);
-    if (baselineOffset) {
-      for (var i = 0; i < segs.length; i++) {
-        segs[i].startSeconds = Math.max(0, segs[i].startSeconds - baselineOffset);
-      }
-    }
-    return segs;
+    return parseClipTimestamps(cellValue, participant);
   }
 
   // --- Participant helpers ---

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -72,7 +72,7 @@
       var total = 0;
       for (var j = 0; j < participants.length; j++) {
         var c = row.cells[participants[j]];
-        if (c && c.valid) total += parseClipTimestamps(c.value).length;
+        if (c && c.valid) total += parseClipTimestamps(c.value, participants[j]).length;
       }
       return total;
     },
@@ -126,7 +126,7 @@
   }
 
   function expandCellToSegments(info) {
-    var segments = parseClipTimestamps(info.timestamp);
+    var segments = parseClipTimestamps(info.timestamp, info.participant);
     var entries = [];
     for (var i = 0; i < segments.length; i++) {
       entries.push({
@@ -156,38 +156,13 @@
     if (td) td.classList.add("header-highlight");
   }
 
-  function parseClipTimestamps(raw) {
+  function parseClipTimestamps(raw, participantId) {
     var DEFAULT_DUR = (state.sheetData && state.sheetData.defaultDuration) || 60;
-    var cleaned = raw
-      .toLowerCase()
-      .replace(/!key/g, "")
-      .replace(/[+;,]/g, " ");
-    var tokens = cleaned.split(/\s+/).filter(function (t) {
-      return t && t !== "x";
-    });
-    var segments = [];
-    for (var i = 0; i < tokens.length; i++) {
-      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
-      var dashIdx = -1;
-      for (var d = 1; d < tok.length; d++) {
-        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") {
-          dashIdx = d;
-          break;
-        }
-      }
-      if (dashIdx > 0) {
-        var s = parseTimestamp(tok.substring(0, dashIdx));
-        var e = parseTimestamp(tok.substring(dashIdx + 1));
-        if (s !== null && e !== null) {
-          segments.push({ startSeconds: Math.floor(s), duration: Math.max(0, e - s) });
-        }
-      } else if (tok.indexOf(":") > 0) {
-        var sec = parseTimestamp(tok);
-        if (sec !== null) {
-          segments.push({ startSeconds: Math.floor(sec), duration: DEFAULT_DUR });
-        }
-      }
+    var baselineSeconds = 0;
+    if (participantId && state.convergenceBaselines) {
+      baselineSeconds = state.convergenceBaselines[participantId] || 0;
     }
+    var segments = parseClipSegmentsForCell(raw, baselineSeconds, DEFAULT_DUR);
     if (segments.length === 0) {
       segments.push({ startSeconds: 0, duration: DEFAULT_DUR });
     }
@@ -235,7 +210,7 @@
         var row = state.sheetData.rows[k];
         var cell = row.cells[participant];
         if (!cell || !cell.valid) continue;
-        var segs = parseClipTimestamps(cell.value);
+        var segs = parseClipTimestamps(cell.value, participant);
         for (var s = 0; s < segs.length; s++) {
           var segEnd = segs[s].startSeconds + segs[s].duration;
           if (segs[s].startSeconds < end && segEnd > start) {
@@ -666,6 +641,16 @@
         renderHeader();
         renderFilterBar();
         renderGrid();
+        // Load per-participant baselines so the grid color-codes durations
+        // and segment metadata in the video-relative frame (matches Python
+        // prepare_clip behavior) instead of raw clock-time spans. Re-render
+        // once they arrive so cell intensities reflect baselined durations.
+        apiGet("api/sheet/baseline")
+          .then(function (bdata) {
+            state.convergenceBaselines = (bdata.ok && bdata.baselines) ? bdata.baselines : {};
+            if (Object.keys(state.convergenceBaselines).length > 0) renderGrid();
+          })
+          .catch(function () { state.convergenceBaselines = {}; });
         computeGridMaxHeight();
         populateGalleryParticipants(data.participants || []);
         var durInput = qs("#highlightsDuration");
@@ -1235,7 +1220,7 @@
               var sevCellCls = severityClass(row.severity);
               if (sevCellCls) td.classList.add(sevCellCls);
             }
-            var segs = parseClipTimestamps(cellData.value);
+            var segs = parseClipTimestamps(cellData.value, pid);
             var totalDur = 0;
             for (var k = 0; k < segs.length; k++) totalDur += segs[k].duration;
             var intensity;
@@ -1734,7 +1719,7 @@
         segStart = item.segStart;
         segDuration = item.segDuration;
       } else {
-        var parsed = parseClipTimestamps(item.timestamp)[0];
+        var parsed = parseClipTimestamps(item.timestamp, item.participant)[0];
         segStart = parsed.startSeconds;
         segDuration = parsed.duration;
       }
@@ -1868,7 +1853,7 @@
         segStart = item.segStart;
         segDuration = item.segDuration;
       } else {
-        var parsed = parseClipTimestamps(item.timestamp)[0];
+        var parsed = parseClipTimestamps(item.timestamp, item.participant)[0];
         segStart = parsed.startSeconds;
         segDuration = parsed.duration;
       }
@@ -2040,7 +2025,7 @@
     for (var i = 0; i < items.length; i++) {
       var dur = items[i].segDuration;
       if (dur === undefined || dur === null) {
-        var segs = parseClipTimestamps(items[i].timestamp);
+        var segs = parseClipTimestamps(items[i].timestamp, items[i].participant);
         dur = segs.length > 0 ? segs[0].duration : 0;
       }
       total += dur || 0;
@@ -2685,7 +2670,7 @@
           segStart = item.segStart;
           segDuration = item.segDuration;
         } else {
-          var parsed = parseClipTimestamps(item.timestamp)[0];
+          var parsed = parseClipTimestamps(item.timestamp, item.participant)[0];
           segStart = parsed.startSeconds;
           segDuration = parsed.duration;
         }

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -105,6 +105,66 @@ var parseTimestamp = function (str) {
   return isNaN(n) ? null : n;
 };
 
+// Parse a timestamp string in clock semantics: 2-part is HH:MM (not MM:SS).
+// Mirrors Python utils._clock_to_seconds. Returns null on failure.
+var parseClockTimestamp = function (str) {
+  str = (str == null ? "" : String(str)).trim();
+  if (!str) return null;
+  var parts = str.split(":");
+  if (parts.length === 3) {
+    var h = parseFloat(parts[0]), m = parseFloat(parts[1]), s = parseFloat(parts[2]);
+    if (isNaN(h) || isNaN(m) || isNaN(s)) return null;
+    return h * 3600 + m * 60 + s;
+  }
+  if (parts.length === 2) {
+    var h2 = parseFloat(parts[0]), m2 = parseFloat(parts[1]);
+    if (isNaN(h2) || isNaN(m2)) return null;
+    return h2 * 3600 + m2 * 60;
+  }
+  return null;
+};
+
+// Parse a Sheet cell's timestamp tokens into [{startSeconds, duration}].
+// When baselineSeconds > 0, tokens are treated as absolute clock times
+// (2-part = HH:MM) and the baseline is subtracted from both ends of each
+// range. Mirrors files.prepare_clip + utils.convert_clock_pairs_to_relative.
+// Pairs that resolve to negative or zero-length intervals are skipped.
+var parseClipSegmentsForCell = function (raw, baselineSeconds, defaultDuration) {
+  var DEFAULT_DUR = defaultDuration || 60;
+  var hasBaseline = baselineSeconds && baselineSeconds > 0;
+  var tsParse = hasBaseline ? parseClockTimestamp : parseTimestamp;
+  var cleaned = String(raw || "").toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
+  var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
+  var segments = [];
+  for (var i = 0; i < tokens.length; i++) {
+    var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
+    var dashIdx = -1;
+    for (var d = 1; d < tok.length; d++) {
+      if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") { dashIdx = d; break; }
+    }
+    if (dashIdx > 0) {
+      var s = tsParse(tok.substring(0, dashIdx));
+      var e = tsParse(tok.substring(dashIdx + 1));
+      if (s === null || e === null) continue;
+      if (hasBaseline) {
+        s -= baselineSeconds;
+        e -= baselineSeconds;
+        if (s < 0 || e <= 0 || e <= s) continue;
+      }
+      segments.push({ startSeconds: Math.floor(s), duration: Math.max(0, e - s) });
+    } else if (tok.indexOf(":") > 0) {
+      var sec = tsParse(tok);
+      if (sec === null) continue;
+      if (hasBaseline) {
+        sec -= baselineSeconds;
+        if (sec < 0) continue;
+      }
+      segments.push({ startSeconds: Math.floor(sec), duration: DEFAULT_DUR });
+    }
+  }
+  return segments;
+};
+
 // ---- Math ----
 
 var clamp = function (val, min, max) {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.89"
+VERSIONNUM: str = "0.10.90"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -185,6 +185,32 @@ def test_baseline_row_detection_and_relative_conversion():
     assert prepared_p02["times"] == [("09:20:00", "09:21:00")]
 
 
+def test_baseline_subtracts_from_both_ends_of_multiple_ranges():
+    # Regression: when a cell holds multiple baselined HH:MM:SS-HH:MM:SS pairs,
+    # baseline must be subtracted from both ends of *each* pair independently.
+    sheet_data = [
+        ["study", "", "", "", ""],
+        ["Baseline time", "09:12:00", "", "", ""],
+        ["ID", "P01", "P02", "Observation", "Category"],
+        ["1", "09:13:00-09:14:00, 09:15:30-09:16:00", "", "Obs", "CatA"],
+    ]
+    id_cell = SimpleNamespace(row=3, col=1)
+    observation_cell = SimpleNamespace(row=3, col=4)
+    category_cell = SimpleNamespace(row=3, col=5)
+    ctx = _make_context(
+        sheet_data=sheet_data,
+        id_cell=id_cell,
+        observation_cell=observation_cell,
+        category_cell=category_cell,
+        num_participants=2,
+        study_name="study",
+        baseline_row_idx=spreadsheet._detect_baseline_row(sheet_data),
+    )
+    clips = spreadsheet.get_line_timestamps(ctx, 3)
+    prepared = files.prepare_clip(clips[0])
+    assert prepared["times"] == [("0:01:00", "0:02:00"), ("0:03:30", "0:04:00")]
+
+
 def test_no_baseline_row_means_relative_timestamps_only():
     # Same layout as above, but without any 'Baseline time' marker row.
     sheet_data = [


### PR DESCRIPTION
## Summary

- Studio's Sheet Preview ignored the per-participant baseline, so cell color intensity, duration totals, segment metadata, and cross-references on baselined sheets operated in the raw clock frame; two-part `HH:MM` tokens were also misread as `MM:SS`.
- Added a shared `parseClipSegmentsForCell` in `utils.js` that mirrors Python's `convert_clock_pairs_to_relative` semantics, routed Studio/Convergence/Metadata through it, and made `loadSheetData` fetch baselines and re-render the grid.
- Confirmed the interactive CLI was already correct (it routes through `prepare_clip()`); added a Python regression test for multi-pair baselined ranges and bumped VERSIONNUM to 0.10.90.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` (all 586 pass, including new multi-pair baseline test)
- [ ] Manual: launch `uv run clipgen.py --studio` against a sheet with a Baseline time row; confirm cell color intensity for `09:13:00-09:14:00` matches `1:00-2:00` (both 60 s) and segment hover starts at the relative offset, not the clock time.