### PR TITLE
feat: Rich progress bars and tables for Screenspace and export CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1238,6 +1238,37 @@ def _ss_build_params(
     return params
 
 
+def _print_ss_table(
+    title: str,
+    columns: list[tuple[str, dict[str, Any]]],
+    rows: list[list[str]],
+    fallback_lines: list[str],
+) -> None:
+    """Render a Rich table when available, else fall back to plain info_print lines.
+
+    columns is a list of (name, kwargs) tuples passed to Table.add_column.
+    """
+    if utils._use_rich() and utils.console is not None:
+        from rich.table import Table
+
+        table = Table(
+            title=title,
+            show_header=True,
+            header_style="bold cyan",
+            border_style="dim",
+            row_styles=["", "dim"],
+            expand=False,
+        )
+        for name, kwargs in columns:
+            table.add_column(name, **kwargs)
+        for row in rows:
+            table.add_row(*row)
+        utils.console.print(table)
+    else:
+        for line in fallback_lines:
+            utils.info_print(line)
+
+
 def _run_ss_list_regions(args: argparse.Namespace) -> None:
     """List active Screenspace regions from the manifest."""
     import screenspace
@@ -1247,15 +1278,41 @@ def _run_ss_list_regions(args: argparse.Namespace) -> None:
     if not regions:
         utils.info_print("No active Screenspace regions in manifest.")
         return
-    utils.info_print(f"Active regions ({len(regions)}):")
+
+    rows: list[list[str]] = []
+    fallback: list[str] = [f"Active regions ({len(regions)}):"]
     for name in sorted(regions.keys()):
         rd = regions[name]
         sw = rd.get("source_width", "?")
         sh = rd.get("source_height", "?")
-        utils.info_print(
+        rows.append(
+            [
+                name,
+                f"{rd.get('x', 0):.3f}",
+                f"{rd.get('y', 0):.3f}",
+                f"{rd.get('w', 0):.3f}",
+                f"{rd.get('h', 0):.3f}",
+                f"{sw}x{sh}",
+            ]
+        )
+        fallback.append(
             f"  {name}: x={rd.get('x', 0):.3f} y={rd.get('y', 0):.3f} "
             f"w={rd.get('w', 0):.3f} h={rd.get('h', 0):.3f}  source={sw}x{sh}"
         )
+
+    _print_ss_table(
+        f"Active regions ({len(regions)})",
+        [
+            ("Name", {"style": "bold"}),
+            ("x", {"justify": "right"}),
+            ("y", {"justify": "right"}),
+            ("w", {"justify": "right"}),
+            ("h", {"justify": "right"}),
+            ("Source", {"justify": "right"}),
+        ],
+        rows,
+        fallback,
+    )
 
 
 def _run_ss_list_stashes(args: argparse.Namespace) -> None:
@@ -1267,14 +1324,36 @@ def _run_ss_list_stashes(args: argparse.Namespace) -> None:
     if not stashes:
         utils.info_print("No Screenspace region stashes in manifest.")
         return
-    utils.info_print(f"Stashes ({len(stashes)}):")
+
+    rows: list[list[str]] = []
+    fallback: list[str] = [f"Stashes ({len(stashes)}):"]
     for stash in stashes:
         regions = stash.get("regions", {})
         names = ", ".join(sorted(regions.keys())) or "(empty)"
-        utils.info_print(
+        rows.append(
+            [
+                str(stash.get("id", "?")),
+                str(stash.get("name", "(unnamed)")),
+                str(len(regions)),
+                names,
+            ]
+        )
+        fallback.append(
             f"  {stash.get('id', '?')}  {stash.get('name', '(unnamed)')}: "
             f"{len(regions)} region(s) — {names}"
         )
+
+    _print_ss_table(
+        f"Stashes ({len(stashes)})",
+        [
+            ("ID", {"style": "bold"}),
+            ("Name", {}),
+            ("Regions", {"justify": "right"}),
+            ("Names", {"overflow": "fold"}),
+        ],
+        rows,
+        fallback,
+    )
 
 
 def _run_ss_list_tasks(args: argparse.Namespace) -> None:
@@ -1292,16 +1371,42 @@ def _run_ss_list_tasks(args: argparse.Namespace) -> None:
         else:
             utils.info_print("No Screenspace tasks in manifest.")
         return
+
     label = f" (status={status_filter})" if status_filter else ""
-    utils.info_print(f"Tasks{label}: {len(tasks)}")
+    rows: list[list[str]] = []
+    fallback: list[str] = [f"Tasks{label}: {len(tasks)}"]
     for t in tasks:
         result = t.get("result")
         result_count = len(result) if isinstance(result, list) else 0
-        utils.info_print(
+        rows.append(
+            [
+                str(t.get("id", "?")),
+                str(t.get("type", "?")),
+                str(t.get("participant", "?")),
+                str(t.get("region", "?")),
+                str(t.get("status", "?")),
+                str(result_count),
+            ]
+        )
+        fallback.append(
             f"  {t.get('id', '?')}  {t.get('type', '?'):10s}  "
             f"{t.get('participant', '?'):8s}  region={t.get('region', '?'):16s}  "
             f"status={t.get('status', '?'):10s}  results={result_count}"
         )
+
+    _print_ss_table(
+        f"Tasks{label} ({len(tasks)})",
+        [
+            ("ID", {"style": "bold"}),
+            ("Type", {}),
+            ("Participant", {}),
+            ("Region", {}),
+            ("Status", {}),
+            ("Results", {"justify": "right"}),
+        ],
+        rows,
+        fallback,
+    )
 
 
 def _run_ss_task(args: argparse.Namespace) -> None:
@@ -1370,22 +1475,43 @@ def _run_ss_task(args: argparse.Namespace) -> None:
     task_id = worker.enqueue(task)
     utils.info_print(f"Running {task_type} on {participant} (region: {region_name})...")
 
-    last_progress = -1.0
     final_task: dict[str, Any] | None = None
+    progress_bar = utils.create_progress_bar()
     try:
-        while True:
-            current = worker.get_task(task_id)
-            if current is None:
-                break
-            status = current.get("status", "")
-            progress = float(current.get("progress", 0.0))
-            if progress - last_progress > 0.05:
-                utils.info_print(f"  {status}: {int(progress * 100)}%")
-                last_progress = progress
-            if status in ("completed", "failed", "cancelled"):
-                final_task = current
-                break
-            time.sleep(0.25)
+        if progress_bar:
+            with progress_bar:
+                ptask = progress_bar.add_task(f"{task_type} (queued)", total=100)
+                while True:
+                    current = worker.get_task(task_id)
+                    if current is None:
+                        break
+                    status = current.get("status", "")
+                    pct = int(float(current.get("progress", 0.0)) * 100)
+                    progress_bar.update(
+                        ptask,
+                        completed=pct,
+                        description=f"{task_type} ({status})",
+                    )
+                    if status in ("completed", "failed", "cancelled"):
+                        final_task = current
+                        progress_bar.update(ptask, completed=100)
+                        break
+                    time.sleep(0.25)
+        else:
+            last_progress = -1.0
+            while True:
+                current = worker.get_task(task_id)
+                if current is None:
+                    break
+                status = current.get("status", "")
+                progress = float(current.get("progress", 0.0))
+                if progress - last_progress > 0.05:
+                    utils.info_print(f"  {status}: {int(progress * 100)}%")
+                    last_progress = progress
+                if status in ("completed", "failed", "cancelled"):
+                    final_task = current
+                    break
+                time.sleep(0.25)
     finally:
         new_events = worker.drain_new_events()
         all_tasks = worker.get_all_tasks()

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.113"
+VERSIONNUM: str = "0.10.114"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/data_export.py
+++ b/data_export.py
@@ -356,10 +356,19 @@ def write_export_bundle(output_dir: Path | None = None) -> list[Path]:
     """
     base = Path(output_dir) if output_dir else Path(utils.get_effective_output_dir())
     written: list[Path] = []
-    for output_basename, surface_key, manifest_filename, preferred_cols in _SURFACES:
+    summaries: list[str] = []
+
+    progress = utils.create_progress_bar()
+
+    def _process_surface(
+        output_basename: str,
+        surface_key: str,
+        manifest_filename: str,
+        preferred_cols: tuple[str, ...],
+    ) -> None:
         manifest_path = base / manifest_filename
         if not manifest_path.is_file():
-            continue
+            return
         try:
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as err:
@@ -367,13 +376,13 @@ def write_export_bundle(output_dir: Path | None = None) -> list[Path]:
                 f"Skipping {manifest_filename}: could not read manifest.",
                 [f"Error: {err}"],
             )
-            continue
+            return
         records = _build_for_surface(surface_key, manifest)
         if not records:
-            utils.info_print(
+            summaries.append(
                 f"Skipping {output_basename}: manifest is present but contains no records."
             )
-            continue
+            return
         json_path = base / f"clipgen_export_{output_basename}.json"
         csv_path = base / f"clipgen_export_{output_basename}.csv"
         json_path.write_text(to_json(records), encoding="utf-8")
@@ -382,9 +391,37 @@ def write_export_bundle(output_dir: Path | None = None) -> list[Path]:
             encoding="utf-8",
         )
         written.extend([json_path, csv_path])
-        utils.info_print(
+        summaries.append(
             f"Exported {len(records)} record(s) to {json_path.name} and {csv_path.name}"
         )
+
+    if progress:
+        with progress:
+            ptask = progress.add_task("Exporting", total=len(_SURFACES))
+            for (
+                output_basename,
+                surface_key,
+                manifest_filename,
+                preferred_cols,
+            ) in _SURFACES:
+                progress.update(ptask, description=f"Exporting {output_basename}")
+                _process_surface(
+                    output_basename, surface_key, manifest_filename, preferred_cols
+                )
+                progress.update(ptask, advance=1)
+    else:
+        for (
+            output_basename,
+            surface_key,
+            manifest_filename,
+            preferred_cols,
+        ) in _SURFACES:
+            _process_surface(
+                output_basename, surface_key, manifest_filename, preferred_cols
+            )
+
+    for line in summaries:
+        utils.info_print(line)
     return written
 
 


### PR DESCRIPTION
## Summary
- Brings the recently added Screenspace (`--ss-task`, `--ss-list-regions`, `--ss-list-stashes`, `--ss-list-tasks`) and `--export` CLI flows up to printing parity with the rest of clipgen.
- `--ss-task` now drives a Rich progress bar from the worker's 0.0–1.0 progress with the live status as the description, replacing 5%-step `info_print` lines.
- The three `--ss-list-*` subcommands render as Rich tables (bold-cyan headers, dim borders) via a small co-located `_print_ss_table` helper; `--export` shows per-surface progress while sweeping manifests.
- Plain-line fallbacks preserved for non-Rich terminals; `VERSIONNUM` bumped 0.10.113 → 0.10.114.

## Test plan
- [x] `uv run ruff check && uv run ruff format`
- [x] `uv run ty check` (edited files clean)
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 661 passed
- [ ] Manual smoke: `--ss-list-regions`, `--ss-list-stashes`, `--ss-list-tasks`, `--ss-task …`, `--export` against a populated workspace