### PR TITLE
refactor: drop backwards-compat shims and overly-defensive guards

### DIFF
--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -26,10 +26,11 @@
   // ---- Helpers ----
 
   function countBucketArtifacts(insight) {
-    var c = (insight.causes || {}).artifacts || [];
-    var b = (insight.behaviors || {}).artifacts || [];
-    var i = (insight.impacts || {}).artifacts || [];
-    return c.length + b.length + i.length;
+    return (
+      insight.causes.artifacts.length +
+      insight.behaviors.artifacts.length +
+      insight.impacts.artifacts.length
+    );
   }
 
   function findArtifact(id) {
@@ -993,7 +994,7 @@
       el("div", "bucket-label bucket-label-" + bucketName, bucketName)
     );
 
-    var bucket = insight[bucketName] || { narrative: "", artifacts: [] };
+    var bucket = insight[bucketName];
 
     // Narrative
     var narrative = document.createElement("textarea");
@@ -1004,10 +1005,9 @@
       impacts: "What were the consequences?",
     };
     narrative.placeholder = placeholders[bucketName] || "";
-    narrative.value = bucket.narrative || "";
+    narrative.value = bucket.narrative;
     narrative.addEventListener("input", function () {
       bucket.narrative = this.value;
-      if (!insight[bucketName]) insight[bucketName] = bucket;
       markDirty(insight.id);
     });
     section.appendChild(narrative);

--- a/assets/web/insights-viewer.js
+++ b/assets/web/insights-viewer.js
@@ -9,10 +9,11 @@
   // ---- Helpers ----
 
   function countArtifacts(insight) {
-    var c = (insight.causes || {}).artifacts || [];
-    var b = (insight.behaviors || {}).artifacts || [];
-    var i = (insight.impacts || {}).artifacts || [];
-    return c.length + b.length + i.length;
+    return (
+      insight.causes.artifacts.length +
+      insight.behaviors.artifacts.length +
+      insight.impacts.artifacts.length
+    );
   }
 
   // ---- Render index ----
@@ -114,10 +115,7 @@
     ];
     for (var i = 0; i < buckets.length; i++) {
       var bucket = insight[buckets[i].key];
-      if (!bucket) continue;
-      var hasContent =
-        (bucket.narrative && bucket.narrative.trim()) ||
-        (bucket.artifacts && bucket.artifacts.length > 0);
+      var hasContent = bucket.narrative.trim() || bucket.artifacts.length > 0;
       if (!hasContent) continue;
 
       var section = el("div", "detail-bucket");
@@ -129,11 +127,11 @@
         )
       );
 
-      if (bucket.narrative && bucket.narrative.trim()) {
+      if (bucket.narrative.trim()) {
         section.appendChild(el("div", "detail-narrative", bucket.narrative));
       }
 
-      if (bucket.artifacts && bucket.artifacts.length > 0) {
+      if (bucket.artifacts.length > 0) {
         var grid = el("div", "detail-artifacts-grid");
         for (var j = 0; j < bucket.artifacts.length; j++) {
           var art = artifactMap[bucket.artifacts[j]];

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.99"
+VERSIONNUM: str = "0.10.100"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/insights.py
+++ b/insights.py
@@ -40,19 +40,10 @@ def load_insights_manifest() -> dict[str, Any]:
     """Load the insights manifest from the output directory.
 
     Returns a dict with 'meta' and 'insights' keys.
-    Handles missing 'summary' field on legacy insights (defaults to "").
     """
-    data = utils.load_json_manifest(config.INSIGHTS_MANIFEST_FILENAME)
-    if not isinstance(data, dict):
-        return _empty_manifest()
-
-    for insight in data.get("insights", []):
-        insight.setdefault("summary", "")
-
-    return {
-        "meta": data.get("meta", {}),
-        "insights": data.get("insights", []),
-    }
+    return utils.load_json_manifest(
+        config.INSIGHTS_MANIFEST_FILENAME, default=_empty_manifest()
+    )
 
 
 def save_insights_manifest(

--- a/screenspace.py
+++ b/screenspace.py
@@ -3074,19 +3074,10 @@ def _empty_screenspace_manifest() -> dict[str, Any]:
 
 
 def load_screenspace_manifest() -> dict[str, Any]:
-    """Load the screenspace manifest from the output directory.
-
-    Returns a dict with ``regions`` and ``tasks`` keys.
-    """
-    data = utils.load_json_manifest(config.SCREENSPACE_MANIFEST_FILENAME)
-    if not isinstance(data, dict):
-        return _empty_screenspace_manifest()
-    return {
-        "regions": data.get("regions", {}),
-        "tasks": data.get("tasks", []),
-        "events": data.get("events", []),
-        "stashes": data.get("stashes", []),
-    }
+    """Load the screenspace manifest from the output directory."""
+    return utils.load_json_manifest(
+        config.SCREENSPACE_MANIFEST_FILENAME, default=_empty_screenspace_manifest()
+    )
 
 
 def save_screenspace_manifest(

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -479,12 +479,7 @@ def _normalize_region(
 def _denormalize_region(
     region: dict[str, Any], target_w: int, target_h: int
 ) -> dict[str, int]:
-    """Convert normalized region to pixel coordinates for a target resolution.
-
-    Legacy regions (without ``source_width``) pass through unchanged.
-    """
-    if "source_width" not in region:
-        return {"x": region["x"], "y": region["y"], "w": region["w"], "h": region["h"]}
+    """Convert normalized region to pixel coordinates for a target resolution."""
     return {
         "x": int(round(region["x"] * target_w)),
         "y": int(round(region["y"] * target_h)),
@@ -520,23 +515,25 @@ def api_regions_create() -> FlaskResponse:
 
     canvas_w = data.get("canvas_width")
     canvas_h = data.get("canvas_height")
-    region: dict[str, Any]
     if (
-        isinstance(canvas_w, (int, float))
-        and isinstance(canvas_h, (int, float))
-        and canvas_w > 0
-        and canvas_h > 0
+        not isinstance(canvas_w, (int, float))
+        or not isinstance(canvas_h, (int, float))
+        or canvas_w <= 0
+        or canvas_h <= 0
     ):
-        region = _normalize_region(
-            data["x"], data["y"], data["w"], data["h"], int(canvas_w), int(canvas_h)
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "'canvas_width' and 'canvas_height' must be positive numbers",
+                }
+            ),
+            400,
         )
-    else:
-        region = {
-            "x": int(data["x"]),
-            "y": int(data["y"]),
-            "w": int(data["w"]),
-            "h": int(data["h"]),
-        }
+
+    region = _normalize_region(
+        data["x"], data["y"], data["w"], data["h"], int(canvas_w), int(canvas_h)
+    )
     if "description" in data:
         region["description"] = str(data["description"])
 

--- a/server.py
+++ b/server.py
@@ -440,10 +440,7 @@ def _generate_intake_clips(
 
 
 def _load_stashes() -> list[dict[str, Any]]:
-    data = utils.load_json_manifest(config.STASHES_MANIFEST_FILENAME, default=[])
-    if not isinstance(data, list):
-        return []
-    return data
+    return utils.load_json_manifest(config.STASHES_MANIFEST_FILENAME, default=[])
 
 
 def _save_stashes(stashes: list[dict[str, Any]]) -> Path | None:
@@ -451,12 +448,9 @@ def _save_stashes(stashes: list[dict[str, Any]]) -> Path | None:
 
 
 def _load_artifact_stashes() -> list[dict[str, Any]]:
-    data = utils.load_json_manifest(
+    return utils.load_json_manifest(
         config.ARTIFACT_STASHES_MANIFEST_FILENAME, default=[]
     )
-    if not isinstance(data, list):
-        return []
-    return data
 
 
 def _save_artifact_stashes(stashes: list[dict[str, Any]]) -> Path | None:
@@ -466,8 +460,6 @@ def _save_artifact_stashes(stashes: list[dict[str, Any]]) -> Path | None:
 def _load_studio_settings() -> dict[str, Any]:
     """Load studio_settings.json and apply non-default values to config module."""
     data = utils.load_json_manifest(config.STUDIO_SETTINGS_FILENAME, default={})
-    if not isinstance(data, dict):
-        return {}
 
     applied: dict[str, Any] = {}
     for name, value in data.items():

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,4 +1,3 @@
-import json
 import time
 
 import config
@@ -118,12 +117,3 @@ def test_load_handles_missing_and_malformed(tmp_path, monkeypatch):
     manifest_path.write_text("not json at all")
     result = insights.load_insights_manifest()
     assert result == {"meta": {}, "insights": []}
-
-    # Legacy insight missing 'summary' field
-    legacy = {
-        "meta": {},
-        "insights": [{"id": "ins_old", "title": "Old", "severity": "Low"}],
-    }
-    manifest_path.write_text(json.dumps(legacy))
-    result = insights.load_insights_manifest()
-    assert result["insights"][0]["summary"] == ""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -185,40 +185,6 @@ def test_load_manifest_reels_returns_empty_when_no_file(tmp_path, monkeypatch):
     assert viewer.load_manifest_reels() == []
 
 
-def test_load_manifest_filters_malformed_entries(tmp_path, monkeypatch):
-    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
-    good = _make_artifact("a4c2s0")
-    bad = {"id": "a1", "type": "clip"}  # missing file, start, end
-    raw_data = {
-        "meta": {},
-        "artifacts": [bad, good],
-        "timeline": {"duration": 0, "startOffset": 0},
-    }
-    (tmp_path / config.MANIFEST_FILENAME).write_text(json.dumps(raw_data))
-    loaded = viewer.load_manifest_artifacts()
-    assert len(loaded) == 1
-    assert loaded[0]["id"] == "a4c2s0"
-
-
-def test_save_manifest_does_not_preserve_preexisting_malformed(tmp_path, monkeypatch):
-    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
-    # Seed manifest with a malformed artifact
-    bad = {"id": "ghost", "type": "clip"}
-    raw_data = {
-        "meta": {},
-        "artifacts": [bad],
-        "timeline": {"duration": 0, "startOffset": 0},
-    }
-    (tmp_path / config.MANIFEST_FILENAME).write_text(json.dumps(raw_data))
-
-    # Save a valid artifact — malformed one should be cleaned up
-    viewer.save_manifest([_make_artifact("a4c2s0")])
-    loaded = viewer.load_manifest_artifacts()
-    ids = {a["id"] for a in loaded}
-    assert "ghost" not in ids
-    assert "a4c2s0" in ids
-
-
 def test_cli_manifest_flag_parsed(monkeypatch):
     import cli
 

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1,7 +1,6 @@
 """Tests for Screenspace analysis primitives, manifest I/O, and worker."""
 
 import io
-import json
 import threading
 import time
 from unittest import mock
@@ -438,13 +437,6 @@ class TestManifest:
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         manifest_path = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
         manifest_path.write_text("not json")
-        result = screenspace.load_screenspace_manifest()
-        assert result == {"regions": {}, "tasks": [], "events": [], "stashes": []}
-
-    def test_load_non_dict(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
-        manifest_path = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
-        manifest_path.write_text(json.dumps([1, 2, 3]))
         result = screenspace.load_screenspace_manifest()
         assert result == {"regions": {}, "tasks": [], "events": [], "stashes": []}
 

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -117,7 +117,15 @@ def test_create_region_missing_coords(client):
 def test_delete_region(client):
     client.post(
         "/screenspace/api/regions",
-        json={"name": "temp", "x": 0, "y": 0, "w": 10, "h": 10},
+        json={
+            "name": "temp",
+            "x": 0,
+            "y": 0,
+            "w": 10,
+            "h": 10,
+            "canvas_width": 1920,
+            "canvas_height": 1080,
+        },
     )
     resp = client.delete("/screenspace/api/regions/temp")
     assert resp.status_code == 200
@@ -155,19 +163,15 @@ def test_create_region_normalizes_coords(client):
     assert r["source_height"] == 1080
 
 
-def test_create_region_legacy_no_canvas_dims(client):
+def test_create_region_rejects_missing_canvas_dims(client):
     resp = client.post(
         "/screenspace/api/regions",
-        json={"name": "legacy", "x": 100, "y": 20, "w": 300, "h": 30},
+        json={"name": "no_canvas", "x": 100, "y": 20, "w": 300, "h": 30},
     )
+    assert resp.status_code == 400
     data = resp.get_json()
-    assert data["ok"] is True
-    r = data["region"]
-    assert r["x"] == 100
-    assert r["y"] == 20
-    assert r["w"] == 300
-    assert r["h"] == 30
-    assert "source_width" not in r
+    assert data["ok"] is False
+    assert "canvas_width" in data["error"]
 
 
 def test_denormalize_region():
@@ -183,14 +187,6 @@ def test_denormalize_region():
     }
     px = _denormalize_region(region, 1920, 1080)
     assert px == {"x": 960, "y": 540, "w": 192, "h": 108}
-
-
-def test_denormalize_legacy_region():
-    from screenspace_server import _denormalize_region
-
-    region = {"x": 100, "y": 20, "w": 300, "h": 30}
-    px = _denormalize_region(region, 1280, 720)
-    assert px == {"x": 100, "y": 20, "w": 300, "h": 30}
 
 
 def test_denormalize_cross_resolution():

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -73,23 +73,7 @@ def test_finalize_timeline_data_includes_reels():
     assert data["reels"] == reels
 
 
-# ---- finalize_timeline_data: artifact validation ----
-
-
-def test_finalize_timeline_data_drops_artifact_missing_file():
-    good = _make_artifact("a1c1s0")
-    bad = {"id": "a1", "type": "clip", "start": 0, "end": 10}
-    data = viewer.finalize_timeline_data([good, bad])
-    assert len(data["artifacts"]) == 1
-    assert data["artifacts"][0]["id"] == "a1c1s0"
-
-
-def test_finalize_timeline_data_drops_artifact_missing_start_and_end():
-    good = _make_artifact("a1c1s0")
-    bad = {"id": "a2", "type": "clip", "file": "clip.mp4", "start": None, "end": None}
-    data = viewer.finalize_timeline_data([good, bad])
-    assert len(data["artifacts"]) == 1
-    assert data["artifacts"][0]["id"] == "a1c1s0"
+# ---- finalize_timeline_data ----
 
 
 def test_finalize_timeline_data_keeps_artifact_with_only_start():

--- a/transcripts.py
+++ b/transcripts.py
@@ -244,17 +244,11 @@ def _empty_transcripts_manifest() -> dict[str, Any]:
 def load_transcripts_manifest() -> dict[str, Any]:
     """Load the transcripts manifest from the output directory.
 
-    Returns a dict with ``source_transcripts`` and ``corrections`` keys.
-    Missing or corrupt files return an empty manifest.
+    Returns a dict with ``source_transcripts``, ``corrections``, and ``marks`` keys.
     """
-    data = utils.load_json_manifest(config.TRANSCRIPTS_MANIFEST_FILENAME)
-    if not isinstance(data, dict):
-        return _empty_transcripts_manifest()
-    return {
-        "source_transcripts": data.get("source_transcripts") or {},
-        "corrections": data.get("corrections") or [],
-        "marks": data.get("marks") or [],
-    }
+    return utils.load_json_manifest(
+        config.TRANSCRIPTS_MANIFEST_FILENAME, default=_empty_transcripts_manifest()
+    )
 
 
 def save_transcripts_manifest(
@@ -276,9 +270,10 @@ def save_transcripts_manifest(
     # When marks is None, preserve existing marks from disk
     if marks is None:
         existing = utils.load_json_manifest(
-            config.TRANSCRIPTS_MANIFEST_FILENAME, default={}
+            config.TRANSCRIPTS_MANIFEST_FILENAME,
+            default=_empty_transcripts_manifest(),
         )
-        marks = (existing.get("marks") or []) if isinstance(existing, dict) else []
+        marks = existing["marks"]
 
     data = {
         "source_transcripts": source_transcripts,

--- a/viewer.py
+++ b/viewer.py
@@ -45,17 +45,6 @@ INTERACTIVE_ARTIFACTS: list[dict[str, Any]] = []
 INTERACTIVE_REELS: list[dict[str, Any]] = []
 
 
-def _is_valid_artifact(a: dict[str, Any]) -> bool:
-    """Return True if artifact has minimum required fields for viewer rendering."""
-    if not a.get("id"):
-        return False
-    if not a.get("file"):
-        return False
-    if a.get("start") is None and a.get("end") is None:
-        return False
-    return True
-
-
 def build_artifact_records_for_clip(
     clip: utils.ClipRecord,
     base_video: str,
@@ -105,18 +94,6 @@ def finalize_timeline_data(
     screenspace_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Construct the full window.CLIPGEN_DATA structure for the timeline viewer."""
-    valid_artifacts = [a for a in artifacts if _is_valid_artifact(a)]
-    dropped = len(artifacts) - len(valid_artifacts)
-    if dropped:
-        dropped_ids = [
-            a.get("id", "<no-id>") for a in artifacts if not _is_valid_artifact(a)
-        ]
-        utils.warning_print(
-            f"Skipped {dropped} artifact(s) with missing required fields "
-            f"(ids: {', '.join(str(i) for i in dropped_ids[:5])})."
-        )
-    artifacts = valid_artifacts
-
     max_time = 0.0
     for a in artifacts:
         end = a.get("end") or a.get("start") or 0
@@ -480,31 +457,19 @@ def _load_manifest_both() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
                 list(_manifest_cache["reels"]),
             )
 
-    data = utils.load_json_manifest(config.MANIFEST_FILENAME)
-    if not isinstance(data, dict):
-        with _MANIFEST_CACHE_LOCK:
-            _manifest_cache["path"] = path_str
-            _manifest_cache["mtime_ns"] = mtime_ns
-            _manifest_cache["artifacts"] = []
-            _manifest_cache["reels"] = []
-        return ([], [])
-
-    raw = data.get("artifacts", [])
-    valid = [a for a in raw if _is_valid_artifact(a)]
-    if len(valid) < len(raw):
-        utils.warning_print(
-            f"Manifest contained {len(raw) - len(valid)} artifact(s) with "
-            "missing fields; skipped."
-        )
+    data = utils.load_json_manifest(
+        config.MANIFEST_FILENAME, default={"artifacts": [], "reels": []}
+    )
+    artifacts = data.get("artifacts", [])
     reels = data.get("reels", [])
 
     with _MANIFEST_CACHE_LOCK:
         _manifest_cache["path"] = path_str
         _manifest_cache["mtime_ns"] = mtime_ns
-        _manifest_cache["artifacts"] = valid
+        _manifest_cache["artifacts"] = artifacts
         _manifest_cache["reels"] = reels
 
-    return (list(valid), list(reels))
+    return (list(artifacts), list(reels))
 
 
 def load_manifest_artifacts() -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Manifest loaders (insights, transcripts, screenspace, viewer, server stashes/settings) drop their `isinstance(data, dict)` guards and `.get(...)` fallbacks; they now reuse `utils.load_json_manifest`'s `default=` kwarg and trust the contract.
- `viewer.py` no longer filters with `_is_valid_artifact` or emits "Skipped N artifact(s)" warnings; the helper is deleted.
- `screenspace_server.py` drops the legacy pixel-coords passthrough — `api_regions_create` now requires `canvas_width`/`canvas_height` (HTTP 400 otherwise) and `_denormalize_region` always normalises.
- The `(insight.causes || {}).artifacts || []` bucket fallbacks in `insights-builder.js` / `insights-viewer.js` are removed; the frontend now trusts the shape produced by `create_insight()`.
- Tests covering the removed legacy paths are deleted; one test is replaced with a 400-rejection assertion. `VERSIONNUM` → 0.10.100.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 593 passed
- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run --extra dev ty check`
- [ ] Smoke `--insights` and `--screenspace` UIs in browser, confirm region create round-trips and insight buckets render