### PR TITLE
fix: restore white text on filled primary buttons

### DIFF
--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -344,17 +344,17 @@ body:not(.cg-grid-bg-on) {
 /* Primary CTA button — shared across Studio / Screenspace / Transcripts / Insights.
  * Page CSS still defines the base .btn (size, padding, border-radius) so visual
  * weight stays page-specific; only the primary variant's color treatment is shared. */
-.btn-primary {
+.btn.btn-primary {
   background: var(--color-accent);
   color: #fff;
   border-color: var(--color-accent);
 }
-.btn-primary:hover {
+.btn.btn-primary:hover {
   background: var(--color-accent-strong-hover);
   border-color: var(--color-accent-strong-hover);
   color: #fff;
 }
-.btn-primary:disabled:hover {
+.btn.btn-primary:disabled:hover {
   background: var(--color-accent);
   border-color: var(--color-accent);
   color: #fff;

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.115"
+VERSIONNUM: str = "0.10.116"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary
- Filled primary buttons (Studio "Generate"/"Find Highlights", Screenspace "Run", etc.) were rendering with dark text on the dark accent background, producing low-contrast labels in both light and dark themes.
- Root cause: commit 187293e consolidated \`.btn-primary\` into \`tokens.css\` (loads first), but page-CSS \`.btn { color: var(--color-text) }\` then overrode \`color: #fff\` due to equal specificity and later source order. Fix bumps the selector to \`.btn.btn-primary\` so specificity wins regardless of load order.
- Bumps \`VERSIONNUM\` to 0.10.116.

## Test plan
- [ ] Run \`uv run clipgen.py --screenspace -i DIR -o DIR\` and confirm "Run" has white text on dark blue.
- [ ] Run \`uv run clipgen.py --studio\` with a spreadsheet and confirm "Generate" / "Find Highlights" render with white text.
- [ ] Toggle OS dark mode and reload — primary buttons still white.
- [ ] \`uv run --extra dev pytest -c tests/pytest.ini\` passes.