### PR TITLE
feat: remember last-selected tab and participant in web UIs

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -609,6 +609,7 @@
     _frameRequestVersion += 1;
     _heatmapOverlayRequestVersion += 1;
     state.selectedParticipant = pid;
+    setStoredUIStateField("screenspace", "selectedParticipant", pid);
     state.currentTimestamp = 0;
     state.videoInfo = null;
     state.frameImage = null;
@@ -4488,6 +4489,7 @@
 
   function setRightPaneTab(tab) {
     state.rightPaneTab = tab;
+    setStoredUIStateField("screenspace", "rightPaneTab", tab);
     qsa("#rightPaneTabs .rp-tab").forEach(function (b) {
       b.classList.toggle("active", b.dataset.tab === tab);
     });
@@ -6073,9 +6075,21 @@
             .catch(function () {});
         });
         if (state.participants.length > 0) {
-          var first = state.participants[0].id;
-          selectParticipant(first);
-          state.runParticipants = [first];
+          var stored = getStoredUIState("screenspace");
+          var pickId = state.participants[0].id;
+          if (stored.selectedParticipant) {
+            for (var spi = 0; spi < state.participants.length; spi++) {
+              if (state.participants[spi].id === stored.selectedParticipant) {
+                pickId = stored.selectedParticipant;
+                break;
+              }
+            }
+          }
+          selectParticipant(pickId);
+          state.runParticipants = [pickId];
+          if (stored.rightPaneTab === "queue" || stored.rightPaneTab === "results") {
+            setRightPaneTab(stored.rightPaneTab);
+          }
         }
         renderRunParticipantPicker();
         renderScanModePicker();

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -543,12 +543,36 @@
         var target = this.dataset.tab;
         if (target === state.activePreviewTab) return;
         state.activePreviewTab = target;
+        setStoredUIStateField("studio", "activeTab", target);
         var allTabs = qsa(".preview-tab");
         for (var j = 0; j < allTabs.length; j++) allTabs[j].classList.remove("active");
         this.classList.add("active");
         syncPreviewTab();
       });
     }
+    restoreStoredPreviewTab();
+  }
+
+  var _previewTabRestored = false;
+  function restoreStoredPreviewTab() {
+    if (_previewTabRestored) return;
+    var stored = getStoredUIState("studio").activeTab;
+    if (!stored) return;
+    var match = null;
+    var tabs = qsa(".preview-tab");
+    for (var i = 0; i < tabs.length; i++) {
+      if (tabs[i].dataset.tab === stored && !tabs[i].classList.contains("hidden")) {
+        match = tabs[i];
+        break;
+      }
+    }
+    if (!match) return;
+    _previewTabRestored = true;
+    if (stored === state.activePreviewTab) return;
+    state.activePreviewTab = stored;
+    for (var k = 0; k < tabs.length; k++) tabs[k].classList.remove("active");
+    match.classList.add("active");
+    syncPreviewTab();
   }
 
   function syncPreviewTab() {
@@ -3125,6 +3149,7 @@
     } else {
       tab.classList.add("hidden");
     }
+    restoreStoredPreviewTab();
   }
 
   function checkNavLinks() {
@@ -3138,6 +3163,7 @@
           var trIntakeTab = qs('.preview-tab[data-tab="transcript-intake"]');
           if (trIntakeTab) trIntakeTab.classList.remove("hidden");
         }
+        restoreStoredPreviewTab();
       })
       .catch(function () {});
   }

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -467,17 +467,28 @@
       }
       refreshTranscriptionModelHintOnce();
 
-      // Preserve current selection if still valid
+      // Preserve current in-memory selection if still valid (soft refresh)
       if (state.selectedParticipant) {
         for (var i = 0; i < state.participants.length; i++) {
           if (state.participants[i].id === state.selectedParticipant) return;
         }
       }
 
+      // Restore from localStorage if present and still valid (fresh page load)
+      var storedPid = getStoredUIState("transcripts").selectedParticipant;
+      if (storedPid) {
+        for (var j = 0; j < state.participants.length; j++) {
+          if (state.participants[j].id === storedPid) {
+            selectParticipant(storedPid);
+            return;
+          }
+        }
+      }
+
       // Auto-select first participant with a transcript, or just the first
       var first = null;
-      for (var i = 0; i < state.participants.length; i++) {
-        if (state.participants[i].has_transcript) { first = state.participants[i]; break; }
+      for (var k = 0; k < state.participants.length; k++) {
+        if (state.participants[k].has_transcript) { first = state.participants[k]; break; }
       }
       if (!first && state.participants.length > 0) first = state.participants[0];
       if (first) selectParticipant(first.id);
@@ -488,6 +499,7 @@
 
   function selectParticipant(pid) {
     state.selectedParticipant = pid;
+    setStoredUIStateField("transcripts", "selectedParticipant", pid);
     renderPills();
 
     // Find participant info

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -525,3 +525,30 @@ var setStoredTooltipPref = function (enabled) {
     window.localStorage.setItem(TOOLTIP_STORAGE_KEY, enabled ? "true" : "false");
   } catch (_) {}
 };
+
+// ---- Per-page UI state (localStorage) ----
+
+var UI_STATE_STORAGE_KEY = "clipgen-ui-state";
+
+var getStoredUIState = function (page) {
+  try {
+    var raw = window.localStorage.getItem(UI_STATE_STORAGE_KEY);
+    if (!raw) return {};
+    var all = JSON.parse(raw);
+    return (all && typeof all[page] === "object" && all[page]) ? all[page] : {};
+  } catch (_) { return {}; }
+};
+
+var setStoredUIStateField = function (page, field, value) {
+  try {
+    var raw = window.localStorage.getItem(UI_STATE_STORAGE_KEY);
+    var all = {};
+    if (raw) {
+      try { all = JSON.parse(raw) || {}; } catch (_) { all = {}; }
+    }
+    if (!all[page] || typeof all[page] !== "object") all[page] = {};
+    if (value === null || value === undefined) delete all[page][field];
+    else all[page][field] = value;
+    window.localStorage.setItem(UI_STATE_STORAGE_KEY, JSON.stringify(all));
+  } catch (_) {}
+};

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.96"
+VERSIONNUM: str = "0.10.97"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Studio, Screenspace, and Transcripts now persist the active tab and selected participant to `localStorage`, so navigating between pages or reloading lands on the same view.
- Adds two small generic helpers (`getStoredUIState`, `setStoredUIStateField`) in `assets/web/utils.js` that namespace per-page state under a single `clipgen-ui-state` key, matching the existing tooltip/theme helper pattern.
- Restoration is defensive: stored values are validated against the current participant list and tab visibility (e.g. hidden Intake/Convergence tabs) before being applied, falling through to existing defaults otherwise.

## Test plan
- [ ] Studio: switch to Metadata tab, reload — Metadata is still active.
- [ ] Screenspace: pick a non-default participant, switch to Results tab, reload — selection and tab restored; deleting that participant's video falls back gracefully to the first.
- [ ] Transcripts: click a non-auto-selected pill, reload — same pill stays selected.
- [ ] Cross-page: change state on each page, navigate between them — each page key is independent.
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` passes.