### PR TITLE
feat: recall video position and Screenspace tool across navigation

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -634,6 +634,7 @@
     state.currentTimestamp = timestamp;
     qs("#timestampInput").value = formatTimestamp(timestamp);
     renderPlayhead();
+    persistVideoTime(timestamp);
   }
 
   var _pendingFrameTs = null;
@@ -780,6 +781,7 @@
       var t = video.currentTime;
       state.currentTimestamp = t;
       qs("#timestampInput").value = formatTimestamp(t);
+      persistVideoTime(t);
       if (!_playheadRaf) {
         _playheadRaf = requestAnimationFrame(function () {
           _playheadRaf = 0;
@@ -787,6 +789,15 @@
         });
       }
     });
+  }
+
+  function persistVideoTime(t) {
+    if (!state.selectedParticipant || !isFinite(t)) return;
+    var stored = getStoredUIState("screenspace");
+    var map = (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant === "object")
+      ? stored.videoTimeByParticipant : {};
+    map[state.selectedParticipant] = t;
+    setStoredUIStateField("screenspace", "videoTimeByParticipant", map);
   }
 
   function playVideo() {
@@ -2347,6 +2358,7 @@
       tab.addEventListener("click", function () {
         hideToolInfoTooltip(true);
         state.activeWorkflow = tab.dataset.type;
+        setStoredUIStateField("screenspace", "activeWorkflow", state.activeWorkflow);
         qsa(".wf-tab").forEach(function (t) { t.classList.remove("active"); });
         tab.classList.add("active");
         renderWorkflowParams();
@@ -6245,7 +6257,12 @@
     qs("#participantSelect").addEventListener("change", function () {
       var pid = this.value;
       if (pid) {
-        selectParticipant(pid);
+        var stored = getStoredUIState("screenspace");
+        var ts;
+        if (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant[pid] === "number") {
+          ts = stored.videoTimeByParticipant[pid];
+        }
+        selectParticipant(pid, ts);
         state.runParticipants = [pid];
         renderRunParticipantPicker();
       }
@@ -6282,10 +6299,18 @@
               }
             }
           }
-          selectParticipant(pickId);
+          var initialTs;
+          if (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant[pickId] === "number") {
+            initialTs = stored.videoTimeByParticipant[pickId];
+          }
+          selectParticipant(pickId, initialTs);
           state.runParticipants = [pickId];
           if (stored.rightPaneTab === "queue" || stored.rightPaneTab === "results") {
             setRightPaneTab(stored.rightPaneTab);
+          }
+          if (stored.activeWorkflow) {
+            var wfTab = qs('.wf-tab[data-type="' + stored.activeWorkflow + '"]');
+            if (wfTab) wfTab.click();
           }
         }
         renderRunParticipantPicker();

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -531,6 +531,16 @@
       // Set VTT track
       var track = qs("#subtitleTrack");
       track.src = "api/vtt/" + pid;
+
+      var storedMap = getStoredUIState("transcripts").videoTimeByParticipant;
+      if (storedMap && typeof storedMap[pid] === "number") {
+        var savedTime = storedMap[pid];
+        var restoreTime = function () {
+          video.removeEventListener("loadedmetadata", restoreTime);
+          if (state.selectedParticipant === pid) video.currentTime = savedTime;
+        };
+        video.addEventListener("loadedmetadata", restoreTime);
+      }
     } else {
       video.removeAttribute("src");
       video.load();
@@ -1284,13 +1294,26 @@
 
   function initVideoSync() {
     var video = qs("#videoPlayer");
+    var save = function () { persistVideoTime(video.currentTime); };
     video.addEventListener("timeupdate", function () {
+      save();
       if (_syncRaf) return;
       _syncRaf = requestAnimationFrame(function () {
         _syncRaf = 0;
         highlightActiveSegment();
       });
     });
+    // Native scrubbing on a paused video doesn't always fire timeupdate.
+    video.addEventListener("seeked", save);
+  }
+
+  function persistVideoTime(t) {
+    if (!state.selectedParticipant || !isFinite(t)) return;
+    var stored = getStoredUIState("transcripts");
+    var map = (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant === "object")
+      ? stored.videoTimeByParticipant : {};
+    map[state.selectedParticipant] = t;
+    setStoredUIStateField("transcripts", "videoTimeByParticipant", map);
   }
 
   function highlightActiveSegment() {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.102"
+VERSIONNUM: str = "0.10.103"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Screenspace and Transcripts now remember the video playhead per participant when navigating between frontends.
- Screenspace also remembers the selected analysis tool.
- Reuses the existing \`clipgen-ui-state\` localStorage shape (no new keys/files); state is saved via the existing \`seekPlayhead\`/\`timeupdate\` paths and restored on page init.

## Test plan
- [ ] Open Screenspace, scrub to ~30s on P02, switch tool from color to text, navigate to Transcripts and back — playhead and tool restored.
- [ ] Switch participant in-page; confirm each participant's last position is recalled independently.
- [ ] Repeat in Transcripts (time + participant only).
- [ ] Hard reload the page; confirm state still restored from localStorage.