### PR TITLE
feat: WebP/JPG/WebM image format options for screenshots and gifs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ dist/
 /*.flv
 /*.mov
 /*.mkv
+/*.webm
+/*.webp
+/*.jpg
 /*.xlsx
 output/
 .cursor/

--- a/assets/web/gallery.css
+++ b/assets/web/gallery.css
@@ -181,7 +181,8 @@ body {
   box-shadow: var(--shadow-lg);
 }
 
-.gallery-card img {
+.gallery-card img,
+.gallery-card video {
   width: 100%;
   display: block;
   aspect-ratio: 16 / 9;
@@ -237,7 +238,8 @@ body {
   justify-content: center;
 }
 
-#lightboxContent img {
+#lightboxContent img,
+#lightboxContent video {
   max-width: 90vw;
   max-height: 80vh;
   object-fit: contain;

--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -68,11 +68,17 @@
       card.className = "gallery-card";
       card.setAttribute("data-index", i);
 
-      var img = document.createElement("img");
-      img.src = a.data || a.file;
-      img.alt = a.timestamp_formatted || formatTime(a.timestamp);
-      img.loading = "lazy";
-      card.appendChild(img);
+      var src = a.data || a.file;
+      var altText = a.timestamp_formatted || formatTime(a.timestamp);
+      if (isVideoLoop(a.file)) {
+        card.appendChild(createLoopVideo(src, altText));
+      } else {
+        var img = document.createElement("img");
+        img.src = src;
+        img.alt = altText;
+        img.loading = "lazy";
+        card.appendChild(img);
+      }
 
       var overlay = document.createElement("span");
       overlay.className = "timestamp-overlay";
@@ -119,10 +125,16 @@
     var a = state.artifacts[index];
     var content = qs("#lightboxContent");
     content.innerHTML = "";
-    var img = document.createElement("img");
-    img.src = a.data || a.file;
-    img.alt = a.timestamp_formatted || formatTime(a.timestamp);
-    content.appendChild(img);
+    var src = a.data || a.file;
+    var altText = a.timestamp_formatted || formatTime(a.timestamp);
+    if (isVideoLoop(a.file)) {
+      content.appendChild(createLoopVideo(src, altText));
+    } else {
+      var img = document.createElement("img");
+      img.src = src;
+      img.alt = altText;
+      content.appendChild(img);
+    }
 
     var caption = qs("#lightboxCaption");
     if (caption) {

--- a/assets/web/insights-builder.css
+++ b/assets/web/insights-builder.css
@@ -467,7 +467,8 @@ body {
   overflow: hidden;
 }
 
-.artifact-media img {
+.artifact-media img,
+.artifact-media video {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -354,14 +354,18 @@
       media.addEventListener("mousemove", spriteHover);
       media.addEventListener("mouseleave", spriteReset);
     } else {
-      var img = document.createElement("img");
       var fileSrc = "media/" + encodeURIComponent(artifact.file);
-      img.src = fileSrc;
-      img.alt = artifact.description || "";
-      img.loading = "lazy";
-      media.appendChild(img);
-      if (artifact.type === "gif") {
-        setupGifHover(card, img, fileSrc);
+      if (isVideoLoop(artifact.file)) {
+        media.appendChild(createLoopVideo(fileSrc, artifact.description || ""));
+      } else {
+        var img = document.createElement("img");
+        img.src = fileSrc;
+        img.alt = artifact.description || "";
+        img.loading = "lazy";
+        media.appendChild(img);
+        if (artifact.type === "gif") {
+          setupGifHover(card, img, fileSrc);
+        }
       }
     }
     card.appendChild(media);
@@ -1140,14 +1144,18 @@
       media.addEventListener("mousemove", spriteHover);
       media.addEventListener("mouseleave", spriteReset);
     } else {
-      var img = document.createElement("img");
       var fileSrc = "media/" + encodeURIComponent(artifact.file);
-      img.src = fileSrc;
-      img.alt = artifact.description || "";
-      img.loading = "lazy";
-      media.appendChild(img);
-      if (artifact.type === "gif") {
-        setupGifHover(card, img, fileSrc);
+      if (isVideoLoop(artifact.file)) {
+        media.appendChild(createLoopVideo(fileSrc, artifact.description || ""));
+      } else {
+        var img = document.createElement("img");
+        img.src = fileSrc;
+        img.alt = artifact.description || "";
+        img.loading = "lazy";
+        media.appendChild(img);
+        if (artifact.type === "gif") {
+          setupGifHover(card, img, fileSrc);
+        }
       }
     }
     card.appendChild(media);

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -206,8 +206,12 @@
       .then(function (r) { return r.json(); })
       .then(function (data) {
         if (_statusEl) {
-          _statusEl.textContent = data.ok ? "Saved" : "Save failed";
-          setTimeout(function () { if (_statusEl) _statusEl.textContent = ""; }, 2000);
+          if (data.ok) {
+            _statusEl.textContent = "Saved";
+            setTimeout(function () { if (_statusEl) _statusEl.textContent = ""; }, 2000);
+          } else {
+            _statusEl.textContent = data.error ? "Save failed: " + data.error : "Save failed";
+          }
         }
         if (data.ok && typeof _opts.onSave === "function") {
           _opts.onSave(data.applied || {}, _settings.slice());
@@ -356,6 +360,7 @@
       var input = document.createElement("input");
       input.type = "number";
       if (s.min !== undefined && s.min !== null) input.min = s.min;
+      if (s.max !== undefined && s.max !== null) input.max = s.max;
       if (s.step !== undefined && s.step !== null) input.step = s.step;
       input.value = s.value;
       input.placeholder = String(s.default);

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -26,6 +26,28 @@ var el = function (tag, cls, text) {
   return e;
 };
 
+// True when an animated artifact's filename should render via <video> rather
+// than <img>. Used by the gallery, viewer, and insights builder so they all
+// agree which extensions are looping video. Keep as the single source of truth.
+var isVideoLoop = function (filename) {
+  return /\.webm$/i.test(filename || "");
+};
+
+// Create a looping, silent, autoplay <video> element for animated artifacts
+// stored as .webm. Centralized so the attribute set is consistent everywhere.
+var createLoopVideo = function (src, alt) {
+  var v = document.createElement("video");
+  v.src = src;
+  v.autoplay = true;
+  v.loop = true;
+  v.muted = true;
+  v.setAttribute("muted", "");
+  v.setAttribute("playsinline", "");
+  v.preload = "auto";
+  if (alt) v.setAttribute("aria-label", alt);
+  return v;
+};
+
 // ---- Hover tooltips (dark pill, pairs with .cg-tooltip in tokens.css) ----
 
 var createTooltip = function (opts) {

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -650,7 +650,8 @@ body {
   overflow: hidden;
 }
 
-.artifact-media img {
+.artifact-media img,
+.artifact-media video {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1484,10 +1484,14 @@
       img.alt = a.description || "screenshot";
       preview.appendChild(img);
     } else if (a.type === "gif") {
-      var gifImg = document.createElement("img");
-      gifImg.src = a.file;
-      gifImg.alt = a.description || "gif";
-      preview.appendChild(gifImg);
+      if (isVideoLoop(a.file)) {
+        preview.appendChild(createLoopVideo(a.file, a.description || "gif"));
+      } else {
+        var gifImg = document.createElement("img");
+        gifImg.src = a.file;
+        gifImg.alt = a.description || "gif";
+        preview.appendChild(gifImg);
+      }
     } else {
       var vid = document.createElement("video");
       vid.controls = true;
@@ -1559,10 +1563,14 @@
     }
 
     if (a.type === "gif") {
-      var gifImg = document.createElement("img");
-      gifImg.src = a.file;
-      gifImg.alt = a.description || "gif";
-      preview.appendChild(gifImg);
+      if (isVideoLoop(a.file)) {
+        preview.appendChild(createLoopVideo(a.file, a.description || "gif"));
+      } else {
+        var gifImg = document.createElement("img");
+        gifImg.src = a.file;
+        gifImg.alt = a.description || "gif";
+        preview.appendChild(gifImg);
+      }
       _preview = { id: id, videoEl: null, wrapEl: null };
       return;
     }
@@ -1945,10 +1953,14 @@
       img.alt = a.description || "screenshot";
       preview.appendChild(img);
     } else if (a.type === "gif") {
-      var gifImg = document.createElement("img");
-      gifImg.src = a.file;
-      gifImg.alt = a.description || "gif";
-      preview.appendChild(gifImg);
+      if (isVideoLoop(a.file)) {
+        preview.appendChild(createLoopVideo(a.file, a.description || "gif"));
+      } else {
+        var gifImg = document.createElement("img");
+        gifImg.src = a.file;
+        gifImg.alt = a.description || "gif";
+        preview.appendChild(gifImg);
+      }
     } else {
       var vid = document.createElement("video");
       vid.controls = true;

--- a/cli.py
+++ b/cli.py
@@ -1478,6 +1478,24 @@ def main() -> None:
     if not video.check_ffmpeg_tools_available():
         sys.exit(1)
 
+    webp_formats = [
+        name
+        for name, value in (
+            ("SCREENSHOT_FORMAT", config.SCREENSHOT_FORMAT),
+            ("GIF_FORMAT", config.GIF_FORMAT),
+        )
+        if value.lower() == ".webp"
+    ]
+    if webp_formats and not video.check_webp_support():
+        utils.error_print(
+            "WebP output is configured but ffmpeg lacks libwebp support.",
+            [
+                f"Affected config: {', '.join(webp_formats)}",
+                "Install an ffmpeg build with libwebp, or change the format(s) back to .png/.jpg/.gif in config.py.",
+            ],
+        )
+        sys.exit(1)
+
     if _dispatch_standalone_mode(args, cli_mode, gallery_arg):
         sys.exit(0)
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.89"
+VERSIONNUM: str = "0.10.94"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -231,6 +231,9 @@ MAX_MMSS_LENGTH: int = 5  # Max length of an MM:SS timestamp string
 # ── FFmpeg ────────────────────────────────────────────────────────────
 FFMPEG_LOGLEVEL: str = "16"  # ffmpeg -loglevel value (16 = error)
 FFMPEG_SCREENSHOT_QUALITY: str = "2"  # -q:v value for screenshots (1=best, 31=worst)
+SCREENSHOT_FORMAT: str = ".png"  # ".png" | ".jpg" | ".webp"
+GIF_FORMAT: str = ".gif"  # ".gif" | ".webp" | ".webm" (WebM uses VP9 silent-loop video)
+WEBP_QUALITY: int = 80  # 0-100, used by libwebp when output is .webp
 GIF_FPS: int = 10
 GIF_SCALE_WIDTH: int = 480
 AUDIO_BITRATE_KBPS: int = 128
@@ -290,6 +293,9 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "OLLAMA_SUMMARY_ENABLED": "Auto-generate AI summaries of transcripts using a local Ollama model.",
     "OLLAMA_SUMMARY_MODEL": "Ollama model used for transcript summaries and citation linking.",
     "OLLAMA_BASE_URL": "Base URL of the local Ollama server.",
+    "SCREENSHOT_FORMAT": "File format for screenshot artifacts. WebP is smaller but requires modern browsers (Safari 16+).",
+    "GIF_FORMAT": "File format for animated artifacts. WebM (VP9) is the smallest and most-compatible modern option; animated WebP is also small but requires Safari 16+; GIF works everywhere but is large.",
+    "WEBP_QUALITY": "WebP encoding quality (0-100). Higher values mean better quality and larger files.",
 }
 
 # Studio-exposed settings with UI metadata (tab, group, type, constraints).
@@ -311,6 +317,26 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
         "tab": "General",
         "group": "Sheet Preview",
         "type": "bool",
+    },
+    "SCREENSHOT_FORMAT": {
+        "tab": "General",
+        "group": "Image Output",
+        "type": "select",
+        "options": [".png", ".jpg", ".webp"],
+    },
+    "GIF_FORMAT": {
+        "tab": "General",
+        "group": "Image Output",
+        "type": "select",
+        "options": [".gif", ".webp", ".webm"],
+    },
+    "WEBP_QUALITY": {
+        "tab": "General",
+        "group": "Image Output",
+        "type": "int",
+        "min": 0,
+        "max": 100,
+        "step": 1,
     },
     "REENCODING": {"tab": "Video & Clips", "group": "Video Output", "type": "bool"},
     "AUDIO_NORMALIZE": {

--- a/pipeline.py
+++ b/pipeline.py
@@ -188,8 +188,8 @@ def _process_single_clip_segments(
     output_paths: list[tuple[str, str, str]] = []
     extension_map = {
         "clip": config.FILEFORMAT,
-        "screen": ".png",
-        "gif": ".gif",
+        "screen": config.SCREENSHOT_FORMAT,
+        "gif": config.GIF_FORMAT,
     }
     file_extension = extension_map.get(output_format)
     if not file_extension:

--- a/server.py
+++ b/server.py
@@ -1125,6 +1125,7 @@ def _settings_records() -> list[dict[str, Any]]:
                 "type": meta.get("type", "str"),
                 "options": meta.get("options"),
                 "min": meta.get("min"),
+                "max": meta.get("max"),
                 "step": meta.get("step"),
                 "provider": meta.get("provider"),
             }
@@ -1168,6 +1169,24 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
     settings_data = data.get("settings")
     if not isinstance(settings_data, dict):
         return {}, "Invalid settings payload"
+
+    for webp_name in ("SCREENSHOT_FORMAT", "GIF_FORMAT"):
+        if webp_name not in settings_data:
+            continue
+        new_value = str(settings_data[webp_name]).lower()
+        current_value = str(getattr(config, webp_name, "")).lower()
+        # Only validate when the user is *changing* the value to .webp; an
+        # unchanged .webp value already on disk shouldn't block edits to other
+        # fields.
+        if (
+            new_value == ".webp"
+            and current_value != ".webp"
+            and not video.check_webp_support()
+        ):
+            return {}, (
+                f"WebP not available: ffmpeg has no libwebp encoder. "
+                f"Install an ffmpeg build with libwebp to set {webp_name} to .webp."
+            )
 
     applied = {}
     for name, value in settings_data.items():

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -398,6 +398,139 @@ def test_check_ffmpeg_tools_available_missing(monkeypatch):
     assert ok is False
 
 
+_FFMPEG_ENCODERS_WITH_WEBP = (
+    "Encoders:\n"
+    " V..... = Video\n"
+    " ------\n"
+    " V..... libwebp_anim    libwebp WebP image (codec webp)\n"
+    " V..... libwebp         libwebp WebP image (codec webp)\n"
+)
+
+_FFMPEG_ENCODERS_NO_WEBP = (
+    "Encoders:\n V..... = Video\n ------\n V..... libx264         H.264 (codec h264)\n"
+)
+
+# The codecs listing mentions 'webp' even on builds without libwebp; the old
+# check matched this and produced a false positive. Used here as a regression
+# guard.
+_FFMPEG_CODECS_WITHOUT_LIBWEBP_ENCODER = (
+    "Codecs:\n D..... = Decoder\n .EV..L webp     WebP (encoders: )\n"
+)
+
+
+def test_check_webp_support_detects_libwebp(monkeypatch):
+    monkeypatch.setattr(video, "_webp_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_ENCODERS_WITH_WEBP, stderr=""
+        ),
+    )
+    assert video.check_webp_support() is True
+
+    monkeypatch.setattr(video, "_webp_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_ENCODERS_NO_WEBP, stderr=""
+        ),
+    )
+    assert video.check_webp_support() is False
+
+
+def test_check_webp_support_ignores_codecs_listing(monkeypatch):
+    """Regression: the codecs listing is not authoritative; only -encoders is."""
+    monkeypatch.setattr(video, "_webp_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_CODECS_WITHOUT_LIBWEBP_ENCODER, stderr=""
+        ),
+    )
+    assert video.check_webp_support() is False
+
+
+def test_extract_gif_includes_webp_quality_for_webp_output(monkeypatch):
+    import config as cfg
+
+    monkeypatch.setattr(cfg, "DEBUGGING", False)
+    monkeypatch.setattr(video, "get_file_duration", lambda _f: 600)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(
+        video.Path, "stat", lambda self: type("S", (), {"st_size": 1})()
+    )
+    monkeypatch.setattr(video, "check_webp_support", lambda: True)
+
+    captured: dict = {}
+
+    def fake_run(cmd, **_kw):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.extract_gif("/in.mp4", "/out.webp", "0:10", 3)
+    assert ok is True
+    assert "-quality" in captured["cmd"]
+    assert str(cfg.WEBP_QUALITY) in captured["cmd"]
+
+    captured.clear()
+    ok = video.extract_gif("/in.mp4", "/out.gif", "0:10", 3)
+    assert ok is True
+    assert "-quality" not in captured["cmd"]
+
+
+def test_extract_gif_uses_vp9_for_webm_output(monkeypatch):
+    import config as cfg
+
+    monkeypatch.setattr(cfg, "DEBUGGING", False)
+    monkeypatch.setattr(video, "get_file_duration", lambda _f: 600)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(
+        video.Path, "stat", lambda self: type("S", (), {"st_size": 1})()
+    )
+
+    captured: dict = {}
+
+    def fake_run(cmd, **_kw):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.extract_gif("/in.mp4", "/out.webm", "0:10", 3)
+    assert ok is True
+    cmd = captured["cmd"]
+    assert "libvpx-vp9" in cmd
+    assert "-an" in cmd
+    # WebM container does not honor -loop; that flag must not be added.
+    assert "-loop" not in cmd
+    # WebP-only quality flag must not leak into the WebM command either.
+    assert "-quality" not in cmd
+
+
+def test_extract_gif_rejects_webp_when_unsupported(monkeypatch):
+    monkeypatch.setattr(video, "check_webp_support", lambda: False)
+    monkeypatch.setattr(video, "_webp_missing_warned", False)
+
+    called = {"run": False}
+
+    def fake_run(*_a, **_kw):
+        called["run"] = True
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.extract_gif("/in.mp4", "/out.webp", "0:10", 3)
+    assert ok is False
+    assert called["run"] is False
+
+
 # ---- extract_frame_at_timestamp ----
 
 

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -210,6 +210,22 @@ def test_finalize_gallery_data_bundle_embeds_gif(tmp_path, monkeypatch):
     assert data_uri.startswith("data:image/gif;base64,")
 
 
+def test_finalize_gallery_data_bundle_picks_mime_by_extension(tmp_path, monkeypatch):
+    """Bundle MIME is chosen by file extension, not artifact type. WebM gifs
+    must be embedded as video/webm so the viewer's <video> element loads them."""
+    monkeypatch.chdir(tmp_path)
+    cases = [
+        ("cap.webp", b"RIFF\x00\x00\x00\x00WEBPVP8 ", "data:image/webp;base64,"),
+        ("cap.webm", b"\x1a\x45\xdf\xa3", "data:video/webm;base64,"),
+        ("cap.jpg", b"\xff\xd8\xff\xe0", "data:image/jpeg;base64,"),
+    ]
+    for filename, payload, expected_prefix in cases:
+        (tmp_path / filename).write_bytes(payload)
+        artifacts = [{"file": filename, "timestamp": 0.0, "type": "gif"}]
+        viewer.finalize_gallery_data(artifacts, bundle=True)
+        assert str(artifacts[0]["data"]).startswith(expected_prefix), filename
+
+
 def test_finalize_gallery_data_bundle_skips_missing_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     artifacts = [{"file": "missing.png", "timestamp": 0.0, "type": "screen"}]

--- a/video.py
+++ b/video.py
@@ -72,6 +72,56 @@ def check_ffmpeg_tools_available() -> bool:
     return False
 
 
+_webp_support_cache: bool | None = None
+_webp_missing_warned: bool = False
+
+
+def check_webp_support() -> bool:
+    """Return True when ffmpeg has a libwebp encoder available.
+
+    Queries `ffmpeg -encoders` (not `-codecs`) — only the encoders listing is
+    authoritative for "can ffmpeg write this format". The codecs listing
+    includes the webp muxer/decoder even on builds without libwebp. Looks for
+    a line starting with `libwebp` or `libwebp_anim`. Result is cached.
+    """
+    global _webp_support_cache
+    if _webp_support_cache is not None:
+        return _webp_support_cache
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-encoders"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        stdout = result.stdout or ""
+        _webp_support_cache = False
+        for line in stdout.splitlines():
+            tokens = line.strip().split()
+            if len(tokens) >= 2 and tokens[1] in ("libwebp", "libwebp_anim"):
+                _webp_support_cache = True
+                break
+    except (OSError, subprocess.SubprocessError):
+        _webp_support_cache = False
+    return _webp_support_cache
+
+
+def _warn_webp_unavailable_once(output_file: str) -> None:
+    """Print a single clear error per session when WebP is requested but unsupported."""
+    global _webp_missing_warned
+    if _webp_missing_warned:
+        return
+    _webp_missing_warned = True
+    utils.error_print(
+        "WebP output requested but ffmpeg has no libwebp encoder.",
+        [
+            f"Tried to write: '{output_file}'",
+            "Install an ffmpeg build with libwebp, or change SCREENSHOT_FORMAT/GIF_FORMAT back to .png/.jpg/.gif.",
+            "Skipping all WebP outputs for this run.",
+        ],
+    )
+
+
 def run_ffmpeg_process(
     ffmpeg_command: list[str],
     *,
@@ -332,6 +382,9 @@ def extract_screenshot(input_file: str, output_file: str, timestamp: str) -> boo
     """
     if config.DEBUGGING:
         ic(input_file, output_file, timestamp)
+    if output_file.lower().endswith(".webp") and not check_webp_support():
+        _warn_webp_unavailable_once(output_file)
+        return False
     if not Path(input_file).is_file():
         utils.error_print(
             f"Input video file not found: '{input_file}'",
@@ -470,6 +523,9 @@ def extract_gif(
     """
     if config.DEBUGGING:
         ic(input_file, output_file, timestamp, duration_seconds)
+    if output_file.lower().endswith(".webp") and not check_webp_support():
+        _warn_webp_unavailable_once(output_file)
+        return False
     if not Path(input_file).is_file():
         utils.error_print(
             f"Input video file not found: '{input_file}'",
@@ -511,6 +567,10 @@ def extract_gif(
         )
         return False
 
+    out_lower = output_file.lower()
+    is_webm = out_lower.endswith(".webm")
+    is_webp = out_lower.endswith(".webp")
+
     ffmpeg_command = [
         "ffmpeg",
         "-y",
@@ -524,10 +584,26 @@ def extract_gif(
         input_file,
         "-vf",
         f"fps={config.GIF_FPS},scale={config.GIF_SCALE_WIDTH}:-1:flags=lanczos",
-        "-loop",
-        "0",
-        output_file,
     ]
+    if is_webm:
+        # Silent VP9 loop; the loop is controlled by the <video loop> attribute
+        # in the viewer, not by the container. -an strips audio.
+        ffmpeg_command += [
+            "-c:v",
+            "libvpx-vp9",
+            "-b:v",
+            "0",
+            "-crf",
+            "32",
+            "-row-mt",
+            "1",
+            "-an",
+        ]
+    else:
+        ffmpeg_command += ["-loop", "0"]
+        if is_webp:
+            ffmpeg_command += ["-quality", str(config.WEBP_QUALITY)]
+    ffmpeg_command.append(output_file)
     utils.debug_print(f"ffmpeg gif command: {' '.join(ffmpeg_command)}")
 
     ffmpeg_result = run_ffmpeg_process(
@@ -1355,6 +1431,10 @@ def _batch_extract_screenshots(
     Uses fps=1/interval filter to avoid spawning one process per frame.
     Returns artifact list on success, or None to signal fallback.
     """
+    ext = config.SCREENSHOT_FORMAT
+    if ext.lower() == ".webp" and not check_webp_support():
+        _warn_webp_unavailable_once(f"frame_*{ext}")
+        return None
     tmpdir = tempfile.mkdtemp(prefix="clipgen_gallery_")
     try:
         ffmpeg_command = [
@@ -1368,7 +1448,7 @@ def _batch_extract_screenshots(
             f"fps=1/{interval_seconds}",
             "-q:v",
             config.FFMPEG_SCREENSHOT_QUALITY,
-            os.path.join(tmpdir, "frame_%04d.png"),
+            os.path.join(tmpdir, f"frame_%04d{ext}"),
         ]
         utils.debug_print(
             f"ffmpeg batch screenshot command: {' '.join(ffmpeg_command)}"
@@ -1377,7 +1457,7 @@ def _batch_extract_screenshots(
         ffmpeg_result = run_ffmpeg_process(
             ffmpeg_command,
             input_file=input_file,
-            output_file=os.path.join(tmpdir, "frame_*.png"),
+            output_file=os.path.join(tmpdir, f"frame_*{ext}"),
             os_error_message="ffmpeg could not run for batch screenshot extraction.",
         )
         if ffmpeg_result is None or ffmpeg_result.returncode != 0:
@@ -1385,13 +1465,13 @@ def _batch_extract_screenshots(
 
         artifacts: list[dict[str, Any]] = []
         for i, ts in enumerate(timestamps):
-            frame_file = os.path.join(tmpdir, f"frame_{i + 1:04d}.png")
+            frame_file = os.path.join(tmpdir, f"frame_{i + 1:04d}{ext}")
             if not os.path.isfile(frame_file):
                 continue
             ts_str = utils.seconds_to_timestamp(ts)
             ts_safe = ts_str.replace(":", "_")
-            filename = f"gallery_{ts_safe}.png"
-            output_path = files.get_unique_filename(filename, file_format=".png")
+            filename = f"gallery_{ts_safe}{ext}"
+            output_path = files.get_unique_filename(filename, file_format=ext)
             shutil.move(frame_file, output_path)
             artifacts.append(
                 {
@@ -1421,12 +1501,13 @@ def _parallel_extract_gifs(
 
     Returns artifact list on success, or None to signal fallback.
     """
+    ext = config.GIF_FORMAT
     tasks: list[tuple[str, str, str, int, float]] = []
     for ts in timestamps:
         ts_str = utils.seconds_to_timestamp(ts)
         ts_safe = ts_str.replace(":", "_")
-        filename = f"gallery_{ts_safe}.gif"
-        output_path = files.get_unique_filename(filename, file_format=".gif")
+        filename = f"gallery_{ts_safe}{ext}"
+        output_path = files.get_unique_filename(filename, file_format=ext)
         gif_dur = min(gif_duration_seconds, duration - ts)
         if gif_dur <= 0:
             break
@@ -1508,7 +1589,7 @@ def generate_interval_captures(
         utils.error_print("Interval must be a positive number of seconds.")
         return []
 
-    ext = ".png" if output_format == "screen" else ".gif"
+    ext = config.SCREENSHOT_FORMAT if output_format == "screen" else config.GIF_FORMAT
     timestamps = list(range(0, duration, interval_seconds))
     total = len(timestamps)
     artifacts: list[dict[str, Any]] = []

--- a/viewer.py
+++ b/viewer.py
@@ -342,7 +342,14 @@ def finalize_gallery_data(
 ) -> dict[str, Any]:
     """Construct the window.CLIPGEN_DATA structure for the gallery viewer."""
     if bundle:
-        mime_map = {"screen": "image/png", "gif": "image/gif"}
+        ext_mime_map = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".gif": "image/gif",
+            ".webp": "image/webp",
+            ".webm": "video/webm",
+        }
         output_dir = Path(utils.get_effective_output_dir())
         for a in artifacts:
             file_path = output_dir / a["file"]
@@ -351,7 +358,7 @@ def finalize_gallery_data(
                     f"Bundle: file not found, skipping embed: {a['file']}"
                 )
                 continue
-            mime = mime_map.get(a.get("type", "screen"), "image/png")
+            mime = ext_mime_map.get(file_path.suffix.lower(), "image/png")
             try:
                 raw = file_path.read_bytes()
                 encoded = base64.b64encode(raw).decode("ascii")


### PR DESCRIPTION
## Summary
- Adds `SCREENSHOT_FORMAT` (`.png` / `.jpg` / `.webp`) and `GIF_FORMAT` (`.gif` / `.webp` / `.webm`) settings under General → Image Output. Defaults stay on `.png` / `.gif` so existing behavior is unchanged.
- WebM uses VP9 silent loops rendered via `<video autoplay loop muted playsinline>`; gallery, viewer, and insights builder all branch on a shared `isVideoLoop()` helper in `utils.js` and skip GIF-hover for video.
- WebP is gated on libwebp encoder detection (`ffmpeg -encoders`, not `-codecs`), with a single clear runtime error in `extract_screenshot`/`extract_gif` and a 400 from `PUT /api/settings` when an unsupported `.webp` is selected — runtime config mutation can no longer bypass the startup check.
- Gallery bundle MIME is now extension-based; `.gitignore` now excludes the new `.webp`/`.webm`/`.jpg` artifacts; settings modal surfaces the server's actual error message on save failures.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 591 tests pass
- [x] `uv run ruff check` and `uv run ty check` clean
- [ ] Generate a gallery with `GIF_FORMAT = ".webm"` and confirm silent looping playback in Chrome and Safari
- [ ] On a machine without libwebp, set `SCREENSHOT_FORMAT = ".webp"` via the Studio modal and confirm the 400 + actionable error
- [ ] Set `SCREENSHOT_FORMAT = ".jpg"` and verify file sizes are smaller than `.png` baseline