### PR TITLE
refactor: single source of truth for shared Python/JS config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,10 @@ Patterns distilled from recurring post-review and post-merge fixes across the pr
 - **Data contract completeness**: When creating records consumed by the frontend (artifacts, events, tasks), include all fields the renderer expects — even optional ones. Missing fields cause empty/broken cards.
 - **New flags in mode detection**: When adding a CLI flag, verify it appears in the mode-detection logic (`cli.py`), not just in argparse definition.
 - **Bundled/frozen paths**: Use `utils.get_bundled_assets_root()` for asset resolution, never raw `Path(__file__).parent`. Test that asset paths resolve in both source and PyInstaller environments.
+- **No duplicated constants between Python and JS.** Any value that lives in `config.py` (or a Python helper) and that the frontend also needs — severity labels, default clip duration, annotation keyphrases (`!key`), ignored timestamp tokens (`x`) — must flow through `utils.get_frontend_config()`, not be hardcoded in JS. When adding a new one:
+  1. Extend `get_frontend_config()` in `utils.py`.
+  2. Confirm every consumer already embeds `"config": utils.get_frontend_config()` (server.py `/api/sheet`, insights_server.py `/api/artifacts`, viewer.py `finalize_timeline_data` / gallery / insights viewer). Add it if missing.
+  3. Add the default to `CLIPGEN_CONFIG` in `assets/web/utils.js` and extend `clipgenApplyConfig` to copy the new key.
+  4. Add an assertion in `tests/test_shared_constants.py` that the JS default matches the Python value.
+
+  Why: severity tables, `!key`, `x`, and the 60s default each previously drifted across 3–5 JS files (`studio.js`, `viewer.js`, `insights-builder.js`, `metadata.js`, `transcripts.js`) because they were independently hardcoded. Renaming `!key` in `config.py` would update the backend silently while the frontend kept stripping the old token. Same risk class as `MARK_CATEGORIES` (already guarded by `test_shared_constants.py`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Source video filenames follow `{study}_{participant}.mp4` (e.g. `mystudy_P01.mp4
 
 ## Conventions and patterns
 
+- **Shared Python/JS config:** values mirrored on the frontend (severity labels, `DEFAULT_DURATION_SECONDS`, `ANNOTATION_KEYPHRASES`, `IGNORED_TIMESTAMP_TOKENS`) flow through `utils.get_frontend_config()`. Server routes (`server.py`, `insights_server.py`) embed it as `"config":` in their JSON; `viewer.py` finalize_* functions embed it in `window.CLIPGEN_DATA`. JS overlays the payload onto `CLIPGEN_CONFIG` in `assets/web/utils.js` via `clipgenApplyConfig()`; the `CLIPGEN_CONFIG` defaults are the offline-fallback for re-opened exported viewers. `tests/test_shared_constants.py` asserts the JS defaults match Python.
 - **Coordinates:** gspread uses **1-based** row/col. `sheet.get_all_values()` is a list of lists with **0-based** indices: `sheet_data[row_idx][col_idx]`. Conversions: sheet row = `row_idx + 1`, sheet col = `col_idx + 1`.
 - **Timestamps:** Formats `MM:SS` or `HH:MM:SS`. Ranges with `-` (e.g. `1:23-1:45`). Multiple pairs separated by `,`, `;`, `+`, or space. Single time gets end = start + `DEFAULT_DURATION_SECONDS`.
 - **Annotations:** `utils.parse_cell_annotations()` strips supported keyphrases (configured in `ANNOTATION_KEYPHRASES`, currently `!key`) before timestamp parsing. Ignored tokens (configured in `IGNORED_TIMESTAMP_TOKENS`, currently `x`) are skipped.

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -189,8 +189,7 @@
           var cell = row.cells[pid];
           if (!cell || !cell.valid) continue;
           var baselineOffset = (cvState.baselines && cvState.baselines[pid]) || 0;
-          var defaultDur = (state.sheetData && state.sheetData.defaultDuration) || 60;
-          var segs = parseClipSegmentsForCell(cell.value, baselineOffset, defaultDur);
+          var segs = parseClipSegmentsForCell(cell.value, baselineOffset, CLIPGEN_CONFIG.defaultDuration);
           for (var s = 0; s < segs.length; s++) {
             var start = segs[s].startSeconds;
             var end = start + segs[s].duration;
@@ -1336,9 +1335,8 @@
         ? rawRow.cells[event.participant].value : "";
       var parts = event.id.split("_");
       var segIdx = parseInt(parts[parts.length - 1]) || 0;
-      var defaultDur2 = (state.sheetData && state.sheetData.defaultDuration) || 60;
       var baselineOffset2 = (cvState.baselines && cvState.baselines[event.participant]) || 0;
-      var segs = parseClipSegmentsForCell(cellValue, baselineOffset2, defaultDur2);
+      var segs = parseClipSegmentsForCell(cellValue, baselineOffset2, CLIPGEN_CONFIG.defaultDuration);
       item.row = rawRow.rowNum;
       item.desc = rawRow.observation || event.label || event.eventType;
       item.timestamp = cellValue;

--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -3,6 +3,7 @@
   "use strict";
 
   var data = window.CLIPGEN_DATA || null;
+  if (data) clipgenApplyConfig(data.config);
   var state = { artifacts: [], lightboxIndex: -1 };
   // ---- Init ----
 

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -4,33 +4,12 @@
   "use strict";
 
   var SIDEBAR_WIDTH_KEY = "clipgen-insights-sidebar-width";
-  var SEVERITY_OPTIONS = [
-    "",
-    "Critical",
-    "High",
-    "Medium",
-    "Low",
-    "N/A",
-    "Positive",
-    "Very Positive",
-  ];
 
   var SORT_DEFAULT_DIR = {
     severity: "desc",
     chrono: "asc",
     duration: "desc",
     alpha: "asc",
-  };
-
-  var SEVERITY_SORT = {
-    "sev-critical": -4,
-    "sev-high": -3,
-    "sev-medium": -2,
-    "sev-low": -1,
-    "sev-na": 0,
-    "sev-positive": 1,
-    "sev-very-positive": 2,
-    "sev-unknown": 998,
   };
 
   var state = {
@@ -67,6 +46,7 @@
       apiGet("api/artifacts"),
       apiGet("api/insights"),
     ]).then(function (results) {
+      clipgenApplyConfig(results[0].config);
       state.artifacts = results[0].artifacts || [];
       state.insights = results[1].insights || [];
       state.filteredArtifacts = state.artifacts.slice();
@@ -213,10 +193,10 @@
         else if (ae) r = 1;
         else if (be) r = -1;
         else {
-          var ca = severityClass(a.severity);
-          var cb = severityClass(b.severity);
-          var na = SEVERITY_SORT.hasOwnProperty(ca) ? SEVERITY_SORT[ca] : 999;
-          var nb = SEVERITY_SORT.hasOwnProperty(cb) ? SEVERITY_SORT[cb] : 999;
+          var na = severityRank(a.severity);
+          var nb = severityRank(b.severity);
+          if (na === null) na = 999;
+          if (nb === null) nb = 999;
           if (dir === "desc") r = na - nb;
           else r = nb - na;
         }
@@ -931,11 +911,14 @@
       fields.appendChild(titleInput);
 
       var sevSelect = document.createElement("select");
-      for (var s = 0; s < SEVERITY_OPTIONS.length; s++) {
+      var sevOpts = [""].concat(
+        CLIPGEN_CONFIG.severity.map(function (s) { return s.label; })
+      );
+      for (var s = 0; s < sevOpts.length; s++) {
         var opt = document.createElement("option");
-        opt.value = SEVERITY_OPTIONS[s];
-        opt.textContent = SEVERITY_OPTIONS[s] || "No severity";
-        if (SEVERITY_OPTIONS[s] === insight.severity) opt.selected = true;
+        opt.value = sevOpts[s];
+        opt.textContent = sevOpts[s] || "No severity";
+        if (sevOpts[s] === insight.severity) opt.selected = true;
         sevSelect.appendChild(opt);
       }
       sevSelect.addEventListener("change", function () {

--- a/assets/web/insights-viewer.js
+++ b/assets/web/insights-viewer.js
@@ -197,6 +197,7 @@
       );
       return;
     }
+    clipgenApplyConfig(data.config);
 
     // Build artifact lookup
     var artifacts = data.artifacts || [];

--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -16,8 +16,8 @@
   var clusterIntakeEvents;
   var clusterTranscriptMarks;
   var ROW_FUNCTIONS;
-  var SEVERITY_ORDER;
-  var severityRank;
+  // CLIPGEN_CONFIG.severity and severityRank are read directly from utils.js
+  // (CLIPGEN_CONFIG.severity / severityRank) and need no per-module alias.
 
   var MD_HISTOGRAM_HEIGHT = 140;
 
@@ -261,17 +261,17 @@
 
   function computeSeverityDistribution(rows) {
     var dist = {};
-    for (var i = 0; i < SEVERITY_ORDER.length; i++) {
-      dist[SEVERITY_ORDER[i].label] = 0;
+    for (var i = 0; i < CLIPGEN_CONFIG.severity.length; i++) {
+      dist[CLIPGEN_CONFIG.severity[i].label] = 0;
     }
     for (var j = 0; j < rows.length; j++) {
       var sev = (rows[j].severity || "").trim();
       if (!sev) continue;
       // Match against known labels (case-insensitive)
       var matched = false;
-      for (var k = 0; k < SEVERITY_ORDER.length; k++) {
-        if (SEVERITY_ORDER[k].label.toLowerCase() === sev.toLowerCase()) {
-          dist[SEVERITY_ORDER[k].label]++;
+      for (var k = 0; k < CLIPGEN_CONFIG.severity.length; k++) {
+        if (CLIPGEN_CONFIG.severity[k].label.toLowerCase() === sev.toLowerCase()) {
+          dist[CLIPGEN_CONFIG.severity[k].label]++;
           matched = true;
           break;
         }
@@ -1083,8 +1083,8 @@
   function renderSeverityBar(dist, compact) {
     var total = 0;
     var entries = [];
-    for (var i = 0; i < SEVERITY_ORDER.length; i++) {
-      var label = SEVERITY_ORDER[i].label;
+    for (var i = 0; i < CLIPGEN_CONFIG.severity.length; i++) {
+      var label = CLIPGEN_CONFIG.severity[i].label;
       var count = dist[label] || 0;
       if (count > 0) {
         entries.push({ label: label, count: count });
@@ -1095,8 +1095,8 @@
     var keys = Object.keys(dist);
     for (var k = 0; k < keys.length; k++) {
       var found = false;
-      for (var s = 0; s < SEVERITY_ORDER.length; s++) {
-        if (SEVERITY_ORDER[s].label === keys[k]) { found = true; break; }
+      for (var s = 0; s < CLIPGEN_CONFIG.severity.length; s++) {
+        if (CLIPGEN_CONFIG.severity[s].label === keys[k]) { found = true; break; }
       }
       if (!found && dist[keys[k]] > 0) {
         entries.push({ label: keys[k], count: dist[keys[k]] });
@@ -1130,8 +1130,8 @@
 
     // Legend / exact counts
     var legend = el("div", "md-severity-legend");
-    for (var i = 0; i < SEVERITY_ORDER.length; i++) {
-      var label = SEVERITY_ORDER[i].label;
+    for (var i = 0; i < CLIPGEN_CONFIG.severity.length; i++) {
+      var label = CLIPGEN_CONFIG.severity[i].label;
       var count = cache.severityDist[label] || 0;
       if (count === 0) continue;
       var item = el("span", "md-severity-legend-item");
@@ -1691,8 +1691,6 @@
       clusterIntakeEvents = window._studioClusterIntakeEvents;
       clusterTranscriptMarks = window._studioClusterTranscriptMarks;
       ROW_FUNCTIONS = window._studioROW_FUNCTIONS;
-      SEVERITY_ORDER = window._studioSEVERITY_ORDER;
-      severityRank = window._studioSeverityRank;
     }
     if (mdState._snapshot) {
       checkStaleness();

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -57,16 +57,6 @@
     return source === "screenspace" || source === "transcript";
   }
 
-  var SEVERITY_ORDER = [
-    { label: "Critical", rank: -4 },
-    { label: "High", rank: -3 },
-    { label: "Medium", rank: -2 },
-    { label: "Low", rank: -1 },
-    { label: "N/A", rank: 0 },
-    { label: "Positive", rank: 1 },
-    { label: "Very Positive", rank: 2 },
-  ];
-
   var ROW_FUNCTIONS = {
     Count: function (row, participants) {
       var total = 0;
@@ -157,7 +147,7 @@
   }
 
   function parseClipTimestamps(raw, participantId) {
-    var DEFAULT_DUR = (state.sheetData && state.sheetData.defaultDuration) || 60;
+    var DEFAULT_DUR = CLIPGEN_CONFIG.defaultDuration;
     var baselineSeconds = 0;
     if (participantId && state.convergenceBaselines) {
       baselineSeconds = state.convergenceBaselines[participantId] || 0;
@@ -246,15 +236,6 @@
   }
 
   // ---- Filtering ----
-
-  function severityRank(label) {
-    if (!label) return null;
-    var k = label.trim().toLowerCase();
-    for (var i = 0; i < SEVERITY_ORDER.length; i++) {
-      if (SEVERITY_ORDER[i].label.toLowerCase() === k) return SEVERITY_ORDER[i].rank;
-    }
-    return null;
-  }
 
   function hasActiveFilters() {
     var f = state.filters;
@@ -396,10 +377,10 @@
       sevMinDefault.value = "";
       sevMinDefault.textContent = "Any";
       sevMin.appendChild(sevMinDefault);
-      for (var si = 0; si < SEVERITY_ORDER.length; si++) {
+      for (var si = 0; si < CLIPGEN_CONFIG.severity.length; si++) {
         var opt = document.createElement("option");
-        opt.value = SEVERITY_ORDER[si].label;
-        opt.textContent = SEVERITY_ORDER[si].label;
+        opt.value = CLIPGEN_CONFIG.severity[si].label;
+        opt.textContent = CLIPGEN_CONFIG.severity[si].label;
         sevMin.appendChild(opt);
       }
 
@@ -410,10 +391,10 @@
       sevMaxDefault.value = "";
       sevMaxDefault.textContent = "Any";
       sevMax.appendChild(sevMaxDefault);
-      for (var sj = 0; sj < SEVERITY_ORDER.length; sj++) {
+      for (var sj = 0; sj < CLIPGEN_CONFIG.severity.length; sj++) {
         var opt2 = document.createElement("option");
-        opt2.value = SEVERITY_ORDER[sj].label;
-        opt2.textContent = SEVERITY_ORDER[sj].label;
+        opt2.value = CLIPGEN_CONFIG.severity[sj].label;
+        opt2.textContent = CLIPGEN_CONFIG.severity[sj].label;
         sevMax.appendChild(opt2);
       }
 
@@ -638,6 +619,7 @@
           return;
         }
         state.sheetData = data;
+        clipgenApplyConfig(data.config);
         renderHeader();
         renderFilterBar();
         renderGrid();
@@ -4484,7 +4466,5 @@
   window._studioClusterIntakeEvents = clusterIntakeEvents;
   window._studioClusterTranscriptMarks = clusterTranscriptMarks;
   window._studioROW_FUNCTIONS = ROW_FUNCTIONS;
-  window._studioSEVERITY_ORDER = SEVERITY_ORDER;
-  window._studioSeverityRank = severityRank;
   window._studioSyncPreviewTab = syncPreviewTab;
 })();

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -22,7 +22,6 @@
     ssEventsLoaded: false,
     sheetRows: [],
     sheetParticipants: [],
-    sheetDefaultDuration: 60,
     sheetLoaded: false,
     xrefPollTimer: null,
     xrefEligible: false,
@@ -96,9 +95,9 @@
       .then(function (r) { return r.json(); })
       .then(function (data) {
         if (data.ok) {
+          clipgenApplyConfig(data.config);
           state.sheetRows = data.rows || [];
           state.sheetParticipants = data.participants || [];
-          state.sheetDefaultDuration = data.defaultDuration || 60;
           state.sheetLoaded = true;
           _buildSheetIndex();
           if (state.searchResults) renderSearchResults(state.searchResults);
@@ -107,34 +106,13 @@
       .catch(function () {});
   }
 
-  function parseTS(str) {
-    var parts = str.split(":");
-    if (parts.length === 3) return (+parts[0]) * 3600 + (+parts[1]) * 60 + (+parts[2]);
-    if (parts.length === 2) return (+parts[0]) * 60 + (+parts[1]);
-    return NaN;
-  }
-
   function parseSheetTimestamps(raw) {
-    var DEFAULT_DUR = state.sheetDefaultDuration || 60;
-    var cleaned = raw.toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
-    var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
-    var segments = [];
-    for (var i = 0; i < tokens.length; i++) {
-      var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
-      var dashIdx = -1;
-      for (var d = 1; d < tok.length; d++) {
-        if (tok[d] === "-" && tok[d - 1] >= "0" && tok[d - 1] <= "9") { dashIdx = d; break; }
-      }
-      if (dashIdx > 0) {
-        var s = parseTS(tok.substring(0, dashIdx));
-        var e = parseTS(tok.substring(dashIdx + 1));
-        if (!isNaN(s) && !isNaN(e)) segments.push({ start: Math.floor(s), duration: Math.max(0, e - s) });
-      } else if (tok.indexOf(":") > 0) {
-        var sec = parseTS(tok);
-        if (!isNaN(sec)) segments.push({ start: Math.floor(sec), duration: DEFAULT_DUR });
-      }
-    }
-    return segments;
+    // Cross-reference search; baselines are not applied here so timestamps
+    // are interpreted in their relative form (MM:SS for 2-part).
+    var segs = parseClipSegmentsForCell(raw, 0, CLIPGEN_CONFIG.defaultDuration);
+    return segs.map(function (s) {
+      return { start: s.startSeconds, duration: s.duration };
+    });
   }
 
   // Per-participant indexes keyed on start time. Rebuilt when loadCrossRefData

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -14,6 +14,47 @@
 // the static CSS line-grid defined in tokens.css.
 var CLIPGEN_ANIMATED_BG = true;
 
+// ---- Canonical config (mirror of config.py via utils.get_frontend_config)
+//
+// Source of truth: every API response (server.py /api/sheet-data,
+// insights_server.py /api/artifacts) and every exported viewer payload
+// (viewer.py finalize_*) embeds a `config` field. Pages call
+// clipgenApplyConfig(payload) to overlay the live values onto these defaults.
+// The hardcoded defaults below cover purely-offline contexts (re-opened
+// older exported viewers); tests/test_shared_constants.py asserts they
+// match config.py.
+
+var CLIPGEN_CONFIG = {
+  defaultDuration: 60,
+  severity: [
+    { label: "Critical",      rank: -4, cssClass: "sev-critical" },
+    { label: "High",          rank: -3, cssClass: "sev-high" },
+    { label: "Medium",        rank: -2, cssClass: "sev-medium" },
+    { label: "Low",           rank: -1, cssClass: "sev-low" },
+    { label: "N/A",           rank:  0, cssClass: "sev-na" },
+    { label: "Positive",      rank:  1, cssClass: "sev-positive" },
+    { label: "Very Positive", rank:  2, cssClass: "sev-very-positive" },
+  ],
+  annotationKeyphrases: ["!key"],
+  ignoredTimestampTokens: ["x"],
+};
+
+var clipgenApplyConfig = function (payload) {
+  if (!payload || typeof payload !== "object") return;
+  if (typeof payload.defaultDuration === "number") {
+    CLIPGEN_CONFIG.defaultDuration = payload.defaultDuration;
+  }
+  if (Array.isArray(payload.severity) && payload.severity.length) {
+    CLIPGEN_CONFIG.severity = payload.severity;
+  }
+  if (Array.isArray(payload.annotationKeyphrases)) {
+    CLIPGEN_CONFIG.annotationKeyphrases = payload.annotationKeyphrases;
+  }
+  if (Array.isArray(payload.ignoredTimestampTokens)) {
+    CLIPGEN_CONFIG.ignoredTimestampTokens = payload.ignoredTimestampTokens;
+  }
+};
+
 // ---- DOM helpers ----
 
 var qs = function (sel) { return document.querySelector(sel); };
@@ -151,12 +192,23 @@ var parseClockTimestamp = function (str) {
 // (2-part = HH:MM) and the baseline is subtracted from both ends of each
 // range. Mirrors files.prepare_clip + utils.convert_clock_pairs_to_relative.
 // Pairs that resolve to negative or zero-length intervals are skipped.
+// defaultDuration: required (per-clip duration when only a start time is
+// given). Callers must pass CLIPGEN_CONFIG.defaultDuration; a missing value
+// is a contract bug.
 var parseClipSegmentsForCell = function (raw, baselineSeconds, defaultDuration) {
-  var DEFAULT_DUR = defaultDuration || 60;
+  var DEFAULT_DUR = defaultDuration;
   var hasBaseline = baselineSeconds && baselineSeconds > 0;
   var tsParse = hasBaseline ? parseClockTimestamp : parseTimestamp;
-  var cleaned = String(raw || "").toLowerCase().replace(/!key/g, "").replace(/[+;,]/g, " ");
-  var tokens = cleaned.split(/\s+/).filter(function (t) { return t && t !== "x"; });
+  var cleaned = String(raw || "").toLowerCase();
+  for (var ki = 0; ki < CLIPGEN_CONFIG.annotationKeyphrases.length; ki++) {
+    var phrase = CLIPGEN_CONFIG.annotationKeyphrases[ki];
+    cleaned = cleaned.split(phrase).join("");
+  }
+  cleaned = cleaned.replace(/[+;,]/g, " ");
+  var ignored = CLIPGEN_CONFIG.ignoredTimestampTokens;
+  var tokens = cleaned.split(/\s+/).filter(function (t) {
+    return t && ignored.indexOf(t) === -1;
+  });
   var segments = [];
   for (var i = 0; i < tokens.length; i++) {
     var tok = tokens[i].replace(/\.$/, "").replace(/\./g, ":");
@@ -249,20 +301,47 @@ var showToast = function (msg, opts) {
 };
 
 // ---- Severity ----
+//
+// Read severity metadata from CLIPGEN_CONFIG.severity (kept in sync with
+// config.py SEVERITY_NUMERIC_TO_LABEL via tests/test_shared_constants.py).
 
 var severityClass = function (raw) {
   if (!raw || !String(raw).trim()) return "";
   var k = String(raw).trim().toLowerCase();
-  var map = {
-    critical: "sev-critical",
-    high: "sev-high",
-    medium: "sev-medium",
-    low: "sev-low",
-    "n/a": "sev-na",
-    positive: "sev-positive",
-    "very positive": "sev-very-positive",
-  };
-  return map[k] || "sev-unknown";
+  for (var i = 0; i < CLIPGEN_CONFIG.severity.length; i++) {
+    if (CLIPGEN_CONFIG.severity[i].label.toLowerCase() === k) {
+      return CLIPGEN_CONFIG.severity[i].cssClass;
+    }
+  }
+  return "sev-unknown";
+};
+
+// Numeric rank (most-severe = lowest, e.g. Critical = -4) used by sorters
+// and Studio's severity filter. Returns null for empty or unrecognized input
+// — callers decide how to treat unknown (Studio filters them out; viewer
+// and insights sort them last).
+var severityRank = function (raw) {
+  if (!raw || !String(raw).trim()) return null;
+  var k = String(raw).trim().toLowerCase();
+  for (var i = 0; i < CLIPGEN_CONFIG.severity.length; i++) {
+    if (CLIPGEN_CONFIG.severity[i].label.toLowerCase() === k) {
+      return CLIPGEN_CONFIG.severity[i].rank;
+    }
+  }
+  return null;
+};
+
+// Same as severityRank but keyed by CSS class (sev-critical, sev-high, ...).
+// Useful when the caller has already resolved the class via severityClass().
+// Returns null for unknown class so sort callers can fall back to 999.
+var severityRankByClass = function (cssClass) {
+  if (!cssClass) return null;
+  for (var i = 0; i < CLIPGEN_CONFIG.severity.length; i++) {
+    if (CLIPGEN_CONFIG.severity[i].cssClass === cssClass) {
+      return CLIPGEN_CONFIG.severity[i].rank;
+    }
+  }
+  return null;
 };
 
 // ---- API helpers (always check r.ok) ----

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -3,6 +3,7 @@
   "use strict";
 
   var data = window.CLIPGEN_DATA || null;
+  if (data) clipgenApplyConfig(data.config);
 
   var state = {
     artifacts: [],
@@ -44,17 +45,6 @@
 
   // ---- Helpers ----
 
-  var SEVERITY_SORT = {
-    "sev-critical": -4,
-    "sev-high": -3,
-    "sev-medium": -2,
-    "sev-low": -1,
-    "sev-na": 0,
-    "sev-positive": 1,
-    "sev-very-positive": 2,
-    "sev-unknown": 998,
-  };
-
   function markerTypeClass(type) {
     var t = type || "clip";
     if (t === "transcript") return "transcript";
@@ -81,10 +71,10 @@
       labels.push(s);
     });
     labels.sort(function (a, b) {
-      var ca = severityClass(a);
-      var cb = severityClass(b);
-      var na = SEVERITY_SORT.hasOwnProperty(ca) ? SEVERITY_SORT[ca] : 999;
-      var nb = SEVERITY_SORT.hasOwnProperty(cb) ? SEVERITY_SORT[cb] : 999;
+      var na = severityRank(a);
+      var nb = severityRank(b);
+      if (na === null) na = 999;
+      if (nb === null) nb = 999;
       if (na !== nb) return na - nb;
       return a.localeCompare(b);
     });
@@ -906,8 +896,8 @@
     var items = artifacts.map(function (a) {
       var s = a.start || 0;
       var e = a.end || a.start || 0;
-      var cls = severityClass(a.severity);
-      var sevVal = cls && SEVERITY_SORT.hasOwnProperty(cls) ? SEVERITY_SORT[cls] : 999;
+      var rank = severityRank(a.severity);
+      var sevVal = rank !== null ? rank : 999;
       return { id: a.id, duration: e - s, start: s, sevVal: sevVal };
     });
     items.sort(function (a, b) {
@@ -1118,10 +1108,10 @@
         else if (ae) r = 1;
         else if (be) r = -1;
         else {
-          var ca = severityClass(a.severity);
-          var cb = severityClass(b.severity);
-          var na = SEVERITY_SORT.hasOwnProperty(ca) ? SEVERITY_SORT[ca] : 999;
-          var nb = SEVERITY_SORT.hasOwnProperty(cb) ? SEVERITY_SORT[cb] : 999;
+          var na = severityRank(a.severity);
+          var nb = severityRank(b.severity);
+          if (na === null) na = 999;
+          if (nb === null) nb = 999;
           if (dir === "desc") r = na - nb;
           else r = nb - na;
         }

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.95"
+VERSIONNUM: str = "0.10.96"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/insights_server.py
+++ b/insights_server.py
@@ -69,7 +69,13 @@ def api_artifacts() -> FlaskResponse:
         duration = (end or 0) - (start or 0)
         if duration > 0:
             art["spriteData"] = _compute_sprite_metadata(duration)
-    return jsonify({"ok": True, "artifacts": fresh_artifacts})
+    return jsonify(
+        {
+            "ok": True,
+            "artifacts": fresh_artifacts,
+            "config": utils.get_frontend_config(),
+        }
+    )
 
 
 @insights_bp.route("/api/insights")

--- a/server.py
+++ b/server.py
@@ -223,6 +223,7 @@ def api_sheet() -> FlaskResponse:
             "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
             "cellColorCoding": config.STUDIO_SHEET_CELL_COLOR_CODING,
             "defaultDuration": config.DEFAULT_DURATION_SECONDS,
+            "config": utils.get_frontend_config(),
             "participants": participants,
             "rows": rows,
         }

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -4,30 +4,45 @@ import json
 import re
 from pathlib import Path
 
+import config
 import transcripts
+import utils
+
+JS_PATH = Path(__file__).resolve().parent.parent / "assets" / "web" / "utils.js"
 
 
-def _parse_js_mark_categories() -> dict:
-    """Extract MARK_CATEGORIES from assets/web/utils.js as a Python dict."""
-    js_path = Path(__file__).resolve().parent.parent / "assets" / "web" / "utils.js"
-    text = js_path.read_text(encoding="utf-8")
-    # Grab the object literal assigned to MARK_CATEGORIES
+def _js_source() -> str:
+    return JS_PATH.read_text(encoding="utf-8")
+
+
+def _parse_js_object_literal(name: str) -> dict:
+    """Extract a top-level JS object literal `var <name> = { ... };` as a dict.
+
+    Handles unquoted keys and trailing commas; values must be JSON-compatible.
+    """
     match = re.search(
-        r"var\s+MARK_CATEGORIES\s*=\s*\{(.+?)\};",
-        text,
+        r"var\s+" + re.escape(name) + r"\s*=\s*(\{.+?\n\});",
+        _js_source(),
         re.DOTALL,
     )
-    assert match, "MARK_CATEGORIES not found in utils.js"
-    raw = "{" + match.group(1) + "}"
-    # Convert JS object to valid JSON: unquoted keys → quoted keys
-    raw = re.sub(r"(\w+)\s*:", r'"\1":', raw)
-    # Remove trailing commas
+    assert match, f"{name} not found in utils.js"
+    raw = match.group(1)
+    raw = re.sub(r"(\b\w+)\s*:", r'"\1":', raw)
     raw = re.sub(r",\s*([}\]])", r"\1", raw)
     return json.loads(raw)
 
 
 def test_mark_categories_match_python():
-    js_cats = _parse_js_mark_categories()
+    match = re.search(
+        r"var\s+MARK_CATEGORIES\s*=\s*\{(.+?)\};",
+        _js_source(),
+        re.DOTALL,
+    )
+    assert match, "MARK_CATEGORIES not found in utils.js"
+    raw = "{" + match.group(1) + "}"
+    raw = re.sub(r"(\w+)\s*:", r'"\1":', raw)
+    raw = re.sub(r",\s*([}\]])", r"\1", raw)
+    js_cats = json.loads(raw)
     py_cats = transcripts.MARK_CATEGORIES
     assert set(js_cats.keys()) == set(py_cats.keys()), (
         f"Key mismatch: JS={sorted(js_cats)} vs Python={sorted(py_cats)}"
@@ -39,3 +54,92 @@ def test_mark_categories_match_python():
         assert js_cats[key]["color"] == py_cats[key]["color"], (
             f"MARK_CATEGORIES[{key!r}].color differs"
         )
+
+
+def test_clipgen_config_defaults_match_python():
+    """utils.js CLIPGEN_CONFIG fallback must match utils.get_frontend_config().
+
+    The fallback is what a re-opened older exported viewer (lacking the
+    `config` field in window.CLIPGEN_DATA) sees, so it must mirror the
+    canonical Python config exactly.
+    """
+    js_config = _parse_js_object_literal("CLIPGEN_CONFIG")
+    py_config = utils.get_frontend_config()
+
+    assert js_config["defaultDuration"] == py_config["defaultDuration"]
+    assert js_config["annotationKeyphrases"] == py_config["annotationKeyphrases"]
+    assert js_config["ignoredTimestampTokens"] == py_config["ignoredTimestampTokens"]
+
+    assert len(js_config["severity"]) == len(py_config["severity"])
+    for js_sev, py_sev in zip(js_config["severity"], py_config["severity"]):
+        assert js_sev["label"] == py_sev["label"]
+        assert js_sev["rank"] == py_sev["rank"]
+        assert js_sev["cssClass"] == py_sev["cssClass"]
+
+
+def test_get_frontend_config_shape():
+    """Contract: every consumer of get_frontend_config relies on these keys."""
+    cfg = utils.get_frontend_config()
+    assert set(cfg.keys()) == {
+        "defaultDuration",
+        "severity",
+        "annotationKeyphrases",
+        "ignoredTimestampTokens",
+    }
+    assert isinstance(cfg["defaultDuration"], int)
+    assert cfg["defaultDuration"] == config.DEFAULT_DURATION_SECONDS
+    assert isinstance(cfg["severity"], list) and cfg["severity"]
+    for entry in cfg["severity"]:
+        assert set(entry.keys()) == {"label", "rank", "cssClass"}
+        assert entry["cssClass"].startswith("sev-")
+    assert sorted(cfg["annotationKeyphrases"]) == sorted(
+        utils.get_known_annotation_map().keys()
+    )
+    assert sorted(cfg["ignoredTimestampTokens"]) == sorted(
+        utils.get_ignored_timestamp_tokens()
+    )
+
+
+def test_severity_css_class_mapping():
+    """severity_css_class returns the CSS classes tokens.css defines."""
+    expected = {
+        "Critical": "sev-critical",
+        "High": "sev-high",
+        "Medium": "sev-medium",
+        "Low": "sev-low",
+        "N/A": "sev-na",
+        "Positive": "sev-positive",
+        "Very Positive": "sev-very-positive",
+    }
+    for label, css in expected.items():
+        assert utils.severity_css_class(label) == css
+    assert utils.severity_css_class("") == ""
+    assert utils.severity_css_class("Bogus") == "sev-unknown"
+
+
+def test_studio_api_payload_includes_config():
+    """server.api_sheet must pass utils.get_frontend_config() to the JS layer."""
+    src = (Path(__file__).resolve().parent.parent / "server.py").read_text("utf-8")
+    assert '"config": utils.get_frontend_config()' in src, (
+        "server.py /api/sheet response must embed `config: utils.get_frontend_config()` "
+        "so JS reads canonical values instead of hardcoding them"
+    )
+
+
+def test_insights_api_payload_includes_config():
+    src = (Path(__file__).resolve().parent.parent / "insights_server.py").read_text(
+        "utf-8"
+    )
+    assert '"config": utils.get_frontend_config()' in src, (
+        "insights_server.py /api/artifacts response must embed `config`"
+    )
+
+
+def test_exported_viewer_payloads_include_config():
+    """finalize_timeline_data / gallery / insights viewer all embed `config`."""
+    src = (Path(__file__).resolve().parent.parent / "viewer.py").read_text("utf-8")
+    occurrences = src.count('"config": utils.get_frontend_config()')
+    assert occurrences >= 3, (
+        f"Expected at least 3 occurrences of config payload in viewer.py "
+        f"(timeline/gallery/insights viewer), found {occurrences}"
+    )

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -38,7 +38,7 @@ def test_finalize_timeline_data_duration_and_structure():
         mode="batch",
     )
 
-    assert set(data.keys()) == {"meta", "artifacts", "timeline"}
+    assert set(data.keys()) == {"meta", "config", "artifacts", "timeline"}
     assert data["timeline"]["duration"] == 50.0 * 1.05
     assert data["timeline"]["startOffset"] == 0.0
     assert data["meta"]["study"] == "s"

--- a/utils.py
+++ b/utils.py
@@ -663,6 +663,50 @@ def get_severity_style(severity_label: str) -> str:
     return _STYLE_MAP.get(severity_label.strip().lower(), "")
 
 
+def severity_css_class(severity_label: str) -> str:
+    """Map a canonical severity label to its tokens.css CSS class.
+
+    "Critical" → "sev-critical", "Very Positive" → "sev-very-positive",
+    "N/A" → "sev-na", unknown → "sev-unknown".
+    """
+    label = severity_label.strip().lower()
+    if not label:
+        return ""
+    if label not in config.SEVERITY_LABEL_TO_NUMERIC:
+        return "sev-unknown"
+    return "sev-" + label.replace("/", "").replace(" ", "-")
+
+
+# ---- Frontend config payload ----
+
+
+def get_frontend_config() -> dict[str, Any]:
+    """Return canonical config the JS layer needs (severity, timestamp tokens).
+
+    Embedded in API responses (server.py /api/sheet-data) and exported viewer
+    payloads (viewer.py finalize_*) so JS does not duplicate config.py.
+    The hardcoded fallback in assets/web/utils.js mirrors this; the contract
+    is asserted by tests/test_shared_constants.py.
+    """
+    severity = []
+    for numeric_str, label in sorted(
+        config.SEVERITY_NUMERIC_TO_LABEL.items(), key=lambda kv: int(kv[0])
+    ):
+        severity.append(
+            {
+                "label": label,
+                "rank": int(numeric_str),
+                "cssClass": severity_css_class(label),
+            }
+        )
+    return {
+        "defaultDuration": config.DEFAULT_DURATION_SECONDS,
+        "severity": severity,
+        "annotationKeyphrases": sorted(get_known_annotation_map().keys()),
+        "ignoredTimestampTokens": sorted(get_ignored_timestamp_tokens()),
+    }
+
+
 # ---- Column index / letter conversion ----
 
 

--- a/viewer.py
+++ b/viewer.py
@@ -155,6 +155,7 @@ def finalize_timeline_data(
             "sourceFileType": "excel" if is_excel else "google",
             "filmstripEnabled": config.FILMSTRIP_ENABLED,
         },
+        "config": utils.get_frontend_config(),
         "artifacts": artifacts,
         "timeline": {
             "duration": duration,
@@ -376,6 +377,7 @@ def finalize_gallery_data(
             "videoDuration": video_duration,
             "bundled": bundle,
         },
+        "config": utils.get_frontend_config(),
         "artifacts": artifacts,
     }
 
@@ -423,6 +425,7 @@ def finalize_insights_viewer_data(
             "version": config.VERSIONNUM,
             "timelineViewerFile": timeline_viewer_file,
         },
+        "config": utils.get_frontend_config(),
         "insights": visible,
         "artifacts": referenced_artifacts,
     }


### PR DESCRIPTION
## Summary

- Severity labels, `!key`, `x`, and `DEFAULT_DURATION_SECONDS` were each duplicated across 3–5 JS files (`studio.js`, `viewer.js`, `insights-builder.js`, `metadata.js`, `transcripts.js`) and would silently drift from `config.py`.
- All four now flow through `utils.get_frontend_config()`: server endpoints (`/studio/api/sheet`, `/insights/api/artifacts`) and exported viewer payloads (`finalize_timeline_data` / gallery / insights viewer) embed it as `"config":`, JS overlays it via `clipgenApplyConfig()` onto the `CLIPGEN_CONFIG` fallback in `utils.js`, and `tests/test_shared_constants.py` asserts the JS defaults stay in sync.
- Also drops the duplicated `parseSheetTimestamps` in `transcripts.js`, the `window._studioSEVERITY_ORDER` cross-module hack, the hardcoded `|| 60` fallbacks; adds drift-prevention notes to `CLAUDE.md` and `AGENTS.md`.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 599 passed
- [x] `uv run ruff check` and `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [ ] Smoke-test Studio, Insights builder, and an exported viewer in the browser