### PR TITLE
fix: backfill Screenspace events for completed tasks missing them

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.115"
+VERSIONNUM: str = "0.10.116"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace.py
+++ b/screenspace.py
@@ -2601,43 +2601,7 @@ class ScreenspaceWorker:
     def _generate_events_from_results(
         self, task: dict[str, Any], raw_results: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Convert raw task results into ScreenspaceEvent records."""
-        task_type = task.get("type", "")
-        if task_type == "timelapse":
-            return []
-        events: list[dict[str, Any]] = []
-        for r in raw_results:
-            ts = r.get("timestamp", r.get("start", 0.0))
-            confidence = _extract_confidence(task_type, r)
-            metadata: dict[str, Any] = {}
-            if task_type == "change":
-                metadata["magnitude"] = r.get("magnitude", 0.0)
-            elif task_type == "similarity":
-                metadata["score"] = r.get("score", 0.0)
-            elif task_type == "text":
-                metadata["text_found"] = r.get("text_found", "")
-            elif task_type == "numbers":
-                metadata["value"] = r.get("number_found", 0)
-            elif task_type == "template":
-                metadata["match_count"] = r.get("match_count", 0)
-                metadata["best_score"] = r.get("best_score", 0.0)
-            elif task_type == "flow":
-                metadata["magnitude"] = r.get("magnitude", 0.0)
-                metadata["angle"] = r.get("angle", 0.0)
-            elif task_type == "scene":
-                metadata["scene_name"] = r.get("scene_name", "")
-                metadata["score"] = r.get("score", 0.0)
-            elif task_type == "multitool":
-                metadata["tool_types"] = r.get("tool_types", [])
-                metadata["steps"] = r.get("steps", [])
-            elif task_type == "inactivity":
-                metadata["duration"] = r.get("duration", 0.0)
-                metadata["avg_distance"] = r.get("avg_distance", 0.0)
-            ev = create_event(task, ts, confidence, metadata)
-            if task_type == "inactivity" and "end" in r:
-                ev["time_out"] = round(r["end"], 2)
-            events.append(ev)
-        return events
+        return generate_events_from_results(task, raw_results)
 
     def _generate_heatmap(
         self, task: dict[str, Any], results: list[dict[str, Any]]
@@ -3146,6 +3110,48 @@ def save_screenspace_manifest(
         },
         warn_label="screenspace manifest",
     )
+
+
+def generate_events_from_results(
+    task: dict[str, Any], raw_results: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Convert raw task results into ScreenspaceEvent records."""
+    task_type = task.get("type", "")
+    if task_type == "timelapse":
+        return []
+    events: list[dict[str, Any]] = []
+    for r in raw_results:
+        ts = r.get("timestamp", r.get("start", 0.0))
+        confidence = _extract_confidence(task_type, r)
+        metadata: dict[str, Any] = {}
+        if task_type == "change":
+            metadata["magnitude"] = r.get("magnitude", 0.0)
+        elif task_type == "similarity":
+            metadata["score"] = r.get("score", 0.0)
+        elif task_type == "text":
+            metadata["text_found"] = r.get("text_found", "")
+        elif task_type == "numbers":
+            metadata["value"] = r.get("number_found", 0)
+        elif task_type == "template":
+            metadata["match_count"] = r.get("match_count", 0)
+            metadata["best_score"] = r.get("best_score", 0.0)
+        elif task_type == "flow":
+            metadata["magnitude"] = r.get("magnitude", 0.0)
+            metadata["angle"] = r.get("angle", 0.0)
+        elif task_type == "scene":
+            metadata["scene_name"] = r.get("scene_name", "")
+            metadata["score"] = r.get("score", 0.0)
+        elif task_type == "multitool":
+            metadata["tool_types"] = r.get("tool_types", [])
+            metadata["steps"] = r.get("steps", [])
+        elif task_type == "inactivity":
+            metadata["duration"] = r.get("duration", 0.0)
+            metadata["avg_distance"] = r.get("avg_distance", 0.0)
+        ev = create_event(task, ts, confidence, metadata)
+        if task_type == "inactivity" and "end" in r:
+            ev["time_out"] = round(r["end"], 2)
+        events.append(ev)
+    return events
 
 
 def create_event(

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -1577,6 +1577,40 @@ def _clean_task(task: dict[str, Any]) -> dict[str, Any]:
 # ---- State initialization ----
 
 
+def _backfill_missing_events(manifest: dict[str, Any]) -> None:
+    """Heal manifests where completed tasks have results but no events.
+
+    Why: events are generated only at task completion. Tasks completed before
+    the events system existed (or whose events were lost) leave the frontend
+    unable to render exclude toggles. Backfill so older results behave like
+    new ones.
+    """
+    import screenspace
+
+    events = manifest.setdefault("events", [])
+    task_ids_with_events = {e.get("task_id") for e in events if e.get("task_id")}
+    added = 0
+    for task in manifest.get("tasks", []):
+        if task.get("status") != screenspace.TASK_STATUS_COMPLETED:
+            continue
+        if task.get("id") in task_ids_with_events:
+            continue
+        result = task.get("result")
+        if not isinstance(result, list) or not result:
+            continue
+        new_events = screenspace.generate_events_from_results(task, result)
+        if new_events:
+            events.extend(new_events)
+            added += len(new_events)
+    if added:
+        screenspace.save_screenspace_manifest(
+            manifest.get("regions", {}),
+            manifest.get("tasks", []),
+            events,
+            stashes=manifest.get("stashes", []),
+        )
+
+
 def _init_screenspace_state(
     sheet_context: Any = None,
     participant_list: list[str] | None = None,
@@ -1592,6 +1626,7 @@ def _init_screenspace_state(
 
     _output_dir = str(utils.get_effective_output_dir())
     _manifest = screenspace.load_screenspace_manifest()
+    _backfill_missing_events(_manifest)
 
     _participants = []
     study_name = ""

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -632,6 +632,61 @@ class TestManifestWithEvents:
         assert loaded["events"] == []
 
 
+class TestBackfillMissingEvents:
+    def _completed_template_task(self):
+        return {
+            "id": "ss_template1",
+            "type": "template",
+            "status": "completed",
+            "source_video": "study_P01.mp4",
+            "participant": "P01",
+            "region": "icon",
+            "parameters": {},
+            "result": [
+                {"timestamp": 5.0, "best_score": 0.9, "match_count": 1},
+                {"timestamp": 10.0, "best_score": 0.7, "match_count": 2},
+            ],
+        }
+
+    def test_backfills_when_no_events(self, tmp_path, monkeypatch):
+        import screenspace_server
+
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        manifest = {
+            "regions": {},
+            "tasks": [self._completed_template_task()],
+            "events": [],
+            "stashes": [],
+        }
+        screenspace_server._backfill_missing_events(manifest)
+        assert len(manifest["events"]) == 2
+        assert all(e["task_id"] == "ss_template1" for e in manifest["events"])
+        assert manifest["events"][0]["detector"] == "template"
+
+    def test_skips_tasks_with_existing_events(self, tmp_path, monkeypatch):
+        import screenspace_server
+
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        manifest = {
+            "regions": {},
+            "tasks": [self._completed_template_task()],
+            "events": [{"id": "ev_x", "task_id": "ss_template1"}],
+            "stashes": [],
+        }
+        screenspace_server._backfill_missing_events(manifest)
+        assert len(manifest["events"]) == 1
+
+    def test_skips_non_completed_tasks(self, tmp_path, monkeypatch):
+        import screenspace_server
+
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        task = self._completed_template_task()
+        task["status"] = "running"
+        manifest = {"regions": {}, "tasks": [task], "events": [], "stashes": []}
+        screenspace_server._backfill_missing_events(manifest)
+        assert manifest["events"] == []
+
+
 class TestDrainNewEvents:
     def test_drain_collects_and_clears(self):
         worker = screenspace.ScreenspaceWorker()


### PR DESCRIPTION
## Summary
- The Screenspace Exclude/Include toggle and per-row buttons are gated on event presence, so completed tasks (any tool, including Template) loaded from a manifest that predates or lost its events showed no toggle.
- On manifest load, walk completed tasks and regenerate events from stored `result` arrays for any task whose id has no entry in `events`. Persist once if anything was added.
- Promoted the existing event-generation helper to a module-level `generate_events_from_results()` so the server can reuse it; the worker method now delegates to it.
- Added `TestBackfillMissingEvents` covering the heal, the no-op when events already exist, and the skip for non-completed tasks. Bumped `VERSIONNUM` to 0.10.116.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace.py tests/test_screenspace_api.py`
- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run ty check screenspace.py screenspace_server.py`
- [ ] Manual: open a Screenspace workspace with a completed Template task whose manifest has no events; confirm the toggle and per-row buttons appear after restart.