### PR TITLE
docs: light commenting pass on frontend JS

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -1,4 +1,15 @@
-/* Convergence Browser – Phase 1–4 */
+/* Convergence Browser.
+ *
+ * Pulls events from multiple participants/streams (Screenspace detector
+ * events + Transcripts marks + sheet timestamps) onto a single timeline,
+ * then clusters moments where many participants do the same thing within a
+ * short window into "convergence zones". Renders a marker timeline and a
+ * frame-preview panel.
+ *
+ * `cvState._snapshot` records the last (ss, tr, sh) input lengths the view
+ * was built against, so we can detect when upstream data changed and the
+ * view needs to be rebuilt.
+ */
 
 (function () {
   "use strict";
@@ -287,22 +298,33 @@
   }
 
   // --- Convergence Algorithm ---
+  //
+  // Two passes:
+  //   1. For each event, count distinct participants whose events overlap
+  //      the window [start - W, start + W]. Events meeting `minParticipants`
+  //      are "qualifying".
+  //   2. Walk qualifying events in time order and merge any two within W of
+  //      each other into a single zone. This collapses contiguous bursts of
+  //      activity into one entry instead of one-zone-per-event.
+  //
+  // The inner loop in pass 1 is O(n²) in the worst case but breaks early on
+  // the sorted array once we pass the right edge of the window.
 
   function computeConvergenceZones(events, windowSec, minParticipants) {
     if (!events.length) return [];
 
-    // Sort by start time
     var sorted = events.slice().sort(function (a, b) { return a.start - b.start; });
 
-    // For each event, find distinct participants within ±windowSec
-    var qualifying = []; // indices of events that meet threshold
+    // Pass 1: per-event distinct-participant count within ±windowSec
+    var qualifying = []; // indices into sorted[] that meet threshold
     for (var i = 0; i < sorted.length; i++) {
       var center = sorted[i].start;
       var seen = {};
       for (var j = 0; j < sorted.length; j++) {
         if (sorted[j].start > center + windowSec) break;
+        // Skip if event j ends before the window opens.
         if (sorted[j].end < center - windowSec && sorted[j].start < center - windowSec) continue;
-        // Event j overlaps the window [center - W, center + W]
+        // Event j overlaps the window [center - W, center + W].
         if (sorted[j].start <= center + windowSec && sorted[j].end >= center - windowSec) {
           seen[sorted[j].participant] = true;
         }

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -1,4 +1,15 @@
-/* clipgen Insights */
+/* clipgen Insights builder.
+ *
+ * Edit/create insight records that group artifacts under three buckets:
+ * causes, behaviors, impacts. Artifact grid on one side, insight list on
+ * the other; popover posters expand individual artifacts in place.
+ *
+ * Each insight has the three buckets `causes`, `behaviors`, `impacts`,
+ * each holding `{ narrative, artifacts: [artifactId, ...] }` (see the
+ * Python `insights.py` for the canonical record shape). `dirtyIds` tracks
+ * which insights have unsaved local edits so the autosave layer knows
+ * what to push.
+ */
 
 (function () {
   "use strict";

--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -123,6 +123,9 @@
     return cov;
   }
 
+  // Group Screenspace events by event_type. First pass builds a per-key
+  // accumulator (counts, sums, min/max, per-participant subgroups); second
+  // pass converts each accumulator into the row shape the UI consumes.
   function computeEventTypeStats(events, participants) {
     var groups = {};
     for (var i = 0; i < events.length; i++) {
@@ -142,41 +145,41 @@
           per_participant: {},
         };
       }
-      var g = groups[key];
-      g.total_count++;
-      if (ev.time_in < g.first_sec) g.first_sec = ev.time_in;
-      if (ev.time_out > g.last_sec) g.last_sec = ev.time_out;
-      g.sum_time += ev.time_in;
-      g.sum_confidence += (ev.confidence || 0);
-      g.sum_duration += ((ev.time_out || 0) - (ev.time_in || 0));
-      g.participants_seen[ev.participant] = true;
-      if (!g.per_participant[ev.participant]) {
-        g.per_participant[ev.participant] = { count: 0, sum_time: 0 };
+      var group = groups[key];
+      group.total_count++;
+      if (ev.time_in < group.first_sec) group.first_sec = ev.time_in;
+      if (ev.time_out > group.last_sec) group.last_sec = ev.time_out;
+      group.sum_time += ev.time_in;
+      group.sum_confidence += (ev.confidence || 0);
+      group.sum_duration += ((ev.time_out || 0) - (ev.time_in || 0));
+      group.participants_seen[ev.participant] = true;
+      if (!group.per_participant[ev.participant]) {
+        group.per_participant[ev.participant] = { count: 0, sum_time: 0 };
       }
-      g.per_participant[ev.participant].count++;
-      g.per_participant[ev.participant].sum_time += ev.time_in;
+      group.per_participant[ev.participant].count++;
+      group.per_participant[ev.participant].sum_time += ev.time_in;
     }
     var result = [];
     var keys = Object.keys(groups);
     for (var j = 0; j < keys.length; j++) {
-      var g2 = groups[keys[j]];
+      var group = groups[keys[j]];
       var pp = {};
-      var ppKeys = Object.keys(g2.per_participant);
+      var ppKeys = Object.keys(group.per_participant);
       for (var k = 0; k < ppKeys.length; k++) {
-        var ppd = g2.per_participant[ppKeys[k]];
+        var ppd = group.per_participant[ppKeys[k]];
         pp[ppKeys[k]] = { count: ppd.count, mean_time: ppd.sum_time / ppd.count };
       }
       result.push({
-        event_type: g2.event_type,
-        detector: g2.detector,
-        total_count: g2.total_count,
-        participant_coverage: Object.keys(g2.participants_seen).length,
+        event_type: group.event_type,
+        detector: group.detector,
+        total_count: group.total_count,
+        participant_coverage: Object.keys(group.participants_seen).length,
         participant_total: participants.length,
-        first_sec: g2.first_sec === Infinity ? 0 : g2.first_sec,
-        last_sec: g2.last_sec === -Infinity ? 0 : g2.last_sec,
-        mean_time: g2.total_count ? g2.sum_time / g2.total_count : 0,
-        mean_confidence: g2.total_count ? g2.sum_confidence / g2.total_count : 0,
-        mean_duration: g2.total_count ? g2.sum_duration / g2.total_count : 0,
+        first_sec: group.first_sec === Infinity ? 0 : group.first_sec,
+        last_sec: group.last_sec === -Infinity ? 0 : group.last_sec,
+        mean_time: group.total_count ? group.sum_time / group.total_count : 0,
+        mean_confidence: group.total_count ? group.sum_confidence / group.total_count : 0,
+        mean_duration: group.total_count ? group.sum_duration / group.total_count : 0,
         per_participant: pp,
       });
     }
@@ -184,6 +187,10 @@
     return result;
   }
 
+  // Group Transcript marks by category. Same two-pass shape as
+  // computeEventTypeStats above. Marks may arrive with `time_in/time_out`
+  // (from the transcripts API) or `start/end` (from the studio queue
+  // shape); the fallback covers both.
   function computeTranscriptCategoryStats(marks, participants) {
     var groups = {};
     for (var i = 0; i < marks.length; i++) {
@@ -199,28 +206,28 @@
           per_participant: {},
         };
       }
-      var g = groups[cat];
-      g.total_count++;
-      var tin = m.time_in !== undefined ? m.time_in : m.start;
-      var tout = m.time_out !== undefined ? m.time_out : m.end;
-      if (tin < g.first_sec) g.first_sec = tin;
-      if (tout > g.last_sec) g.last_sec = tout;
-      g.participants_seen[m.participant] = true;
-      if (!g.per_participant[m.participant]) g.per_participant[m.participant] = 0;
-      g.per_participant[m.participant]++;
+      var group = groups[cat];
+      group.total_count++;
+      var timeIn = m.time_in !== undefined ? m.time_in : m.start;
+      var timeOut = m.time_out !== undefined ? m.time_out : m.end;
+      if (timeIn < group.first_sec) group.first_sec = timeIn;
+      if (timeOut > group.last_sec) group.last_sec = timeOut;
+      group.participants_seen[m.participant] = true;
+      if (!group.per_participant[m.participant]) group.per_participant[m.participant] = 0;
+      group.per_participant[m.participant]++;
     }
     var result = [];
     var keys = Object.keys(groups);
     for (var j = 0; j < keys.length; j++) {
-      var g2 = groups[keys[j]];
+      var group = groups[keys[j]];
       result.push({
-        category: g2.category,
-        total_count: g2.total_count,
-        participant_coverage: Object.keys(g2.participants_seen).length,
+        category: group.category,
+        total_count: group.total_count,
+        participant_coverage: Object.keys(group.participants_seen).length,
         participant_total: participants.length,
-        first_sec: g2.first_sec === Infinity ? 0 : g2.first_sec,
-        last_sec: g2.last_sec === -Infinity ? 0 : g2.last_sec,
-        per_participant: g2.per_participant,
+        first_sec: group.first_sec === Infinity ? 0 : group.first_sec,
+        last_sec: group.last_sec === -Infinity ? 0 : group.last_sec,
+        per_participant: group.per_participant,
       });
     }
     result.sort(function (a, b) { return b.total_count - a.total_count; });
@@ -396,8 +403,8 @@
     }
     // Transcript
     for (var m = 0; m < marks.length; m++) {
-      var tin = marks[m].time_in !== undefined ? marks[m].time_in : marks[m].start;
-      allTimes.push({ time: tin, stream: "transcript" });
+      var timeIn = marks[m].time_in !== undefined ? marks[m].time_in : marks[m].start;
+      allTimes.push({ time: timeIn, stream: "transcript" });
     }
     if (!allTimes.length) return { bins: [], binWidth: 0, maxTime: 0, maxCount: 0 };
 

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1,4 +1,20 @@
-/* clipgen Screenspace */
+/* clipgen Screenspace page.
+ *
+ * Frame canvas + overlay editor for defining regions and templates on a video
+ * frame, then running detector tasks (color/change/similarity/text/numbers/
+ * timelapse/template/flow/scene/inactivity, plus the multitool chain).
+ *
+ * Two patterns recur and are worth knowing up front:
+ *
+ *   - Request versioning. Frame fetches and participant switches are async,
+ *     and a fast user can issue several before the first lands. Every async
+ *     entry point bumps a `_*RequestVersion` counter and stale callbacks
+ *     compare against the latest version on resolution. See `_fetchFrame`.
+ *   - Overlay interactions. The overlay canvas is a small state machine over
+ *     four mutually-exclusive modes (drag template / drag region / resize
+ *     region / draw region), driven by `state.draggingTemplate`,
+ *     `state.draggingRegion`, `state.resizingRegion`, `state.drawingRegion`.
+ */
 
 (function () {
   "use strict";
@@ -559,6 +575,11 @@
     }, true);
   }
 
+  // Switching participants must clear the entire frame/overlay/playback
+  // pipeline together — keeping any one of these around (frameImage, video
+  // src, scene refs, pending fetch ids) would let the previous participant's
+  // state leak into the new one. Bumping the request-version counters also
+  // invalidates any in-flight frame/heatmap loads from the prior participant.
   function selectParticipant(pid, initialTimestamp) {
     var participantRequestVersion = ++_participantRequestVersion;
     _frameRequestVersion += 1;
@@ -637,6 +658,13 @@
     _fetchFrame(timestamp);
   }
 
+  // Frame loads are async and the user can scrub faster than the network.
+  // We coalesce: at most one in-flight image at a time. While one is loading,
+  // newer requests park their timestamp in `_pendingFrameTs` (loadFrame above)
+  // and the onload/onerror handler picks it up after the current load
+  // completes. `frameRequestVersion` plus the participant check rejects stale
+  // images whose participant has since changed, so we never paint a frame
+  // belonging to a participant the user already switched away from.
   function _fetchFrame(timestamp) {
     var participantId = state.selectedParticipant;
     var frameRequestVersion = ++_frameRequestVersion;
@@ -921,6 +949,18 @@
       .catch(function () { showToast("Failed to update region"); });
   }
 
+  // ---- Overlay interaction state machine ----
+  //
+  // Mousedown picks a mode based on what's under the cursor:
+  //   - inside the template overlay        → state.draggingTemplate
+  //   - on a region's resize handle        → state.resizingRegion
+  //   - inside a region body               → state.draggingRegion
+  //   - empty area                         → state.drawingRegion (new region)
+  //
+  // Mousemove updates whichever mode is active; mouseup commits and clears it.
+  // Document-level move/up listeners mirror the canvas handlers so a drag
+  // continues smoothly when the cursor leaves the overlay (the canvas-level
+  // handlers stop firing, the document ones take over).
   function initRegionDrawing() {
     var overlay = qs("#overlayCanvas");
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1,4 +1,20 @@
-/* clipgen Studio */
+/* clipgen Studio page.
+ *
+ * Main hub: spreadsheet grid on top, artifact + reel queues + generated
+ * outputs below, with intake panels that surface Screenspace and Transcript
+ * activity for cross-referencing.
+ *
+ * Key shapes on `state`:
+ *   sheetData                  — rows/cells from the loaded spreadsheet.
+ *   artifactQueue / reelQueue  — pending generation work; persisted to
+ *                                sessionStorage under QUEUE_STORAGE_KEY.
+ *   generatedArtifacts         — completed outputs surfaced to the UI.
+ *   cellResults                — per-cell success/error status overlaid
+ *                                onto the sheet grid (keyed by cellKey()).
+ *   intakeEvents / intakeClusters / intakeSeenIds — Screenspace polling
+ *                                snapshot; trIntakeMarks/Clusters mirror
+ *                                this for Transcripts.
+ */
 
 (function () {
   "use strict";
@@ -715,6 +731,12 @@
       });
   }
 
+  // On page load, reconcile the persisted manifest against the live sheet:
+  // for each manifest artifact, find its (participant, row) in sheetData,
+  // mark that cell green, and re-enqueue any artifact whose cell still has
+  // a valid timestamp but isn't already queued. The `seen` dedup guards
+  // against multiple artifacts mapping to the same cell (e.g. two clips
+  // generated from the same timestamp).
   function loadManifestState() {
     apiGet("api/manifest")
       .then(function (data) {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1,3 +1,17 @@
+/* clipgen Transcripts page.
+ *
+ * Editor for per-participant Whisper transcripts, plus cross-references into
+ * Screenspace events and the source spreadsheet. Two long-running side flows
+ * piggyback on the same `state`:
+ *
+ *   - Transcription warmup: a single `tryPostTranscriptionWarmup()` post that
+ *     asks the backend to preload the Whisper model. `_transcriptionWarmupPosted`
+ *     guards it so we never double-post per page load.
+ *   - Summary / citations: Ollama-generated; `_summaryPollTimer` and
+ *     `_citationsPollTimer` poll the backend until the result lands or the
+ *     user navigates away.
+ */
+
 (function () {
   "use strict";
 
@@ -400,6 +414,15 @@
     tryPostTranscriptionWarmup();
   }
 
+  // Ask the backend to preload the Whisper model. Idempotent per page load
+  // via `_transcriptionWarmupPosted`; we reset the flag whenever the post
+  // didn't actually lead to a load (skipped / error / no-op response) so a
+  // later trigger (e.g. pill hover) can retry. Five response branches:
+  //   skipped         — backend declined (e.g. no GPU policy met); keep flag
+  //                     down so a later hover can re-prompt.
+  //   already_loaded  — model is in memory; nothing to poll.
+  //   started / warming — kick off the model-hint poller until it finishes.
+  //   !ok / catch     — treat as transient; clear flag for retry.
   function tryPostTranscriptionWarmup() {
     if (_transcriptionWarmupPosted) return;
     if (state.transcribePrewarm === "off") return;
@@ -565,6 +588,16 @@
   }
 
   // ---- AI Summary ----
+  //
+  // Two cooperating pollers:
+  //   _summaryPollTimer   — runs while the backend is still generating the
+  //                         summary. Stops as soon as a summary lands, or
+  //                         when the user switches participant.
+  //   _citationsPollTimer — runs after the summary arrives if citations are
+  //                         still being computed (citations depend on summary).
+  // Both are cleared by their own _stop*Poll() helpers; either also stops if
+  // `state.selectedParticipant` no longer matches the participant the timer
+  // was started for.
 
   var _summaryPollTimer = null;
 

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1,4 +1,15 @@
-/* clipgen Timeline Viewer – viewer.js */
+/* clipgen Timeline Viewer.
+ *
+ * Renders the artifact timeline + list + filmstrip overlay. Artifacts come
+ * from `window.CLIPGEN_DATA` injected by the Python side — the same data
+ * contract is used both in-app (Studio embeds this viewer) and in the
+ * exported standalone viewer (artifacts inlined as base64), so we never
+ * assume a live backend is reachable.
+ *
+ * Lazy thumbnails: clip cards request thumbnails as they scroll into view
+ * via _thumbObserver / _thumbQueue, with results cached in _thumbCache for
+ * the session. Filmstrip mode does the same with its own observer/queue.
+ */
 (function () {
   "use strict";
 
@@ -251,6 +262,11 @@
     _cardScrub = null;
   }
 
+  // Lazy clip thumbnails. Called on initial render and again after any list
+  // rebuild — we tear down the previous observer first so old card elements
+  // (now detached) don't keep firing intersection callbacks. Each card is
+  // either served from `_thumbCache` immediately or queued for generation;
+  // unobserve fires once the card has been seen so we don't re-enqueue.
   function initClipThumbnails() {
     if (_thumbObserver) { _thumbObserver.disconnect(); _thumbObserver = null; }
     _thumbQueue = [];


### PR DESCRIPTION
## Summary
- Module-level headers added to `transcripts.js`, `screenspace.js`, `convergence.js`, `studio.js`, `viewer.js`, `insights-builder.js` so each file briefly explains its role and the key shapes on `state`.
- Why-comments added at the genuinely opaque sites: warmup state machine + summary/citation poller lifecycle (transcripts), `_fetchFrame` request versioning, `selectParticipant` cascade, region-drawing state machine (screenspace), two-pass convergence-zone algorithm (convergence), manifest reconcile dedup (studio), lazy-thumbnail observer reuse (viewer).
- Renamed cryptic locals in `metadata.js` (`tin/tout` → `timeIn/timeOut`, `g`/`g2` → `group`) so the code reads cleanly without needing comments.
- No behavioral changes; 613 pytests pass.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 613 passed
- [x] `node --check` on all 7 modified files
- [ ] Smoke-test Studio / Screenspace / Transcripts / Viewer in a browser