### PR TITLE
feat: configurable CV resolution scale for Screenspace

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5980,7 +5980,7 @@
     if (settingsBtn) {
       settingsBtn.addEventListener("click", function () {
         if (typeof window.openSettingsModal === "function") {
-          window.openSettingsModal({ initialTab: "General" });
+          window.openSettingsModal({ initialTab: "Screenspace" });
         }
       });
     }

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -12,6 +12,7 @@
   var TAB_ORDER = [
     "General",
     "Video & Clips",
+    "Screenspace",
     "Transcription",
     "AI / Ollama",
     "CLI",
@@ -352,10 +353,33 @@
         _scheduleSave();
       });
       controlDiv.appendChild(txtInput);
+    } else if (s.type === "float") {
+      var fInput = document.createElement("input");
+      fInput.type = "number";
+      if (s.min !== undefined && s.min !== null) fInput.min = s.min;
+      if (s.max !== undefined && s.max !== null) fInput.max = s.max;
+      fInput.step = s.step !== undefined && s.step !== null ? s.step : "any";
+      fInput.value = s.value;
+      fInput.placeholder = String(s.default);
+      fInput.addEventListener("change", function () {
+        var setting = _findSetting(settingName);
+        if (setting) {
+          var n = parseFloat(this.value);
+          if (isNaN(n)) n = setting.default;
+          if (setting.min !== undefined && setting.min !== null && n < setting.min) n = setting.min;
+          if (setting.max !== undefined && setting.max !== null && n > setting.max) n = setting.max;
+          setting.value = n;
+          this.value = n;
+        }
+        _updateChanged(settingName);
+        _scheduleSave();
+      });
+      controlDiv.appendChild(fInput);
     } else {
       var input = document.createElement("input");
       input.type = "number";
       if (s.min !== undefined && s.min !== null) input.min = s.min;
+      if (s.max !== undefined && s.max !== null) input.max = s.max;
       if (s.step !== undefined && s.step !== null) input.step = s.step;
       input.value = s.value;
       input.placeholder = String(s.default);

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.90"
+VERSIONNUM: str = "0.10.91"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -189,6 +189,10 @@ SCREENSPACE_INACTIVITY_PHASH_THRESHOLD: int = (
 SCREENSPACE_INACTIVITY_MIN_DURATION: float = (
     2.0  # min seconds to report an inactivity span
 )
+SCREENSPACE_CV_RESOLUTION_SCALE: float = (
+    1.0  # multiplier applied to extracted region frames before CV analysis
+    # (1.0 = no change; >1 sharper but slower and more memory; <1 faster but coarser)
+)
 
 # ── Highlights Reel ──────────────────────────────────────────────────
 HIGHLIGHTS_REEL_DURATION_SECONDS: int = 180  # 3-minute budget for highlights reel
@@ -290,6 +294,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "OLLAMA_SUMMARY_ENABLED": "Auto-generate AI summaries of transcripts using a local Ollama model.",
     "OLLAMA_SUMMARY_MODEL": "Ollama model used for transcript summaries and citation linking.",
     "OLLAMA_BASE_URL": "Base URL of the local Ollama server.",
+    "SCREENSPACE_CV_RESOLUTION_SCALE": "Scale extracted region frames before CV analysis. Higher (e.g. 2.0) gives the models more signal on noisy/compressed video at the cost of speed and memory; lower speeds up scans on large footage. 1.0 = unchanged.",
 }
 
 # Studio-exposed settings with UI metadata (tab, group, type, constraints).
@@ -399,6 +404,14 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
         "provider": "ollama",
     },
     "OLLAMA_BASE_URL": {"tab": "AI / Ollama", "group": "AI Summary", "type": "str"},
+    "SCREENSPACE_CV_RESOLUTION_SCALE": {
+        "tab": "Screenspace",
+        "group": "Analysis Quality",
+        "type": "float",
+        "min": 0.25,
+        "max": 4.0,
+        "step": 0.25,
+    },
     "RICH_COLORS": {"tab": "CLI", "group": "Terminal Output", "type": "bool"},
     "RICH_PANELS": {"tab": "CLI", "group": "Terminal Output", "type": "bool"},
     "RICH_PROGRESS": {"tab": "CLI", "group": "Terminal Output", "type": "bool"},

--- a/screenspace.py
+++ b/screenspace.py
@@ -529,6 +529,7 @@ def scan_video_frames(
     fps: float = 0.0,
     duration: float = 0.0,
     fast_opts: dict[str, Any] | None = None,
+    cv_scale: float | None = None,
 ) -> None:
     """Iterate through video at interval, extract region, call callback.
 
@@ -545,6 +546,8 @@ def scan_video_frames(
     - ``max_region_dim``: downscale extracted region to this max dimension
     """
     full_frame = region is None
+    if cv_scale is None:
+        cv_scale = config.SCREENSPACE_CV_RESOLUTION_SCALE
 
     # Extract frames via ffmpeg pipe (faster H.264 decoding, no cv2.VideoCapture)
     if not _scan_via_ffmpeg_pipe(
@@ -558,6 +561,7 @@ def scan_video_frames(
         duration=duration,
         fast_opts=fast_opts,
         full_frame=full_frame,
+        cv_scale=cv_scale,
     ):
         utils.warning_print(
             f"ffmpeg pipe extraction failed for {Path(video_path).name}"
@@ -574,6 +578,7 @@ def scan_video_full_frames(
     fps: float = 0.0,
     duration: float = 0.0,
     fast_opts: dict[str, Any] | None = None,
+    cv_scale: float | None = None,
 ) -> None:
     """Like :func:`scan_video_frames` but passes the full frame (no region crop).
 
@@ -589,6 +594,7 @@ def scan_video_full_frames(
         fps=fps,
         duration=duration,
         fast_opts=fast_opts,
+        cv_scale=cv_scale,
     )
 
 
@@ -607,6 +613,7 @@ def _ffmpeg_pipe_frames(
     frame_width: int = 0,
     frame_height: int = 0,
     max_dim: int = 0,
+    cv_scale: float = 1.0,
 ) -> Iterator[tuple[float, np.ndarray]]:
     """Yield ``(timestamp, frame)`` tuples extracted via an ffmpeg pipe.
 
@@ -635,6 +642,17 @@ def _ffmpeg_pipe_frames(
 
     if out_w <= 0 or out_h <= 0:
         return
+
+    # Global CV resolution scale: applied after the region crop, before any
+    # max_dim cap. Skipped at 1.0 so default-config runs are byte-identical
+    # to pre-feature behavior.
+    if cv_scale > 0 and abs(cv_scale - 1.0) > 1e-6:
+        scaled_w = max(2, int(round(out_w * cv_scale)))
+        scaled_h = max(2, int(round(out_h * cv_scale)))
+        scaled_w += scaled_w % 2
+        scaled_h += scaled_h % 2
+        filters.append(f"scale={scaled_w}:{scaled_h}:flags=lanczos")
+        out_w, out_h = scaled_w, scaled_h
 
     if max_dim > 0 and (out_w > max_dim or out_h > max_dim):
         scale = max_dim / max(out_w, out_h)
@@ -703,6 +721,7 @@ def _scan_via_ffmpeg_pipe(
     duration: float = 0.0,
     fast_opts: dict[str, Any] | None = None,
     full_frame: bool = False,
+    cv_scale: float = 1.0,
 ) -> bool:
     """Try to scan frames via ffmpeg pipe, calling *callback* for each.
 
@@ -748,6 +767,7 @@ def _scan_via_ffmpeg_pipe(
             frame_width=frame_width,
             frame_height=frame_height,
             max_dim=pipe_max_dim,
+            cv_scale=cv_scale,
         ):
             if _phash_skip:
                 fh = compute_phash(frame)
@@ -1420,17 +1440,25 @@ def scan_template(
 
     _tmpl_downscale = bool(fast_opts and fast_opts.get("template_downscale"))
 
-    # Resize the template (and mask) once up front based on user-supplied
-    # scale. The opt-in slider lets users compensate when their uploaded
-    # PNG is captured at a different pixel scale than its in-video
-    # rendering (e.g. a 50x50 icon appearing as 24x24 on screen).
+    # Combine the user-supplied template_scale with the global CV resolution
+    # scale so the template matches at the same relative size on the
+    # (possibly upscaled) extracted frames. The opt-in template_scale slider
+    # lets users compensate when their uploaded PNG is captured at a
+    # different pixel scale than its in-video rendering (e.g. a 50x50 icon
+    # appearing as 24x24 on screen).
+    _cv_scale_template = (
+        config.SCREENSPACE_CV_RESOLUTION_SCALE
+        if config.SCREENSPACE_CV_RESOLUTION_SCALE > 0
+        else 1.0
+    )
+    effective_template_scale = template_scale * _cv_scale_template
     scaled_template = template_image
     scaled_mask = template_mask
-    if template_scale > 0 and abs(template_scale - 1.0) > 1e-6:
+    if effective_template_scale > 0 and abs(effective_template_scale - 1.0) > 1e-6:
         th, tw = template_image.shape[:2]
-        nw = max(8, int(round(tw * template_scale)))
-        nh = max(8, int(round(th * template_scale)))
-        interp = cv2.INTER_AREA if template_scale < 1.0 else cv2.INTER_CUBIC
+        nw = max(8, int(round(tw * effective_template_scale)))
+        nh = max(8, int(round(th * effective_template_scale)))
+        interp = cv2.INTER_AREA if effective_template_scale < 1.0 else cv2.INTER_CUBIC
         scaled_template = cv2.resize(template_image, (nw, nh), interpolation=interp)
         if template_mask is not None:
             scaled_mask = cv2.resize(
@@ -1447,6 +1475,14 @@ def scan_template(
         return results
 
     _nms_overlap = config.SCREENSPACE_TEMPLATE_NMS_OVERLAP
+    # Frame is already at cv_scale * original due to ffmpeg scaling. We need
+    # to undo both the user-set cv_scale and the fast-scan internal 2x
+    # downscale to report match boxes in original-frame pixels.
+    _cv_scale = (
+        config.SCREENSPACE_CV_RESOLUTION_SCALE
+        if config.SCREENSPACE_CV_RESOLUTION_SCALE > 0
+        else 1.0
+    )
 
     def _cb(ts: float, frame: np.ndarray) -> bool | None:
         if cancel_flag and cancel_flag():
@@ -1465,12 +1501,15 @@ def scan_template(
             work_frame, _prepared, threshold, _nms_overlap
         )
         if matches:
-            if scale_back > 1:
+            # Undo fast-scan downscale, then undo cv_scale, so reported
+            # coords are in the original (un-scaled) frame coordinate space.
+            inv = scale_back / _cv_scale
+            if abs(inv - 1.0) > 1e-6:
                 for m in matches:
-                    m["x"] *= scale_back
-                    m["y"] *= scale_back
-                    m["w"] *= scale_back
-                    m["h"] *= scale_back
+                    m["x"] = int(round(m["x"] * inv))
+                    m["y"] = int(round(m["y"] * inv))
+                    m["w"] = int(round(m["w"] * inv))
+                    m["h"] = int(round(m["h"] * inv))
             best = max(m["score"] for m in matches)
             rd = {
                 "timestamp": ts,

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 
 from flask import Blueprint, Response, jsonify, request, send_file
 
+import config
 import files
 import utils
 import video
@@ -1087,6 +1088,11 @@ def api_tasks_create() -> FlaskResponse:
         parameters = cast(dict[str, Any], prepared)
 
     import screenspace
+
+    # Snapshot the global CV resolution scale into the task so the manifest
+    # records what scale produced each result (useful when re-running with
+    # a different scale to compare outputs).
+    parameters.setdefault("cv_resolution_scale", config.SCREENSPACE_CV_RESOLUTION_SCALE)
 
     task = screenspace.create_task(
         task_type=task_type,

--- a/server.py
+++ b/server.py
@@ -1125,6 +1125,7 @@ def _settings_records() -> list[dict[str, Any]]:
                 "type": meta.get("type", "str"),
                 "options": meta.get("options"),
                 "min": meta.get("min"),
+                "max": meta.get("max"),
                 "step": meta.get("step"),
                 "provider": meta.get("provider"),
             }

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1111,6 +1111,21 @@ def test_api_settings_includes_cli_settings(client):
         assert by_name[name]["type"] == "bool"
 
 
+def test_api_settings_includes_screenspace_cv_resolution_scale(client):
+    """GET /api/settings exposes the Screenspace CV resolution scale knob."""
+    resp = client.get("/studio/api/settings")
+    data = resp.get_json()
+    by_name = {s["name"]: s for s in data["settings"]}
+    assert "SCREENSPACE_CV_RESOLUTION_SCALE" in by_name
+    s = by_name["SCREENSPACE_CV_RESOLUTION_SCALE"]
+    assert s["tab"] == "Screenspace"
+    assert s["type"] == "float"
+    assert s["min"] == 0.25
+    assert s["max"] == 4.0
+    assert s["step"] == 0.25
+    assert isinstance(s["value"], float)
+
+
 def test_api_settings_includes_provider_field(client):
     """model_select settings include a provider field."""
     resp = client.get("/studio/api/settings")


### PR DESCRIPTION
## Summary
- Adds `SCREENSPACE_CV_RESOLUTION_SCALE` (default 1.0, range 0.25–4.0) — a global knob to scale extracted region frames before CV analysis, so users can trade speed for fidelity when models struggle on noisy/compressed source video.
- Scale is applied as an ffmpeg `scale=…:flags=lanczos` filter after the region crop, so all eleven analysis tools benefit without per-tool changes; default 1.0 is byte-identical to prior behavior.
- Template matching scales the uploaded template by the same factor and inverse-scales match boxes, so reported coords stay in original-frame space.
- Exposed in the Settings modal under a new "Screenspace" tab (new `float` control type with min/max/step support); each task records its `cv_resolution_scale` in the manifest for reproducibility.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite passes (587 tests), including new smoke test asserting the setting is exposed via `/api/settings` with the right tab/type/bounds.
- [x] `uv run ruff check && uv run ruff format` — clean.
- [x] `uv run ty check` — no new diagnostics.
- [ ] Manual: open `--screenspace`, verify Settings → Screenspace shows the slider; run a Change/Similarity task at 1.0, then 2.0, then 0.5 and confirm manifest records the scale and Template match boxes draw at correct positions.