### PR TITLE
refactor: collapse parallel data shapes onto canonical records (Python + frontend)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - If a problem is reoccurring and survives fix attempts, check git logs for clues.
 - Never edit .gitignore automatically, always confirm changes to this file with the user.
 - When working through a plan file, e.g. FEATURE-PLAN.md, always make sure to check off items after they are completed.
+- **No backwards-compatibility layers.** Do not add migration shims, schema-version checks for hard-break detection, legacy-format readers, or "warn and ignore" branches for old persisted state (manifests, stashes, sessionStorage queues, settings files, etc.). The user base is small and the work is ephemeral; just change the shape and let users re-run. Tests covering persisted shapes get updated to the new shape, not gated behind a version flag.
 
 ## Learned Workspace Facts
 

--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -1307,8 +1307,8 @@
   function buildQueueItem(event) {
     var item = {
       participant: event.participant,
-      segStart: event.start,
-      segDuration: event.end - event.start,
+      start: event.start,
+      end: event.end,
     };
     if (event.source === "screenspace") {
       item.desc = event.eventType;
@@ -1342,10 +1342,6 @@
       item.timestamp = cellValue;
       item.segIdx = segIdx;
       item.segTotal = segs.length;
-      // Use baseline-adjusted times for thumbnails; row+timestamp
-      // fields are preserved for server-side generation
-      item.segStart = event.start;
-      item.segDuration = event.end - event.start;
     }
     return item;
   }

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -170,16 +170,6 @@
 
   // ---- Sorting ----
 
-  function artifactDurationSec(a) {
-    var s = Number(a.start);
-    var e = Number(a.end);
-    if (isNaN(s)) s = 0;
-    if (isNaN(e)) e = isNaN(s) ? 0 : s;
-    var d = e - s;
-    if (isNaN(d) || d < 0) return 0;
-    return d;
-  }
-
   function orderedArtifactsForList() {
     if (!state.listSort) return state.filteredArtifacts;
     var key = state.listSort.key;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -125,8 +125,8 @@
         desc: info.desc,
         timestamp: info.timestamp,
         segIdx: i,
-        segStart: segments[i].startSeconds,
-        segDuration: segments[i].duration,
+        start: segments[i].startSeconds,
+        end: segments[i].startSeconds + segments[i].duration,
         segTotal: segments.length,
       });
     }
@@ -178,7 +178,8 @@
   function findOverlappingData(participant, start, end) {
     var result = { transcriptSnippets: [], screenspaceEvents: [], sheetObservations: [] };
 
-    // Transcript marks/clusters
+    // Transcript marks/clusters — keep a small projection because `text` has
+    // fallback logic (text || label) that consumers expect already resolved.
     for (var i = 0; i < state.trIntakeClusters.length; i++) {
       var tc = state.trIntakeClusters[i];
       if (tc.participant === participant && tc.start < end && tc.end > start) {
@@ -186,15 +187,16 @@
       }
     }
 
-    // Screenspace event clusters
+    // Screenspace event clusters — pass through the original object; consumers
+    // only read detector / event_type and the extra fields are harmless.
     for (var j = 0; j < state.intakeClusters.length; j++) {
       var sc = state.intakeClusters[j];
       if (sc.participant === participant && sc.start < end && sc.end > start) {
-        result.screenspaceEvents.push({ detector: sc.detector, event_type: sc.event_type, start: sc.start, end: sc.end });
+        result.screenspaceEvents.push(sc);
       }
     }
 
-    // Sheet observations
+    // Sheet observations — pass through the row directly.
     if (state.sheetData && state.sheetData.rows) {
       for (var k = 0; k < state.sheetData.rows.length; k++) {
         var row = state.sheetData.rows[k];
@@ -204,7 +206,7 @@
         for (var s = 0; s < segs.length; s++) {
           var segEnd = segs[s].startSeconds + segs[s].duration;
           if (segs[s].startSeconds < end && segEnd > start) {
-            result.sheetObservations.push({ observation: row.observation, category: row.category, severity: row.severity });
+            result.sheetObservations.push(row);
             break;
           }
         }
@@ -627,8 +629,8 @@
       var raw = sessionStorage.getItem(QUEUE_STORAGE_KEY);
       if (!raw) return;
       var saved = JSON.parse(raw);
-      if (saved.artifactQueue) state.artifactQueue = saved.artifactQueue;
-      if (saved.reelQueue) state.reelQueue = saved.reelQueue;
+      if (saved.artifactQueue) state.artifactQueue = saved.artifactQueue.map(migrateStashItem);
+      if (saved.reelQueue) state.reelQueue = saved.reelQueue.map(migrateStashItem);
     } catch (e) { /* ignore parse errors */ }
   }
 
@@ -1655,8 +1657,8 @@
           desc: reelItem.desc,
           timestamp: reelItem.timestamp,
           segIdx: reelItem.segIdx,
-          segStart: reelItem.segStart,
-          segDuration: reelItem.segDuration,
+          start: reelItem.start,
+          end: reelItem.end,
           segTotal: reelItem.segTotal,
           source: "reel",
         };
@@ -1716,15 +1718,6 @@
     for (var i = 0; i < n; i++) {
       var item = state.artifactQueue[i];
       var isIntake = isIntakeSource(item.source);
-      var segStart, segDuration;
-      if (item.segStart !== undefined && item.segDuration !== undefined) {
-        segStart = item.segStart;
-        segDuration = item.segDuration;
-      } else {
-        var parsed = parseClipTimestamps(item.timestamp, item.participant)[0];
-        segStart = parsed.startSeconds;
-        segDuration = parsed.duration;
-      }
       var segTotal = item.segTotal || 1;
       var segIdx = item.segIdx || 0;
 
@@ -1739,8 +1732,8 @@
           var data = {
             participant: itm.participant,
             desc: itm.desc,
-            segStart: itm.segStart,
-            segDuration: itm.segDuration,
+            start: itm.start,
+            end: itm.end,
             source: isI ? itm.source : "artifact",
           };
           if (!isI) {
@@ -1765,9 +1758,9 @@
       img.draggable = false;
       thumb.appendChild(img);
       if (isIntake) {
-        ssObserveThumb(card, img, thumb, item.participant, segStart);
+        ssObserveThumb(card, img, thumb, item.participant, item.start);
       } else {
-        img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + segStart;
+        img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + item.start;
         img.loading = "lazy";
         (function (cardEl, thumbEl) {
           img.addEventListener("error", function () {
@@ -1777,7 +1770,7 @@
           });
         })(card, thumb);
       }
-      thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
+      thumb.appendChild(el("span", "queue-card-duration", formatDuration(item.end - item.start)));
       if (isIntake) {
         var ssBadge = el("span", "queue-card-source-badge");
         if (item.source === "transcript") {
@@ -1850,15 +1843,7 @@
     for (var i = 0; i < n; i++) {
       var item = state.reelQueue[i];
       var isIntake = isIntakeSource(item.source);
-      var segStart, segDuration;
-      if (item.segStart !== undefined && item.segDuration !== undefined) {
-        segStart = item.segStart;
-        segDuration = item.segDuration;
-      } else {
-        var parsed = parseClipTimestamps(item.timestamp, item.participant)[0];
-        segStart = parsed.startSeconds;
-        segDuration = parsed.duration;
-      }
+      var segDuration = item.end - item.start;
       var segTotal = item.segTotal || 1;
       var segIdx = item.segIdx || 0;
       totalDur += segDuration;
@@ -1877,9 +1862,9 @@
       img.draggable = false;
       thumb.appendChild(img);
       if (isIntake) {
-        ssObserveThumb(card, img, thumb, item.participant, segStart);
+        ssObserveThumb(card, img, thumb, item.participant, item.start);
       } else {
-        img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + segStart;
+        img.src = "api/thumbnail/" + encodeURIComponent(item.participant) + "/" + item.start;
         img.loading = "lazy";
         (function (cardEl, thumbEl) {
           img.addEventListener("error", function () {
@@ -2023,12 +2008,7 @@
   function computeReelDuration(items) {
     var total = 0;
     for (var i = 0; i < items.length; i++) {
-      var dur = items[i].segDuration;
-      if (dur === undefined || dur === null) {
-        var segs = parseClipTimestamps(items[i].timestamp, items[i].participant);
-        dur = segs.length > 0 ? segs[0].duration : 0;
-      }
-      total += dur || 0;
+      total += Math.max(0, items[i].end - items[i].start);
     }
     return total;
   }
@@ -2055,8 +2035,19 @@
       .catch(function () {});
   }
 
+  // Normalize legacy stash items written before queue items moved to {start, end}.
+  function migrateStashItem(item) {
+    if (item.start === undefined && item.segStart !== undefined) {
+      item.start = item.segStart;
+      item.end = item.segStart + (item.segDuration || 0);
+      delete item.segStart;
+      delete item.segDuration;
+    }
+    return item;
+  }
+
   function recallStash(stash) {
-    state.reelQueue = stash.items.slice();
+    state.reelQueue = stash.items.slice().map(migrateStashItem);
     renderReelQueue();
     updateCellClasses();
   }
@@ -2223,7 +2214,7 @@
   }
 
   function recallArtifactStash(stash) {
-    state.artifactQueue = stash.items.slice();
+    state.artifactQueue = stash.items.slice().map(migrateStashItem);
     renderArtifactQueue();
     updateCellClasses();
   }
@@ -2558,8 +2549,8 @@
       var intakePayload = intakeItems.map(function (itm) {
         return {
           participant: itm.participant,
-          start: itm.segStart,
-          end: itm.segStart + itm.segDuration,
+          start: itm.start,
+          end: itm.end,
           event_type: itm.event_type || itm.desc || "",
           event_ids: itm.event_ids || [],
           source: itm.source || "screenspace",
@@ -2623,19 +2614,10 @@
       var segments = [];
       for (var si = 0; si < state.reelQueue.length; si++) {
         var item = state.reelQueue[si];
-        var segStart, segDuration;
-        if (item.segStart !== undefined && item.segDuration !== undefined) {
-          segStart = item.segStart;
-          segDuration = item.segDuration;
-        } else {
-          var parsed = parseClipTimestamps(item.timestamp, item.participant)[0];
-          segStart = parsed.startSeconds;
-          segDuration = parsed.duration;
-        }
         segments.push({
           participant: item.participant,
-          start: segStart,
-          end: segStart + segDuration,
+          start: item.start,
+          end: item.end,
           source: item.source || "screenspace",
         });
       }
@@ -3603,8 +3585,8 @@
           ev.dataTransfer.setData("application/json", JSON.stringify({
             participant: cluster.participant,
             desc: cluster.event_type,
-            segStart: cluster.start,
-            segDuration: cluster.end - cluster.start,
+            start: cluster.start,
+            end: cluster.end,
             source: "screenspace",
             event_type: cluster.event_type,
             event_ids: cluster.events.map(function (e) { return e.id; }),
@@ -3621,8 +3603,8 @@
   function intakeAddToArtifacts(cluster) {
     state.artifactQueue.push({
       participant: cluster.participant,
-      segStart: cluster.start,
-      segDuration: cluster.end - cluster.start,
+      start: cluster.start,
+      end: cluster.end,
       desc: cluster.event_type,
       source: "screenspace",
       event_type: cluster.event_type,
@@ -3641,8 +3623,8 @@
   function intakeAddToReel(cluster) {
     state.reelQueue.push({
       participant: cluster.participant,
-      segStart: cluster.start,
-      segDuration: cluster.end - cluster.start,
+      start: cluster.start,
+      end: cluster.end,
       desc: cluster.event_type,
       source: "screenspace",
       event_type: cluster.event_type,
@@ -4058,8 +4040,8 @@
           ev.dataTransfer.setData("application/json", JSON.stringify({
             participant: cluster.participant,
             desc: cluster.category || "transcript",
-            segStart: cluster.start,
-            segDuration: cluster.end - cluster.start,
+            start: cluster.start,
+            end: cluster.end,
             source: "transcript",
             mark_ids: cluster.marks.map(function (m) { return m.id; }),
           }));
@@ -4077,8 +4059,8 @@
   function trIntakeAddToArtifacts(cluster) {
     state.artifactQueue.push({
       participant: cluster.participant,
-      segStart: cluster.start,
-      segDuration: cluster.end - cluster.start,
+      start: cluster.start,
+      end: cluster.end,
       desc: cluster.category || "transcript",
       source: "transcript",
       mark_ids: cluster.marks.map(function (m) { return m.id; }),
@@ -4089,8 +4071,8 @@
   function trIntakeAddToReel(cluster) {
     state.reelQueue.push({
       participant: cluster.participant,
-      segStart: cluster.start,
-      segDuration: cluster.end - cluster.start,
+      start: cluster.start,
+      end: cluster.end,
       desc: cluster.category || "transcript",
       source: "transcript",
       mark_ids: cluster.marks.map(function (m) { return m.id; }),

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -629,8 +629,8 @@
       var raw = sessionStorage.getItem(QUEUE_STORAGE_KEY);
       if (!raw) return;
       var saved = JSON.parse(raw);
-      if (saved.artifactQueue) state.artifactQueue = saved.artifactQueue.map(migrateStashItem);
-      if (saved.reelQueue) state.reelQueue = saved.reelQueue.map(migrateStashItem);
+      if (saved.artifactQueue) state.artifactQueue = saved.artifactQueue;
+      if (saved.reelQueue) state.reelQueue = saved.reelQueue;
     } catch (e) { /* ignore parse errors */ }
   }
 
@@ -2035,19 +2035,8 @@
       .catch(function () {});
   }
 
-  // Normalize legacy stash items written before queue items moved to {start, end}.
-  function migrateStashItem(item) {
-    if (item.start === undefined && item.segStart !== undefined) {
-      item.start = item.segStart;
-      item.end = item.segStart + (item.segDuration || 0);
-      delete item.segStart;
-      delete item.segDuration;
-    }
-    return item;
-  }
-
   function recallStash(stash) {
-    state.reelQueue = stash.items.slice().map(migrateStashItem);
+    state.reelQueue = stash.items.slice();
     renderReelQueue();
     updateCellClasses();
   }
@@ -2214,7 +2203,7 @@
   }
 
   function recallArtifactStash(stash) {
-    state.artifactQueue = stash.items.slice().map(migrateStashItem);
+    state.artifactQueue = stash.items.slice();
     renderArtifactQueue();
     updateCellClasses();
   }

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -144,6 +144,16 @@ var formatTime = function (sec) {
   return m + ":" + pad2(s);
 };
 
+var artifactDurationSec = function (a) {
+  var s = Number(a.start);
+  var e = Number(a.end);
+  if (isNaN(s)) s = 0;
+  if (isNaN(e)) e = isNaN(s) ? 0 : s;
+  var d = e - s;
+  if (isNaN(d) || d < 0) return 0;
+  return d;
+};
+
 var truncate = function (str, max) {
   if (!str) return "";
   return str.length > max ? str.slice(0, max) + "\u2026" : str;

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1085,16 +1085,6 @@
 
   // ---- List rendering ----
 
-  function artifactDurationSec(a) {
-    var s = Number(a.start);
-    var e = Number(a.end);
-    if (isNaN(s)) s = 0;
-    if (isNaN(e)) e = isNaN(s) ? 0 : s;
-    var d = e - s;
-    if (isNaN(d) || d < 0) return 0;
-    return d;
-  }
-
   function orderedArtifactsForList() {
     if (!state.listSort) return state.artifacts;
     var key = state.listSort.key;

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.98"
+VERSIONNUM: str = "0.10.99"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.97"
+VERSIONNUM: str = "0.10.98"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )
@@ -123,6 +123,7 @@ CLIP_PARALLEL_WORKERS: int = 0  # Max concurrent ffmpeg processes for clip/scree
 MAX_FILESIZE_MB: int = 0  # Maximum output file size in MB (0 = disabled)
 MIN_SOURCE_VIDEO_SIZE_MB: int = 100  # Minimum file size (MB) to consider as a source video candidate during fuzzy matching
 MANIFEST_FILENAME: str = "clipgen_manifest.json"  # cumulative artifact manifest; consumed by Insights and --regenerate
+MANIFEST_SCHEMA: int = 2  # bumped when artifact/reel record shape changes; legacy manifests are ignored on load
 MANIFEST_ENABLED: bool = (
     False  # use --manifest CLI flag or set True to write manifest alongside artifacts
 )

--- a/config.py
+++ b/config.py
@@ -123,7 +123,6 @@ CLIP_PARALLEL_WORKERS: int = 0  # Max concurrent ffmpeg processes for clip/scree
 MAX_FILESIZE_MB: int = 0  # Maximum output file size in MB (0 = disabled)
 MIN_SOURCE_VIDEO_SIZE_MB: int = 100  # Minimum file size (MB) to consider as a source video candidate during fuzzy matching
 MANIFEST_FILENAME: str = "clipgen_manifest.json"  # cumulative artifact manifest; consumed by Insights and --regenerate
-MANIFEST_SCHEMA: int = 2  # bumped when artifact/reel record shape changes; legacy manifests are ignored on load
 MANIFEST_ENABLED: bool = (
     False  # use --manifest CLI flag or set True to write manifest alongside artifacts
 )

--- a/pipeline.py
+++ b/pipeline.py
@@ -168,7 +168,7 @@ def _process_single_clip_segments(
     output_format: str = "clip",
     collect_paths: bool = False,
     include_severity: bool = False,
-) -> tuple[int, list[tuple[str, str, str]]]:
+) -> tuple[int, list[tuple[str, int]]]:
     """Process one clip's segments: run ffmpeg for each (start, end), optionally collect output paths.
 
     Caller must have already called prepare_clip(clip). Does not add to missing_videos; caller handles that.
@@ -178,14 +178,16 @@ def _process_single_clip_segments(
         base_video: Path to source video file
         missing_videos: Set of already-reported missing paths (read-only here)
         filename_prefix: Prefix for output filename (e.g. '_reel_part_' for reel)
-        collect_paths: If True, return list of output paths; otherwise return empty list
+        collect_paths: If True, return list of (output_path, time_index) pairs; otherwise return empty list
         include_severity: If True and clip has severity, include [Severity] in filename
 
     Returns:
-        (number of segments successfully generated, list of output paths if collect_paths else [])
+        (number of segments successfully generated, list of (out_path, time_index) pairs
+        if collect_paths else []). The ``time_index`` indexes into ``clip['times']``;
+        downstream callers look up start/end strings there rather than carrying duplicates.
     """
     generated = 0
-    output_paths: list[tuple[str, str, str]] = []
+    output_paths: list[tuple[str, int]] = []
     extension_map = {
         "clip": config.FILEFORMAT,
         "screen": config.SCREENSHOT_FORMAT,
@@ -209,7 +211,7 @@ def _process_single_clip_segments(
         if props:
             source_resolution = f"{props['width']}x{props['height']}"
 
-    for start_time, end_time in clip["times"]:
+    for time_idx, (start_time, end_time) in enumerate(clip["times"]):
         try:
             out_name = files.get_unique_filename(template, file_format=file_extension)
             if config.DEBUGGING:
@@ -253,7 +255,7 @@ def _process_single_clip_segments(
         if ok:
             generated += 1
             if collect_paths:
-                output_paths.append((out_name, start_time, end_time))
+                output_paths.append((out_name, time_idx))
     return (generated, output_paths)
 
 
@@ -393,13 +395,14 @@ def _embed_transcript_on_artifacts(
     clip: Any,
     base_video: str,
     artifacts: list[dict[str, Any]],
-    segment_details: list[tuple[str, str, str]],
+    segment_details: list[tuple[str, int]],
     transcript_cache: dict[str, Any],
     transcripts_manifest: dict[str, Any] | None = None,
 ) -> None:
     """Embed transcript segments on clip artifact records.
 
     Source priority: transcripts manifest -> in-memory cache. Modifies artifacts in-place.
+    ``segment_details`` is a list of (out_path, time_index) pairs aligned to ``artifacts``.
     """
 
     participant = clip.get("participant", "")
@@ -426,9 +429,11 @@ def _embed_transcript_on_artifacts(
     if not full_transcript:
         return
 
-    for art_idx, (_out_path, start_str, end_str) in enumerate(segment_details):
+    times = clip.get("times", [])
+    for art_idx, (_out_path, time_idx) in enumerate(segment_details):
         if art_idx >= len(artifacts):
             break
+        start_str, end_str = times[time_idx]
         start_sec = utils.timestamp_to_seconds(start_str) or 0.0
         end_sec = utils.timestamp_to_seconds(end_str) or 0.0
         clipped = transcripts.filter_segments(
@@ -453,12 +458,16 @@ def _embed_transcript_on_artifacts(
 def _transcribe_segments(
     clip: Any,
     base_video: str,
-    segment_details: list[tuple[str, str, str]],
+    segment_details: list[tuple[str, int]],
     all_artifacts: list[dict[str, Any]],
     transcript_cache: dict[str, Any],
     transcripts_manifest: dict[str, Any] | None = None,
 ) -> None:
-    """Transcribe segments of a clip and write transcript files."""
+    """Transcribe segments of a clip and write transcript files.
+
+    ``segment_details`` is a list of (out_path, time_index) pairs;
+    start/end strings are looked up via ``clip['times'][time_index]``.
+    """
     if base_video not in transcript_cache:
         participant = clip.get("participant", "")
         manifest = transcripts_manifest or transcripts.load_transcripts_manifest()
@@ -487,13 +496,10 @@ def _transcribe_segments(
         return
 
     ext = transcripts.get_transcript_extension()
-    cell = clip.get("cell")
-    cell_row = getattr(cell, "row", None)
-    cell_col = getattr(cell, "col", None)
-    cell_a1 = utils.safe_cell_a1(cell_row, cell_col)
-    annotations = list(clip.get("cell_annotations", []))
+    times = clip.get("times", [])
 
-    for seg_idx, (out_path, start_str, end_str) in enumerate(segment_details):
+    for seg_idx, (out_path, time_idx) in enumerate(segment_details):
+        start_str, end_str = times[time_idx]
         start_sec = utils.timestamp_to_seconds(start_str) or 0.0
         end_sec = utils.timestamp_to_seconds(end_str) or 0.0
         clipped = transcripts.filter_segments(
@@ -501,27 +507,18 @@ def _transcribe_segments(
         )
         t_path = files.get_unique_filename(Path(out_path).stem + ext, file_format=ext)
         if transcripts.write_transcript(clipped, t_path):
-            all_artifacts.append(
-                {
-                    "id": f"a{cell_row}c{cell_col}s{seg_idx}_transcript",
-                    "type": "transcript",
-                    "file": Path(t_path).name,
-                    "start": start_sec,
-                    "end": end_sec,
-                    "thumbnail": "",
-                    "study": clip.get("study", ""),
-                    "participant": clip.get("participant", ""),
-                    "category": clip.get("category", ""),
-                    "severity": clip.get("severity", ""),
-                    "description": clip.get("desc", ""),
-                    "cellRow": cell_row,
-                    "cellCol": cell_col,
-                    "cellA1": cell_a1,
-                    "annotations": annotations,
-                    "sourceVideo": base_video,
-                    "transcriptFormat": config.TRANSCRIBE_FORMAT,
-                }
+            artifact = utils.build_artifact_record(
+                clip,
+                base_video,
+                t_path,
+                start_str,
+                end_str,
+                artifact_type="transcript",
+                seg_idx=seg_idx,
             )
+            artifact["id"] += "_transcript"
+            artifact["transcriptFormat"] = config.TRANSCRIBE_FORMAT
+            all_artifacts.append(artifact)
 
 
 def process_clips(
@@ -605,11 +602,9 @@ def process_clips(
     # -- Phase 2: Execute ffmpeg work ------------------------------------------
     workers = _resolve_clip_workers()
     use_parallel = workers >= 2 and len(prepared) >= 2
-    _EMPTY_RESULT: tuple[int, list[tuple[str, str, str]]] = (0, [])
+    _EMPTY_RESULT: tuple[int, list[tuple[str, int]]] = (0, [])
     # Pre-allocate results in original order for deterministic artifact output
-    results: list[tuple[int, list[tuple[str, str, str]]]] = [_EMPTY_RESULT] * len(
-        prepared
-    )
+    results: list[tuple[int, list[tuple[str, int]]]] = [_EMPTY_RESULT] * len(prepared)
 
     if use_parallel:
         progress = utils.create_progress_bar()
@@ -898,7 +893,7 @@ def process_reel(
 
     def process_reel_clip(
         clip: Any, missing_videos: set[str]
-    ) -> tuple[list[tuple[str, str, str]], list[dict[str, Any]]]:
+    ) -> tuple[list[tuple[str, int]], list[dict[str, Any]]]:
         """Process one clip for reel mode and return (segment_paths, component_dicts)."""
         clip, base_video = _prepare_and_check_clip(clip, missing_videos, fuzzy_matches)
         if base_video is None:
@@ -910,21 +905,11 @@ def process_reel(
             filename_prefix="_reel_part_",
             collect_paths=True,
         )
-        clip_components = []
-        for _out_path, start_str, end_str in segment_paths:
-            clip_components.append(
-                {
-                    "cellRow": getattr(clip.get("cell"), "row", None),
-                    "cellCol": getattr(clip.get("cell"), "col", None),
-                    "participant": clip.get("participant", ""),
-                    "sourceVideo": base_video,
-                    "start": utils.timestamp_to_seconds(start_str),
-                    "end": utils.timestamp_to_seconds(end_str),
-                    "category": clip.get("category", ""),
-                    "description": clip.get("desc", ""),
-                    "severity": clip.get("severity", ""),
-                }
-            )
+        times = clip.get("times", [])
+        clip_components = [
+            utils.build_reel_component(clip, base_video, *times[time_idx])
+            for _out_path, time_idx in segment_paths
+        ]
         return (segment_paths, clip_components)
 
     all_results, _ = _run_clip_pipeline(

--- a/server.py
+++ b/server.py
@@ -785,19 +785,15 @@ def api_reel() -> FlaskResponse:
                     {"ok": False, "error": "No clips found for the specified cells"}
                 ), 400
 
-            # Check if an identical reel already exists
+            # Check if an identical reel already exists. compute_reel_id only
+            # hashes cellRow/cellCol/start/end, so the components built here
+            # don't need an accurate sourceVideo — they are throwaway.
             components: list[dict[str, Any]] = []
             for clip in clips:
                 files.prepare_clip(clip)
-                cell = clip.get("cell")
                 for start_str, end_str in clip.get("times", []):
                     components.append(
-                        {
-                            "cellRow": getattr(cell, "row", None),
-                            "cellCol": getattr(cell, "col", None),
-                            "start": utils.timestamp_to_seconds(start_str),
-                            "end": utils.timestamp_to_seconds(end_str),
-                        }
+                        utils.build_reel_component(clip, "", start_str, end_str)
                     )
             if components:
                 expected_id = pipeline.compute_reel_id(components)

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -96,9 +96,10 @@ def test_build_artifact_records_for_clip_and_finalize_timeline_data(
         "category": "CatA",
         "desc": "Obs one",
         "cell_annotations": ["key"],
+        "times": [("00:10", "00:20")],
     }
     base_video = "study_P01.mp4"
-    segment_details = [("out_1.mp4", "00:10", "00:20")]
+    segment_details = [("out_1.mp4", 0)]
 
     artifacts = viewer.build_artifact_records_for_clip(
         clip,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -190,7 +190,6 @@ def test_load_manifest_filters_malformed_entries(tmp_path, monkeypatch):
     good = _make_artifact("a4c2s0")
     bad = {"id": "a1", "type": "clip"}  # missing file, start, end
     raw_data = {
-        "schema": config.MANIFEST_SCHEMA,
         "meta": {},
         "artifacts": [bad, good],
         "timeline": {"duration": 0, "startOffset": 0},
@@ -206,7 +205,6 @@ def test_save_manifest_does_not_preserve_preexisting_malformed(tmp_path, monkeyp
     # Seed manifest with a malformed artifact
     bad = {"id": "ghost", "type": "clip"}
     raw_data = {
-        "schema": config.MANIFEST_SCHEMA,
         "meta": {},
         "artifacts": [bad],
         "timeline": {"duration": 0, "startOffset": 0},

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -190,6 +190,7 @@ def test_load_manifest_filters_malformed_entries(tmp_path, monkeypatch):
     good = _make_artifact("a4c2s0")
     bad = {"id": "a1", "type": "clip"}  # missing file, start, end
     raw_data = {
+        "schema": config.MANIFEST_SCHEMA,
         "meta": {},
         "artifacts": [bad, good],
         "timeline": {"duration": 0, "startOffset": 0},
@@ -205,6 +206,7 @@ def test_save_manifest_does_not_preserve_preexisting_malformed(tmp_path, monkeyp
     # Seed manifest with a malformed artifact
     bad = {"id": "ghost", "type": "clip"}
     raw_data = {
+        "schema": config.MANIFEST_SCHEMA,
         "meta": {},
         "artifacts": [bad],
         "timeline": {"duration": 0, "startOffset": 0},

--- a/utils.py
+++ b/utils.py
@@ -756,6 +756,79 @@ def safe_cell_a1(row: int | None, col: int | None) -> str:
         return ""
 
 
+def _clip_metadata_fields(
+    clip: "ClipRecord", base_video: str, start_str: str, end_str: str
+) -> dict[str, Any]:
+    """Extract the shared per-segment metadata that every persisted record needs.
+
+    Used by both ``build_artifact_record`` (manifest artifacts) and
+    ``build_reel_component`` (reel-component records). The two shapes only differ
+    by file-specific fields (id/file/type/thumbnail), so the body of every
+    persisted record flows from one place.
+    """
+    cell = clip.get("cell")
+    cell_row = getattr(cell, "row", None)
+    cell_col = getattr(cell, "col", None)
+    return {
+        "start": timestamp_to_seconds(start_str),
+        "end": timestamp_to_seconds(end_str),
+        "study": clip.get("study", ""),
+        "participant": clip.get("participant", ""),
+        "category": clip.get("category", ""),
+        "severity": clip.get("severity", ""),
+        "description": clip.get("desc", ""),
+        "cellRow": cell_row,
+        "cellCol": cell_col,
+        "cellA1": safe_cell_a1(cell_row, cell_col),
+        "annotations": list(clip.get("cell_annotations", [])),
+        "sourceVideo": base_video,
+    }
+
+
+def build_artifact_record(
+    clip: "ClipRecord",
+    base_video: str,
+    out_path: str,
+    start_str: str,
+    end_str: str,
+    *,
+    artifact_type: str,
+    seg_idx: int,
+) -> dict[str, Any]:
+    """Build one artifact dict from a clip record + one segment.
+
+    Single source of truth for the artifact record shape used by clipgen_manifest
+    and the timeline viewer. Callers may add or override fields after the call
+    (e.g. transcripts append ``transcriptFormat``).
+    """
+    cell = clip.get("cell")
+    cell_row = getattr(cell, "row", None)
+    cell_col = getattr(cell, "col", None)
+    return {
+        "id": f"a{cell_row or 0}c{cell_col or 0}s{seg_idx}",
+        "type": artifact_type,
+        "file": Path(out_path).name,
+        "thumbnail": "",
+        **_clip_metadata_fields(clip, base_video, start_str, end_str),
+    }
+
+
+def build_reel_component(
+    clip: "ClipRecord",
+    base_video: str,
+    start_str: str,
+    end_str: str,
+) -> dict[str, Any]:
+    """Build one reel-component dict from a clip record + one segment.
+
+    Reel components describe an input segment used to assemble a reel — they
+    share the artifact record's per-segment metadata shape but omit the
+    file/id/type fields (the rendered output is the reel itself, not the
+    component). Stored in the ``components`` list of a reel manifest entry.
+    """
+    return _clip_metadata_fields(clip, base_video, start_str, end_str)
+
+
 # ---- Timestamp parsing pipeline ----
 #
 # Reading order: token splitting/cleaning → add_duration → _parse_single_timestamp_token

--- a/viewer.py
+++ b/viewer.py
@@ -489,20 +489,6 @@ def _load_manifest_both() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
             _manifest_cache["reels"] = []
         return ([], [])
 
-    schema = data.get("schema")
-    if schema != config.MANIFEST_SCHEMA:
-        utils.warning_print(
-            f"Manifest schema {schema} does not match expected "
-            f"{config.MANIFEST_SCHEMA}; ignoring legacy entries.",
-            ["Re-run clipgen to regenerate the manifest in the current schema."],
-        )
-        with _MANIFEST_CACHE_LOCK:
-            _manifest_cache["path"] = path_str
-            _manifest_cache["mtime_ns"] = mtime_ns
-            _manifest_cache["artifacts"] = []
-            _manifest_cache["reels"] = []
-        return ([], [])
-
     raw = data.get("artifacts", [])
     valid = [a for a in raw if _is_valid_artifact(a)]
     if len(valid) < len(raw):
@@ -570,7 +556,6 @@ def save_manifest(
         mode=mode,
         output_format=output_format,
     )
-    data["schema"] = config.MANIFEST_SCHEMA
 
     result = utils.save_json_manifest(
         config.MANIFEST_FILENAME, data, warn_label="manifest"

--- a/viewer.py
+++ b/viewer.py
@@ -59,7 +59,7 @@ def _is_valid_artifact(a: dict[str, Any]) -> bool:
 def build_artifact_records_for_clip(
     clip: utils.ClipRecord,
     base_video: str,
-    segment_details: list,
+    segment_details: list[tuple[str, int]],
     output_format: str,
 ) -> list[dict[str, Any]]:
     """Build artifact metadata records from a processed clip's successful outputs.
@@ -67,49 +67,29 @@ def build_artifact_records_for_clip(
     Args:
         clip: Prepared clip dict with 'times', 'category', 'study', etc.
         base_video: Source video filename
-        segment_details: List of (output_path, start_time_str, end_time_str) tuples
+        segment_details: List of (output_path, time_index) pairs.
+            ``time_index`` is the index into ``clip['times']`` for this segment.
         output_format: 'clip', 'screen', or 'gif'
 
     Returns:
         List of artifact dicts ready for JSON serialization
     """
-    artifacts: list[dict[str, Any]] = []
     artifact_type = (
         output_format if output_format in ("clip", "screen", "gif") else "clip"
     )
-
-    cell = clip.get("cell")
-    cell_row = getattr(cell, "row", None)
-    cell_col = getattr(cell, "col", None)
-    cell_a1 = utils.safe_cell_a1(cell_row, cell_col)
-
-    annotations = list(clip.get("cell_annotations", []))
-
-    for seg_idx, (out_path, start_str, end_str) in enumerate(segment_details):
-        start_sec = utils.timestamp_to_seconds(start_str)
-        end_sec = utils.timestamp_to_seconds(end_str)
-
-        artifacts.append(
-            {
-                "id": f"a{cell_row or 0}c{cell_col or 0}s{seg_idx}",
-                "type": artifact_type,
-                "file": Path(out_path).name,
-                "start": start_sec,
-                "end": end_sec,
-                "thumbnail": "",
-                "study": clip.get("study", ""),
-                "participant": clip.get("participant", ""),
-                "category": clip.get("category", ""),
-                "severity": clip.get("severity", ""),
-                "description": clip.get("desc", ""),
-                "cellRow": cell_row,
-                "cellCol": cell_col,
-                "cellA1": cell_a1,
-                "annotations": annotations,
-                "sourceVideo": base_video,
-            }
+    times = clip.get("times", [])
+    return [
+        utils.build_artifact_record(
+            clip,
+            base_video,
+            out_path,
+            times[time_idx][0],
+            times[time_idx][1],
+            artifact_type=artifact_type,
+            seg_idx=seg_idx,
         )
-    return artifacts
+        for seg_idx, (out_path, time_idx) in enumerate(segment_details)
+    ]
 
 
 def finalize_timeline_data(
@@ -509,6 +489,20 @@ def _load_manifest_both() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
             _manifest_cache["reels"] = []
         return ([], [])
 
+    schema = data.get("schema")
+    if schema != config.MANIFEST_SCHEMA:
+        utils.warning_print(
+            f"Manifest schema {schema} does not match expected "
+            f"{config.MANIFEST_SCHEMA}; ignoring legacy entries.",
+            ["Re-run clipgen to regenerate the manifest in the current schema."],
+        )
+        with _MANIFEST_CACHE_LOCK:
+            _manifest_cache["path"] = path_str
+            _manifest_cache["mtime_ns"] = mtime_ns
+            _manifest_cache["artifacts"] = []
+            _manifest_cache["reels"] = []
+        return ([], [])
+
     raw = data.get("artifacts", [])
     valid = [a for a in raw if _is_valid_artifact(a)]
     if len(valid) < len(raw):
@@ -576,6 +570,7 @@ def save_manifest(
         mode=mode,
         output_format=output_format,
     )
+    data["schema"] = config.MANIFEST_SCHEMA
 
     result = utils.save_json_manifest(
         config.MANIFEST_FILENAME, data, warn_label="manifest"


### PR DESCRIPTION
## Summary

Removes unnecessary data reframing on both sides of the wire — places where a broad/rich shape was unpacked into narrower variables and rebuilt elsewhere with different field names, duplicating the same logical data in multiple shapes.

**Python:** introduces \`utils.build_artifact_record\` / \`utils.build_reel_component\` so the artifact-dict shape has one source of truth (was rebuilt field-by-field in three places); drops the \`(out_path, start, end)\` tuple from \`_process_single_clip_segments\` in favor of \`(out_path, time_index)\` since timestamps already live on \`clip['times']\`; collapses reel components onto the artifact shape via a shared \`_clip_metadata_fields\` helper.

**Frontend:** moves \`artifactDurationSec\` from duplicate definitions in viewer.js / insights-builder.js into utils.js; collapses studio queue items from \`{segStart, segDuration}\` onto \`{start, end}\` (matching intake clusters and server payloads — three defensive fallbacks deleted as dead code); drops two strict-subset projections in \`findOverlappingData\`. Also adds an AGENTS.md preference: no backwards-compatibility shims for this small, ephemeral user base.

## Test plan

- [x] \`uv run --extra dev pytest -c tests/pytest.ini\` — all tests pass
- [x] \`uv run ruff check && uv run ruff format --check\` — clean
- [x] \`uv run ty check\` — clean
- [x] Manual: clip generation, reel ordering, and card dragging in studio confirmed working