### PR TITLE
feat: user-configurable transcript marker categories

### DIFF
--- a/assets/web/settings-modal.css
+++ b/assets/web/settings-modal.css
@@ -220,6 +220,82 @@
   transform: translateX(16px);
 }
 
+/* ---- Mark categories editor ---- */
+
+.settings-row-stacked {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.settings-row-stacked .settings-label {
+  margin-bottom: var(--space-2);
+}
+
+.settings-row-stacked .settings-control {
+  flex-shrink: 1;
+  width: 100%;
+}
+
+.mark-cat-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.mark-cat-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.mark-cat-row input[type="text"].mark-cat-label {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+}
+
+.mark-cat-row input[type="color"].mark-cat-color {
+  width: 36px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--color-surface);
+  cursor: pointer;
+}
+
+.mark-cat-key {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+  min-width: 6rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mark-cat-delete {
+  flex-shrink: 0;
+}
+
+.mark-cat-add-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.mark-cat-error {
+  font-size: var(--text-xs);
+  color: var(--sev-critical);
+  margin-top: var(--space-1);
+}
+
 /* ---- Per-tab reset ---- */
 
 .settings-tab-reset {

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -379,6 +379,9 @@
         _scheduleSave();
       });
       controlDiv.appendChild(fInput);
+    } else if (s.type === "mark_categories") {
+      row.classList.add("settings-row-stacked");
+      _renderMarkCategoriesEditor(controlDiv, settingName);
     } else {
       var input = document.createElement("input");
       input.type = "number";
@@ -399,6 +402,120 @@
     row.appendChild(labelDiv);
     row.appendChild(controlDiv);
     return row;
+  }
+
+  function _slugifyKey(label, existingKeys) {
+    var base = String(label || "").toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "");
+    if (!base) base = "category";
+    var key = base;
+    var n = 2;
+    while (existingKeys.indexOf(key) !== -1) {
+      key = base + "_" + n;
+      n++;
+    }
+    return key;
+  }
+
+  function _renderMarkCategoriesEditor(container, settingName) {
+    container.innerHTML = "";
+    var setting = _findSetting(settingName);
+    if (!setting) return;
+    var value = setting.value && typeof setting.value === "object" ? setting.value : {};
+
+    var editor = el("div", "mark-cat-editor");
+    var keys = Object.keys(value);
+    for (var i = 0; i < keys.length; i++) {
+      (function (key) {
+        var entry = value[key] || { label: "", color: "#888888" };
+        var rowEl = el("div", "mark-cat-row");
+
+        var keyEl = el("span", "mark-cat-key", key);
+        keyEl.title = key;
+        rowEl.appendChild(keyEl);
+
+        var labelInput = document.createElement("input");
+        labelInput.type = "text";
+        labelInput.className = "mark-cat-label";
+        labelInput.autocomplete = "off";
+        labelInput.value = entry.label || "";
+        labelInput.placeholder = "Label";
+        labelInput.addEventListener("change", function () {
+          var s = _findSetting(settingName);
+          if (!s || !s.value || !s.value[key]) return;
+          var v = this.value.trim() || key;
+          s.value[key].label = v;
+          this.value = v;
+          _updateChanged(settingName);
+          _scheduleSave();
+        });
+        rowEl.appendChild(labelInput);
+
+        var colorInput = document.createElement("input");
+        colorInput.type = "color";
+        colorInput.className = "mark-cat-color";
+        colorInput.value = entry.color || "#888888";
+        colorInput.addEventListener("change", function () {
+          var s = _findSetting(settingName);
+          if (!s || !s.value || !s.value[key]) return;
+          s.value[key].color = this.value;
+          _updateChanged(settingName);
+          _scheduleSave();
+        });
+        rowEl.appendChild(colorInput);
+
+        var delBtn = el("button", "btn btn-small mark-cat-delete", "Remove");
+        delBtn.type = "button";
+        delBtn.addEventListener("click", function () {
+          var s = _findSetting(settingName);
+          if (!s || !s.value) return;
+          delete s.value[key];
+          _updateChanged(settingName);
+          _renderMarkCategoriesEditor(container, settingName);
+          _scheduleSave();
+        });
+        rowEl.appendChild(delBtn);
+
+        editor.appendChild(rowEl);
+      })(keys[i]);
+    }
+
+    var addRow = el("div", "mark-cat-add-row");
+    var addLabel = document.createElement("input");
+    addLabel.type = "text";
+    addLabel.className = "mark-cat-label";
+    addLabel.autocomplete = "off";
+    addLabel.placeholder = "New category label";
+    addRow.appendChild(addLabel);
+
+    var addColor = document.createElement("input");
+    addColor.type = "color";
+    addColor.className = "mark-cat-color";
+    addColor.value = "#888888";
+    addRow.appendChild(addColor);
+
+    var addBtn = el("button", "btn btn-small", "Add");
+    addBtn.type = "button";
+    addBtn.addEventListener("click", function () {
+      var s = _findSetting(settingName);
+      if (!s) return;
+      var label = addLabel.value.trim();
+      if (!label) {
+        addLabel.focus();
+        return;
+      }
+      if (!s.value || typeof s.value !== "object") s.value = {};
+      var newKey = _slugifyKey(label, Object.keys(s.value));
+      s.value[newKey] = { label: label, color: addColor.value };
+      _updateChanged(settingName);
+      _renderMarkCategoriesEditor(container, settingName);
+      _scheduleSave();
+    });
+    addRow.appendChild(addBtn);
+
+    editor.appendChild(addRow);
+    container.appendChild(editor);
   }
 
   function _render() {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2310,10 +2310,12 @@
         onSave: function (_applied, full) {
           state.settingsData = full;
           syncInlineControls();
+          _syncMarkCategoriesFromSettings(full);
         },
         onReset: function (_scope, full) {
           state.settingsData = full;
           syncInlineControls();
+          _syncMarkCategoriesFromSettings(full);
         },
       });
     });
@@ -3847,10 +3849,21 @@
     return getComputedStyle(document.documentElement).getPropertyValue(entry.token).trim();
   }
 
+  function _syncMarkCategoriesFromSettings(settings) {
+    if (!settings) return;
+    for (var i = 0; i < settings.length; i++) {
+      if (settings[i].name === "MARK_CATEGORIES" && settings[i].value) {
+        setMarkCategories(settings[i].value);
+        return;
+      }
+    }
+  }
+
   function pollTranscriptIntakeMarks() {
     apiGet("../transcripts/api/marks")
       .then(function (data) {
         if (!data.ok) return;
+        if (data.categories) setMarkCategories(data.categories);
         state.trIntakeMarks = data.marks.filter(function (m) { return m.valid; });
         var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value) || 5;
         state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, threshold);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1196,6 +1196,7 @@
     _streamingMarksLoaded = true;
     apiGet("api/marks").then(function (data) {
       if (!data.ok) return;
+      if (data.categories) setMarkCategories(data.categories);
       var added = false;
       data.marks.forEach(function (m) {
         if (!m.valid || m.participant !== pid) return;
@@ -2686,19 +2687,51 @@
     return _trModelsCachePromise;
   }
 
+  function _applySettingsSnapshot(applied, settings) {
+    var nextCats = null;
+    if (applied && applied.MARK_CATEGORIES) {
+      nextCats = applied.MARK_CATEGORIES;
+    } else if (settings) {
+      for (var i = 0; i < settings.length; i++) {
+        if (settings[i].name === "MARK_CATEGORIES") {
+          nextCats = settings[i].value;
+          break;
+        }
+      }
+    }
+    if (nextCats) {
+      setMarkCategories(nextCats);
+      if (!MARK_CATEGORIES[state.lastMarkCategory]) {
+        var firstKey = Object.keys(MARK_CATEGORIES)[0];
+        state.lastMarkCategory = firstKey || "bookmark";
+      }
+      // Refresh streaming mark colors and re-render the visible transcript.
+      for (var sid in _streamingMarks) {
+        var sm = _streamingMarks[sid];
+        var cat = MARK_CATEGORIES[sm.category];
+        if (cat) sm.color = cat.color;
+      }
+      _bumpStreamingMarksVersion();
+      hideMarkPopover();
+      if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
+    }
+  }
+
   function initTranscriptSettings() {
     var btn = qs("#settingsBtn");
     if (!btn) return;
     btn.addEventListener("click", function () {
       openSettingsModal({
         initialTab: "Transcription",
-        onSave: function () {
+        onSave: function (applied, settings) {
           _trModelsCache = null;
           _trModelsCachePromise = null;
+          _applySettingsSnapshot(applied, settings);
         },
-        onReset: function () {
+        onReset: function (scope, settings) {
           _trModelsCache = null;
           _trModelsCachePromise = null;
+          _applySettingsSnapshot(null, settings);
         },
       });
     });
@@ -2734,6 +2767,17 @@
 
     // Load initial data
     loadParticipants();
+
+    // Fetch live mark categories so the popover/pill renders match overrides.
+    apiGet("api/marks").then(function (data) {
+      if (data && data.ok && data.categories) {
+        setMarkCategories(data.categories);
+        if (!MARK_CATEGORIES[state.lastMarkCategory]) {
+          var firstKey = Object.keys(MARK_CATEGORIES)[0];
+          state.lastMarkCategory = firstKey || "bookmark";
+        }
+      }
+    });
 
     // Check for active tasks on load
     pollTaskStatus();

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -307,8 +307,12 @@ var apiDelete = function (path) {
 
 var POLL_INTERVAL = 3000;
 
-// ---- Mark categories (mirrored from transcripts.py MARK_CATEGORIES) ----
-// Kept in sync by tests/test_shared_constants.py — update both together.
+// ---- Mark categories ----
+// Hardcoded fallback that mirrors config.MARK_CATEGORIES defaults; the live
+// values are repopulated in place by setMarkCategories() once the page fetches
+// settings from the server. Existing references to MARK_CATEGORIES keep
+// working because we mutate this object rather than replace it.
+// Verified against config.MARK_CATEGORIES by tests/test_shared_constants.py.
 
 var MARK_CATEGORIES = {
   pain_point: { label: "Pain Point", color: "#dc2626" },
@@ -318,6 +322,25 @@ var MARK_CATEGORIES = {
   task:       { label: "Task Issue", color: "#8b5cf6" },
   bookmark:   { label: "Bookmark",   color: "#0891b2" },
 };
+
+function setMarkCategories(next) {
+  if (!next || typeof next !== "object") return;
+  for (var k in MARK_CATEGORIES) {
+    if (Object.prototype.hasOwnProperty.call(MARK_CATEGORIES, k)) {
+      delete MARK_CATEGORIES[k];
+    }
+  }
+  for (var key in next) {
+    if (!Object.prototype.hasOwnProperty.call(next, key)) continue;
+    var entry = next[key];
+    if (entry && typeof entry === "object") {
+      MARK_CATEGORIES[key] = {
+        label: entry.label || key,
+        color: entry.color || "#888888",
+      };
+    }
+  }
+}
 
 // ---- Cross-reference badge metadata ----
 // Icon names reference files in assets/icons/; rendered via CSS mask-image.

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.95"
+VERSIONNUM: str = "0.10.96"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -257,6 +257,15 @@ TRANSCRIBE_INITIAL_PROMPT: str = "This is a recorded user experience research se
 TRANSCRIBE_BEAM_SIZE: int = 5  # beam search width
 # When to pre-load faster-whisper in the Transcripts web UI: off, queue_open (open Queue panel), page_load (after participants load).
 TRANSCRIBE_PREWARM: str = "queue_open"
+# Mark categories shown in the Transcripts mark popover. Each value is {label, color}.
+MARK_CATEGORIES: dict[str, dict[str, str]] = {
+    "pain_point": {"label": "Pain Point", "color": "#dc2626"},
+    "delight": {"label": "Delight", "color": "#16a34a"},
+    "quote": {"label": "Quote", "color": "#2563eb"},
+    "insight": {"label": "Insight", "color": "#f97316"},
+    "task": {"label": "Task Issue", "color": "#8b5cf6"},
+    "bookmark": {"label": "Bookmark", "color": "#0891b2"},
+}
 
 # ── Ollama (Local AI) ───────────────────────────────────────────────
 OLLAMA_SUMMARY_ENABLED: bool = True  # auto-generate transcript summaries via Ollama
@@ -287,6 +296,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "TRANSCRIBE_MODEL": "Whisper model size: tiny, base, small, medium, large-v3.",
     "TRANSCRIBE_FORMAT": "Transcript output format: md (Markdown), srt, or vtt.",
     "TRANSCRIBE_PREWARM": "When the Transcripts page pre-loads the Whisper model: off, queue_open (opening a pill's options pane or hovering a pill that needs transcription), or page_load (after listing participants).",
+    "MARK_CATEGORIES": "Categories available when marking transcript segments. Each entry has a label and a color swatch.",
     "HIGHLIGHTS_REEL_DURATION_SECONDS": "Maximum duration in seconds for the highlights reel time budget.",
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
@@ -417,6 +427,11 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
         "group": "Transcription",
         "type": "select",
         "options": ["off", "queue_open", "page_load"],
+    },
+    "MARK_CATEGORIES": {
+        "tab": "Transcription",
+        "group": "Markers",
+        "type": "mark_categories",
     },
     "OLLAMA_SUMMARY_ENABLED": {
         "tab": "AI / Ollama",

--- a/server.py
+++ b/server.py
@@ -30,9 +30,11 @@ Studio API endpoints (all under /studio/):
 """
 
 import concurrent.futures
+import copy
 import hashlib
 import json
 import os
+import re
 import sys
 import threading
 import webbrowser
@@ -70,9 +72,38 @@ _thumbnail_cache: dict[tuple, bytes] = {}
 _reel_cancel_event = threading.Event()
 
 # Snapshot config defaults before any settings file is loaded.
+# Deep-copied so dict-valued defaults are not aliased to live config state.
 _settings_defaults: dict[str, Any] = {
-    name: getattr(config, name) for name in getattr(config, "STUDIO_SETTINGS", {})
+    name: copy.deepcopy(getattr(config, name))
+    for name in getattr(config, "STUDIO_SETTINGS", {})
 }
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+_MARK_KEY_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+def _coerce_mark_categories(value: Any) -> dict[str, dict[str, str]] | None:
+    """Validate and normalize a mark_categories payload.
+
+    Returns the cleaned dict, or None if the payload is structurally invalid.
+    """
+    if not isinstance(value, dict):
+        return None
+    cleaned: dict[str, dict[str, str]] = {}
+    for raw_key, raw_entry in value.items():
+        if not isinstance(raw_key, str):
+            return None
+        key = raw_key.strip()
+        if not key or not _MARK_KEY_RE.match(key):
+            return None
+        if not isinstance(raw_entry, dict):
+            return None
+        label = str(raw_entry.get("label", "")).strip()
+        color = str(raw_entry.get("color", "")).strip()
+        if not label or not _HEX_COLOR_RE.match(color):
+            return None
+        cleaned[key] = {"label": label, "color": color}
+    return cleaned
 
 
 @contextmanager
@@ -441,7 +472,15 @@ def _load_studio_settings() -> dict[str, Any]:
     for name, value in data.items():
         if name not in config.STUDIO_SETTINGS:
             continue
+        meta = config.STUDIO_SETTINGS[name]
         default = _settings_defaults.get(name)
+        if meta.get("type") == "mark_categories":
+            cleaned = _coerce_mark_categories(value)
+            if cleaned is None:
+                continue
+            setattr(config, name, cleaned)
+            applied[name] = cleaned
+            continue
         expected_type = type(default) if default is not None else str
         try:
             if expected_type is bool:
@@ -1154,7 +1193,7 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
 
         applied: dict[str, Any] = {}
         for name in target_names:
-            default = _settings_defaults.get(name)
+            default = copy.deepcopy(_settings_defaults.get(name))
             setattr(config, name, default)
             applied[name] = default
 
@@ -1192,7 +1231,15 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
     for name, value in settings_data.items():
         if name not in config.STUDIO_SETTINGS:
             continue
+        meta = config.STUDIO_SETTINGS[name]
         default = _settings_defaults.get(name)
+        if meta.get("type") == "mark_categories":
+            cleaned = _coerce_mark_categories(value)
+            if cleaned is None:
+                return {}, f"Invalid {name} payload"
+            setattr(config, name, cleaned)
+            applied[name] = cleaned
+            continue
         expected_type = type(default) if default is not None else str
         try:
             if expected_type is bool:

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -1,14 +1,19 @@
-"""Verify that JS constants in utils.js stay in sync with their Python sources."""
+"""Verify that JS fallback constants in utils.js match their config.py defaults.
+
+The live values are repopulated at runtime from the server, but utils.js carries
+hardcoded defaults so exported viewers and the brief boot window before the
+first /api/marks fetch still render with the same colors.
+"""
 
 import json
 import re
 from pathlib import Path
 
-import transcripts
+import config
 
 
 def _parse_js_mark_categories() -> dict:
-    """Extract MARK_CATEGORIES from assets/web/utils.js as a Python dict."""
+    """Extract the MARK_CATEGORIES fallback from assets/web/utils.js."""
     js_path = Path(__file__).resolve().parent.parent / "assets" / "web" / "utils.js"
     text = js_path.read_text(encoding="utf-8")
     # Grab the object literal assigned to MARK_CATEGORIES
@@ -28,7 +33,7 @@ def _parse_js_mark_categories() -> dict:
 
 def test_mark_categories_match_python():
     js_cats = _parse_js_mark_categories()
-    py_cats = transcripts.MARK_CATEGORIES
+    py_cats = config.MARK_CATEGORIES
     assert set(js_cats.keys()) == set(py_cats.keys()), (
         f"Key mismatch: JS={sorted(js_cats)} vs Python={sorted(py_cats)}"
     )

--- a/transcripts.py
+++ b/transcripts.py
@@ -74,19 +74,6 @@ class ManifestSegment(TypedDict):
     text: str
 
 
-# ---------------------------------------------------------------------------
-# Mark categories (shared constant — mirrored in transcripts.js)
-# ---------------------------------------------------------------------------
-
-MARK_CATEGORIES: dict[str, dict[str, str]] = {
-    "pain_point": {"label": "Pain Point", "color": "#dc2626"},
-    "delight": {"label": "Delight", "color": "#16a34a"},
-    "quote": {"label": "Quote", "color": "#2563eb"},
-    "insight": {"label": "Insight", "color": "#f97316"},
-    "task": {"label": "Task Issue", "color": "#8b5cf6"},
-    "bookmark": {"label": "Bookmark", "color": "#0891b2"},
-}
-
 # Known faster-whisper model variants with approximate download sizes.
 WHISPER_MODELS: list[dict[str, Any]] = [
     {"name": "tiny", "size_mb": 40, "description": "Fastest, least accurate"},

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -605,7 +605,7 @@ def api_marks_list() -> FlaskResponse:
         {
             "ok": True,
             "marks": resolved,
-            "categories": transcripts.MARK_CATEGORIES,
+            "categories": config.MARK_CATEGORIES,
         }
     )
 


### PR DESCRIPTION
## Summary
- Move `MARK_CATEGORIES` from `transcripts.py` to `config.py` so it is the single source of truth, and expose it through `STUDIO_SETTINGS` (Transcription tab → Markers group, type `mark_categories`).
- Add a stacked editor in `settings-modal.js`/`.css` that lets users rename, recolor, add, and remove categories; values flow through `/api/settings` with validation (`#RRGGBB` colors, snake_case keys) and deep-copied defaults so reset works correctly.
- Frontend repopulates the live `MARK_CATEGORIES` global in place from `/api/marks` on boot and from settings save/reset callbacks (transcripts + studio), so existing references keep working and `lastMarkCategory` falls back if the user deletes their selection.
- `tests/test_shared_constants.py` now compares the JS fallback against `config.MARK_CATEGORIES`; full test suite (593) passes; `VERSIONNUM` bumped to 0.10.96.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini`
- [x] `uv run ruff check --fix && uv run ruff format`
- [ ] Manual: open Transcripts → Settings → Transcription tab → edit a category label/color, add a new one, delete one; confirm marks recolor without reload.
- [ ] Manual: edit categories from Studio settings; confirm transcript-intake marker colors update.