### PR TITLE
refactor: extract shared JS helpers and tighten naming

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -57,20 +57,9 @@
   }
 
 
-  function stddev(nums) {
-    if (nums.length < 2) return 0;
-    var sum = 0;
-    for (var i = 0; i < nums.length; i++) sum += nums[i];
-    var mean = sum / nums.length;
-    var sqSum = 0;
-    for (var j = 0; j < nums.length; j++) sqSum += (nums[j] - mean) * (nums[j] - mean);
-    return Math.sqrt(sqSum / nums.length);
-  }
-
   function parseAccentColor() {
-    try {
-      var raw = getComputedStyle(document.documentElement).getPropertyValue("--color-accent").trim();
-      if (!raw) return { r: 59, g: 130, b: 246 };
+    var raw = getCSSVar("--color-accent", "");
+    if (raw) {
       if (raw.charAt(0) === "#") {
         return {
           r: parseInt(raw.slice(1, 3), 16),
@@ -80,7 +69,7 @@
       }
       var m = raw.match(/(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
       if (m) return { r: +m[1], g: +m[2], b: +m[3] };
-    } catch (_) { /* fall through */ }
+    }
     return { r: 59, g: 130, b: 246 };
   }
 

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -36,14 +36,6 @@
 
   // ---- Helpers ----
 
-  function countBucketArtifacts(insight) {
-    return (
-      insight.causes.artifacts.length +
-      insight.behaviors.artifacts.length +
-      insight.impacts.artifacts.length
-    );
-  }
-
   function findArtifact(id) {
     for (var i = 0; i < state.artifacts.length; i++) {
       if (state.artifacts[i].id === id) return state.artifacts[i];
@@ -75,51 +67,23 @@
     qs("#insightCount").textContent = state.insights.length + " insights";
   }
 
-  // ---- Filter system (ported from viewer.js) ----
-
-  function uniqueValues(field) {
-    var seen = {};
-    var vals = [];
-    for (var i = 0; i < state.artifacts.length; i++) {
-      var v = (state.artifacts[i][field] || "").trim();
-      if (v && !seen[v]) {
-        seen[v] = true;
-        vals.push(v);
-      }
-    }
-    return vals.sort();
-  }
-
-  function fillSelect(sel, values, allLabel) {
-    while (sel.options.length > 0) sel.remove(0);
-    var frag = document.createDocumentFragment();
-    var opt = document.createElement("option");
-    opt.value = "";
-    opt.textContent = allLabel;
-    frag.appendChild(opt);
-    for (var i = 0; i < values.length; i++) {
-      var o = document.createElement("option");
-      o.value = values[i];
-      o.textContent = values[i];
-      frag.appendChild(o);
-    }
-    sel.appendChild(frag);
-  }
+  // ---- Filter system ----
 
   function populateFilters() {
-    fillSelect(
+    var trimmed = { trim: true };
+    populateSelect(
       qs("#filterParticipant"),
-      uniqueValues("participant"),
+      uniqueFieldValues(state.artifacts, "participant", trimmed),
       "All participants"
     );
-    fillSelect(
+    populateSelect(
       qs("#filterCategory"),
-      uniqueValues("category"),
+      uniqueFieldValues(state.artifacts, "category", trimmed),
       "All categories"
     );
-    var sevs = uniqueValues("severity");
+    var sevs = uniqueFieldValues(state.artifacts, "severity", trimmed);
     var sevSel = qs("#filterSeverity");
-    fillSelect(sevSel, sevs, "All severities");
+    populateSelect(sevSel, sevs, "All severities");
     sevSel.parentElement.style.display = sevs.length ? "" : "none";
 
     var types = {};
@@ -881,7 +845,7 @@
     var statusCls = insight.status === "final" ? "status-final" : "status-draft";
     header.appendChild(el("span", "insight-status-badge " + statusCls, insight.status || "draft"));
 
-    var count = countBucketArtifacts(insight);
+    var count = countInsightArtifacts(insight);
     header.appendChild(el("span", "insight-collapsed-count", count + " artifact" + (count !== 1 ? "s" : "")));
 
     header.addEventListener("click", function () {

--- a/assets/web/insights-viewer.js
+++ b/assets/web/insights-viewer.js
@@ -6,19 +6,9 @@
   var data = null;
   var artifactMap = {};
 
-  // ---- Helpers ----
-
-  function countArtifacts(insight) {
-    return (
-      insight.causes.artifacts.length +
-      insight.behaviors.artifacts.length +
-      insight.impacts.artifacts.length
-    );
-  }
-
   // ---- Render index ----
 
-  function renderIndex() {
+  function renderInsightsIndex() {
     var container = qs("#insightsIndex");
     container.innerHTML = "";
 
@@ -55,7 +45,7 @@
       );
     }
 
-    var count = countArtifacts(insight);
+    var count = countInsightArtifacts(insight);
     card.appendChild(
       el("div", "index-card-count", count + " artifact" + (count !== 1 ? "s" : ""))
     );
@@ -226,7 +216,7 @@
       qs("#viewerFooter").classList.remove("hidden");
     }
 
-    renderIndex();
+    renderInsightsIndex();
   }
 
   if (document.readyState === "loading") {

--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -33,13 +33,6 @@
 
   // --- Helpers ---
 
-  function median(arr) {
-    if (!arr.length) return 0;
-    var sorted = arr.slice().sort(function (a, b) { return a - b; });
-    var mid = Math.floor(sorted.length / 2);
-    return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
-  }
-
   function getStudyName() {
     return (state.sheetData && state.sheetData.study) || "study";
   }
@@ -784,7 +777,7 @@
       if (c.transcript > maxTR) maxTR = c.transcript;
     }
 
-    var hm = getComputedStyle(document.documentElement).getPropertyValue("--color-heatmap").trim() || "168, 130, 214";
+    var hm = getCSSVar("--color-heatmap", "168, 130, 214");
 
     for (var j = 0; j < participants.length; j++) {
       var pid = participants[j];

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -4486,9 +4486,10 @@
   }
 
   // ---- Task queue ----
-  // SVG icons use createElementNS() to build inline SVG from Heroicons paths (assets/icons/).
-  // Pattern: create <svg> with createElementNS, set viewBox/width/height, then append <path>
-  // elements with the d attribute copied from the relevant .svg file in assets/icons/.
+  // TODO: These inline SVG builders predate the project rule against SVG paths
+  // in JS (AGENTS.md "Icons" / "SVG icons" sections). Migrate to the CSS
+  // mask-image pattern — see XREF_BADGES in utils.js and .xref-badge-icon in
+  // tokens.css for the canonical example.
 
   function svgEditIcon() {
     var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -29,7 +29,7 @@
   var _modelsCache = null;
   var _modelsCachePromise = null;
 
-  function _apiRoot() {
+  function _getApiRoot() {
     // Each page is served under a different prefix (/studio/, /transcripts/,
     // /insights/, /screenspace/). Settings + models are registered at the
     // combined-app root, so request them from an absolute path.
@@ -44,7 +44,7 @@
   function _fetchModels() {
     if (_modelsCache) return Promise.resolve(_modelsCache);
     if (_modelsCachePromise) return _modelsCachePromise;
-    _modelsCachePromise = fetch(_apiRoot() + "/models")
+    _modelsCachePromise = fetch(_getApiRoot() + "/models")
       .then(function (r) { return r.json(); })
       .then(function (data) {
         if (data && data.ok) _modelsCache = data;
@@ -153,7 +153,7 @@
 
   function _load() {
     _panelsEl.textContent = "Loading settings\u2026";
-    fetch(_apiRoot() + "/settings")
+    fetch(_getApiRoot() + "/settings")
       .then(function (r) { return r.json(); })
       .then(function (data) {
         if (!data.ok) {
@@ -199,7 +199,7 @@
     }
     if (_statusEl) _statusEl.textContent = "Saving\u2026";
 
-    fetch(_apiRoot() + "/settings", {
+    fetch(_getApiRoot() + "/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ settings: payload }),
@@ -224,7 +224,7 @@
   }
 
   function _resetTab(tabName) {
-    fetch(_apiRoot() + "/settings", {
+    fetch(_getApiRoot() + "/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ reset: "tab:" + tabName }),
@@ -247,7 +247,7 @@
   }
 
   function _resetAll() {
-    fetch(_apiRoot() + "/settings", {
+    fetch(_getApiRoot() + "/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ reset: "all" }),
@@ -270,7 +270,7 @@
   }
 
   function _reloadAfterReset(scope) {
-    fetch(_apiRoot() + "/settings")
+    fetch(_getApiRoot() + "/settings")
       .then(function (r) { return r.json(); })
       .then(function (data) {
         if (!data.ok) return;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1287,7 +1287,7 @@
     for (var k = 0; k < values.length; k++) {
       if (values[k] !== null && values[k] > max) max = values[k];
     }
-    var hm = getComputedStyle(document.documentElement).getPropertyValue("--color-heatmap").trim() || "168, 130, 214";
+    var hm = getCSSVar("--color-heatmap", "168, 130, 214");
     for (var m = 0; m < cells.length; m++) {
       if (values[m] !== null && max > 0) {
         var t = values[m] / max;
@@ -3846,7 +3846,7 @@
 
   function trIntakeCategoryColor(key) {
     var entry = TR_INTAKE_CATEGORIES[key] || TR_INTAKE_CATEGORIES.bookmark;
-    return getComputedStyle(document.documentElement).getPropertyValue(entry.token).trim();
+    return getCSSVar(entry.token, "");
   }
 
   function _syncMarkCategoriesFromSettings(settings) {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1379,11 +1379,6 @@
     });
   }
 
-  function getThemeColor(name, fallback) {
-    var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-    return v || fallback;
-  }
-
   function computeTickInterval(visLen) {
     var candidates = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
     var target = visLen / 8;
@@ -1408,9 +1403,9 @@
     var cssH = canvas.offsetHeight;
     ctx.clearRect(0, 0, cssW, cssH);
 
-    var surfaceAlt = getThemeColor("--color-surface-alt", "#f1ece4");
-    var border = getThemeColor("--color-border", "#e0ddd7");
-    var textDim = getThemeColor("--color-text-dim", "#6b7280");
+    var surfaceAlt = getCSSVar("--color-surface-alt", "#f1ece4");
+    var border = getCSSVar("--color-border", "#e0ddd7");
+    var textDim = getCSSVar("--color-text-dim", "#6b7280");
 
     ctx.fillStyle = surfaceAlt;
     ctx.fillRect(0, 0, cssW, cssH);
@@ -1433,7 +1428,7 @@
     var firstTick = Math.ceil(0 / tickInterval) * tickInterval;
     ctx.strokeStyle = border;
     ctx.fillStyle = textDim;
-    ctx.font = "10px " + getThemeColor("--font-mono", "monospace");
+    ctx.font = "10px " + getCSSVar("--font-mono", "monospace");
     ctx.textAlign = "center";
     ctx.lineWidth = 1;
     for (var t = firstTick; t <= dur; t += tickInterval) {
@@ -1485,7 +1480,7 @@
     var dur = isFinite(v.duration) ? v.duration : 0;
     if (dur <= 0) return;
     var px = (v.currentTime / dur) * cssW;
-    var accent = getThemeColor("--color-accent", "#1d4f72");
+    var accent = getCSSVar("--color-accent", "#1d4f72");
     ctx.strokeStyle = accent;
     ctx.lineWidth = 2;
     ctx.beginPath();

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -268,6 +268,25 @@ var clamp = function (val, min, max) {
   return Math.max(min, Math.min(max, val));
 };
 
+// Median of a numeric array. Returns 0 for empty input.
+var median = function (arr) {
+  if (!arr.length) return 0;
+  var sorted = arr.slice().sort(function (a, b) { return a - b; });
+  var mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+// Population standard deviation. Returns 0 for arrays shorter than 2.
+var stddev = function (nums) {
+  if (nums.length < 2) return 0;
+  var sum = 0;
+  for (var i = 0; i < nums.length; i++) sum += nums[i];
+  var mean = sum / nums.length;
+  var sq = 0;
+  for (var j = 0; j < nums.length; j++) sq += (nums[j] - mean) * (nums[j] - mean);
+  return Math.sqrt(sq / nums.length);
+};
+
 // ---- Tooltip positioning ----
 
 // Position a tooltip element centered above an anchor rect, flipping below
@@ -306,6 +325,17 @@ var hexToRgba = function (hex, alpha) {
   var g = parseInt(hex.slice(3, 5), 16);
   var b = parseInt(hex.slice(5, 7), 16);
   return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
+};
+
+// Read a CSS custom property from :root, returning fallback when unset/empty.
+// Pages use this for theme-aware values (--color-accent, --color-heatmap, ...).
+var getCSSVar = function (name, fallback) {
+  try {
+    var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return v || fallback;
+  } catch (_) {
+    return fallback;
+  }
 };
 
 var SHOW_TOAST_DEFAULT_MS = 3000;
@@ -451,6 +481,52 @@ var XREF_BADGES = {
   screenspace: { icon: "squares-2x2", color: "rgba(52, 152, 219, 0.85)" },
   transcript:  { icon: "chat-bubble-bottom-center-text", color: "rgba(16, 163, 74, 0.85)" },
   sheet:       { icon: "table-cells", color: "rgba(234, 179, 8, 0.85)" },
+};
+
+// ---- Insight helpers ----
+
+// Sum of artifacts across all three buckets of an insight record. Shared by
+// the insights builder and the exported insights viewer.
+var countInsightArtifacts = function (insight) {
+  return insight.causes.artifacts.length
+       + insight.behaviors.artifacts.length
+       + insight.impacts.artifacts.length;
+};
+
+// ---- Filter helpers (artifact grids in viewer + insights builder) ----
+
+// Sorted unique non-empty values of `field` across `items`.
+// opts.trim: trim string values before deduping (default false).
+var uniqueFieldValues = function (items, field, opts) {
+  var trim = opts && opts.trim;
+  var seen = {};
+  var out = [];
+  for (var i = 0; i < items.length; i++) {
+    var v = items[i][field];
+    if (v == null) continue;
+    if (trim) v = String(v).trim();
+    if (v && !seen[v]) { seen[v] = true; out.push(v); }
+  }
+  return out.sort();
+};
+
+// Replace a <select>'s options with [allLabel, ...values]. The "all" option
+// has empty value "" so callers can detect it via select.value === "".
+var populateSelect = function (selectEl, values, allLabel) {
+  if (!selectEl) return;
+  selectEl.innerHTML = "";
+  var frag = document.createDocumentFragment();
+  var allOpt = document.createElement("option");
+  allOpt.value = "";
+  allOpt.textContent = allLabel;
+  frag.appendChild(allOpt);
+  for (var i = 0; i < values.length; i++) {
+    var o = document.createElement("option");
+    o.value = values[i];
+    o.textContent = values[i];
+    frag.appendChild(o);
+  }
+  selectEl.appendChild(frag);
 };
 
 // ---- Detector colors ----

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -107,6 +107,10 @@
 
   // ---- Clip thumbnails ----
 
+  // Off-DOM video element seeks to ~25% (clamped to 0.5–5s) and captures a
+  // 320x180 JPEG poster. The 8s timeout guards against clips that never fire
+  // 'seeked' (corrupt files, codec stalls); finish() is idempotent so timeout
+  // and seek both safely call it. Blob URL is owned by _thumbCache.
   function generateClipThumbnail(mediaEl, artifact, callback) {
     var done = false;
     function finish() {
@@ -699,11 +703,11 @@
   // ---- Filters ----
 
   function populateFilters() {
-    var categories = uniqueValues("category");
-    var participants = uniqueValues("participant");
+    var categories = uniqueFieldValues(state.artifacts, "category");
+    var participants = uniqueFieldValues(state.artifacts, "participant");
 
-    fillSelect("#filterCategory", categories, "All categories");
-    fillSelect("#filterParticipant", participants, "All participants");
+    populateSelect(qs("#filterCategory"), categories, "All categories");
+    populateSelect(qs("#filterParticipant"), participants, "All participants");
 
     var severities = sortedUniqueSeverities();
     var wrap = qs("#filterSeverityWrap");
@@ -712,7 +716,7 @@
         wrap.classList.add("hidden");
       } else {
         wrap.classList.remove("hidden");
-        fillSelect("#filterSeverity", severities, "All severities");
+        populateSelect(qs("#filterSeverity"), severities, "All severities");
       }
     }
   }
@@ -791,31 +795,6 @@
         fieldset.style.display = "";
       }
     }
-  }
-
-  function uniqueValues(field) {
-    var seen = {};
-    state.artifacts.forEach(function (a) {
-      var v = a[field];
-      if (v) seen[v] = true;
-    });
-    return Object.keys(seen).sort();
-  }
-
-  function fillSelect(sel, values, allLabel) {
-    var select = qs(sel);
-    if (!select) return;
-    select.innerHTML = "";
-    var optAll = document.createElement("option");
-    optAll.value = "";
-    optAll.textContent = allLabel;
-    select.appendChild(optAll);
-    values.forEach(function (v) {
-      var opt = document.createElement("option");
-      opt.value = v;
-      opt.textContent = v;
-      select.appendChild(opt);
-    });
   }
 
   function bindFilterEvents() {


### PR DESCRIPTION
## Summary
- Extracted 6 helpers to `assets/web/utils.js` and migrated all callers: `getCSSVar` (replaces inlined `getComputedStyle().getPropertyValue().trim()` in 4 files), `countInsightArtifacts` (dedupes builder + viewer), `uniqueFieldValues` + `populateSelect` (reconciles two divergent filter helpers in `viewer.js` and `insights-builder.js`), and `median` / `stddev` (moved alongside existing `clamp`).
- Renamed `_apiRoot` -> `_getApiRoot` (settings-modal.js) and `renderIndex` -> `renderInsightsIndex` (insights-viewer.js); added a WHY-comment to `viewer.js:generateClipThumbnail` explaining the seek bounds, 8s timeout, and idempotent finish; replaced the inline-SVG comment block in `screenspace.js` with a TODO referencing AGENTS.md (those ~290 lines of SVG paths violate the project rule but converting them is its own task).
- Net diff: +119 / -132 across 10 files; behavior unchanged.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` (706/706 pass; `tests/test_shared_constants.py` still green)
- [x] `node --check` on every modified JS file
- [ ] Manual browser smoke checks on Studio / Insights / Screenspace / exported viewers (filter dropdowns, heatmap colors, insight bucket counts)