### PR TITLE
refactor: backend cleanups (titlecard paths, terminate helper, mode-conflict table)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12,7 +12,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 from icecream import ic
 
@@ -1058,6 +1058,102 @@ def run_cli_mode(worksheet: Any, args: Any, cli_mode_args: CliModeArgs) -> None:
 # ---- Main entry point ----
 
 
+_BASE_SELECTOR_ATTRS = (
+    "batch",
+    "lines",
+    "range",
+    "category",
+    "cell",
+    "participant",
+    "keyword",
+    "severity",
+    "mixed",
+    "reel",
+    "chronologic",
+    "screen",
+    "gif",
+    "viewer",
+    "regenerate",
+)
+
+
+class _ModeSpec(NamedTuple):
+    """Declarative description of one exclusive mode for conflict validation."""
+
+    key: str  # attribute on args (also returned in result dict)
+    truthy: Callable[[Any], bool]  # how to detect this mode is active
+    error: str
+    hint: str
+    selector_attrs: tuple[str, ...] = _BASE_SELECTOR_ATTRS
+    blocks_modes: tuple[str, ...] = ()  # earlier mode keys that conflict
+
+
+_EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
+    _ModeSpec(
+        key="timeline_viewer",
+        truthy=lambda a: bool(getattr(a, "timeline_viewer", False)),
+        error="--timeline-viewer cannot be combined with mode, format, or --viewer/--regenerate flags.",
+        hint="Only -s (spreadsheet) and -v (verbose) may be used alongside --timeline-viewer.",
+    ),
+    _ModeSpec(
+        key="studio",
+        truthy=lambda a: bool(getattr(a, "studio", False)),
+        error="--studio cannot be combined with mode, format, or --viewer/--regenerate flags.",
+        hint="Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --studio.",
+        blocks_modes=("timeline_viewer",),
+    ),
+    _ModeSpec(
+        key="insights",
+        truthy=lambda a: bool(getattr(a, "insights", False)),
+        error="--insights cannot be combined with mode, format, or --viewer/--regenerate/--studio/--screenspace flags.",
+        hint="Only -i/-o (directories) and -v (verbose) may be used alongside --insights.",
+        blocks_modes=("timeline_viewer", "studio", "screenspace", "transcripts"),
+    ),
+    _ModeSpec(
+        key="screenspace",
+        truthy=lambda a: bool(getattr(a, "screenspace", False)),
+        error="--screenspace cannot be combined with mode, format, or --viewer/--regenerate/--studio/--insights flags.",
+        hint="Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --screenspace.",
+        blocks_modes=("timeline_viewer", "studio", "insights", "transcripts"),
+    ),
+    _ModeSpec(
+        key="transcripts",
+        truthy=lambda a: bool(getattr(a, "transcripts", False)),
+        error="--transcripts cannot be combined with mode, format, or --viewer/--regenerate/--studio/--insights/--screenspace flags.",
+        hint="Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --transcripts.",
+        blocks_modes=("timeline_viewer", "studio", "insights", "screenspace"),
+    ),
+    _ModeSpec(
+        key="gallery",
+        # `gallery` carries an optional VIDEO arg, so use `is not None` to detect it.
+        truthy=lambda a: getattr(a, "gallery", None) is not None,
+        error="--gallery cannot be combined with selection modes, --viewer, --regenerate, --studio, or --timeline-viewer.",
+        hint="Only --gif, --interval, --bundle, -i/-o (directories), and -v (verbose) may be used alongside --gallery.",
+        # Gallery permits --screen and --gif as output-format toggles.
+        selector_attrs=tuple(
+            a for a in _BASE_SELECTOR_ATTRS if a not in ("screen", "gif")
+        ),
+        blocks_modes=("timeline_viewer", "studio", "screenspace", "transcripts"),
+    ),
+    _ModeSpec(
+        key="pre_transcribe",
+        truthy=lambda a: getattr(a, "pre_transcribe", None) is not None,
+        error="--pre-transcribe cannot be combined with mode, format, or --studio/--insights/--screenspace/--transcripts flags.",
+        hint="Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --pre-transcribe.",
+        # pre-transcribe additionally conflicts with --highlights.
+        selector_attrs=_BASE_SELECTOR_ATTRS + ("highlights",),
+        blocks_modes=(
+            "timeline_viewer",
+            "studio",
+            "insights",
+            "screenspace",
+            "transcripts",
+            "gallery",
+        ),
+    ),
+)
+
+
 def _validate_mode_conflicts(
     args: Any,
 ) -> tuple[bool, bool, bool, bool, bool, Any, bool]:
@@ -1067,234 +1163,24 @@ def _validate_mode_conflicts(
         (timeline_viewer, studio_mode, insights_mode, screenspace_mode,
          transcripts_mode, gallery_arg, pre_transcribe_mode)
     """
-    mixed_selectors = getattr(args, "mixed", None)
-    timeline_viewer = getattr(args, "timeline_viewer", False)
-
-    if timeline_viewer:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.screen,
-            args.gif,
-            args.viewer,
-            getattr(args, "regenerate", False),
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--timeline-viewer cannot be combined with mode, format, or --viewer/--regenerate flags.",
-                [
-                    "Only -s (spreadsheet) and -v (verbose) may be used alongside --timeline-viewer."
-                ],
-            )
-            sys.exit(1)
-
-    studio_mode = getattr(args, "studio", False)
-    if studio_mode:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.screen,
-            args.gif,
-            args.viewer,
-            getattr(args, "regenerate", False),
-            timeline_viewer,
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--studio cannot be combined with mode, format, or --viewer/--regenerate flags.",
-                [
-                    "Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --studio."
-                ],
-            )
-            sys.exit(1)
-
-    insights_mode = getattr(args, "insights", False)
-    if insights_mode:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.screen,
-            args.gif,
-            args.viewer,
-            getattr(args, "regenerate", False),
-            timeline_viewer,
-            studio_mode,
-            getattr(args, "screenspace", False),
-            getattr(args, "transcripts", False),
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--insights cannot be combined with mode, format, or --viewer/--regenerate/--studio/--screenspace flags.",
-                [
-                    "Only -i/-o (directories) and -v (verbose) may be used alongside --insights."
-                ],
-            )
-            sys.exit(1)
-
-    screenspace_mode = getattr(args, "screenspace", False)
-    if screenspace_mode:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.screen,
-            args.gif,
-            args.viewer,
-            getattr(args, "regenerate", False),
-            timeline_viewer,
-            studio_mode,
-            insights_mode,
-            getattr(args, "transcripts", False),
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--screenspace cannot be combined with mode, format, or --viewer/--regenerate/--studio/--insights flags.",
-                [
-                    "Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --screenspace."
-                ],
-            )
-            sys.exit(1)
-
-    transcripts_mode = getattr(args, "transcripts", False)
-    if transcripts_mode:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.screen,
-            args.gif,
-            args.viewer,
-            getattr(args, "regenerate", False),
-            timeline_viewer,
-            studio_mode,
-            insights_mode,
-            screenspace_mode,
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--transcripts cannot be combined with mode, format, or --viewer/--regenerate/--studio/--insights/--screenspace flags.",
-                [
-                    "Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --transcripts."
-                ],
-            )
-            sys.exit(1)
-
-    gallery_arg = getattr(args, "gallery", None)
-    if gallery_arg is not None:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.viewer,
-            getattr(args, "regenerate", False),
-            timeline_viewer,
-            studio_mode,
-            screenspace_mode,
-            transcripts_mode,
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--gallery cannot be combined with selection modes, --viewer, --regenerate, --studio, or --timeline-viewer.",
-                [
-                    "Only --gif, --interval, --bundle, -i/-o (directories), and -v (verbose) may be used alongside --gallery."
-                ],
-            )
-            sys.exit(1)
-
-    pre_transcribe_mode = getattr(args, "pre_transcribe", None) is not None
-    if pre_transcribe_mode:
-        conflicting = [
-            args.batch,
-            args.lines,
-            args.range,
-            args.category,
-            args.cell,
-            args.participant,
-            args.keyword,
-            args.severity,
-            mixed_selectors,
-            args.reel,
-            args.chronologic,
-            args.highlights,
-            args.screen,
-            args.gif,
-            args.viewer,
-            getattr(args, "regenerate", False),
-            timeline_viewer,
-            studio_mode,
-            insights_mode,
-            screenspace_mode,
-            transcripts_mode,
-            gallery_arg is not None,
-        ]
-        if any(conflicting):
-            utils.error_print(
-                "--pre-transcribe cannot be combined with mode, format, or --studio/--insights/--screenspace/--transcripts flags.",
-                [
-                    "Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --pre-transcribe."
-                ],
-            )
+    active = {spec.key: spec.truthy(args) for spec in _EXCLUSIVE_MODES}
+    for spec in _EXCLUSIVE_MODES:
+        if not active[spec.key]:
+            continue
+        conflicts = [getattr(args, attr, None) for attr in spec.selector_attrs]
+        conflicts.extend(active[m] for m in spec.blocks_modes)
+        if any(conflicts):
+            utils.error_print(spec.error, [spec.hint])
             sys.exit(1)
 
     return (
-        timeline_viewer,
-        studio_mode,
-        insights_mode,
-        screenspace_mode,
-        transcripts_mode,
-        gallery_arg,
-        pre_transcribe_mode,
+        active["timeline_viewer"],
+        active["studio"],
+        active["insights"],
+        active["screenspace"],
+        active["transcripts"],
+        getattr(args, "gallery", None),
+        active["pre_transcribe"],
     )
 
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.100"
+VERSIONNUM: str = "0.10.101"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace.py
+++ b/screenspace.py
@@ -56,6 +56,14 @@ _ocr_readers: dict[tuple, Any] = {}
 _ocr_lock = threading.Lock()
 
 
+ScanCallback = Callable[[float, np.ndarray], bool | None]
+"""Per-frame callback signature for scan_video_frames and friends.
+
+Receives ``(timestamp_seconds, region_pixels)`` and may return ``False`` to stop
+iteration early. Used by all eight scan tools (color, change, similarity, text,
+numbers, flow, scene, inactivity)."""
+
+
 def _get_ocr_reader(languages: list[str]) -> Any:
     """Return a cached EasyOCR Reader for the given language set."""
     import easyocr
@@ -522,7 +530,7 @@ def scan_video_frames(
     video_path: str,
     region: dict[str, int] | None,
     interval_seconds: float,
-    callback: Callable[[float, np.ndarray], bool | None],
+    callback: ScanCallback,
     *,
     start_seconds: float = 0.0,
     end_seconds: float | None = None,
@@ -571,7 +579,7 @@ def scan_video_frames(
 def scan_video_full_frames(
     video_path: str,
     interval_seconds: float,
-    callback: Callable[[float, np.ndarray], bool | None],
+    callback: ScanCallback,
     *,
     start_seconds: float = 0.0,
     end_seconds: float | None = None,
@@ -701,19 +709,14 @@ def _ffmpeg_pipe_frames(
     finally:
         if proc.stdout:
             proc.stdout.close()
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+        utils.terminate_subprocess(proc)
 
 
 def _scan_via_ffmpeg_pipe(
     video_path: str,
     region: dict[str, int] | None,
     interval_seconds: float,
-    callback: Callable[[float, np.ndarray], bool | None],
+    callback: ScanCallback,
     *,
     start_seconds: float = 0.0,
     end_seconds: float = 0.0,
@@ -1379,12 +1382,7 @@ def generate_timelapse(
                 except (ValueError, ZeroDivisionError):
                     pass
             if cancel_flag and cancel_flag():
-                proc.terminate()
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait()
+                utils.terminate_subprocess(proc)
                 return None
     finally:
         if proc.stdout:

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -40,38 +40,38 @@ def _empty_result() -> TranscriptResult:
 
 class TestFmtDisplay:
     def test_seconds_only(self):
-        assert transcripts._fmt_display(5.0) == "0:05"
+        assert transcripts._format_timestamp(5.0, "display") == "0:05"
 
     def test_minutes_and_seconds(self):
-        assert transcripts._fmt_display(125.0) == "2:05"
+        assert transcripts._format_timestamp(125.0, "display") == "2:05"
 
     def test_hours(self):
-        assert transcripts._fmt_display(3661.5) == "1:01:01"
+        assert transcripts._format_timestamp(3661.5, "display") == "1:01:01"
 
     def test_zero(self):
-        assert transcripts._fmt_display(0.0) == "0:00"
+        assert transcripts._format_timestamp(0.0, "display") == "0:00"
 
 
 class TestFmtSrt:
     def test_basic(self):
-        assert transcripts._fmt_srt(0.0) == "00:00:00,000"
+        assert transcripts._format_timestamp(0.0, "srt") == "00:00:00,000"
 
     def test_with_milliseconds(self):
-        assert transcripts._fmt_srt(12.5) == "00:00:12,500"
+        assert transcripts._format_timestamp(12.5, "srt") == "00:00:12,500"
 
     def test_over_an_hour(self):
-        assert transcripts._fmt_srt(3661.5) == "01:01:01,500"
+        assert transcripts._format_timestamp(3661.5, "srt") == "01:01:01,500"
 
 
 class TestFmtVtt:
     def test_under_an_hour(self):
-        assert transcripts._fmt_vtt(12.5) == "00:12.500"
+        assert transcripts._format_timestamp(12.5, "vtt") == "00:12.500"
 
     def test_over_an_hour(self):
-        assert transcripts._fmt_vtt(3661.5) == "01:01:01.500"
+        assert transcripts._format_timestamp(3661.5, "vtt") == "01:01:01.500"
 
     def test_zero(self):
-        assert transcripts._fmt_vtt(0.0) == "00:00.000"
+        assert transcripts._format_timestamp(0.0, "vtt") == "00:00.000"
 
 
 # ---------------------------------------------------------------------------

--- a/titlecards.py
+++ b/titlecards.py
@@ -177,7 +177,7 @@ def build_titlecard_frame(clip: ClipRecord, resolution: str) -> str | None:
     """Generate a short titlecard video segment for a clip."""
     return _build_card_frame(
         resolution=resolution,
-        background_path=Path("assets") / "titlecard.png",
+        background_path=utils.get_bundled_assets_root() / "assets" / "titlecard.png",
         label="titlecard",
         drawtext_filter=_build_drawtext_filter(str(clip.get("desc", ""))),
         allow_color_fallback=True,
@@ -188,7 +188,7 @@ def build_endcard_frame(resolution: str) -> str | None:
     """Generate a short endcard video segment if assets/endcard.png exists."""
     return _build_card_frame(
         resolution=resolution,
-        background_path=Path("assets") / "endcard.png",
+        background_path=utils.get_bundled_assets_root() / "assets" / "endcard.png",
         label="endcard",
     )
 

--- a/transcripts.py
+++ b/transcripts.py
@@ -42,7 +42,7 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, TypedDict
+from typing import Any, Callable, Literal, TypedDict
 
 import config
 import utils
@@ -387,31 +387,22 @@ def filter_segments(
 # ---------------------------------------------------------------------------
 
 
-def _fmt_display(seconds: float) -> str:
-    """Format seconds as M:SS or H:MM:SS for Markdown display."""
+def _format_timestamp(seconds: float, fmt: Literal["display", "srt", "vtt"]) -> str:
+    """Format a seconds value for transcript output.
+
+    ``display`` is M:SS / H:MM:SS for Markdown. ``srt`` is HH:MM:SS,mmm.
+    ``vtt`` is MM:SS.mmm or HH:MM:SS.mmm.
+    """
     total = int(seconds)
     h, remainder = divmod(total, 3600)
     m, s = divmod(remainder, 60)
-    if h > 0:
-        return f"{h}:{m:02d}:{s:02d}"
-    return f"{m}:{s:02d}"
-
-
-def _fmt_srt(seconds: float) -> str:
-    """Format seconds as HH:MM:SS,mmm for SRT."""
-    total = int(seconds)
+    if fmt == "display":
+        if h > 0:
+            return f"{h}:{m:02d}:{s:02d}"
+        return f"{m}:{s:02d}"
     ms = int((seconds - total) * 1000)
-    h, remainder = divmod(total, 3600)
-    m, s = divmod(remainder, 60)
-    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
-
-
-def _fmt_vtt(seconds: float) -> str:
-    """Format seconds as MM:SS.mmm for VTT."""
-    total = int(seconds)
-    ms = int((seconds - total) * 1000)
-    h, remainder = divmod(total, 3600)
-    m, s = divmod(remainder, 60)
+    if fmt == "srt":
+        return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
     if h > 0:
         return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
     return f"{m:02d}:{s:02d}.{ms:03d}"
@@ -436,7 +427,9 @@ def _format_markdown(result: TranscriptResult) -> str:
         "",
     ]
     for seg in result["segments"]:
-        lines.append(f"**[{_fmt_display(seg['start'])} - {_fmt_display(seg['end'])}]**")
+        start = _format_timestamp(seg["start"], "display")
+        end = _format_timestamp(seg["end"], "display")
+        lines.append(f"**[{start} - {end}]**")
         lines.append(seg["text"])
         lines.append("")
     return "\n".join(lines)
@@ -445,16 +438,18 @@ def _format_markdown(result: TranscriptResult) -> str:
 def _format_srt(result: TranscriptResult) -> str:
     blocks: list[str] = []
     for i, seg in enumerate(result["segments"], start=1):
-        blocks.append(
-            f"{i}\n{_fmt_srt(seg['start'])} --> {_fmt_srt(seg['end'])}\n{seg['text']}"
-        )
+        start = _format_timestamp(seg["start"], "srt")
+        end = _format_timestamp(seg["end"], "srt")
+        blocks.append(f"{i}\n{start} --> {end}\n{seg['text']}")
     return "\n\n".join(blocks) + "\n" if blocks else ""
 
 
 def _format_vtt(result: TranscriptResult) -> str:
     lines = ["WEBVTT", ""]
     for seg in result["segments"]:
-        lines.append(f"{_fmt_vtt(seg['start'])} --> {_fmt_vtt(seg['end'])}")
+        start = _format_timestamp(seg["start"], "vtt")
+        end = _format_timestamp(seg["end"], "vtt")
+        lines.append(f"{start} --> {end}")
         lines.append(seg["text"])
         lines.append("")
     return "\n".join(lines)

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@
 
 import difflib
 import json
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -549,6 +550,16 @@ def get_bundled_assets_root() -> Path:
             getattr(sys, "_MEIPASS", str(Path(sys.executable).resolve().parent))
         )
     return Path(__file__).resolve().parent
+
+
+def terminate_subprocess(proc: subprocess.Popen, timeout: int = 5) -> None:
+    """Terminate a subprocess, escalating to kill if it ignores SIGTERM."""
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
 
 
 # ---- Filename and study name helpers ----

--- a/video.py
+++ b/video.py
@@ -145,8 +145,7 @@ def run_ffmpeg_process(
             )
             while proc.poll() is None:
                 if cancel_flag():
-                    proc.terminate()
-                    proc.wait(timeout=5)
+                    utils.terminate_subprocess(proc)
                     return None
                 try:
                     proc.wait(timeout=0.5)


### PR DESCRIPTION
## Summary

Five small, independent backend refactors verified against the actual source:

- **titlecards.py**: resolve `titlecard.png` / `endcard.png` via `utils.get_bundled_assets_root()` instead of `Path("assets")`, so PyInstaller builds and non-cwd invocations find the assets.
- **utils.terminate_subprocess**: extract the `terminate → wait(timeout) → kill → wait` pattern; replace 3 sites in `video.py` and `screenspace.py`. `video.py` now also escalates to `kill()` if SIGTERM is ignored.
- **ScanCallback** type alias in `screenspace.py` for the per-frame callback shared by all 8 scan tools.
- **transcripts.py**: collapse `_fmt_display`/`_fmt_srt`/`_fmt_vtt` into one `_format_timestamp(seconds, fmt)`; tests updated.
- **cli.py**: replace 237 repetitive lines in `_validate_mode_conflicts` with a `_ModeSpec` table + one validation loop (~120 lines). Adding a new exclusive mode is now one entry.

Net: +171 / -282 across 8 files; patch version bumped to 0.10.101 (titlecard path and kill-fallback are user-visible).

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 593 passed
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run clipgen.py --help` smoke