### PR TITLE
feat: data export for Screenspace, Insights, and Transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ node_modules/
 /*.html
 /*.gif
 /*.png
+*.csv
 
 # Files we want to keep
 !package.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ clipgen is a Python CLI tool that generates clips from timestamps stored in a Go
 | [screenspace_server.py](screenspace_server.py) | Screenspace Flask REST API: region CRUD, video frame extraction, task queue management, results retrieval |
 | [insights.py](insights.py) | Insights data model: CRUD operations for insight records, insights manifest read/write |
 | [insights_server.py](insights_server.py) | Insights Flask REST API: insight CRUD, artifact browsing, sprite sheet generation, viewer export |
+| [data_export.py](data_export.py) | Analysis-ready JSON+CSV export from Screenspace, Insights, and Transcripts manifests; powers `--export` CLI flag and `/screenspace/api/export/events` endpoint |
 | [assets/web/](assets/web/) | Static HTML/JS/CSS templates: timeline viewer (`viewer.html/js/css`), gallery (`gallery.html/js/css`), studio (`studio.html/js/css`), insights (`insights-builder.html/js/css`), insights viewer (`insights-viewer.html/js/css`), screenspace (`screenspace.html/js/css`). Shared utilities and constants live in `utils.js` (loaded before each page's main script) |
 
 ### Timeline HTML Viewer

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -2436,6 +2436,54 @@ body.panel-dragging #bottomPanel {
   -webkit-mask-image: url("/screenspace/icons/scissors.svg");
 }
 
+.rp-icon-download {
+  mask-image: url("/screenspace/icons/arrow-down-tray.svg");
+  -webkit-mask-image: url("/screenspace/icons/arrow-down-tray.svg");
+}
+
+.rp-export-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.rp-export-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 8rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-1);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rp-export-menu.hidden {
+  display: none;
+}
+
+.rp-export-item {
+  display: flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  color: var(--color-text);
+  background: none;
+  border: none;
+  text-align: left;
+  width: 100%;
+}
+
+.rp-export-item:hover {
+  background: var(--color-surface-alt);
+}
+
 /* Certainty slider wrapper */
 .rp-certainty-wrap {
   display: inline-flex;

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -199,6 +199,15 @@
           <button id="excludeNonVisibleBtn" class="rp-icon-btn hidden" type="button" aria-label="Exclude hidden">
             <span class="rp-icon-btn-icon rp-icon-scissors"></span>
           </button>
+          <div id="exportEventsWrap" class="rp-export-wrap">
+            <button id="exportEventsBtn" class="rp-icon-btn" type="button" aria-label="Export events" aria-haspopup="menu" aria-expanded="false">
+              <span class="rp-icon-btn-icon rp-icon-download"></span>
+            </button>
+            <div id="exportEventsMenu" class="rp-export-menu hidden" role="menu">
+              <button class="rp-export-item" type="button" role="menuitem" data-format="csv">CSV</button>
+              <button class="rp-export-item" type="button" role="menuitem" data-format="json">JSON</button>
+            </div>
+          </div>
         </div>
         <div id="resultsSwitcherPanel" class="rp-switcher-panel hidden"></div>
       </div>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5753,6 +5753,45 @@
       return state.showExcluded ? "Hiding excluded results is off" : "Hiding excluded results is on";
     }, { align: "center" });
 
+    function downloadEventsExport(format) {
+      var url = "api/export/events?format=" + encodeURIComponent(format);
+      if (!state.showExcluded) url += "&excluded=false";
+      var a = document.createElement("a");
+      a.href = url;
+      var ext = format === "csv" ? "csv" : "json";
+      a.download = "screenspace_events." + ext;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    }
+
+    var exportBtn = qs("#exportEventsBtn");
+    var exportMenu = qs("#exportEventsMenu");
+    if (exportBtn && exportMenu) {
+      attachHoverTooltip(exportBtn, "Export events", { align: "center" });
+      var closeExportMenu = function () {
+        exportMenu.classList.add("hidden");
+        exportBtn.setAttribute("aria-expanded", "false");
+      };
+      exportBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        var open = exportMenu.classList.toggle("hidden");
+        exportBtn.setAttribute("aria-expanded", open ? "false" : "true");
+      });
+      exportMenu.addEventListener("click", function (e) {
+        var item = e.target.closest(".rp-export-item");
+        if (!item) return;
+        e.stopPropagation();
+        downloadEventsExport(item.dataset.format);
+        closeExportMenu();
+      });
+      document.addEventListener("click", function (e) {
+        if (exportMenu.classList.contains("hidden")) return;
+        if (e.target.closest("#exportEventsWrap")) return;
+        closeExportMenu();
+      });
+    }
+
     var certaintySlider = qs("#certaintyCutoff");
     certaintySlider.addEventListener("input", function () {
       state.certaintyCutoff = parseInt(this.value, 10) / 100;

--- a/cli.py
+++ b/cli.py
@@ -296,6 +296,11 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         help="Write artifact metadata to a cumulative manifest JSON file alongside generated clips",
     )
     viewer_manifest.add_argument(
+        "--export",
+        action="store_true",
+        help="Export analysis-ready JSON+CSV from manifests in the output directory (Screenspace events, Insights, Transcripts). Skips manifests that aren't present.",
+    )
+    viewer_manifest.add_argument(
         "--timeline-viewer",
         action="store_true",
         help="Batch-export all clips and generate a per-participant timeline HTML viewer",
@@ -1757,21 +1762,27 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
         truthy=lambda a: bool(getattr(a, "insights", False)),
         error="--insights cannot be combined with mode, format, or --viewer/--regenerate/--studio/--screenspace flags.",
         hint="Only -i/-o (directories) and -v (verbose) may be used alongside --insights.",
-        blocks_modes=("timeline_viewer", "studio", "screenspace", "transcripts"),
+        blocks_modes=(
+            "timeline_viewer",
+            "studio",
+            "screenspace",
+            "transcripts",
+            "export",
+        ),
     ),
     _ModeSpec(
         key="screenspace",
         truthy=lambda a: bool(getattr(a, "screenspace", False)),
         error="--screenspace cannot be combined with mode, format, or --viewer/--regenerate/--studio/--insights flags.",
         hint="Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --screenspace.",
-        blocks_modes=("timeline_viewer", "studio", "insights", "transcripts"),
+        blocks_modes=("timeline_viewer", "studio", "insights", "transcripts", "export"),
     ),
     _ModeSpec(
         key="transcripts",
         truthy=lambda a: bool(getattr(a, "transcripts", False)),
         error="--transcripts cannot be combined with mode, format, or --viewer/--regenerate/--studio/--insights/--screenspace flags.",
         hint="Only -s (spreadsheet), -i/-o (directories), and -v (verbose) may be used alongside --transcripts.",
-        blocks_modes=("timeline_viewer", "studio", "insights", "screenspace"),
+        blocks_modes=("timeline_viewer", "studio", "insights", "screenspace", "export"),
     ),
     _ModeSpec(
         key="gallery",
@@ -1783,7 +1794,13 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
         selector_attrs=tuple(
             a for a in _BASE_SELECTOR_ATTRS if a not in ("screen", "gif")
         ),
-        blocks_modes=("timeline_viewer", "studio", "screenspace", "transcripts"),
+        blocks_modes=(
+            "timeline_viewer",
+            "studio",
+            "screenspace",
+            "transcripts",
+            "export",
+        ),
     ),
     _ModeSpec(
         key="pre_transcribe",
@@ -1799,6 +1816,23 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "screenspace",
             "transcripts",
             "gallery",
+            "export",
+        ),
+    ),
+    _ModeSpec(
+        key="export",
+        truthy=lambda a: bool(getattr(a, "export", False)),
+        error="--export cannot be combined with mode, format, or other standalone flags.",
+        hint="Use --export with -i/-o (directories) and -v (verbose) only.",
+        selector_attrs=_BASE_SELECTOR_ATTRS + ("highlights",),
+        blocks_modes=(
+            "timeline_viewer",
+            "studio",
+            "insights",
+            "screenspace",
+            "transcripts",
+            "gallery",
+            "pre_transcribe",
         ),
     ),
     _ModeSpec(
@@ -1815,6 +1849,7 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "transcripts",
             "gallery",
             "pre_transcribe",
+            "export",
             "ss_list_regions",
             "ss_list_stashes",
             "ss_list_tasks",
@@ -1836,6 +1871,7 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "transcripts",
             "gallery",
             "pre_transcribe",
+            "export",
             "ss_task",
             "ss_list_stashes",
             "ss_list_tasks",
@@ -1857,6 +1893,7 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "transcripts",
             "gallery",
             "pre_transcribe",
+            "export",
             "ss_task",
             "ss_list_regions",
             "ss_list_tasks",
@@ -1878,6 +1915,7 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "transcripts",
             "gallery",
             "pre_transcribe",
+            "export",
             "ss_task",
             "ss_list_regions",
             "ss_list_stashes",
@@ -1899,6 +1937,7 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "transcripts",
             "gallery",
             "pre_transcribe",
+            "export",
             "ss_task",
             "ss_list_regions",
             "ss_list_stashes",
@@ -1920,6 +1959,7 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "transcripts",
             "gallery",
             "pre_transcribe",
+            "export",
             "ss_task",
             "ss_list_regions",
             "ss_list_stashes",
@@ -2024,6 +2064,12 @@ def _dispatch_standalone_mode(
 
         server.start_combined_server(worksheet=None, default_page="insights")
         return True
+
+    # Standalone analysis-data export
+    if getattr(args, "export", False):
+        import data_export
+
+        sys.exit(data_export.run_cli_export())
 
     # Standalone Screenspace CLI tasks (no UI)
     if getattr(args, "ss_list_regions", False):
@@ -2132,6 +2178,7 @@ def main() -> None:
         or modes["ss_list_tasks"]
         or modes["summarize"]
         or modes["citations"]
+        or modes["export"]
         or pre_transcribe_mode
     )
 

--- a/clipgen.py
+++ b/clipgen.py
@@ -84,6 +84,8 @@ MODE_ALIASES = {
     "screenspace": "screenspace",
     "tr": "transcripts",
     "transcripts": "transcripts",
+    "ex": "export",
+    "export": "export",
     "se": "settings",
     "settings": "settings",
 }
@@ -1028,6 +1030,11 @@ def _dispatch_interactive_mode(
 
         server.start_combined_server(worksheet=worksheet, default_page="transcripts")
         return None
+    if mode == "export":
+        import data_export
+
+        data_export.run_cli_export()
+        return ([], False, None)
     if mode == "timeline-viewer":
         clips_list = spreadsheet.generate_list(worksheet, "batch", skip_prompts=True)
         outputs_generated, artifacts = process_clips(clips_list, output_format="clip")
@@ -1113,7 +1120,7 @@ def run_interactive_mode(worksheet: Any) -> None:
                 "\nEnter mode or input directly:\n"
                 "  Tools: (s)creen, (g)if, (re)el, (rl) reel-late, (rg) regenerate, (se)ttings \n"
                 "  Front: (st) studio, (in) insights, (ss) screenspace, (tr)anscripts, (br)owse \n"
-                "  Packs: (v)iewer, (tv) timeline-viewer, (gv) gallery \n"
+                "  Packs: (v)iewer, (tv) timeline-viewer, (gv) gallery, (ex)port \n"
                 "  Modes: (b)atch, (r)ange, (c)ategory, (l)ine, (ce)ll, (p)articipant, (k)eyword, (sv) severity \n"
                 '  Or enter mixed selectors directly: e.g. 5, P01.11, 13-16, "Observations"\n>> '
             )

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.112"
+VERSIONNUM: str = "0.10.113"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/data_export.py
+++ b/data_export.py
@@ -1,0 +1,430 @@
+# -*- coding: utf-8 -*-
+"""Analysis-ready data export for Screenspace, Insights, and Transcripts.
+
+Reads the on-disk manifests and produces flat, one-row-per-atomic-unit
+records suitable for direct loading into pandas / spreadsheets / BI tools.
+
+Exposed builders:
+    build_screenspace_events(manifest, *, include_excluded, participants, detectors)
+    build_insights_records(manifest)
+    build_transcript_segments(manifest)
+
+CSV serialization:
+    to_csv(records, *, preferred_column_order)
+
+Bundle writer (used by the --export CLI flag):
+    write_export_bundle(output_dir) -> list[Path]
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import config
+import utils
+
+
+# ---- Column ordering ----------------------------------------------------
+
+_SCREENSPACE_EVENT_BASE_COLS = (
+    "id",
+    "participant",
+    "source_video",
+    "detector",
+    "event_type",
+    "region",
+    "time_in",
+    "time_out",
+    "duration",
+    "confidence",
+    "excluded",
+    "task_id",
+)
+
+_INSIGHTS_BASE_COLS = (
+    "id",
+    "title",
+    "severity",
+    "status",
+    "summary",
+    "createdAt",
+    "updatedAt",
+    "timelineContext",
+    "causes_narrative",
+    "behaviors_narrative",
+    "impacts_narrative",
+    "causes_artifact_ids",
+    "behaviors_artifact_ids",
+    "impacts_artifact_ids",
+)
+
+_TRANSCRIPT_SEGMENT_BASE_COLS = (
+    "participant",
+    "segment_id",
+    "start",
+    "end",
+    "duration",
+    "text",
+    "language",
+    "model",
+    "source_file",
+    "transcribed_at",
+    "mark_categories",
+    "mark_labels",
+)
+
+
+# ---- Helpers ------------------------------------------------------------
+
+
+def _scalar_safe(value: Any) -> Any:
+    """Replace non-finite floats with None; pass everything else through."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+def _flatten_value_for_csv(value: Any) -> Any:
+    """Coerce list/dict values into CSV-safe strings.
+
+    Lists are joined with ';'. Dicts and other non-primitive types are
+    serialized as compact JSON. Strings, numbers, booleans, and None pass
+    through.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return _scalar_safe(value)
+    if isinstance(value, list):
+        if all(
+            isinstance(item, (str, int, float, bool)) or item is None for item in value
+        ):
+            return ";".join("" if item is None else str(item) for item in value)
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _ordered_columns(
+    records: list[dict[str, Any]],
+    preferred: tuple[str, ...] | list[str],
+) -> list[str]:
+    """Build a column list: preferred order first, then alphabetical tail."""
+    seen_keys: set[str] = set()
+    for rec in records:
+        seen_keys.update(rec.keys())
+    head = [c for c in preferred if c in seen_keys]
+    tail = sorted(k for k in seen_keys if k not in head)
+    return head + tail
+
+
+# ---- Builders -----------------------------------------------------------
+
+
+def build_screenspace_events(
+    manifest: dict[str, Any],
+    *,
+    include_excluded: bool = False,
+    participants: list[str] | None = None,
+    detectors: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Flatten Screenspace events into analysis-ready rows.
+
+    Hoists every key in ``event["metadata"]`` to the top level so each
+    detector's tool-specific values (magnitude, score, text_found, ...) become
+    their own columns.
+    """
+    raw_events = manifest.get("events", []) or []
+    participant_set = set(participants) if participants else None
+    detector_set = set(detectors) if detectors else None
+
+    records: list[dict[str, Any]] = []
+    for ev in raw_events:
+        if not isinstance(ev, dict):
+            continue
+        if not include_excluded and ev.get("excluded"):
+            continue
+        if participant_set and ev.get("participant") not in participant_set:
+            continue
+        if detector_set and ev.get("detector") not in detector_set:
+            continue
+
+        time_in = ev.get("time_in", 0.0)
+        time_out = ev.get("time_out", time_in)
+        try:
+            duration = float(time_out) - float(time_in)
+        except (TypeError, ValueError):
+            duration = 0.0
+
+        record: dict[str, Any] = {
+            "id": ev.get("id", ""),
+            "participant": ev.get("participant", ""),
+            "source_video": ev.get("source_video", ""),
+            "detector": ev.get("detector", ""),
+            "event_type": ev.get("event_type", ""),
+            "region": ev.get("region", ""),
+            "time_in": _scalar_safe(time_in),
+            "time_out": _scalar_safe(time_out),
+            "duration": _scalar_safe(round(duration, 4)),
+            "confidence": _scalar_safe(ev.get("confidence", 0.0)),
+            "excluded": bool(ev.get("excluded", False)),
+            "task_id": ev.get("task_id", ""),
+        }
+        metadata = ev.get("metadata", {}) or {}
+        if isinstance(metadata, dict):
+            for k, v in metadata.items():
+                if k in record:
+                    continue
+                record[k] = _scalar_safe(v)
+        records.append(record)
+    return records
+
+
+def build_insights_records(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten Insights into one row per insight with narratives hoisted."""
+    raw = manifest.get("insights", []) or []
+    records: list[dict[str, Any]] = []
+    for ins in raw:
+        if not isinstance(ins, dict):
+            continue
+        causes = ins.get("causes", {}) or {}
+        behaviors = ins.get("behaviors", {}) or {}
+        impacts = ins.get("impacts", {}) or {}
+        records.append(
+            {
+                "id": ins.get("id", ""),
+                "title": ins.get("title", ""),
+                "severity": ins.get("severity", ""),
+                "status": ins.get("status", ""),
+                "summary": ins.get("summary", ""),
+                "createdAt": ins.get("createdAt", ""),
+                "updatedAt": ins.get("updatedAt", ""),
+                "timelineContext": ins.get("timelineContext", ""),
+                "causes_narrative": causes.get("narrative", "")
+                if isinstance(causes, dict)
+                else "",
+                "behaviors_narrative": behaviors.get("narrative", "")
+                if isinstance(behaviors, dict)
+                else "",
+                "impacts_narrative": impacts.get("narrative", "")
+                if isinstance(impacts, dict)
+                else "",
+                "causes_artifact_ids": list(causes.get("artifacts", []) or [])
+                if isinstance(causes, dict)
+                else [],
+                "behaviors_artifact_ids": list(behaviors.get("artifacts", []) or [])
+                if isinstance(behaviors, dict)
+                else [],
+                "impacts_artifact_ids": list(impacts.get("artifacts", []) or [])
+                if isinstance(impacts, dict)
+                else [],
+            }
+        )
+    return records
+
+
+def build_transcript_segments(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """One row per transcript segment, with participant and mark info joined."""
+    source = manifest.get("source_transcripts", {}) or {}
+    marks = manifest.get("marks", []) or []
+
+    marks_by_segment: dict[str, list[dict[str, Any]]] = {}
+    for mk in marks:
+        if not isinstance(mk, dict):
+            continue
+        seg_id = mk.get("segment_id")
+        if not seg_id:
+            continue
+        marks_by_segment.setdefault(seg_id, []).append(mk)
+
+    records: list[dict[str, Any]] = []
+    for participant_id, entry in source.items():
+        if not isinstance(entry, dict):
+            continue
+        language = entry.get("language", "")
+        model = entry.get("model", "")
+        source_file = entry.get("source_file", "")
+        transcribed_at = entry.get("transcribed_at", "")
+        for idx, seg in enumerate(entry.get("segments", []) or []):
+            if not isinstance(seg, dict):
+                continue
+            seg_id = seg.get("id") or f"{participant_id}:{idx}"
+            try:
+                start = float(seg.get("start", 0.0))
+                end = float(seg.get("end", 0.0))
+            except (TypeError, ValueError):
+                start = 0.0
+                end = 0.0
+            seg_marks = marks_by_segment.get(seg_id, [])
+            records.append(
+                {
+                    "participant": participant_id,
+                    "segment_id": seg_id,
+                    "start": _scalar_safe(start),
+                    "end": _scalar_safe(end),
+                    "duration": _scalar_safe(round(end - start, 4)),
+                    "text": seg.get("text", ""),
+                    "language": language,
+                    "model": model,
+                    "source_file": source_file,
+                    "transcribed_at": transcribed_at,
+                    "mark_categories": [m.get("category", "") for m in seg_marks],
+                    "mark_labels": [m.get("label", "") for m in seg_marks],
+                }
+            )
+    return records
+
+
+# ---- Serialization ------------------------------------------------------
+
+
+def to_csv(
+    records: list[dict[str, Any]],
+    *,
+    preferred_column_order: tuple[str, ...] | list[str] = (),
+) -> str:
+    """Serialize records to a CSV string.
+
+    Columns: ``preferred_column_order`` first (those that actually appear in
+    the data), then any remaining keys sorted alphabetically. List/dict
+    values are flattened via :func:`_flatten_value_for_csv`.
+    """
+    columns = _ordered_columns(records, preferred_column_order)
+    if not columns:
+        return ""
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=columns, extrasaction="ignore")
+    writer.writeheader()
+    for rec in records:
+        flat = {col: _flatten_value_for_csv(rec.get(col)) for col in columns}
+        writer.writerow(flat)
+    return buf.getvalue()
+
+
+def to_json(records: list[dict[str, Any]]) -> str:
+    """Serialize records to a JSON string with an export envelope."""
+    payload = {
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "version": getattr(config, "VERSIONNUM", ""),
+        "records": records,
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2, default=_scalar_safe)
+
+
+# ---- Bundle writer ------------------------------------------------------
+
+
+_SURFACES: tuple[tuple[str, str, str, tuple[str, ...]], ...] = (
+    (
+        "screenspace_events",
+        "screenspace",
+        config.SCREENSPACE_MANIFEST_FILENAME,
+        _SCREENSPACE_EVENT_BASE_COLS,
+    ),
+    ("insights", "insights", config.INSIGHTS_MANIFEST_FILENAME, _INSIGHTS_BASE_COLS),
+    (
+        "transcripts",
+        "transcripts",
+        config.TRANSCRIPTS_MANIFEST_FILENAME,
+        _TRANSCRIPT_SEGMENT_BASE_COLS,
+    ),
+)
+
+
+def _build_for_surface(
+    surface_key: str, manifest: dict[str, Any]
+) -> list[dict[str, Any]]:
+    if surface_key == "screenspace":
+        return build_screenspace_events(manifest)
+    if surface_key == "insights":
+        return build_insights_records(manifest)
+    if surface_key == "transcripts":
+        return build_transcript_segments(manifest)
+    raise ValueError(f"Unknown surface: {surface_key}")
+
+
+def write_export_bundle(output_dir: Path | None = None) -> list[Path]:
+    """Write JSON+CSV exports for every manifest present in *output_dir*.
+
+    Manifests that don't exist on disk are silently skipped. Returns the
+    list of files actually written.
+    """
+    base = Path(output_dir) if output_dir else Path(utils.get_effective_output_dir())
+    written: list[Path] = []
+    for output_basename, surface_key, manifest_filename, preferred_cols in _SURFACES:
+        manifest_path = base / manifest_filename
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as err:
+            utils.warning_print(
+                f"Skipping {manifest_filename}: could not read manifest.",
+                [f"Error: {err}"],
+            )
+            continue
+        records = _build_for_surface(surface_key, manifest)
+        if not records:
+            utils.info_print(
+                f"Skipping {output_basename}: manifest is present but contains no records."
+            )
+            continue
+        json_path = base / f"clipgen_export_{output_basename}.json"
+        csv_path = base / f"clipgen_export_{output_basename}.csv"
+        json_path.write_text(to_json(records), encoding="utf-8")
+        csv_path.write_text(
+            to_csv(records, preferred_column_order=preferred_cols),
+            encoding="utf-8",
+        )
+        written.extend([json_path, csv_path])
+        utils.info_print(
+            f"Exported {len(records)} record(s) to {json_path.name} and {csv_path.name}"
+        )
+    return written
+
+
+def run_cli_export() -> int:
+    """Entry point for the ``--export`` CLI flag.
+
+    Reads manifests from the effective output directory, writes export
+    files, prints a summary, and returns an exit code (0 on success).
+    """
+    output_dir = Path(utils.get_effective_output_dir())
+    utils.info_print(f"Exporting analysis data from manifests in {output_dir}")
+    written = write_export_bundle(output_dir)
+    if not written:
+        utils.warning_print(
+            "No exports written.",
+            [
+                "No manifest files were found in the output directory.",
+                f"Expected one or more of: {config.SCREENSPACE_MANIFEST_FILENAME}, "
+                f"{config.INSIGHTS_MANIFEST_FILENAME}, {config.TRANSCRIPTS_MANIFEST_FILENAME}",
+            ],
+        )
+        return 1
+    utils.info_print(f"Wrote {len(written)} export file(s).")
+    return 0
+
+
+SCREENSPACE_EVENT_COLUMNS: tuple[str, ...] = _SCREENSPACE_EVENT_BASE_COLS
+INSIGHTS_COLUMNS: tuple[str, ...] = _INSIGHTS_BASE_COLS
+TRANSCRIPT_SEGMENT_COLUMNS: tuple[str, ...] = _TRANSCRIPT_SEGMENT_BASE_COLS
+
+
+__all__ = [
+    "build_screenspace_events",
+    "build_insights_records",
+    "build_transcript_segments",
+    "to_csv",
+    "to_json",
+    "write_export_bundle",
+    "run_cli_export",
+    "SCREENSPACE_EVENT_COLUMNS",
+    "INSIGHTS_COLUMNS",
+    "TRANSCRIPT_SEGMENT_COLUMNS",
+]

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -30,6 +30,7 @@ API endpoints (all under /screenspace/):
   POST /api/tasks/resume                   – resume the worker
   GET  /api/tasks/<task_id>/results        – analysis results (timestamps, artifact paths)
   GET  /api/events                         – list result events across all tasks
+  GET  /api/export/events                  – export events as analysis-ready JSON (default) or CSV (?format=csv)
   PUT  /api/events/<event_id>/exclude      – mark an event excluded
   PUT  /api/events/<event_id>/include      – mark an event included
   PUT  /api/events/bulk-exclude            – bulk exclude events by task/time range
@@ -1354,6 +1355,54 @@ def api_events_list() -> FlaskResponse:
     if task_id:
         events = [e for e in events if e.get("task_id") == task_id]
     return jsonify({"ok": True, "events": _sanitize_floats(events)})
+
+
+@screenspace_bp.route("/api/export/events")
+def api_export_events() -> FlaskResponse:
+    """Export Screenspace events as analysis-ready JSON or CSV.
+
+    Query params:
+      format:      "json" (default) or "csv"
+      excluded:    "true" to keep only excluded, "false" to drop excluded; default keeps both
+      participant: keep only events for this participant id
+      detector:    keep only events from this detector type
+    """
+    import data_export
+
+    fmt = (request.args.get("format") or "json").lower()
+    excluded_filter = request.args.get("excluded")
+    participant = request.args.get("participant")
+    detector = request.args.get("detector")
+
+    if excluded_filter == "false":
+        include_excluded = False
+    elif excluded_filter == "true":
+        include_excluded = True
+    else:
+        include_excluded = True
+
+    records = data_export.build_screenspace_events(
+        _manifest,
+        include_excluded=include_excluded,
+        participants=[participant] if participant else None,
+        detectors=[detector] if detector else None,
+    )
+    if excluded_filter == "true":
+        records = [r for r in records if r.get("excluded")]
+
+    if fmt == "csv":
+        body = data_export.to_csv(
+            records,
+            preferred_column_order=data_export.SCREENSPACE_EVENT_COLUMNS,
+        )
+        response = Response(body, mimetype="text/csv")
+        response.headers["Content-Disposition"] = (
+            'attachment; filename="screenspace_events.csv"'
+        )
+        return response
+    if fmt == "json":
+        return jsonify({"ok": True, "events": _sanitize_floats(records)})
+    return jsonify({"ok": False, "error": f"Unsupported format: {fmt}"}), 400
 
 
 @screenspace_bp.route("/api/events/<event_id>/exclude", methods=["PUT"])

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -54,6 +54,7 @@ def _base_args(**overrides):
         "ss_event_label": None,
         "summarize": None,
         "citations": None,
+        "export": False,
     }
     args.update(overrides)
     return Namespace(**args)
@@ -71,6 +72,38 @@ def test_parse_arguments_rejects_conflicting_output_flags(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         cli.parse_arguments()
     assert exc.value.code == 2
+
+
+def test_parse_arguments_export_flag(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--export"])
+    args = cli.parse_arguments()
+    assert getattr(args, "export", False) is True
+
+
+def test_export_dispatch_calls_run_cli_export(monkeypatch):
+    """--export must dispatch to data_export.run_cli_export and exit cleanly."""
+    import data_export
+
+    args = _base_args(export=True)
+    called = {}
+
+    def fake_run():
+        called["yes"] = True
+        return 0
+
+    monkeypatch.setattr(data_export, "run_cli_export", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        cli._dispatch_standalone_mode(args, cli_mode=True, gallery_arg=None)
+    assert exc.value.code == 0
+    assert called.get("yes") is True
+
+
+def test_export_conflicts_with_studio(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--export", "--studio"])
+    args = cli.parse_arguments()
+    with pytest.raises(SystemExit) as exc:
+        cli._validate_mode_conflicts(args)
+    assert exc.value.code == 1
 
 
 def test_parse_arguments_titlecards_flags(monkeypatch):

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1,0 +1,408 @@
+"""Tests for data_export module: builders, CSV writer, and bundle writer."""
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+import config
+import data_export
+
+
+# ---- Fixtures -----------------------------------------------------------
+
+
+def _ss_event(detector, **overrides):
+    """Build a Screenspace event dict matching screenspace.create_event() shape."""
+    base = {
+        "id": f"ev_{detector}_1",
+        "source_video": "study_P01.mp4",
+        "participant": "P01",
+        "detector": detector,
+        "event_type": detector + ": region1",
+        "time_in": 12.5,
+        "time_out": 12.5,
+        "confidence": 0.85,
+        "metadata": {},
+        "excluded": False,
+        "task_id": "ss_abc12345",
+        "region": "region1",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def screenspace_manifest():
+    return {
+        "regions": {},
+        "tasks": [],
+        "events": [
+            _ss_event("color"),
+            _ss_event("change", metadata={"magnitude": 0.42}),
+            _ss_event("similarity", metadata={"score": 0.91}),
+            _ss_event("text", metadata={"text_found": "Game Over"}),
+            _ss_event("numbers", metadata={"value": 250}),
+            _ss_event("template", metadata={"match_count": 3, "best_score": 0.78}),
+            _ss_event("flow", metadata={"magnitude": 0.55, "angle": 90.0}),
+            _ss_event("scene", metadata={"scene_name": "menu", "score": 0.93}),
+            _ss_event(
+                "inactivity",
+                time_in=20.0,
+                time_out=35.5,
+                metadata={"duration": 15.5, "avg_distance": 0.02},
+            ),
+            _ss_event(
+                "color",
+                id="ev_excluded",
+                participant="P02",
+                excluded=True,
+            ),
+        ],
+        "stashes": [],
+    }
+
+
+@pytest.fixture
+def insights_manifest():
+    return {
+        "meta": {"version": "0.0.0"},
+        "insights": [
+            {
+                "id": "ins_abc12345",
+                "title": "Players miss the save button",
+                "summary": "Three of five players failed to find Save.",
+                "severity": "High",
+                "status": "final",
+                "createdAt": "2026-04-01T10:00:00+00:00",
+                "updatedAt": "2026-04-02T10:00:00+00:00",
+                "timelineContext": "early-game tutorial",
+                "causes": {
+                    "narrative": "Save icon is below the fold.",
+                    "artifacts": ["a1", "a2"],
+                },
+                "behaviors": {
+                    "narrative": "Users scroll up looking for it.",
+                    "artifacts": [],
+                },
+                "impacts": {
+                    "narrative": "Lost progress on quit.",
+                    "artifacts": ["a3"],
+                },
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def transcripts_manifest():
+    return {
+        "source_transcripts": {
+            "P01": {
+                "language": "en",
+                "model": "base",
+                "source_file": "study_P01.mp4",
+                "transcribed_at": "2026-04-01T10:00:00+00:00",
+                "segments": [
+                    {"id": "P01:0", "start": 0.0, "end": 5.0, "text": "Hello there."},
+                    {
+                        "id": "P01:1",
+                        "start": 5.0,
+                        "end": 10.0,
+                        "text": "What's this button?",
+                    },
+                ],
+            },
+            "P02": {
+                "language": "en",
+                "model": "base",
+                "source_file": "study_P02.mp4",
+                "transcribed_at": "2026-04-01T11:00:00+00:00",
+                "segments": [
+                    {"id": "P02:0", "start": 0.0, "end": 4.5, "text": "Is this it?"},
+                ],
+            },
+        },
+        "corrections": [],
+        "marks": [
+            {
+                "id": "m_x",
+                "segment_id": "P01:1",
+                "category": "pain_point",
+                "label": "confused",
+                "created": "2026-04-01T12:00:00+00:00",
+            }
+        ],
+    }
+
+
+# ---- Screenspace events builder -----------------------------------------
+
+
+def test_screenspace_events_default_excludes_marked(screenspace_manifest):
+    rows = data_export.build_screenspace_events(screenspace_manifest)
+    assert all(not r["excluded"] for r in rows)
+    assert len(rows) == 9
+    detectors = {r["detector"] for r in rows}
+    assert detectors == {
+        "color",
+        "change",
+        "similarity",
+        "text",
+        "numbers",
+        "template",
+        "flow",
+        "scene",
+        "inactivity",
+    }
+
+
+def test_screenspace_events_include_excluded(screenspace_manifest):
+    rows = data_export.build_screenspace_events(
+        screenspace_manifest, include_excluded=True
+    )
+    assert len(rows) == 10
+    excluded_rows = [r for r in rows if r["excluded"]]
+    assert len(excluded_rows) == 1
+
+
+def test_screenspace_events_filters_participant(screenspace_manifest):
+    rows = data_export.build_screenspace_events(
+        screenspace_manifest, include_excluded=True, participants=["P02"]
+    )
+    assert len(rows) == 1
+    assert rows[0]["participant"] == "P02"
+
+
+def test_screenspace_events_filters_detector(screenspace_manifest):
+    rows = data_export.build_screenspace_events(
+        screenspace_manifest, detectors=["change", "flow"]
+    )
+    assert len(rows) == 2
+    assert {r["detector"] for r in rows} == {"change", "flow"}
+
+
+def test_screenspace_events_metadata_hoisted(screenspace_manifest):
+    rows = data_export.build_screenspace_events(screenspace_manifest)
+    by_detector = {r["detector"]: r for r in rows}
+
+    assert by_detector["change"]["magnitude"] == 0.42
+    assert by_detector["similarity"]["score"] == 0.91
+    assert by_detector["text"]["text_found"] == "Game Over"
+    assert by_detector["numbers"]["value"] == 250
+    assert by_detector["template"]["match_count"] == 3
+    assert by_detector["template"]["best_score"] == 0.78
+    assert by_detector["flow"]["magnitude"] == 0.55
+    assert by_detector["flow"]["angle"] == 90.0
+    assert by_detector["scene"]["scene_name"] == "menu"
+    assert by_detector["inactivity"]["duration"] == 15.5
+    assert by_detector["inactivity"]["avg_distance"] == 0.02
+
+
+def test_screenspace_events_metadata_does_not_overwrite_canonical(
+    screenspace_manifest,
+):
+    # Sneak a metadata key that collides with a canonical column;
+    # the canonical column must win.
+    screenspace_manifest["events"][0]["metadata"] = {"participant": "P99"}
+    rows = data_export.build_screenspace_events(screenspace_manifest)
+    color_row = next(r for r in rows if r["detector"] == "color")
+    assert color_row["participant"] == "P01"
+
+
+def test_screenspace_events_duration_computed(screenspace_manifest):
+    rows = data_export.build_screenspace_events(screenspace_manifest)
+    inactivity = next(r for r in rows if r["detector"] == "inactivity")
+    assert inactivity["duration"] == pytest.approx(15.5, abs=1e-6)
+
+
+def test_screenspace_events_handles_nonfinite_floats():
+    manifest = {
+        "events": [
+            {
+                "id": "ev_nan",
+                "participant": "P01",
+                "detector": "change",
+                "event_type": "change",
+                "time_in": 1.0,
+                "time_out": 1.0,
+                "confidence": float("nan"),
+                "metadata": {"magnitude": float("inf")},
+                "excluded": False,
+                "task_id": "t",
+                "region": "r",
+            }
+        ]
+    }
+    rows = data_export.build_screenspace_events(manifest)
+    assert rows[0]["confidence"] is None
+    assert rows[0]["magnitude"] is None
+
+
+# ---- Insights builder ---------------------------------------------------
+
+
+def test_insights_builder_flattens_narratives(insights_manifest):
+    rows = data_export.build_insights_records(insights_manifest)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["title"] == "Players miss the save button"
+    assert r["causes_narrative"] == "Save icon is below the fold."
+    assert r["behaviors_narrative"] == "Users scroll up looking for it."
+    assert r["impacts_narrative"] == "Lost progress on quit."
+    assert r["causes_artifact_ids"] == ["a1", "a2"]
+    assert r["behaviors_artifact_ids"] == []
+    assert r["impacts_artifact_ids"] == ["a3"]
+
+
+def test_insights_builder_handles_missing_subsections():
+    manifest = {"insights": [{"id": "ins_x", "title": "T"}]}
+    rows = data_export.build_insights_records(manifest)
+    assert rows[0]["causes_narrative"] == ""
+    assert rows[0]["behaviors_artifact_ids"] == []
+
+
+# ---- Transcript segments builder ----------------------------------------
+
+
+def test_transcript_segments_one_row_per_segment(transcripts_manifest):
+    rows = data_export.build_transcript_segments(transcripts_manifest)
+    assert len(rows) == 3
+    by_id = {r["segment_id"]: r for r in rows}
+    assert "P01:0" in by_id
+    assert "P01:1" in by_id
+    assert "P02:0" in by_id
+
+
+def test_transcript_segments_carries_participant_metadata(transcripts_manifest):
+    rows = data_export.build_transcript_segments(transcripts_manifest)
+    for r in rows:
+        assert r["language"] == "en"
+        assert r["model"] == "base"
+        if r["participant"] == "P01":
+            assert r["source_file"] == "study_P01.mp4"
+
+
+def test_transcript_segments_joins_marks(transcripts_manifest):
+    rows = data_export.build_transcript_segments(transcripts_manifest)
+    by_id = {r["segment_id"]: r for r in rows}
+    marked = by_id["P01:1"]
+    unmarked = by_id["P01:0"]
+    assert marked["mark_categories"] == ["pain_point"]
+    assert marked["mark_labels"] == ["confused"]
+    assert unmarked["mark_categories"] == []
+
+
+def test_transcript_segments_duration(transcripts_manifest):
+    rows = data_export.build_transcript_segments(transcripts_manifest)
+    by_id = {r["segment_id"]: r for r in rows}
+    assert by_id["P01:0"]["duration"] == pytest.approx(5.0, abs=1e-6)
+    assert by_id["P02:0"]["duration"] == pytest.approx(4.5, abs=1e-6)
+
+
+# ---- CSV serialization --------------------------------------------------
+
+
+def test_to_csv_uses_preferred_order_then_alphabetical(screenspace_manifest):
+    rows = data_export.build_screenspace_events(screenspace_manifest)
+    csv_text = data_export.to_csv(
+        rows, preferred_column_order=data_export.SCREENSPACE_EVENT_COLUMNS
+    )
+    reader = csv.DictReader(io.StringIO(csv_text))
+    headers = reader.fieldnames
+    assert headers is not None
+    canonical = list(data_export.SCREENSPACE_EVENT_COLUMNS)
+    # Canonical columns should appear first, in order
+    assert headers[: len(canonical)] == canonical
+    # Tail should be alphabetical
+    tail = headers[len(canonical) :]
+    assert tail == sorted(tail)
+
+
+def test_to_csv_flattens_lists_with_semicolon():
+    rows = [{"a": [1, 2, 3], "b": "x"}]
+    csv_text = data_export.to_csv(rows)
+    reader = csv.DictReader(io.StringIO(csv_text))
+    row = next(reader)
+    assert row["a"] == "1;2;3"
+
+
+def test_to_csv_empty_records_returns_empty_string():
+    assert data_export.to_csv([]) == ""
+
+
+def test_to_json_envelope_shape(screenspace_manifest):
+    rows = data_export.build_screenspace_events(screenspace_manifest)
+    parsed = json.loads(data_export.to_json(rows))
+    assert set(parsed.keys()) == {"exported_at", "version", "records"}
+    assert parsed["version"] == config.VERSIONNUM
+    assert len(parsed["records"]) == len(rows)
+
+
+# ---- Bundle writer ------------------------------------------------------
+
+
+def _write_manifest(tmp_path: Path, filename: str, content: dict) -> None:
+    (tmp_path / filename).write_text(json.dumps(content), encoding="utf-8")
+
+
+def test_bundle_writes_all_three(
+    tmp_path, screenspace_manifest, insights_manifest, transcripts_manifest
+):
+    _write_manifest(
+        tmp_path, config.SCREENSPACE_MANIFEST_FILENAME, screenspace_manifest
+    )
+    _write_manifest(tmp_path, config.INSIGHTS_MANIFEST_FILENAME, insights_manifest)
+    _write_manifest(
+        tmp_path, config.TRANSCRIPTS_MANIFEST_FILENAME, transcripts_manifest
+    )
+
+    written = data_export.write_export_bundle(tmp_path)
+    names = {p.name for p in written}
+    assert "clipgen_export_screenspace_events.json" in names
+    assert "clipgen_export_screenspace_events.csv" in names
+    assert "clipgen_export_insights.json" in names
+    assert "clipgen_export_insights.csv" in names
+    assert "clipgen_export_transcripts.json" in names
+    assert "clipgen_export_transcripts.csv" in names
+    assert len(written) == 6
+
+
+def test_bundle_skips_missing_manifests(tmp_path, screenspace_manifest):
+    _write_manifest(
+        tmp_path, config.SCREENSPACE_MANIFEST_FILENAME, screenspace_manifest
+    )
+    written = data_export.write_export_bundle(tmp_path)
+    assert len(written) == 2
+    assert all("screenspace_events" in p.name for p in written)
+
+
+def test_bundle_returns_empty_when_no_manifests(tmp_path):
+    assert data_export.write_export_bundle(tmp_path) == []
+
+
+def test_bundle_skips_empty_manifest(tmp_path):
+    _write_manifest(
+        tmp_path,
+        config.SCREENSPACE_MANIFEST_FILENAME,
+        {"regions": {}, "tasks": [], "events": [], "stashes": []},
+    )
+    assert data_export.write_export_bundle(tmp_path) == []
+
+
+def test_bundle_csv_has_data_rows(tmp_path, screenspace_manifest):
+    _write_manifest(
+        tmp_path, config.SCREENSPACE_MANIFEST_FILENAME, screenspace_manifest
+    )
+    data_export.write_export_bundle(tmp_path)
+    csv_path = tmp_path / "clipgen_export_screenspace_events.csv"
+    text = csv_path.read_text(encoding="utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    # 9 visible events (excluded one filtered out)
+    assert len(rows) == 9
+    fieldnames = reader.fieldnames
+    assert fieldnames is not None
+    assert "magnitude" in fieldnames

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1245,3 +1245,73 @@ def _install_persist_spy(monkeypatch):
 
     monkeypatch.setattr(screenspace_server, "_do_persist", spy)
     return calls
+
+
+# ---- Export endpoint ----
+
+
+def test_export_events_json(client):
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1"),
+        _sample_event("ev_2", excluded=True),
+    ]
+    resp = client.get("/screenspace/api/export/events?format=json")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(data["events"]) == 2
+    # Metadata should be hoisted to top-level "magnitude"
+    assert any("magnitude" in e for e in data["events"])
+
+
+def test_export_events_csv(client):
+    import csv as _csv
+    import io as _io
+
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1"),
+        _sample_event("ev_2", participant="P02"),
+    ]
+    resp = client.get("/screenspace/api/export/events?format=csv")
+    assert resp.status_code == 200
+    assert resp.content_type.startswith("text/csv")
+    assert 'attachment; filename="screenspace_events.csv"' in resp.headers.get(
+        "Content-Disposition", ""
+    )
+    text = resp.get_data(as_text=True)
+    reader = _csv.DictReader(_io.StringIO(text))
+    rows = list(reader)
+    assert len(rows) == 2
+    fieldnames = reader.fieldnames
+    assert fieldnames is not None
+    assert "magnitude" in fieldnames
+    assert fieldnames[0] == "id"
+
+
+def test_export_events_filter_excluded_false(client):
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1"),
+        _sample_event("ev_2", excluded=True),
+    ]
+    resp = client.get("/screenspace/api/export/events?format=json&excluded=false")
+    data = resp.get_json()
+    assert len(data["events"]) == 1
+    assert data["events"][0]["id"] == "ev_1"
+
+
+def test_export_events_filter_participant(client):
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1", participant="P01"),
+        _sample_event("ev_2", participant="P02"),
+    ]
+    resp = client.get("/screenspace/api/export/events?format=json&participant=P02")
+    data = resp.get_json()
+    assert len(data["events"]) == 1
+    assert data["events"][0]["participant"] == "P02"
+
+
+def test_export_events_unsupported_format(client):
+    resp = client.get("/screenspace/api/export/events?format=xml")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["ok"] is False


### PR DESCRIPTION
## Summary
- New \`data_export.py\` flattens Screenspace events (with tool-specific metadata hoisted), Insights, and Transcript segments into one row per atomic unit, then serializes to JSON or CSV
- New \`--export\` CLI flag and interactive \`(ex)port\` mode runs the bundle writer against whatever manifests it finds in the output directory
- New \`GET /screenspace/api/export/events\` endpoint backs a minimal download-icon dropdown in the Screenspace Results panel (CSV / JSON)

## Test plan
- [x] \`uv run --extra dev pytest\` — 23 new builder/writer tests, 5 endpoint tests, 3 CLI conflict tests
- [x] \`uv run ruff check && uv run ruff format --check && uv run ty check\`
- [x] \`bun run lint:js\`
- [x] Manual smoke: \`uv run clipgen.py --export -o <dir>\` writes \`clipgen_export_*.{json,csv}\` and CSV opens cleanly with canonical-then-alphabetical column order