### PR TITLE
fix: center Template heatmap overlay and clarify Run button gate

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -4177,8 +4177,6 @@
     var btn = qs("#runBtn");
     var hasRegion = state.runRegions.length > 0 || !!state.activeRegion;
     var hasParticipants = state.runParticipants.length > 0 || !!state.selectedParticipant;
-    // Template with uploaded image can run without a region (full-frame scan)
-    var templateNoRegion = state.activeWorkflow === "template" && !!state.uploadedTemplate;
     // Multitool uses per-step regions instead of a global region
     var isMultitool = state.activeWorkflow === "multitool";
     var multitoolReady = isMultitool && state.multitoolSteps.length >= 2;
@@ -4195,8 +4193,16 @@
         btn.removeAttribute("data-tooltip");
       }
     } else {
-      btn.disabled = (!hasRegion && !templateNoRegion) || !hasParticipants;
-      if (!hasRegion && !templateNoRegion) {
+      var isTemplate = state.activeWorkflow === "template";
+      var hasUploadedTemplate = !!state.uploadedTemplate;
+      // Template scans full frames regardless of region selection; the region
+      // (or uploaded image) only supplies the template patch.
+      var templateMissingPatch = isTemplate && !hasRegion && !hasUploadedTemplate;
+      var nonTemplateMissingRegion = !isTemplate && !hasRegion;
+      btn.disabled = nonTemplateMissingRegion || templateMissingPatch || !hasParticipants;
+      if (templateMissingPatch) {
+        btn.setAttribute("data-tooltip", "Upload a template image or pick a region first");
+      } else if (nonTemplateMissingRegion) {
         btn.setAttribute("data-tooltip", "Select a region first");
       } else if (!hasParticipants) {
         btn.setAttribute("data-tooltip", "Select participants to run");

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.116"
+VERSIONNUM: str = "0.10.117"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -287,14 +287,23 @@ def _overlay_template_heatmap(
     norm = np.empty_like(result)
     cv2.normalize(result, norm, 0, 255, cv2.NORM_MINMAX)
     heat = cv2.applyColorMap(norm.astype(np.uint8), cv2.COLORMAP_JET)
-    # Pad to frame size so the overlay aligns 1:1 with the frame canvas.
+    # matchTemplate output indexes the top-left anchor of each candidate match,
+    # so offset by half the template size to center the heatmap response over
+    # the match's actual location in the frame. Edge pixels (outside the valid
+    # match range) are filled by replicating nearest values so the overlay
+    # visually covers the whole frame rather than leaving a black border.
     fh, fw = frame.shape[:2]
     hh, hw = heat.shape[:2]
     if (hh, hw) == (fh, fw):
         return heat
-    out = np.zeros((fh, fw, 3), dtype=np.uint8)
-    out[:hh, :hw] = heat
-    return out
+    th, tw = tmpl_gray.shape[:2]
+    top = th // 2
+    left = tw // 2
+    bottom = fh - hh - top
+    right = fw - hw - left
+    return cv2.copyMakeBorder(
+        heat, top, bottom, left, right, borderType=cv2.BORDER_REPLICATE
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Live Template model-view heatmap now centers on match anchors and fills the frame via `BORDER_REPLICATE` instead of zero-padding into the top-left, fixing the visible offset/black-border for non-trivial template sizes.
- Run button for Template no longer requires a region when an uploaded template is present, with a clearer tooltip ("Upload a template image or pick a region first") when neither is supplied.

## Test plan
- [ ] Screenspace → Template with a region: enable Model View overlay / hold `B` blink — heatmap reads centered on actual matches and covers the full frame.
- [ ] Upload a template image, deselect all regions — Run button stays enabled; runs full-frame scan.
- [ ] Other tools (color/change/flow/scene): deselecting all regions still disables Run with "Select a region first".