### PR TITLE
perf: frontend code review pass — polling, theming, drag-reorder

### DIFF
--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -62,6 +62,7 @@
     var grid = qs("#galleryGrid");
     if (!grid) return;
 
+    var frag = document.createDocumentFragment();
     for (var i = 0; i < state.artifacts.length; i++) {
       var a = state.artifacts[i];
       var card = document.createElement("div");
@@ -85,8 +86,9 @@
       overlay.textContent = a.timestamp_formatted || formatTime(a.timestamp);
       card.appendChild(overlay);
 
-      grid.appendChild(card);
+      frag.appendChild(card);
     }
+    grid.appendChild(frag);
 
     grid.addEventListener("click", function (e) {
       var card = e.target.closest(".gallery-card");

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -1094,8 +1094,9 @@
         if (oldIdx === -1) return;
         arts.splice(oldIdx, 1);
 
-        // Calculate new position based on mouse
-        var cards = this.querySelectorAll(".preview-card");
+        // Calculate new position based on mouse (rects measured before splice;
+        // the moved card is .dragging so it's filtered out below).
+        var cards = this.querySelectorAll(".preview-card:not(.dragging)");
         var insertIdx = arts.length;
         for (var ci = 0; ci < cards.length; ci++) {
           var rect = cards[ci].getBoundingClientRect();
@@ -1106,7 +1107,7 @@
         }
         arts.splice(insertIdx, 0, artifactId);
         markDirty(targetInsightId);
-        renderInsightCards();
+        rebuildBucketDropzone(this, ins, targetBucket);
       } else {
         addArtifactToInsight(targetInsightId, targetBucket, artifactId);
       }
@@ -1121,6 +1122,21 @@
       if (state.insights[i].id === id) return state.insights[i];
     }
     return null;
+  }
+
+  function rebuildBucketDropzone(dropzone, insight, bucketName) {
+    var bucket = insight[bucketName] || { artifacts: [], narrative: "" };
+    dropzone.innerHTML = "";
+    if (bucket.artifacts.length === 0) {
+      dropzone.appendChild(el("div", "bucket-empty-hint", "Drag artifacts here"));
+      return;
+    }
+    var frag = document.createDocumentFragment();
+    for (var i = 0; i < bucket.artifacts.length; i++) {
+      var art = findArtifact(bucket.artifacts[i]);
+      if (art) frag.appendChild(createPreviewCard(art, insight.id, bucketName, i));
+    }
+    dropzone.appendChild(frag);
   }
 
   // ---- Preview cards (in buckets) ----

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1987,11 +1987,11 @@ body.panel-dragging #bottomPanel {
 }
 .task-filter-btn.active[data-filter="completed"] {
   opacity: 1;
-  color: #16a34a;
+  color: var(--sev-positive);
 }
 .task-filter-btn.active[data-filter="failed"] {
   opacity: 1;
-  color: #dc2626;
+  color: var(--sev-high);
 }
 
 .panel-header h3 {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2663,13 +2663,28 @@
     }
   }
 
-  function getMultitoolDropIndex(container, clientY) {
+  var _multitoolDragMidpoints = null;
+
+  function _cacheMultitoolDragMidpoints(container) {
     var cards = container.querySelectorAll(".multitool-step:not(.dragging)");
+    var mids = new Array(cards.length);
     for (var i = 0; i < cards.length; i++) {
-      var rect = cards[i].getBoundingClientRect();
-      if (clientY < rect.top + rect.height / 2) return i;
+      var r = cards[i].getBoundingClientRect();
+      mids[i] = r.top + r.height / 2;
     }
-    return cards.length;
+    _multitoolDragMidpoints = mids;
+  }
+
+  function getMultitoolDropIndex(container, clientY) {
+    var mids = _multitoolDragMidpoints;
+    if (!mids) {
+      _cacheMultitoolDragMidpoints(container);
+      mids = _multitoolDragMidpoints;
+    }
+    for (var i = 0; i < mids.length; i++) {
+      if (clientY < mids[i]) return i;
+    }
+    return mids.length;
   }
 
   function clearMultitoolDragIndicators(container) {
@@ -2811,6 +2826,7 @@
       card.classList.add("dragging");
       e.dataTransfer.setData("text/plain", card.dataset.stepIdx);
       e.dataTransfer.effectAllowed = "move";
+      _cacheMultitoolDragMidpoints(stepsDiv);
     });
     stepsDiv.addEventListener("dragend", function (e) {
       var card = e.target.closest(".multitool-step");
@@ -2819,6 +2835,7 @@
         card.removeAttribute("draggable");
       }
       clearMultitoolDragIndicators(stepsDiv);
+      _multitoolDragMidpoints = null;
     });
     stepsDiv.addEventListener("dragover", function (e) {
       if (e.dataTransfer.types.indexOf("text/plain") < 0) return;
@@ -4701,6 +4718,7 @@
       e.dataTransfer.setData("application/x-task-status", task.status);
       e.dataTransfer.setData("application/x-task-id", card.dataset.taskId);
       e.dataTransfer.effectAllowed = "move";
+      _cacheTaskDragMidpoints(taskListEl);
     });
 
     taskListEl.addEventListener("dragend", function (e) {
@@ -4710,6 +4728,7 @@
         card.removeAttribute("draggable");
       }
       clearDragIndicators(taskListEl);
+      _taskDragCache = null;
     });
 
     taskListEl.addEventListener("dragover", function (e) {
@@ -4811,30 +4830,42 @@
     });
   }
 
-  function getDropIndex(container, clientY) {
+  // Cached at dragstart: { all: number[], statusGrouped: { queued: number[], finished: number[] } }
+  var _taskDragCache = null;
+
+  function _cacheTaskDragMidpoints(container) {
     var cards = container.querySelectorAll(".task-card:not(.dragging)");
+    var all = new Array(cards.length);
+    var queued = [];
+    var finished = [];
     for (var i = 0; i < cards.length; i++) {
-      var rect = cards[i].getBoundingClientRect();
-      if (clientY < rect.top + rect.height / 2) return i;
+      var r = cards[i].getBoundingClientRect();
+      var mid = r.top + r.height / 2;
+      all[i] = mid;
+      var t = findTask(cards[i].dataset.taskId);
+      if (!t) continue;
+      if (t.status === "queued") queued.push(mid);
+      else if (t.status === "completed" || t.status === "failed") finished.push(mid);
     }
-    return cards.length;
+    _taskDragCache = { all: all, queued: queued, finished: finished };
+  }
+
+  function getDropIndex(container, clientY) {
+    if (!_taskDragCache) _cacheTaskDragMidpoints(container);
+    var mids = _taskDragCache.all;
+    for (var i = 0; i < mids.length; i++) {
+      if (clientY < mids[i]) return i;
+    }
+    return mids.length;
   }
 
   function getDropIndexAmongStatus(container, clientY, group) {
-    var cards = container.querySelectorAll(".task-card:not(.dragging)");
-    var idx = 0;
-    for (var i = 0; i < cards.length; i++) {
-      var t = findTask(cards[i].dataset.taskId);
-      if (!t) continue;
-      var match = group === "queued"
-        ? t.status === "queued"
-        : (t.status === "completed" || t.status === "failed");
-      if (!match) continue;
-      var rect = cards[i].getBoundingClientRect();
-      if (clientY < rect.top + rect.height / 2) return idx;
-      idx++;
+    if (!_taskDragCache) _cacheTaskDragMidpoints(container);
+    var mids = group === "queued" ? _taskDragCache.queued : _taskDragCache.finished;
+    for (var i = 0; i < mids.length; i++) {
+      if (clientY < mids[i]) return i;
     }
-    return idx;
+    return mids.length;
   }
 
   function clearDragIndicators(container) {
@@ -5247,7 +5278,15 @@
 
   function startPolling() {
     if (state.pollTimer) return;
+    if (document.hidden) return;
     state.pollTimer = setInterval(pollTasks, POLL_INTERVAL);
+  }
+
+  function stopPolling() {
+    if (state.pollTimer) {
+      clearInterval(state.pollTimer);
+      state.pollTimer = null;
+    }
   }
 
   function pollTasks() {
@@ -5255,8 +5294,7 @@
       return t.status === "queued" || t.status === "running" || t.status === "paused";
     });
     if (!hasActive) {
-      clearInterval(state.pollTimer);
-      state.pollTimer = null;
+      stopPolling();
       return;
     }
 
@@ -5264,6 +5302,25 @@
       .then(function (data) { handleTaskData(data); })
       .catch(function () {});
   }
+
+  function stopSSE() {
+    if (state.eventSource) {
+      state.eventSource.close();
+      state.eventSource = null;
+    }
+  }
+
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden) {
+      stopSSE();
+      stopPolling();
+      return;
+    }
+    var hasActive = state.tasks.some(function (t) {
+      return t.status === "queued" || t.status === "running" || t.status === "paused";
+    });
+    if (hasActive) startSSE();
+  });
 
   // ---- Results ----
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -696,9 +696,7 @@
     var svg = btn.querySelector("svg");
     if (svg) svg.style.animation = "spin 0.7s linear infinite";
 
-    // TODO: no r.ok check; migrating to apiPost would add throw on HTTP error.
-    fetch("api/sheet/refresh", { method: "POST" })
-      .then(function (r) { return r.json(); })
+    apiPost("api/sheet/refresh")
       .then(function (data) {
         if (!data.ok) {
           showResult(null, "Refresh failed: " + (data.error || "Unknown error"));
@@ -716,9 +714,7 @@
   }
 
   function loadManifestState() {
-    // TODO: no r.ok check; migrating to apiGet would add throw on HTTP error.
-    fetch("api/manifest")
-      .then(function (r) { return r.json(); })
+    apiGet("api/manifest")
       .then(function (data) {
         if (!data.ok || !state.sheetData) return;
         var artifacts = data.artifacts || [];
@@ -1941,9 +1937,7 @@
   // ---- Stashed reels ----
 
   function loadStashes() {
-    // TODO: no r.ok check; migrating to apiGet would surface HTTP errors via the catch.
-    fetch("api/stashes")
-      .then(function (r) { return r.json(); })
+    apiGet("api/stashes")
       .then(function (data) {
         if (data.ok) {
           state.stashes = data.stashes || [];
@@ -2038,13 +2032,7 @@
 
     var items = state.reelQueue.slice();
     var totalDuration = computeReelDuration(items);
-    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
-    fetch("api/stashes", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "create", items: items, name: "", totalDuration: totalDuration }),
-    })
-      .then(function (r) { return r.json(); })
+    apiPost("api/stashes", { action: "create", items: items, name: "", totalDuration: totalDuration })
       .then(function (data) {
         if (data.ok) {
           state.stashes.push(data.stash);
@@ -2068,13 +2056,7 @@
   }
 
   function deleteStash(stashId, endpoint, stateArray, renderFn) {
-    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
-    fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "delete", id: stashId }),
-    })
-      .then(function (r) { return r.json(); })
+    apiPost(endpoint, { action: "delete", id: stashId })
       .then(function (data) {
         if (data.ok) {
           for (var i = 0; i < stateArray.length; i++) {
@@ -2108,12 +2090,7 @@
       });
       parent.replaceChild(span, input);
 
-      // TODO: fire-and-forget; needs custom shape, no migration to apiPost.
-      fetch(endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "update", id: stash.id, name: newName }),
-      }).catch(function () {});
+      apiPost(endpoint, { action: "update", id: stash.id, name: newName }).catch(function () {});
     }
 
     input.addEventListener("blur", commit);
@@ -2130,13 +2107,7 @@
 
   function createStashViaAPI(endpoint, items, onSuccess) {
     var totalDuration = computeReelDuration(items);
-    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
-    fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "create", items: items, name: "", totalDuration: totalDuration }),
-    })
-      .then(function (r) { return r.json(); })
+    apiPost(endpoint, { action: "create", items: items, name: "", totalDuration: totalDuration })
       .then(function (data) {
         if (data.ok) onSuccess(data.stash);
       })
@@ -2146,9 +2117,7 @@
   // ---- Stashed artifacts ----
 
   function loadArtifactStashes() {
-    // TODO: no r.ok check; migrating to apiGet would surface HTTP errors via the catch.
-    fetch("api/artifact-stashes")
-      .then(function (r) { return r.json(); })
+    apiGet("api/artifact-stashes")
       .then(function (data) {
         if (data.ok) {
           state.artifactStashes = data.stashes || [];
@@ -2230,13 +2199,7 @@
 
     var items = state.artifactQueue.slice();
     var totalDuration = computeReelDuration(items);
-    // TODO: no r.ok check; migrating to apiPost would surface HTTP errors via the catch.
-    fetch("api/artifact-stashes", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "create", items: items, name: "", totalDuration: totalDuration }),
-    })
-      .then(function (r) { return r.json(); })
+    apiPost("api/artifact-stashes", { action: "create", items: items, name: "", totalDuration: totalDuration })
       .then(function (data) {
         if (data.ok) {
           state.artifactStashes.push(data.stash);
@@ -2364,12 +2327,7 @@
     qs("#statusDismiss").addEventListener("click", hideOverlay);
     qs("#statusOpen").addEventListener("click", function () {
       if (_lastViewerFile) {
-        // TODO: fire-and-forget with no response handling; no clean migration to apiPost.
-        fetch("api/open-viewer", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ file: _lastViewerFile }),
-        });
+        apiPost("api/open-viewer", { file: _lastViewerFile }).catch(function () {});
       }
       hideOverlay();
     });
@@ -2601,14 +2559,7 @@
         };
       });
 
-      // TODO: skips r.ok check — success is signaled by data.ok from server. Migrating to apiPost
-      // would add an r.ok throw that this handler doesn't currently trigger.
-      fetch("api/generate-intake", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: intakePayload, format: format }),
-      })
-        .then(function (r) { return r.json(); })
+      apiPost("api/generate-intake", { items: intakePayload, format: format })
         .then(function (data) {
           var intakeCards = list.querySelectorAll('[data-source="screenspace"], [data-source="transcript"]');
           if (data.ok && data.results) {
@@ -2641,8 +2592,7 @@
 
   function onCancelReel() {
     qs("#cancelReelBtn").classList.add("hidden");
-    // TODO: fire-and-forget POST with no body; apiPost would send JSON.stringify(undefined).
-    fetch("api/reel/cancel", { method: "POST" });
+    apiPost("api/reel/cancel").catch(function () {});
   }
 
   function onBuildReel() {
@@ -3133,13 +3083,7 @@
       TITLECARD_DURATION_SECONDS: parseInt(dur.value, 10) || 2,
     };
 
-    // TODO: skips r.ok; only reacts to data.ok. Silent on HTTP failure — apiPut would expose it via .catch.
-    fetch("api/settings", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ settings: payload }),
-    })
-      .then(function (r) { return r.json(); })
+    apiPut("api/settings", { settings: payload })
       .then(function (data) {
         if (data.ok && state.settingsData) {
           var tcE = _findSetting("TITLECARDS_ENABLED");
@@ -3182,10 +3126,7 @@
   }
 
   function checkNavLinks() {
-    // TODO: skips r.ok; a failed request silently leaves tabs hidden. apiGet would catch but
-    // the current code already swallows errors via the .catch below.
-    fetch("../api/status")
-      .then(function (r) { return r.json(); })
+    apiGet("../api/status")
       .then(function (data) {
         if (data.screenspace) {
           var intakeTab = qs('.preview-tab[data-tab="intake"]');
@@ -3627,7 +3568,7 @@
       thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
 
       var detDot = el("span", "intake-card-det-dot");
-      detDot.style.background = INTAKE_DETECTOR_COLORS[c.detector] || "#888";
+      detDot.style.background = "var(--color-task-" + c.detector + ", #888)";
       thumb.appendChild(detDot);
 
       // Source + cross-reference badges (SS self-badge leads the stack)
@@ -3682,13 +3623,7 @@
 
   function intakeDismissCluster(cluster) {
     var ids = cluster.events.map(function (e) { return e.id; });
-    // TODO: response body ignored; apiPut would parse JSON unnecessarily. Refactor if a
-    // fire-and-forget apiPutVoid helper is added.
-    fetch("../screenspace/api/events/bulk-exclude", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: ids }),
-    })
+    apiPut("../screenspace/api/events/bulk-exclude", { ids: ids })
       .then(function () { pollIntakeEvents(); })
       .catch(function () {});
   }
@@ -3883,11 +3818,8 @@
       });
     }
 
-    // Start polling immediately — silently fails if Screenspace is unavailable
-    pollIntakeEvents();
-    state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
-
-    // Pause polling when browser tab or intake panel is not visible
+    // Polling is started by syncPreviewTab() when the intake tab becomes active.
+    // Pause polling when browser tab is not visible; resume when intake tab is active.
     document.addEventListener("visibilitychange", function () {
       if (document.hidden) {
         if (state.intakePollTimer) { clearInterval(state.intakePollTimer); state.intakePollTimer = null; }
@@ -3900,19 +3832,23 @@
 
   // ---- Transcript Intake ----
 
+  // Colors resolve to CSS tokens (see tokens.css `--cat-*`) so dark mode tracks the theme.
   var TR_INTAKE_CATEGORIES = {
-    pain_point: { label: "Pain Point", color: "#dc2626" },
-    delight:    { label: "Delight",    color: "#16a34a" },
-    quote:      { label: "Quote",      color: "#2563eb" },
-    insight:    { label: "Insight",    color: "#f97316" },
-    task:       { label: "Task Issue", color: "#8b5cf6" },
-    bookmark:   { label: "Bookmark",   color: "#0891b2" },
+    pain_point: { label: "Pain Point", token: "--cat-pain-point" },
+    delight:    { label: "Delight",    token: "--cat-delight" },
+    quote:      { label: "Quote",      token: "--cat-quote" },
+    insight:    { label: "Insight",    token: "--cat-insight" },
+    task:       { label: "Task Issue", token: "--cat-task" },
+    bookmark:   { label: "Bookmark",   token: "--cat-bookmark" },
   };
 
+  function trIntakeCategoryColor(key) {
+    var entry = TR_INTAKE_CATEGORIES[key] || TR_INTAKE_CATEGORIES.bookmark;
+    return getComputedStyle(document.documentElement).getPropertyValue(entry.token).trim();
+  }
+
   function pollTranscriptIntakeMarks() {
-    // TODO: skips r.ok; migrating to apiGet would catch HTTP errors currently silently swallowed.
-    fetch("../transcripts/api/marks")
-      .then(function (r) { return r.json(); })
+    apiGet("../transcripts/api/marks")
       .then(function (data) {
         if (!data.ok) return;
         state.trIntakeMarks = data.marks.filter(function (m) { return m.valid; });
@@ -3921,15 +3857,12 @@
 
         // If "Show all" is enabled, also fetch all segments as unmark items
         if (state.trIntakeShowAll) {
-          // TODO: skips r.ok (same pattern).
-          fetch("../transcripts/api/participants")
-            .then(function (r2) { return r2.json(); })
+          apiGet("../transcripts/api/participants")
             .then(function (pData) {
               if (!pData.ok) return;
               var transcribed = pData.participants.filter(function (p) { return p.has_transcript; });
               var promises = transcribed.map(function (p) {
-                // TODO: skips r.ok (same pattern).
-                return fetch("../transcripts/api/transcript/" + p.id).then(function (r3) { return r3.json(); });
+                return apiGet("../transcripts/api/transcript/" + p.id);
               });
               Promise.all(promises).then(function (results) {
                 var markedIds = {};
@@ -3959,7 +3892,8 @@
                 renderTranscriptIntake();
                 checkConvergenceTabVisibility();
               });
-            });
+            })
+            .catch(function () {});
         } else {
           renderTranscriptIntake();
           checkConvergenceTabVisibility();
@@ -4063,10 +3997,9 @@
       thumb.appendChild(img);
       ssObserveThumb(card, img, thumb, c.participant, c.start);
 
-      var catColor = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
       var dot = document.createElement("span");
       dot.className = "tr-intake-card-category-dot";
-      dot.style.background = catColor;
+      dot.style.background = "var(" + (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).token + ")";
       thumb.appendChild(dot);
 
       var dur = document.createElement("span");
@@ -4240,7 +4173,7 @@
 
     for (var ci = 0; ci < filtered.length; ci++) {
       var c = filtered[ci];
-      var color = (TR_INTAKE_CATEGORIES[c.category] || TR_INTAKE_CATEGORIES.bookmark).color;
+      var color = trIntakeCategoryColor(c.category);
       var highlighted = state.trIntakeHoveredIdx === ci;
       var dimmed = state.trIntakeHoveredIdx !== -1 && !highlighted;
       var alpha = highlighted ? 0.85 : (dimmed ? 0.15 : 0.5);
@@ -4402,7 +4335,7 @@
           var cat = TR_INTAKE_CATEGORIES[key];
           var btn = document.createElement("button");
           btn.className = "intake-filter-det tr-intake-filter-cat";
-          btn.style.setProperty("--det-color", cat.color);
+          btn.style.setProperty("--det-color", "var(" + cat.token + ")");
           btn.textContent = cat.label;
           btn.dataset.category = key;
           btn.addEventListener("click", function () {

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -107,6 +107,17 @@
   --color-behaviors-bg: rgba(37, 99, 235, 0.06);
   --color-impacts-bg: rgba(220, 38, 38, 0.06);
 
+  /* Transcript intake category colors */
+  --cat-pain-point: var(--sev-high);
+  --cat-delight: var(--sev-positive);
+  --cat-quote: #2563eb;
+  --cat-insight: #f97316;
+  --cat-task: #8b5cf6;
+  --cat-bookmark: #0891b2;
+
+  /* In-progress / working pulse */
+  --color-pulse: #a855f7;
+
   /* Transitions */
   --duration-fast: 150ms;
   --duration-normal: 250ms;
@@ -165,6 +176,11 @@
     --color-causes-bg: rgba(251, 146, 60, 0.1);
     --color-behaviors-bg: rgba(96, 165, 250, 0.1);
     --color-impacts-bg: rgba(248, 113, 113, 0.1);
+    --cat-quote: #60a5fa;
+    --cat-insight: #fb923c;
+    --cat-task: #a78bfa;
+    --cat-bookmark: #22d3ee;
+    --color-pulse: #c084fc;
   }
 }
 
@@ -211,6 +227,11 @@ html[data-theme="dark"] {
   --color-causes-bg: rgba(251, 146, 60, 0.1);
   --color-behaviors-bg: rgba(96, 165, 250, 0.1);
   --color-impacts-bg: rgba(248, 113, 113, 0.1);
+  --cat-quote: #60a5fa;
+  --cat-insight: #fb923c;
+  --cat-task: #a78bfa;
+  --cat-bookmark: #22d3ee;
+  --color-pulse: #c084fc;
 }
 
 /* Animated dot-grid background canvas (paired with grid-bg.js) */

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -86,7 +86,7 @@ body {
 .status-indicator--ready { background: var(--sev-very-positive); }
 .status-indicator--error { background: var(--sev-critical); }
 .status-indicator--working {
-  background: #a855f7;
+  background: var(--color-pulse);
   animation: status-pulse 1s ease-in-out infinite;
 }
 @keyframes status-pulse {
@@ -649,7 +649,7 @@ body {
 
 .segment-mark:hover {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(29, 79, 114, 0.15);
+  box-shadow: 0 0 0 2px var(--color-accent-highlight);
 }
 
 .segment-mark.marked {
@@ -657,7 +657,7 @@ body {
 }
 
 .segment-mark.marked:hover {
-  box-shadow: 0 0 0 2px rgba(29, 79, 114, 0.25);
+  box-shadow: 0 0 0 2px var(--color-accent-highlight);
 }
 
 /* Mark popover */

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1781,8 +1781,7 @@
             var det = xref.screenspaceEvents[ei].detector;
             if (seen[det]) continue;
             seen[det] = true;
-            var evColor = SS_DETECTOR_COLORS[det] || "#888";
-            html += '<span class="search-xref-dot" style="background:' + evColor + '" title="' + escapeHtml(xref.screenspaceEvents[ei].event_type || det) + '"></span>';
+            html += '<span class="search-xref-dot" style="background:var(--color-task-' + det + ', #888)" title="' + escapeHtml(xref.screenspaceEvents[ei].event_type || det) + '"></span>';
           }
           html += '</span>';
         }

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -329,32 +329,37 @@ var XREF_BADGES = {
 };
 
 // ---- Detector colors ----
-// Read from CSS custom properties (tokens.css) with hardcoded fallback
-// for exported viewers that may lack tokens.css at parse time.
+// Read from CSS custom properties (tokens.css). Mutable so the same object
+// reference can be re-populated after a theme toggle without breaking callers.
+// Hardcoded fallback supports exported viewers that may lack tokens.css.
 
-var DETECTOR_COLORS = (function () {
-  var types = [
-    "multitool", "color", "change", "similarity", "text",
-    "numbers", "timelapse", "template", "flow", "scene", "inactivity",
-  ];
-  var fallback = {
-    multitool: "#2563eb", color: "#8b5cf6", change: "#f97316",
-    similarity: "#0ea5e9", text: "#10b981", numbers: "#eab308",
-    timelapse: "#ec4899", template: "#f43f5e", flow: "#6366f1",
-    scene: "#14b8a6", inactivity: "#78716c",
-  };
+var DETECTOR_COLORS = {};
+var _DETECTOR_TYPES = [
+  "multitool", "color", "change", "similarity", "text",
+  "numbers", "timelapse", "template", "flow", "scene", "inactivity",
+];
+var _DETECTOR_FALLBACK = {
+  multitool: "#2563eb", color: "#8b5cf6", change: "#f97316",
+  similarity: "#0ea5e9", text: "#10b981", numbers: "#eab308",
+  timelapse: "#ec4899", template: "#f43f5e", flow: "#6366f1",
+  scene: "#14b8a6", inactivity: "#78716c",
+};
+
+function refreshDetectorColors() {
   try {
     var style = getComputedStyle(document.documentElement);
-    var map = {};
-    types.forEach(function (t) {
+    _DETECTOR_TYPES.forEach(function (t) {
       var val = style.getPropertyValue("--color-task-" + t).trim();
-      map[t] = val || fallback[t] || "#888";
+      DETECTOR_COLORS[t] = val || _DETECTOR_FALLBACK[t] || "#888";
     });
-    return map;
   } catch (_) {
-    return fallback;
+    _DETECTOR_TYPES.forEach(function (t) {
+      DETECTOR_COLORS[t] = _DETECTOR_FALLBACK[t] || "#888";
+    });
   }
-})();
+}
+
+refreshDetectorColors();
 
 // ---- Shared settings (localStorage) ----
 
@@ -391,6 +396,7 @@ var toggleThemePreference = function () {
   root.setAttribute("data-theme", next);
   try { window.localStorage.setItem(THEME_STORAGE_KEY, next); } catch (_) {}
   updateThemeToggleButton(next);
+  refreshDetectorColors();
 };
 
 var updateThemeToggleButton = function (explicitTheme) {

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -2086,7 +2086,7 @@
       marker.className = "screenspace-marker ss-type-" + c.type;
       marker.style.left = left + "%";
       marker.style.width = width + "%";
-      marker.style.background = SS_DETECTOR_COLORS[c.type] || "#888";
+      marker.style.background = "var(--color-task-" + c.type + ", #888)";
       marker.addEventListener("mouseenter", function (cluster) {
         return function (ev) { showTooltipForScreenspaceCluster(cluster, ev); };
       }(c));
@@ -2112,7 +2112,7 @@
       item.className = "legend-item";
       var swatch = document.createElement("span");
       swatch.className = "legend-swatch";
-      swatch.style.background = SS_DETECTOR_COLORS[t] || "#888";
+      swatch.style.background = "var(--color-task-" + t + ", #888)";
       item.appendChild(swatch);
       item.appendChild(document.createTextNode(" " + t.charAt(0).toUpperCase() + t.slice(1)));
       legendEl.appendChild(item);

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.94"
+VERSIONNUM: str = "0.10.95"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

Targeted fixes from a broad code review of `assets/web/`, biased toward performance and theme correctness. No feature changes.

- **Wasted polling**: Studio's intake/transcript-intake panels were polling Screenspace + Transcripts every 10s regardless of which tab was active (~360 background req/hr per session). Polling now starts only when the relevant tab becomes active.
- **Silent HTTP errors**: 14 raw `fetch()` callsites in `studio.js` were swallowing 4xx/5xx responses. Migrated to the existing `apiGet/apiPost/apiPut` helpers in `utils.js` so errors surface via `.catch`.
- **Drag-reorder layout thrash**: `getMultitoolDropIndex` and `getDropIndex` were calling `getBoundingClientRect()` on every card on every dragover. Now cached once at dragstart, cleared at dragend.
- **Re-render on reorder**: insights artifact reorder rebuilt the entire `#insightCards` list. Now rebuilds only the affected dropzone via a new `rebuildBucketDropzone` helper.
- **Theming**: hardcoded hex (`TR_INTAKE_CATEGORIES`, screenspace task filter buttons, transcripts pulse, accent rgba shadows) replaced with new/existing tokens. JS-injected `style.background` now uses inline `var(--color-task-X)` so theme toggle applies without a re-render. `DETECTOR_COLORS` lookup table refreshes on theme change as a safety net for canvas paths.
- **Misc perf**: `screenspace.js` SSE + polling now pause on `visibilitychange`; `gallery.js` batches grid appends through a `DocumentFragment`.
- VERSIONNUM bumped 0.10.94 → 0.10.95.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 593 passed
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `node --check` on every edited JS file — clean
- [ ] Manual: Studio → DevTools Network: stay on Sheet tab, confirm no `screenspace/api/events` or `transcripts/api/marks` polls
- [ ] Manual: Toggle dark mode in Studio → transcript intake category dots and Screenspace task filter buttons recolor correctly
- [ ] Manual: DevTools Performance recording while drag-reordering 20+ Screenspace task cards → recalc-style time per dragover frame collapses
- [ ] Manual: Start a long Screenspace task, switch to another browser tab → confirm `api/tasks/stream` connection closes