### PR TITLE
feat: screenspace model-view overlay + blink comparator

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1120,6 +1120,65 @@ body {
   display: none;
 }
 
+.model-view-overlay-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: var(--text-xs);
+  color: var(--color-text-dim);
+}
+
+.model-view-overlay-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  cursor: pointer;
+  user-select: none;
+}
+
+.model-view-overlay-toggle input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.model-view-overlay-toggle.disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.model-view-overlay-toggle.disabled input[type="checkbox"] {
+  cursor: not-allowed;
+}
+
+.model-view-overlay-layer {
+  font-size: var(--text-xs);
+  padding: 2px var(--space-1);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.model-view-overlay-layer.hidden {
+  display: none;
+}
+
+.model-view-overlay-hint {
+  margin-left: auto;
+  opacity: 0.8;
+}
+
+.model-view-overlay-hint kbd {
+  display: inline-block;
+  padding: 0 var(--space-1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
 /* Multitool step list */
 
 .multitool-steps {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -157,6 +157,14 @@
           </button>
           <div id="modelViewBody" class="model-view-body hidden">
             <div id="modelViewMeta" class="model-view-meta">Select a region to preview.</div>
+            <div id="modelViewOverlayRow" class="model-view-overlay-row">
+              <label class="model-view-overlay-toggle">
+                <input id="modelViewOverlayToggle" type="checkbox" />
+                <span>Overlay on frame</span>
+              </label>
+              <select id="modelViewOverlayLayer" class="model-view-overlay-layer hidden" aria-label="Overlay layer"></select>
+              <span class="model-view-overlay-hint">hold <kbd>B</kbd> to blink</span>
+            </div>
             <img id="modelViewImage" alt="Preprocessed preview" />
           </div>
         </div>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -135,6 +135,12 @@
     videoMuted: false,
     videoPlaybackRate: 1,
     modelViewOpen: false,
+    overlayEnabled: false,
+    overlayLayer: null,
+    overlayBlinkActive: false,
+    overlayImage: null,
+    overlayImageObjectUrl: null,
+    overlayLayerSpec: {},
     rightPaneTab: "queue",
     resultsSwitcherOpen: false,
   };
@@ -1745,6 +1751,29 @@
         var rPx = regionToPixels(state.regions[hm.region] || {});
         if (rPx && rPx.w) {
           ctx.drawImage(hm._img, rPx.x, rPx.y, rPx.w, rPx.h);
+        }
+      }
+      ctx.globalAlpha = 1.0;
+    }
+
+    // Model-view overlay (toggle or held-key blink comparator)
+    var overlayActive = (state.overlayEnabled || state.overlayBlinkActive)
+      && state.overlayImage
+      && _overlayEligibleForActiveTool();
+    if (overlayActive) {
+      ctx.globalAlpha = state.overlayBlinkActive ? 1.0 : 0.7;
+      var scope = state.overlayImageScope || "region";
+      if (scope === "frame") {
+        ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
+      } else {
+        var oRegion = state.pendingRegion
+          ? state.pendingRegion
+          : (state.activeRegion ? state.regions[state.activeRegion] : null);
+        if (oRegion) {
+          var oPx = regionToPixels(oRegion);
+          if (oPx && oPx.w && oPx.h) {
+            ctx.drawImage(state.overlayImage, oPx.x, oPx.y, oPx.w, oPx.h);
+          }
         }
       }
       ctx.globalAlpha = 1.0;
@@ -3364,6 +3393,7 @@
     if (scanBtn && scanBtn._updateScanState) scanBtn._updateScanState();
 
     updateRunButton();
+    _updateOverlayUi();
     refreshModelView();
   }
 
@@ -3415,6 +3445,126 @@
   function initModelView() {
     var btn = qs("#modelViewToggle");
     if (btn) btn.addEventListener("click", toggleModelView);
+
+    // Restore persisted overlay preferences (sessionStorage, per-tab).
+    try {
+      var stored = sessionStorage.getItem("ss_overlayEnabled");
+      if (stored === "1") state.overlayEnabled = true;
+    } catch (e) { /* sessionStorage may be unavailable */ }
+    try {
+      var layer = sessionStorage.getItem("ss_overlayLayer");
+      if (layer) state.overlayLayer = layer;
+    } catch (e) { /* ignore */ }
+
+    var toggle = qs("#modelViewOverlayToggle");
+    if (toggle) {
+      toggle.checked = !!state.overlayEnabled;
+      toggle.addEventListener("change", function () {
+        state.overlayEnabled = !!toggle.checked;
+        try { sessionStorage.setItem("ss_overlayEnabled", state.overlayEnabled ? "1" : "0"); } catch (e) { /* ignore */ }
+        if (state.overlayEnabled && !state.overlayImage) refreshModelView();
+        renderOverlay();
+      });
+    }
+
+    var sel = qs("#modelViewOverlayLayer");
+    if (sel) {
+      sel.addEventListener("change", function () {
+        state.overlayLayer = sel.value || null;
+        try { sessionStorage.setItem("ss_overlayLayer", state.overlayLayer || ""); } catch (e) { /* ignore */ }
+        // Force a refetch of the overlay image at the new layer.
+        if (state.overlayImageObjectUrl) {
+          URL.revokeObjectURL(state.overlayImageObjectUrl);
+          state.overlayImageObjectUrl = null;
+        }
+        state.overlayImage = null;
+        refreshModelView();
+        renderOverlay();
+      });
+    }
+
+    // Fetch the overlay-layer catalog once at init.
+    apiGet("api/preview/layers")
+      .then(function (data) {
+        if (data && data.ok && data.layers) {
+          state.overlayLayerSpec = data.layers;
+          _updateOverlayUi();
+        }
+      })
+      .catch(function () { /* leave catalog empty; toggle stays disabled */ });
+  }
+
+  function _activeOverlayTool() {
+    var tool = state.activeWorkflow;
+    if (tool === "multitool") {
+      var first = (state.multitoolSteps || [])[0];
+      tool = first && first.type ? first.type : null;
+    }
+    return tool;
+  }
+
+  function _activeOverlayLayers() {
+    var tool = _activeOverlayTool();
+    if (!tool) return [];
+    return state.overlayLayerSpec[tool] || [];
+  }
+
+  function _overlayEligibleForActiveTool() {
+    return _activeOverlayLayers().length > 0;
+  }
+
+  function _resolveOverlayLayer() {
+    var layers = _activeOverlayLayers();
+    if (!layers.length) return null;
+    if (state.overlayLayer) {
+      for (var i = 0; i < layers.length; i++) {
+        if (layers[i].id === state.overlayLayer) return layers[i];
+      }
+    }
+    return layers[0];
+  }
+
+  function _updateOverlayUi() {
+    var toggle = qs("#modelViewOverlayToggle");
+    var sel = qs("#modelViewOverlayLayer");
+    var label = toggle && toggle.parentElement;
+    var layers = _activeOverlayLayers();
+    var eligible = layers.length > 0;
+
+    if (toggle) {
+      toggle.disabled = !eligible;
+      if (label) {
+        if (eligible) {
+          label.classList.remove("disabled");
+          label.removeAttribute("title");
+        } else {
+          label.classList.add("disabled");
+          label.setAttribute("title", "This tool's preview isn't pixel-aligned to the frame");
+        }
+      }
+      if (!eligible && toggle.checked) {
+        toggle.checked = false;
+        // Don't persist away the user's preference; just disable for this tool.
+      }
+    }
+
+    if (sel) {
+      if (layers.length > 1) {
+        sel.classList.remove("hidden");
+        sel.innerHTML = "";
+        var resolved = _resolveOverlayLayer();
+        layers.forEach(function (layer) {
+          var opt = document.createElement("option");
+          opt.value = layer.id;
+          opt.textContent = layer.label;
+          if (resolved && layer.id === resolved.id) opt.selected = true;
+          sel.appendChild(opt);
+        });
+      } else {
+        sel.classList.add("hidden");
+        sel.innerHTML = "";
+      }
+    }
   }
 
   function toggleModelView() {
@@ -3435,7 +3585,7 @@
   }
 
   function refreshModelView(opts) {
-    if (!state.modelViewOpen) return;
+    if (!state.modelViewOpen && !state.overlayEnabled && !state.overlayBlinkActive) return;
     if (_modelViewTimer) {
       clearTimeout(_modelViewTimer);
       _modelViewTimer = 0;
@@ -3570,6 +3720,54 @@
       meta.textContent = MODEL_VIEW_META[tool] || "";
     }
 
+    function _refetchOverlayLayer() {
+      if (gen !== _modelViewGen) return;
+      var resolved = _resolveOverlayLayer();
+      if (!resolved) {
+        if (state.overlayImageObjectUrl) {
+          URL.revokeObjectURL(state.overlayImageObjectUrl);
+          state.overlayImageObjectUrl = null;
+        }
+        state.overlayImage = null;
+        return;
+      }
+      var layerQs = qsParts.concat(["layer=" + encodeURIComponent(resolved.id)]);
+      var layerUrl = "api/preview/" + encodeURIComponent(state.selectedParticipant)
+        + "/" + ts + "?" + layerQs.join("&");
+      function fetchAsImage(blob) {
+        if (gen !== _modelViewGen) return;
+        if (state.overlayImageObjectUrl) {
+          URL.revokeObjectURL(state.overlayImageObjectUrl);
+          state.overlayImageObjectUrl = null;
+        }
+        var ou = URL.createObjectURL(blob);
+        state.overlayImageObjectUrl = ou;
+        var oi = new Image();
+        oi.onload = function () {
+          if (gen !== _modelViewGen) return;
+          state.overlayImage = oi;
+          state.overlayImageScope = resolved.scope;
+          renderOverlay();
+        };
+        oi.src = ou;
+      }
+      if (useTemplatePost) {
+        fetch(layerUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ template_image_data: state.uploadedTemplate.data }),
+        })
+          .then(function (r) { if (!r.ok) throw new Error("layer http " + r.status); return r.blob(); })
+          .then(fetchAsImage)
+          .catch(function () { /* leave previous overlay image */ });
+      } else {
+        fetch(layerUrl)
+          .then(function (r) { if (!r.ok) throw new Error("layer http " + r.status); return r.blob(); })
+          .then(fetchAsImage)
+          .catch(function () { /* leave previous overlay image */ });
+      }
+    }
+
     var useTemplatePost = tool === "template" && state.uploadedTemplate && state.uploadedTemplate.data;
     if (useTemplatePost) {
       // TODO: utils.apiPost returns JSON; needs an apiPostBlob helper to migrate.
@@ -3585,6 +3783,7 @@
         .then(function (blob) {
           if (gen !== _modelViewGen) return;
           applyPreviewOkFromBlob(blob);
+          _refetchOverlayLayer();
         })
         .catch(function () {
           applyPreviewError();
@@ -3601,6 +3800,7 @@
       }
       img.src = tmp.src;
       meta.textContent = MODEL_VIEW_META[tool] || "";
+      _refetchOverlayLayer();
     };
     tmp.onerror = function () {
       applyPreviewError();
@@ -5793,6 +5993,14 @@
         } else {
           playVideo();
         }
+      } else if (e.key === "b" || e.key === "B") {
+        if (e.repeat) return;
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+        if (!_overlayEligibleForActiveTool()) return;
+        e.preventDefault();
+        state.overlayBlinkActive = true;
+        if (!state.overlayImage) refreshModelView();
+        renderOverlay();
       } else if (e.key === "Escape") {
         if (state.pipetteActive) {
           deactivatePipette();
@@ -5820,6 +6028,24 @@
           updateRunButton();
         }
         hideRegionNameModal();
+      }
+    });
+
+    document.addEventListener("keyup", function (e) {
+      if (e.key === "b" || e.key === "B") {
+        if (state.overlayBlinkActive) {
+          state.overlayBlinkActive = false;
+          renderOverlay();
+        }
+      }
+    });
+
+    // Defensive: clear blink state on window blur so a held key doesn't get
+    // stuck on if the user alt-tabs.
+    window.addEventListener("blur", function () {
+      if (state.overlayBlinkActive) {
+        state.overlayBlinkActive = false;
+        renderOverlay();
       }
     });
   }

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.101"
+VERSIONNUM: str = "0.10.102"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -9,7 +9,12 @@ diff masks, edge maps, flow vectors, pHash bit grids, etc.
 The produced image is always a single ``numpy.ndarray`` of shape (H, W, 3) in
 BGR uint8, suitable for ``cv2.imencode('.png', img)``.
 
-Entry point: :func:`build_preview`.
+Entry points:
+
+- :func:`build_preview` — labeled multi-panel composite for the side panel.
+- :func:`build_overlay_layer` — single layer at native region / frame
+  resolution, suitable for painting on top of the live frame canvas. The
+  catalog of overlay-eligible layers per tool lives in :data:`OVERLAY_LAYERS`.
 """
 
 from typing import Any
@@ -67,6 +72,229 @@ def build_preview(
             )
         return _placeholder("Add a step to see its preview")
     return _placeholder(f"Unknown tool: {tool}")
+
+
+# ---------------------------------------------------------------------------
+# Overlay layers — single-layer images sized to the region (or frame) that
+# the frontend paints on top of the live frame canvas as a "blink comparator".
+# Tools whose preview output isn't pixel-aligned (timelapse, inactivity) are
+# omitted on purpose; the toggle stays disabled in those cases.
+# ---------------------------------------------------------------------------
+
+
+# (layer_id, label, scope) per tool. Scope is "region" (sized to the region
+# rect) or "frame" (sized to the full frame).
+OVERLAY_LAYERS: dict[str, list[tuple[str, str, str]]] = {
+    "color": [("region", "Region (≤64 px)", "region")],
+    "change": [
+        ("gray_blur", "Gray blur", "region"),
+        ("abs_diff", "Abs diff", "region"),
+        ("mask", "Threshold mask", "region"),
+    ],
+    "similarity": [("gray", "Current gray", "region")],
+    "text": [("gray", "OCR input (gray)", "region")],
+    "numbers": [("gray", "OCR input (gray)", "region")],
+    "template": [("match_heatmap", "Match heatmap", "frame")],
+    "flow": [("flow_vectors", "Flow vectors", "region")],
+    "scene": [("edges", "Canny edges", "region")],
+}
+
+
+def overlay_layer_scope(tool: str, layer: str) -> str | None:
+    """Return the scope ("region" or "frame") for a given tool/layer, or None."""
+    if tool == "multitool":
+        return None
+    for layer_id, _label, scope in OVERLAY_LAYERS.get(tool, []):
+        if layer_id == layer:
+            return scope
+    return None
+
+
+def build_overlay_layer(
+    frame: "np.ndarray",
+    prev_frame: "np.ndarray | None",
+    region: dict[str, int] | None,
+    tool: str,
+    layer: str,
+    params: dict[str, Any],
+) -> "np.ndarray | None":
+    """Build a single overlay layer for the given tool, sized to the region or frame.
+
+    Returns BGR uint8. Returns None if the layer can't be produced (e.g. missing
+    prev frame for change/flow). Caller is responsible for validating that
+    ``(tool, layer)`` is in :data:`OVERLAY_LAYERS`.
+    """
+    if tool == "multitool":
+        steps = params.get("steps") or []
+        if not steps:
+            return None
+        step = steps[0]
+        return build_overlay_layer(
+            frame,
+            prev_frame,
+            region,
+            step.get("type", ""),
+            layer,
+            step.get("parameters") or {},
+        )
+
+    scope = overlay_layer_scope(tool, layer)
+    if scope is None:
+        return None
+
+    if scope == "region":
+        pixels = _clip_region_pixels(frame, region)
+        if pixels is None:
+            return None
+    # scope == "frame" doesn't need region pixels
+
+    if tool == "color" and layer == "region":
+        return pixels.copy()
+
+    if tool == "change":
+        return _overlay_change(pixels, prev_frame, region, layer, params)
+
+    if tool == "similarity" and layer == "gray":
+        k = config.SCREENSPACE_BLUR_KERNEL
+        gray = cv2.cvtColor(cv2.GaussianBlur(pixels, (k, k), 0), cv2.COLOR_BGR2GRAY)
+        return _gray_to_bgr(gray)
+
+    if tool in ("text", "numbers") and layer == "gray":
+        return _gray_to_bgr(cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY))
+
+    if tool == "scene" and layer == "edges":
+        gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        edges = cv2.Canny(gray, 100, 200)
+        return _gray_to_bgr(edges)
+
+    if tool == "flow" and layer == "flow_vectors":
+        return _overlay_flow(pixels, prev_frame, region, params)
+
+    if tool == "template" and layer == "match_heatmap":
+        return _overlay_template_heatmap(frame, params)
+
+    return None
+
+
+def _overlay_change(
+    pixels: "np.ndarray",
+    prev_frame: "np.ndarray | None",
+    region: dict[str, int] | None,
+    layer: str,
+    params: dict[str, Any],
+) -> "np.ndarray | None":
+    k = config.SCREENSPACE_BLUR_KERNEL
+    curr_gray = cv2.cvtColor(cv2.GaussianBlur(pixels, (k, k), 0), cv2.COLOR_BGR2GRAY)
+    if layer == "gray_blur":
+        return _gray_to_bgr(curr_gray)
+    if prev_frame is None:
+        return None
+    prev_pixels = _clip_region_pixels(prev_frame, region)
+    if prev_pixels is None or prev_pixels.shape[:2] != pixels.shape[:2]:
+        return None
+    prev_gray = cv2.cvtColor(
+        cv2.GaussianBlur(prev_pixels, (k, k), 0), cv2.COLOR_BGR2GRAY
+    )
+    diff = cv2.absdiff(prev_gray, curr_gray)
+    if layer == "abs_diff":
+        return _gray_to_bgr(diff)
+    if layer == "mask":
+        noise = int(params.get("noise_threshold", config.SCREENSPACE_NOISE_THRESHOLD))
+        _, mask = cv2.threshold(diff, noise, 255, cv2.THRESH_BINARY)
+        mk = config.SCREENSPACE_MORPH_KERNEL
+        mask_clean = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((mk, mk), np.uint8))
+        # Render mask as cyan-on-black so it reads against varying frame content
+        # when alpha-blended onto the live frame canvas.
+        out = np.zeros((mask_clean.shape[0], mask_clean.shape[1], 3), dtype=np.uint8)
+        out[mask_clean > 0] = (220, 220, 0)  # BGR cyan-ish
+        return out
+    return None
+
+
+def _overlay_flow(
+    pixels: "np.ndarray",
+    prev_frame: "np.ndarray | None",
+    region: dict[str, int] | None,
+    params: dict[str, Any],  # noqa: ARG001 — magnitude param affects threshold display only
+) -> "np.ndarray | None":
+    if prev_frame is None:
+        return None
+    prev_pixels = _clip_region_pixels(prev_frame, region)
+    if prev_pixels is None or prev_pixels.shape[:2] != pixels.shape[:2]:
+        return None
+    curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+    prev_gray = cv2.cvtColor(prev_pixels, cv2.COLOR_BGR2GRAY)
+
+    # Compute flow at native region resolution for crisp overlay.
+    flow_out = np.zeros((*prev_gray.shape[:2], 2), dtype=np.float32)
+    flow = cv2.calcOpticalFlowFarneback(
+        prev_gray,
+        curr_gray,
+        flow_out,
+        config.SCREENSPACE_FLOW_PYR_SCALE,
+        3,
+        15,
+        3,
+        5,
+        1.2,
+        0,
+    )
+    vis = cv2.cvtColor(curr_gray, cv2.COLOR_GRAY2BGR)
+    grid_size = config.SCREENSPACE_FLOW_GRID_SIZE
+    gh, gw = flow.shape[:2]
+    step_y = max(1, gh // grid_size)
+    step_x = max(1, gw // grid_size)
+    min_mag = config.SCREENSPACE_FLOW_GRID_MIN_MAG
+    for gy in range(0, gh, step_y):
+        for gx in range(0, gw, step_x):
+            cy = gy + step_y // 2
+            cx = gx + step_x // 2
+            if cy >= gh or cx >= gw:
+                continue
+            fx, fy = float(flow[cy, cx, 0]), float(flow[cy, cx, 1])
+            m = float(np.sqrt(fx * fx + fy * fy))
+            if m < min_mag:
+                continue
+            scale = 4.0
+            end = (int(cx + fx * scale), int(cy + fy * scale))
+            cv2.arrowedLine(vis, (cx, cy), end, (40, 220, 40), 1, tipLength=0.3)
+    return vis
+
+
+def _overlay_template_heatmap(
+    frame: "np.ndarray", params: dict[str, Any]
+) -> "np.ndarray | None":
+    template = params.get("template_image")
+    if not (isinstance(template, np.ndarray) and template.size > 0):
+        return None
+    k = config.SCREENSPACE_BLUR_KERNEL
+    frame_gray = cv2.cvtColor(cv2.GaussianBlur(frame, (k, k), 0), cv2.COLOR_BGR2GRAY)
+    tmpl_gray = cv2.cvtColor(cv2.GaussianBlur(template, (k, k), 0), cv2.COLOR_BGR2GRAY)
+    if (
+        tmpl_gray.shape[0] > frame_gray.shape[0]
+        or tmpl_gray.shape[1] > frame_gray.shape[1]
+        or float(np.std(tmpl_gray)) < 1e-6
+    ):
+        return None
+    mask = params.get("template_mask")
+    gray_mask = None
+    if isinstance(mask, np.ndarray) and mask.size > 0:
+        gray_mask = cv2.GaussianBlur(mask, (k, k), 0)
+    result = cv2.matchTemplate(
+        frame_gray, tmpl_gray, cv2.TM_CCOEFF_NORMED, mask=gray_mask
+    )
+    result = np.nan_to_num(result, nan=0.0, posinf=1.0, neginf=-1.0)
+    norm = np.empty_like(result)
+    cv2.normalize(result, norm, 0, 255, cv2.NORM_MINMAX)
+    heat = cv2.applyColorMap(norm.astype(np.uint8), cv2.COLORMAP_JET)
+    # Pad to frame size so the overlay aligns 1:1 with the frame canvas.
+    fh, fw = frame.shape[:2]
+    hh, hw = heat.shape[:2]
+    if (hh, hw) == (fh, fw):
+        return heat
+    out = np.zeros((fh, fw, 3), dtype=np.uint8)
+    out[:hh, :hw] = heat
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -521,10 +749,14 @@ def _preview_inactivity(
     )
 
 
-def encode_png(img: "np.ndarray") -> bytes:
-    """Encode a BGR image as PNG bytes — convenience for the Flask route."""
-    # Cap overall width so the UI pane never has to scale huge images down.
-    if img.shape[1] > _MAX_WIDTH:
+def encode_png(img: "np.ndarray", *, cap_width: bool = True) -> bytes:
+    """Encode a BGR image as PNG bytes — convenience for the Flask route.
+
+    By default caps width at :data:`_MAX_WIDTH` for the side-panel composite.
+    Pass ``cap_width=False`` for overlay layers, which need native resolution
+    so they paint pixel-true on top of the frame canvas.
+    """
+    if cap_width and img.shape[1] > _MAX_WIDTH:
         img = _fit_width(img, _MAX_WIDTH)
     ok, buf = cv2.imencode(".png", img)
     if not ok:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -10,7 +10,8 @@ API endpoints (all under /screenspace/):
   GET  /media/<filename>                    – serve artifact media files
   GET  /api/participants                    – list discovered participant videos
   GET  /api/video/frame/<participant>/<ts>  – extract a JPEG frame at timestamp
-  GET|POST /api/preview/<participant>/<ts>   – PNG of the active tool's preprocessed view
+  GET|POST /api/preview/<participant>/<ts>   – PNG of the active tool's preprocessed view (?layer=<id> for single-layer overlay)
+  GET  /api/preview/layers                   – JSON catalog of overlay-eligible layers per tool
   GET  /api/video/info/<participant>        – video metadata (duration, resolution, fps)
   GET  /api/video/stream/<participant>     – stream source video (mp4, range-aware)
   GET  /api/regions                         – list regions
@@ -259,6 +260,10 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
       noise=<int>          change tool's noise_threshold override
       h,s,v=<int>          color tool's target HSV override
       magnitude=<float>    flow tool's magnitude threshold override
+      layer=<id>           if set, return that single overlay layer at native
+                           region/frame resolution instead of the labeled
+                           composite. See ``screenspace_preview.OVERLAY_LAYERS``
+                           for valid (tool, layer) pairs.
 
     For **template** with an **uploaded** PNG, send ``POST`` with JSON body
     ``{"template_image_data": "<base64>"}`` (same field as task enqueue); query
@@ -392,6 +397,42 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
                             ref_frame_tpl, region_coords
                         )
 
+    layer = (request.args.get("layer") or "").strip()
+    if layer:
+        # For multitool, the catalog comes from the first step's tool.
+        catalog_tool = tool
+        if tool == "multitool":
+            steps = params.get("steps") or []
+            catalog_tool = (
+                steps[0].get("type", "") if steps and isinstance(steps[0], dict) else ""
+            )
+        valid = {
+            lid
+            for lid, _label, _scope in screenspace_preview.OVERLAY_LAYERS.get(
+                catalog_tool, []
+            )
+        }
+        if layer not in valid:
+            return jsonify(
+                {
+                    "ok": False,
+                    "error": f"Layer '{layer}' not available for tool '{tool}'",
+                }
+            ), 400
+        layer_img = screenspace_preview.build_overlay_layer(
+            frame, prev_frame, region_coords, tool, layer, params
+        )
+        if layer_img is None or getattr(layer_img, "size", 0) == 0:
+            return jsonify({"ok": False, "error": "Could not build overlay layer"}), 500
+        png_bytes = screenspace_preview.encode_png(layer_img, cap_width=False)
+        if not png_bytes:
+            return jsonify({"ok": False, "error": "Could not encode overlay"}), 500
+        return Response(
+            png_bytes,
+            mimetype="image/png",
+            headers={"Cache-Control": "no-cache"},
+        )
+
     img = screenspace_preview.build_preview(
         frame, prev_frame, region_coords, tool, params
     )
@@ -406,6 +447,24 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
         mimetype="image/png",
         headers={"Cache-Control": "no-cache"},
     )
+
+
+@screenspace_bp.route("/api/preview/layers")
+def api_preview_layers() -> FlaskResponse:
+    """Return the per-tool overlay-layer catalog as JSON.
+
+    Shape: ``{tool: [{id, label, scope}, ...], ...}``. Tools whose previews
+    aren't pixel-aligned (timelapse, inactivity) are intentionally absent.
+    """
+    import screenspace_preview
+
+    out = {
+        tool: [
+            {"id": lid, "label": label, "scope": scope} for lid, label, scope in layers
+        ]
+        for tool, layers in screenspace_preview.OVERLAY_LAYERS.items()
+    }
+    return jsonify({"ok": True, "layers": out})
 
 
 @screenspace_bp.route("/api/video/info/<participant>")

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -395,6 +395,77 @@ def test_api_preview_template_post_invalid_image(client, monkeypatch) -> None:
     assert resp.status_code == 400
 
 
+def test_api_preview_layers_catalog(client) -> None:
+    """The catalog endpoint returns each tool's overlay layers."""
+    resp = client.get("/screenspace/api/preview/layers")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["ok"] is True
+    layers = payload["layers"]
+    # Tools with no overlay-eligible layers must not appear.
+    assert "timelapse" not in layers
+    assert "inactivity" not in layers
+    # Multi-layer tools list each layer with id/label/scope.
+    change_layers = layers["change"]
+    assert {layer["id"] for layer in change_layers} == {"gray_blur", "abs_diff", "mask"}
+    assert all(layer["scope"] == "region" for layer in change_layers)
+    # Template's match heatmap is frame-scoped.
+    template_layers = layers["template"]
+    assert any(
+        layer["id"] == "match_heatmap" and layer["scope"] == "frame"
+        for layer in template_layers
+    )
+
+
+def test_api_preview_layer_returns_native_resolution_png(client, monkeypatch) -> None:
+    """layer= returns a region-sized PNG (no max-width cap)."""
+    import cv2
+    import numpy as np
+    import video
+
+    _enable_video_task_setup(monkeypatch, "P01")
+    monkeypatch.setattr(
+        video,
+        "extract_frame_at_timestamp",
+        lambda _path, _ts: np.full((240, 320, 3), 50, dtype=np.uint8),
+    )
+
+    region = "0.25,0.2083333333,0.3125,0.25"  # ~ 100x60 px
+    resp = client.get(
+        f"/screenspace/api/preview/P01/0.500?tool=color&region={region}&layer=region"
+    )
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/png"
+    img = cv2.imdecode(np.frombuffer(resp.data, np.uint8), cv2.IMREAD_COLOR)
+    assert img is not None
+    # Native size matches the requested region in pixels.
+    assert img.shape[:2] == (60, 100)
+
+
+def test_api_preview_layer_invalid_returns_400(client, monkeypatch) -> None:
+    """Asking for a layer the tool doesn't expose returns 400."""
+    import numpy as np
+    import video
+
+    _enable_video_task_setup(monkeypatch, "P01")
+    monkeypatch.setattr(
+        video,
+        "extract_frame_at_timestamp",
+        lambda _path, _ts: np.zeros((240, 320, 3), dtype=np.uint8),
+    )
+    region = "0.25,0.2083333333,0.3125,0.25"
+    # timelapse is intentionally excluded from OVERLAY_LAYERS.
+    resp = client.get(
+        f"/screenspace/api/preview/P01/0.500?tool=timelapse&region={region}&layer=anything"
+    )
+    assert resp.status_code == 400
+    # bogus layer for a valid tool also rejected.
+    resp = client.get(
+        f"/screenspace/api/preview/P01/0.500?tool=color&region={region}&layer=bogus"
+    )
+    assert resp.status_code == 400
+
+
 def test_create_non_template_task_still_requires_region(client):
     """Non-template tasks still require a region."""
     resp = client.post(

--- a/tests/test_screenspace_preview.py
+++ b/tests/test_screenspace_preview.py
@@ -104,3 +104,121 @@ def test_multitool_previews_first_step(
 def test_unknown_tool_returns_placeholder(synthetic_frame: np.ndarray) -> None:
     img = screenspace_preview.build_preview(synthetic_frame, None, None, "bogus", {})
     assert img.size > 0
+
+
+# ---- Overlay layers ----
+
+
+def _all_overlay_pairs() -> list[tuple[str, str, str]]:
+    out: list[tuple[str, str, str]] = []
+    for tool, layers in screenspace_preview.OVERLAY_LAYERS.items():
+        for lid, _label, scope in layers:
+            out.append((tool, lid, scope))
+    return out
+
+
+@pytest.mark.parametrize("tool,layer,scope", _all_overlay_pairs())
+def test_build_overlay_layer_shape_matches_scope(
+    synthetic_frame: np.ndarray,
+    prev_frame: np.ndarray,
+    region: dict[str, int],
+    tool: str,
+    layer: str,
+    scope: str,
+) -> None:
+    """Region-scoped layers match the region rect; frame-scoped layers match the frame."""
+    params: dict = {}
+    if tool == "template":
+        # Use a slice that includes the gradient (non-zero std) so the
+        # heatmap layer can be computed.
+        params["template_image"] = synthetic_frame[10:50, 10:50].copy()
+
+    img = screenspace_preview.build_overlay_layer(
+        synthetic_frame, prev_frame, region, tool, layer, params
+    )
+    assert img is not None, f"overlay layer {tool}/{layer} returned None"
+    assert img.dtype == np.uint8
+    assert img.ndim == 3 and img.shape[2] == 3
+
+    if scope == "region":
+        assert img.shape[:2] == (region["h"], region["w"])
+    elif scope == "frame":
+        assert img.shape[:2] == synthetic_frame.shape[:2]
+
+
+def test_overlay_layer_excluded_tools_have_no_entry() -> None:
+    """timelapse and inactivity are intentionally not overlay-eligible."""
+    assert "timelapse" not in screenspace_preview.OVERLAY_LAYERS
+    assert "inactivity" not in screenspace_preview.OVERLAY_LAYERS
+
+
+def test_overlay_layer_unknown_returns_none(
+    synthetic_frame: np.ndarray, region: dict[str, int]
+) -> None:
+    img = screenspace_preview.build_overlay_layer(
+        synthetic_frame, None, region, "change", "not_a_layer", {}
+    )
+    assert img is None
+
+
+def test_overlay_layer_no_region_returns_none(synthetic_frame: np.ndarray) -> None:
+    img = screenspace_preview.build_overlay_layer(
+        synthetic_frame, None, None, "color", "region", {}
+    )
+    assert img is None
+
+
+def test_overlay_change_without_prev_only_yields_gray_blur(
+    synthetic_frame: np.ndarray, region: dict[str, int]
+) -> None:
+    """change/abs_diff and change/mask need a previous frame; gray_blur does not."""
+    gray_blur = screenspace_preview.build_overlay_layer(
+        synthetic_frame, None, region, "change", "gray_blur", {}
+    )
+    assert gray_blur is not None and gray_blur.shape[:2] == (region["h"], region["w"])
+    assert (
+        screenspace_preview.build_overlay_layer(
+            synthetic_frame, None, region, "change", "abs_diff", {}
+        )
+        is None
+    )
+    assert (
+        screenspace_preview.build_overlay_layer(
+            synthetic_frame, None, region, "change", "mask", {}
+        )
+        is None
+    )
+
+
+def test_overlay_layer_encodes_at_native_resolution(
+    synthetic_frame: np.ndarray, region: dict[str, int]
+) -> None:
+    """encode_png(cap_width=False) keeps the overlay's native size."""
+    img = screenspace_preview.build_overlay_layer(
+        synthetic_frame, None, region, "color", "region", {}
+    )
+    assert img is not None
+    png = screenspace_preview.encode_png(img, cap_width=False)
+    decoded = cv2.imdecode(np.frombuffer(png, dtype=np.uint8), cv2.IMREAD_COLOR)
+    assert decoded is not None
+    assert decoded.shape[:2] == (region["h"], region["w"])
+
+
+def test_overlay_multitool_inherits_first_step(
+    synthetic_frame: np.ndarray, region: dict[str, int]
+) -> None:
+    params = {"steps": [{"type": "scene", "parameters": {}}]}
+    img = screenspace_preview.build_overlay_layer(
+        synthetic_frame, None, region, "multitool", "edges", params
+    )
+    assert img is not None
+    assert img.shape[:2] == (region["h"], region["w"])
+
+
+def test_overlay_layer_scope_helper() -> None:
+    assert screenspace_preview.overlay_layer_scope("change", "mask") == "region"
+    assert (
+        screenspace_preview.overlay_layer_scope("template", "match_heatmap") == "frame"
+    )
+    assert screenspace_preview.overlay_layer_scope("timelapse", "anything") is None
+    assert screenspace_preview.overlay_layer_scope("change", "not_a_layer") is None


### PR DESCRIPTION
## Summary

- Adds a toggle in the Screenspace Model view panel that overlays the active tool's CV-pipeline output (region- or frame-scoped) on top of the live frame, plus a held-key `B` blink comparator at full alpha.
- Backend gains a `layer=` query param on `/api/preview/...` and a new `/api/preview/layers` catalog endpoint, both backed by `OVERLAY_LAYERS` in `screenspace_preview.py` as the single source of truth.
- Tools without pixel-aligned previews (timelapse, inactivity) are excluded; multi-layer tools like `change` get a layer selector for stepping through gray-blur / abs-diff / mask. `template`'s match heatmap is the only frame-scoped overlay.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` (613 passed; 14 new overlay tests)
- [x] `uv run ruff check && uv run ruff format` clean
- [x] `uv run ty check` no new diagnostics
- [ ] Manual: open `--screenspace`, draw a region, toggle overlay across each workflow; hold `B` to blink; verify selector appears for `change`/multi-layer tools and toggle is disabled (with tooltip) on timelapse/inactivity