### PR TITLE
feat: cancel button for clip generation, plumb cancel_flag through ffmpeg helpers

### DIFF
--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -179,6 +179,7 @@
           <span class="titlecard-label-unit">s</span>
         </label>
         <button id="generateBtn" class="btn btn-primary" disabled data-tooltip="Add cells to the work area first">Generate</button>
+        <button id="cancelGenerateBtn" class="btn btn-small btn-cancel hidden">Cancel</button>
         <button id="buildViewerBtn" class="btn btn-primary" disabled data-tooltip="Generate artifacts first">Build Viewer</button>
         <button id="stashArtifactsBtn" class="btn btn-small btn-icon" disabled data-tooltip="Add cells to the work area first">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2287,6 +2287,7 @@
     qs("#stashReelBtn").addEventListener("click", stashCurrentReel);
     qs("#stashArtifactsBtn").addEventListener("click", stashCurrentArtifacts);
     qs("#generateBtn").addEventListener("click", onGenerate);
+    qs("#cancelGenerateBtn").addEventListener("click", onCancelGenerate);
     qs("#buildReelBtn").addEventListener("click", onBuildReel);
     qs("#cancelReelBtn").addEventListener("click", onCancelReel);
     qs("#buildViewerBtn").addEventListener("click", onBuildViewer);
@@ -2428,6 +2429,7 @@
     state.generating = true;
     setGeneratingLock(true);
     setTitleSpinner("artifactsSpinner", true);
+    qs("#cancelGenerateBtn").classList.remove("hidden");
 
     var format = qs("#artifactFormat").value;
     var list = qs("#artifactsList");
@@ -2452,6 +2454,7 @@
     var totalSuccess = 0;
     var totalFail = 0;
     var allArtifacts = [];
+    var cancelled = false;
     var pending = (sheetItems.length > 0 ? 1 : 0) + (intakeItems.length > 0 ? 1 : 0);
 
     function finishBranch() {
@@ -2459,13 +2462,24 @@
       setTitleSpinner("artifactsSpinner", false);
       state.generating = false;
       setGeneratingLock(false);
+      qs("#cancelGenerateBtn").classList.add("hidden");
       updateViewerButton();
-      var msg = "Generated " + totalSuccess + " artifact(s)";
-      if (totalFail > 0) msg += ", " + totalFail + " failed";
-      showResult(
-        totalSuccess > 0 ? msg : null,
-        totalSuccess === 0 && totalFail > 0 ? "All generations failed" : null
-      );
+      var msg;
+      var err = null;
+      if (cancelled) {
+        msg = totalSuccess > 0
+          ? "Cancelled after " + totalSuccess + " artifact(s)"
+          : null;
+        err = totalSuccess > 0 ? null : "Generation cancelled";
+      } else {
+        msg = "Generated " + totalSuccess + " artifact(s)";
+        if (totalFail > 0) msg += ", " + totalFail + " failed";
+        if (totalSuccess === 0 && totalFail > 0) {
+          msg = null;
+          err = "All generations failed";
+        }
+      }
+      showResult(msg, err);
       qs("#statusOverlay").classList.remove("hidden");
     }
 
@@ -2481,7 +2495,16 @@
       function handleLine(line) {
         var data;
         try { data = JSON.parse(line); } catch (_) { return; }
-        if (!data || !data.cell) return;
+        if (!data) return;
+        if (data.cancelled) {
+          cancelled = true;
+          var queuedCards = list.querySelectorAll(".queue-card.queued");
+          for (var qi = 0; qi < queuedCards.length; qi++) {
+            clearCardStatus(queuedCards[qi]);
+          }
+          return;
+        }
+        if (!data.cell) return;
         var dot = data.cell.lastIndexOf(".");
         var participant = data.cell.substring(0, dot);
         var row = data.cell.substring(dot + 1);
@@ -2595,6 +2618,11 @@
   function onCancelReel() {
     qs("#cancelReelBtn").classList.add("hidden");
     apiPost("api/reel/cancel").catch(function () {});
+  }
+
+  function onCancelGenerate() {
+    qs("#cancelGenerateBtn").classList.add("hidden");
+    apiPost("api/generate/cancel").catch(function () {});
   }
 
   function onBuildReel() {

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.112"
+VERSIONNUM: str = "0.10.113"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/pipeline.py
+++ b/pipeline.py
@@ -168,6 +168,7 @@ def _process_single_clip_segments(
     output_format: str = "clip",
     collect_paths: bool = False,
     include_severity: bool = False,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> tuple[int, list[tuple[str, int]]]:
     """Process one clip's segments: run ffmpeg for each (start, end), optionally collect output paths.
 
@@ -180,6 +181,9 @@ def _process_single_clip_segments(
         filename_prefix: Prefix for output filename (e.g. '_reel_part_' for reel)
         collect_paths: If True, return list of (output_path, time_index) pairs; otherwise return empty list
         include_severity: If True and clip has severity, include [Severity] in filename
+        cancel_flag: Optional callable; checked before each segment and forwarded to
+            ffmpeg helpers so an in-flight encode can be terminated. Already-finished
+            segments are kept; the partial output of the killed segment is unlinked.
 
     Returns:
         (number of segments successfully generated, list of (out_path, time_index) pairs
@@ -212,6 +216,8 @@ def _process_single_clip_segments(
             source_resolution = f"{props['width']}x{props['height']}"
 
     for time_idx, (start_time, end_time) in enumerate(clip["times"]):
+        if cancel_flag and cancel_flag():
+            break
         try:
             out_name = files.get_unique_filename(template, file_format=file_extension)
             if config.DEBUGGING:
@@ -234,16 +240,21 @@ def _process_single_clip_segments(
                 start_pos=start_time,
                 end_pos=end_time,
                 reencode=config.REENCODING,
+                cancel_flag=cancel_flag,
             )
             if ok and config.TITLECARDS_ENABLED:
                 ok = titlecards.wrap_clip_with_cards(
-                    clip, out_name, resolution=source_resolution
+                    clip,
+                    out_name,
+                    resolution=source_resolution,
+                    cancel_flag=cancel_flag,
                 )
         elif output_format == "screen":
             ok = video.extract_screenshot(
                 input_file=base_video,
                 output_file=out_name,
                 timestamp=start_time,
+                cancel_flag=cancel_flag,
             )
         else:  # output_format == 'gif'
             ok = video.extract_gif(
@@ -251,11 +262,19 @@ def _process_single_clip_segments(
                 output_file=out_name,
                 timestamp=start_time,
                 duration_seconds=config.DEFAULT_GIF_DURATION_SECONDS,
+                cancel_flag=cancel_flag,
             )
         if ok:
             generated += 1
             if collect_paths:
                 output_paths.append((out_name, time_idx))
+        elif cancel_flag and cancel_flag():
+            # Killed mid-encode: the partial output is corrupt; remove it.
+            try:
+                Path(out_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+            break
     return (generated, output_paths)
 
 
@@ -525,6 +544,8 @@ def process_clips(
     clips_list: list[ClipRecord],
     output_format: str = "clip",
     include_severity: bool = False,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> tuple[int, list[dict[str, Any]]]:
     """Process and generate outputs from the clips list.
 
@@ -532,6 +553,11 @@ def process_clips(
     1. Sequential preparation (user prompts, fuzzy video matching)
     2. Parallel ffmpeg execution via ThreadPoolExecutor (when workers >= 2)
     3. Sequential post-processing (artifact records, transcription)
+
+    When *cancel_flag* is supplied and returns True, the pipeline short-circuits at
+    the next safe boundary. Already-completed segments are kept (each clip is a
+    standalone deliverable); in-flight ffmpeg encodes are terminated and their
+    partial outputs unlinked.
 
     Returns:
         Tuple of (count of files generated, list of artifact records).
@@ -568,6 +594,8 @@ def process_clips(
         with progress:
             prep_task = progress.add_task("Preparing clips", total=len(clips_list))
             for clip in clips_list:
+                if cancel_flag and cancel_flag():
+                    break
                 clip, base_video = _prepare_and_check_clip(
                     clip, missing_videos, fuzzy_matches
                 )
@@ -581,6 +609,8 @@ def process_clips(
         _active_progress = None
     else:
         for clip in clips_list:
+            if cancel_flag and cancel_flag():
+                break
             clip, base_video = _prepare_and_check_clip(
                 clip, missing_videos, fuzzy_matches
             )
@@ -623,10 +653,15 @@ def process_clips(
                             output_format=output_format,
                             collect_paths=True,
                             include_severity=include_severity,
+                            cancel_flag=cancel_flag,
                         ): idx
                         for idx, (clip, base_video) in enumerate(prepared)
                     }
                     for future in concurrent.futures.as_completed(future_to_idx):
+                        if cancel_flag and cancel_flag():
+                            for f in future_to_idx:
+                                f.cancel()
+                            break
                         idx = future_to_idx[future]
                         try:
                             results[idx] = future.result()
@@ -654,10 +689,15 @@ def process_clips(
                         output_format=output_format,
                         collect_paths=True,
                         include_severity=include_severity,
+                        cancel_flag=cancel_flag,
                     ): idx
                     for idx, (clip, base_video) in enumerate(prepared)
                 }
                 for future in concurrent.futures.as_completed(future_to_idx):
+                    if cancel_flag and cancel_flag():
+                        for f in future_to_idx:
+                            f.cancel()
+                        break
                     idx = future_to_idx[future]
                     try:
                         results[idx] = future.result()
@@ -678,6 +718,8 @@ def process_clips(
             with progress:
                 cut_task = progress.add_task("Processing clips", total=len(prepared))
                 for idx, (clip, base_video) in enumerate(prepared):
+                    if cancel_flag and cancel_flag():
+                        break
                     desc_preview = (clip.get("desc") or "")[
                         : config.PROGRESS_DESCRIPTION_LENGTH
                     ]
@@ -693,10 +735,13 @@ def process_clips(
                         output_format=output_format,
                         collect_paths=True,
                         include_severity=include_severity,
+                        cancel_flag=cancel_flag,
                     )
                     progress.update(cut_task, advance=1)
         else:
             for idx, (clip, base_video) in enumerate(prepared):
+                if cancel_flag and cancel_flag():
+                    break
                 if (
                     getattr(config, "VERBOSITY", config.STANDARD) >= config.VERBOSE
                     and len(prepared) > 1
@@ -711,6 +756,7 @@ def process_clips(
                     output_format=output_format,
                     collect_paths=True,
                     include_severity=include_severity,
+                    cancel_flag=cancel_flag,
                 )
 
     # -- Phase 3: Build artifacts and transcribe (sequential) ------------------
@@ -739,7 +785,7 @@ def process_clips(
             )
             all_artifacts.extend(clip_artifacts)
 
-    if config.TRANSCRIBE_ENABLED:
+    if config.TRANSCRIBE_ENABLED and not (cancel_flag and cancel_flag()):
         transcribe_items = [
             (clip, base_video, results[idx][1])
             for idx, (clip, base_video) in enumerate(prepared)

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ Studio API endpoints (all under /studio/):
   POST /api/sheet/refresh      – re-fetch spreadsheet data from source (Google/Excel)
   GET  /api/thumbnail/<p>/<t>  – JPEG thumbnail frame from participant video
   POST /api/generate           – generate clip/screen/gif artifacts for specified cells
+  POST /api/generate/cancel    – cancel an in-progress clip generation
   POST /api/highlights-preview – preview highlights reel selection without generating
   POST /api/reel               – build a reel from specified cells
   POST /api/reel-direct        – build a reel from explicit clip paths
@@ -70,6 +71,8 @@ _generated_artifacts: list[dict[str, Any]] = []
 _generated_reels: list[dict[str, Any]] = []
 _thumbnail_cache: dict[tuple, bytes] = {}
 _reel_cancel_event = threading.Event()
+# Single in-flight job assumed; a second /api/generate clears this.
+_generate_cancel_event = threading.Event()
 
 # Snapshot config defaults before any settings file is loaded.
 # Deep-copied so dict-valued defaults are not aliased to live config state.
@@ -574,6 +577,8 @@ def api_generate() -> FlaskResponse:
                     overrides["TITLECARD_DURATION_SECONDS"] = val
             except (ValueError, TypeError):
                 pass
+        _generate_cancel_event.clear()
+        cancel_flag = _generate_cancel_event.is_set
         with _override_config(**overrides):
             clip_cells: set[str] = set()
 
@@ -616,10 +621,15 @@ def api_generate() -> FlaskResponse:
                                 pipeline.process_clips,
                                 [clip],
                                 output_format=output_format,
+                                cancel_flag=cancel_flag,
                             ): (clip, cell_str)
                             for clip, cell_str in to_generate
                         }
                         for future in concurrent.futures.as_completed(future_to_cell):
+                            if cancel_flag():
+                                for f in future_to_cell:
+                                    f.cancel()
+                                break
                             clip, cell_str = future_to_cell[future]
                             try:
                                 generated, artifacts = future.result()
@@ -644,9 +654,13 @@ def api_generate() -> FlaskResponse:
                                 )
                 else:
                     for clip, cell_str in to_generate:
+                        if cancel_flag():
+                            break
                         try:
                             generated, artifacts = pipeline.process_clips(
-                                [clip], output_format=output_format
+                                [clip],
+                                output_format=output_format,
+                                cancel_flag=cancel_flag,
                             )
                             _generated_artifacts.extend(artifacts)
                             yield (
@@ -674,6 +688,8 @@ def api_generate() -> FlaskResponse:
                         json.dumps({"cell": cs, "ok": False, "error": "No clip found"})
                         + "\n"
                     )
+            if cancel_flag():
+                yield json.dumps({"cancelled": True}) + "\n"
             _save_manifest_quiet()
 
     return Response(
@@ -1352,7 +1368,12 @@ def api_reel_direct() -> FlaskResponse:
                 temp_clips.append(tmp_path)
 
                 ok = video.run_ffmpeg(
-                    video_path, tmp_path, start_str, end_str, config.REENCODING
+                    video_path,
+                    tmp_path,
+                    start_str,
+                    end_str,
+                    config.REENCODING,
+                    cancel_flag=_reel_cancel_event.is_set,
                 )
                 if ok:
                     clip_paths.append(tmp_path)
@@ -1404,6 +1425,13 @@ def api_reel_direct() -> FlaskResponse:
 def api_reel_cancel() -> FlaskResponse:
     """Signal cancellation for the in-progress reel build."""
     _reel_cancel_event.set()
+    return jsonify({"ok": True})
+
+
+@studio_bp.route("/api/generate/cancel", methods=["POST"])
+def api_generate_cancel() -> FlaskResponse:
+    """Signal cancellation for the in-progress clip generation."""
+    _generate_cancel_event.set()
     return jsonify({"ok": True})
 
 

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -234,3 +234,136 @@ def test_run_clip_pipeline_cancel_flag(monkeypatch):
     # Should have processed only the first clip before cancel was detected
     assert len(results) == 1
     assert processed == [0]
+
+
+def test_process_clips_forwards_cancel_flag_to_segments(monkeypatch, make_clip):
+    """process_clips should forward cancel_flag into _process_single_clip_segments."""
+    raw_clip = make_clip()
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+
+    captured = {}
+
+    def fake_segments(*args, **kwargs):
+        captured["cancel_flag"] = kwargs.get("cancel_flag")
+        return (1, [])
+
+    monkeypatch.setattr(pipeline, "_process_single_clip_segments", fake_segments)
+
+    sentinel = lambda: False  # noqa: E731
+    clipgen.process_clips([raw_clip], output_format="clip", cancel_flag=sentinel)
+    assert captured["cancel_flag"] is sentinel
+
+
+def test_process_clips_sequential_short_circuits_on_cancel(monkeypatch, make_clip):
+    """Sequential branch should stop calling _process_single_clip_segments after cancel."""
+    clips = [make_clip(row=i, col=2) for i in range(3, 6)]
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+
+    cancelled = {"flag": False}
+
+    def seg_side_effect(*_args, **_kwargs):
+        # Trip cancel after the first segment finishes; no further calls expected.
+        cancelled["flag"] = True
+        return (1, [])
+
+    seg_mock = Mock(side_effect=seg_side_effect)
+    monkeypatch.setattr(pipeline, "_process_single_clip_segments", seg_mock)
+
+    clipgen.process_clips(
+        clips, output_format="clip", cancel_flag=lambda: cancelled["flag"]
+    )
+    assert seg_mock.call_count == 1
+
+
+def test_process_single_clip_segments_forwards_cancel_to_video(monkeypatch, make_clip):
+    """_process_single_clip_segments should pass cancel_flag to each video helper."""
+    raw_clip = _prepared_clip(make_clip(), [("00:10", "00:20")])
+
+    monkeypatch.setattr(
+        clipgen.files, "get_unique_filename", lambda *_a, **_k: "out.mp4"
+    )
+
+    captured = {}
+
+    def fake_run_ffmpeg(**kwargs):
+        captured["clip"] = kwargs.get("cancel_flag")
+        return True
+
+    def fake_screenshot(**kwargs):
+        captured["screen"] = kwargs.get("cancel_flag")
+        return True
+
+    def fake_gif(**kwargs):
+        captured["gif"] = kwargs.get("cancel_flag")
+        return True
+
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", fake_run_ffmpeg)
+    monkeypatch.setattr(pipeline.video, "extract_screenshot", fake_screenshot)
+    monkeypatch.setattr(pipeline.video, "extract_gif", fake_gif)
+    monkeypatch.setattr(config, "TITLECARDS_ENABLED", False)
+
+    sentinel = lambda: False  # noqa: E731
+    pipeline._process_single_clip_segments(
+        raw_clip, "src.mp4", set(), output_format="clip", cancel_flag=sentinel
+    )
+    pipeline._process_single_clip_segments(
+        raw_clip, "src.mp4", set(), output_format="screen", cancel_flag=sentinel
+    )
+    pipeline._process_single_clip_segments(
+        raw_clip, "src.mp4", set(), output_format="gif", cancel_flag=sentinel
+    )
+
+    assert captured["clip"] is sentinel
+    assert captured["screen"] is sentinel
+    assert captured["gif"] is sentinel
+
+
+def test_process_single_clip_segments_unlinks_partial_on_cancel(
+    monkeypatch, make_clip, tmp_path
+):
+    """When ffmpeg returns False due to cancel, the partial output should be removed."""
+    raw_clip = _prepared_clip(make_clip(), [("00:10", "00:20"), ("00:30", "00:40")])
+
+    out_path = tmp_path / "out.mp4"
+    monkeypatch.setattr(
+        clipgen.files,
+        "get_unique_filename",
+        lambda *_a, **_k: str(out_path),
+    )
+
+    # Simulate ffmpeg writing a partial file then returning False because cancel fired.
+    cancel_state = {"set": False}
+
+    def fake_run_ffmpeg(**_kwargs):
+        out_path.write_bytes(b"partial")
+        cancel_state["set"] = True
+        return False
+
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", fake_run_ffmpeg)
+    monkeypatch.setattr(config, "TITLECARDS_ENABLED", False)
+
+    generated, paths = pipeline._process_single_clip_segments(
+        raw_clip,
+        "src.mp4",
+        set(),
+        output_format="clip",
+        cancel_flag=lambda: cancel_state["set"],
+    )
+
+    assert generated == 0
+    assert paths == []
+    assert not out_path.exists()

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -936,7 +936,7 @@ def test_api_generate_titlecard_override(client, monkeypatch):
     def fake_generate_list(ws, mode, *, ctx=None, cell_specs, skip_prompts):
         return [{"participant": "P01", "cell": cell}]
 
-    def fake_process_clips(clips, *, output_format):
+    def fake_process_clips(clips, *, output_format, cancel_flag=None):
         captured["enabled"] = config.TITLECARDS_ENABLED
         captured["duration"] = config.TITLECARD_DURATION_SECONDS
         return (1, [{"id": "a1", "type": "clip"}])
@@ -978,7 +978,7 @@ def test_api_generate_titlecard_restored_on_error(client, monkeypatch):
     def fake_generate_list(ws, mode, *, ctx=None, cell_specs, skip_prompts):
         return [{"participant": "P01", "cell": cell}]
 
-    def fake_process_clips(clips, *, output_format):
+    def fake_process_clips(clips, *, output_format, cancel_flag=None):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
@@ -1331,3 +1331,13 @@ def test_api_reel_cancel_endpoint(client):
     assert resp.status_code == 200
     assert data["ok"] is True
     assert server._reel_cancel_event.is_set()
+
+
+def test_api_generate_cancel_endpoint(client):
+    """POST /api/generate/cancel should set the cancel event and return ok."""
+    server._generate_cancel_event.clear()
+    resp = client.post("/studio/api/generate/cancel")
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["ok"] is True
+    assert server._generate_cancel_event.is_set()

--- a/tests/test_titlecards.py
+++ b/tests/test_titlecards.py
@@ -307,7 +307,7 @@ def test_pipeline_skips_per_output_probe(monkeypatch, make_clip):
 
     wrap_calls = []
 
-    def fake_wrap(_clip, out_name, resolution=None):
+    def fake_wrap(_clip, out_name, resolution=None, **_kwargs):
         wrap_calls.append((out_name, resolution))
         return True
 

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -583,3 +583,87 @@ def test_extract_frame_at_timestamp_debug_mode(monkeypatch):
     frame = video.extract_frame_at_timestamp("/fake.mp4", 0.0)
     assert frame is not None
     assert frame.shape == (1080, 1920, 3)
+
+
+# -- cancel_flag forwarding --
+
+
+def _captured_run_ffmpeg(captured):
+    def _fake(_cmd, **kwargs):
+        captured.append(kwargs.get("cancel_flag"))
+        return subprocess.CompletedProcess(args=["ffmpeg"], returncode=0, stderr="")
+
+    return _fake
+
+
+def test_run_ffmpeg_forwards_cancel_flag(monkeypatch):
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(
+        video.Path, "stat", lambda self: type("_S", (), {"st_size": 1})()
+    )
+    monkeypatch.setattr(video, "get_duration", lambda *_a: 5)
+    monkeypatch.setattr(video, "get_file_duration", lambda *_a: 60)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 0)
+
+    captured: list = []
+    monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
+
+    sentinel = lambda: False  # noqa: E731
+    ok = video.run_ffmpeg(
+        "in.mp4", "out.mp4", "00:10", "00:15", reencode=False, cancel_flag=sentinel
+    )
+    assert ok is True
+    assert captured == [sentinel]
+
+
+def test_extract_screenshot_forwards_cancel_flag(monkeypatch):
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "get_file_duration", lambda *_a: 60)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        video.Path, "stat", lambda self: type("_S", (), {"st_size": 1})()
+    )
+
+    captured: list = []
+    monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
+
+    sentinel = lambda: False  # noqa: E731
+    ok = video.extract_screenshot("in.mp4", "out.png", "00:10", cancel_flag=sentinel)
+    assert ok is True
+    assert captured == [sentinel]
+
+
+def test_extract_gif_forwards_cancel_flag(monkeypatch):
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(video, "get_file_duration", lambda *_a: 60)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        video.Path, "stat", lambda self: type("_S", (), {"st_size": 1})()
+    )
+
+    captured: list = []
+    monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
+
+    sentinel = lambda: False  # noqa: E731
+    ok = video.extract_gif("in.mp4", "out.gif", "00:10", 5, cancel_flag=sentinel)
+    assert ok is True
+    assert captured == [sentinel]
+
+
+def test_compress_to_size_forwards_cancel_flag_to_both_passes(monkeypatch, tmp_path):
+    big = tmp_path / "big.mp4"
+    big.write_bytes(b"x" * 1024)
+    monkeypatch.setattr(video, "get_file_duration", lambda *_a: 10)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+
+    captured: list = []
+    monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
+
+    # Stub os.replace and unlink so the test doesn't move/delete real files.
+    monkeypatch.setattr(video.os, "replace", lambda *_a, **_kw: None)
+
+    sentinel = lambda: False  # noqa: E731
+    # Target tiny size so compression runs both passes.
+    video.compress_to_size(str(big), 0.0001, cancel_flag=sentinel)
+    assert captured == [sentinel, sentinel]

--- a/titlecards.py
+++ b/titlecards.py
@@ -16,6 +16,7 @@ Key functions:
 import os
 import tempfile
 import threading
+from collections.abc import Callable
 from pathlib import Path
 
 import config
@@ -55,6 +56,7 @@ def _build_card_frame(
     label: str,
     drawtext_filter: str | None = None,
     allow_color_fallback: bool = False,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> str | None:
     """Generate a short title/end card video segment.
 
@@ -150,6 +152,7 @@ def _build_card_frame(
         input_file=input_label,
         output_file=card_path,
         os_error_message=f"ffmpeg could not successfully run for {label} generation.",
+        cancel_flag=cancel_flag,
     )
     if ffmpeg_result is None or ffmpeg_result.returncode != 0:
         utils.warning_print(
@@ -173,7 +176,12 @@ def _build_card_frame(
     return card_path
 
 
-def build_titlecard_frame(clip: ClipRecord, resolution: str) -> str | None:
+def build_titlecard_frame(
+    clip: ClipRecord,
+    resolution: str,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
+) -> str | None:
     """Generate a short titlecard video segment for a clip."""
     return _build_card_frame(
         resolution=resolution,
@@ -181,25 +189,35 @@ def build_titlecard_frame(clip: ClipRecord, resolution: str) -> str | None:
         label="titlecard",
         drawtext_filter=_build_drawtext_filter(str(clip.get("desc", ""))),
         allow_color_fallback=True,
+        cancel_flag=cancel_flag,
     )
 
 
-def build_endcard_frame(resolution: str) -> str | None:
+def build_endcard_frame(
+    resolution: str,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
+) -> str | None:
     """Generate a short endcard video segment if assets/endcard.png exists."""
     return _build_card_frame(
         resolution=resolution,
         background_path=utils.get_bundled_assets_root() / "assets" / "endcard.png",
         label="endcard",
+        cancel_flag=cancel_flag,
     )
 
 
-def get_or_build_endcard(resolution: str) -> str | None:
+def get_or_build_endcard(
+    resolution: str,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
+) -> str | None:
     """Return a cached endcard path for the given resolution, building if needed."""
     with _endcard_lock:
         cached = _endcard_cache.get(resolution)
         if cached and Path(cached).is_file():
             return cached
-    path = build_endcard_frame(resolution)
+    path = build_endcard_frame(resolution, cancel_flag=cancel_flag)
     if path:
         with _endcard_lock:
             existing = _endcard_cache.get(resolution)
@@ -323,13 +341,17 @@ def wrap_clip_with_cards(
     clip: ClipRecord,
     clip_path: str,
     resolution: str | None = None,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> bool:
     """Prepend a titlecard and append an endcard to a clip in a single ffmpeg encode.
 
     Replaces the previous two-invocation (prepend then append) flow so the clip body
     is decoded and re-encoded once instead of twice. Returns True when the clip file
     is usable afterwards (either wrapped or left untouched on soft failure), and
-    False only on a hard failure (e.g. the clip file is missing).
+    False only on a hard failure (e.g. the clip file is missing). When *cancel_flag*
+    is supplied and returns True during a card or wrap encode, the in-flight ffmpeg
+    is terminated and the original clip file is left untouched.
     """
     if not config.TITLECARDS_ENABLED:
         return True
@@ -361,8 +383,8 @@ def wrap_clip_with_cards(
 
     has_clip_audio = bool(probed and probed.get("audio_codec"))
 
-    titlecard_path = build_titlecard_frame(clip, resolution)
-    endcard_path = get_or_build_endcard(resolution)
+    titlecard_path = build_titlecard_frame(clip, resolution, cancel_flag=cancel_flag)
+    endcard_path = get_or_build_endcard(resolution, cancel_flag=cancel_flag)
 
     if not titlecard_path and not endcard_path:
         # Both cards failed to build; nothing to do, keep clip as-is.
@@ -409,6 +431,7 @@ def wrap_clip_with_cards(
             input_file=clip_path,
             output_file=output_temp_path,
             os_error_message="Filter-based concat failed while wrapping clip with cards.",
+            cancel_flag=cancel_flag,
         )
         if ffmpeg_result is None or ffmpeg_result.returncode != 0:
             utils.warning_print(

--- a/video.py
+++ b/video.py
@@ -253,7 +253,13 @@ def build_ffmpeg_cut_command(
 
 
 def run_ffmpeg(
-    input_file: str, output_file: str, start_pos: str, end_pos: str, reencode: bool
+    input_file: str,
+    output_file: str,
+    start_pos: str,
+    end_pos: str,
+    reencode: bool,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> bool:
     """Calls ffmpeg to cut a video clip. Requires ffmpeg in system PATH.
 
@@ -263,6 +269,8 @@ def run_ffmpeg(
         start_pos: Start timestamp (format: HH:MM:SS or MM:SS)
         end_pos: End timestamp (format: HH:MM:SS or MM:SS)
         reencode: If True, re-encode video; if False, use stream copy
+        cancel_flag: Optional callable; when it returns True the in-flight
+            ffmpeg subprocess is terminated and the function returns False.
 
     Returns:
         True if video was generated successfully, False otherwise.
@@ -340,6 +348,7 @@ def run_ffmpeg(
         input_file=input_file,
         output_file=output_file,
         os_error_message="ffmpeg could not successfully run.",
+        cancel_flag=cancel_flag,
     )
     if ffmpeg_result is None:
         return False
@@ -359,7 +368,9 @@ def run_ffmpeg(
         return False
 
     if config.MAX_FILESIZE_MB and config.MAX_FILESIZE_MB > 0:
-        if not compress_to_size(output_file, config.MAX_FILESIZE_MB):
+        if not compress_to_size(
+            output_file, config.MAX_FILESIZE_MB, cancel_flag=cancel_flag
+        ):
             utils.warning_print(f"Could not compress '{output_file}' to target size")
 
     utils.verbose_print(
@@ -368,13 +379,21 @@ def run_ffmpeg(
     return True
 
 
-def extract_screenshot(input_file: str, output_file: str, timestamp: str) -> bool:
+def extract_screenshot(
+    input_file: str,
+    output_file: str,
+    timestamp: str,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
+) -> bool:
     """Extract a single screenshot frame at the given timestamp.
 
     Args:
         input_file: Path to input video file
         output_file: Path for output screenshot file (.png)
         timestamp: Timestamp to capture (format: HH:MM:SS or MM:SS)
+        cancel_flag: Optional callable; when it returns True the in-flight
+            ffmpeg subprocess is terminated and the function returns False.
 
     Returns:
         True if screenshot was generated successfully, False otherwise.
@@ -433,6 +452,7 @@ def extract_screenshot(input_file: str, output_file: str, timestamp: str) -> boo
         input_file=input_file,
         output_file=output_file,
         os_error_message="ffmpeg could not successfully run for screenshot extraction.",
+        cancel_flag=cancel_flag,
     )
     if ffmpeg_result is None:
         return False
@@ -507,7 +527,12 @@ def extract_thumbnail_bytes(
 
 
 def extract_gif(
-    input_file: str, output_file: str, timestamp: str, duration_seconds: int
+    input_file: str,
+    output_file: str,
+    timestamp: str,
+    duration_seconds: int,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> bool:
     """Extract a GIF segment starting at timestamp.
 
@@ -516,6 +541,8 @@ def extract_gif(
         output_file: Path for output GIF file (.gif)
         timestamp: Start timestamp (format: HH:MM:SS or MM:SS)
         duration_seconds: GIF duration in seconds
+        cancel_flag: Optional callable; when it returns True the in-flight
+            ffmpeg subprocess is terminated and the function returns False.
 
     Returns:
         True if GIF was generated successfully, False otherwise.
@@ -610,6 +637,7 @@ def extract_gif(
         input_file=input_file,
         output_file=output_file,
         os_error_message="ffmpeg could not successfully run for GIF extraction.",
+        cancel_flag=cancel_flag,
     )
     if ffmpeg_result is None:
         return False
@@ -935,12 +963,19 @@ def calculate_target_bitrate(
     return max(video_bitrate_kbps, config.MIN_VIDEO_BITRATE_KBPS)
 
 
-def compress_to_size(filepath: str, target_size_mb: float) -> bool:
+def compress_to_size(
+    filepath: str,
+    target_size_mb: float,
+    *,
+    cancel_flag: Callable[[], bool] | None = None,
+) -> bool:
     """Recompress video to fit within target filesize using two-pass encoding.
 
     Args:
         filepath: Path to the video file to compress
         target_size_mb: Maximum file size in megabytes
+        cancel_flag: Optional callable; when it returns True either pass of the
+            in-flight ffmpeg subprocess is terminated and the function returns False.
 
     Returns:
         True if compression succeeded or was unnecessary, False on error
@@ -1010,6 +1045,7 @@ def compress_to_size(filepath: str, target_size_mb: float) -> bool:
             input_file=filepath,
             output_file=null_output,
             os_error_message="ffmpeg could not successfully run during compression pass 1.",
+            cancel_flag=cancel_flag,
         )
         if pass1_result is None:
             return False
@@ -1053,6 +1089,7 @@ def compress_to_size(filepath: str, target_size_mb: float) -> bool:
             input_file=filepath,
             output_file=compressed_temp_path,
             os_error_message="ffmpeg could not successfully run during compression pass 2.",
+            cancel_flag=cancel_flag,
         )
         if pass2_result is None:
             return False


### PR DESCRIPTION
## Summary

Extends the existing reel-cancel pattern (a `threading.Event` polled by `run_ffmpeg_process`, which SIGTERMs ffmpeg every 0.5s) to clip generation. A new `_generate_cancel_event` drives `POST /api/generate/cancel` and a Cancel button in Studio next to Generate; `cancel_flag` is threaded through `video.run_ffmpeg` / `extract_screenshot` / `extract_gif` / `compress_to_size`, `titlecards.wrap_clip_with_cards`, and `pipeline.process_clips` so an in-flight encode dies promptly. Already-finished segments are kept; the partial output of a killed mid-encode is unlinked. Also forwards the existing reel cancel into `api_reel_direct`'s per-segment `run_ffmpeg` call, closing a pre-existing in-segment gap.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 678 pass (7 new tests for the cancel endpoint, pipeline plumbing, partial-file cleanup, and per-helper forwarding)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `bun run lint:js` — clean
- [ ] Manual UI smoke: queue 4–6 clip cells with re-encoding on, click Generate, click Cancel; verify ffmpeg dies in ~0.5s, cancel button hides, status shows "Generation cancelled", `pgrep ffmpeg` is empty