### PR TITLE
feat: cut clips from Screenspace and Transcript events via CLI

### DIFF
--- a/agents/skills/generate/SKILL.md
+++ b/agents/skills/generate/SKILL.md
@@ -54,3 +54,15 @@ Source videos must be named `{study}_{participant}.mp4` — e.g. `mystudy_P01.mp
 | "annotated clips only" | `uv run clipgen.py -k -s "Study" -i . -o ./clips` |
 | "critical and high severity" | `uv run clipgen.py -S Critical,High -s "Study" -i . -o ./clips` |
 | "GIFs for the usability category" | `uv run clipgen.py --gif -C "Usability" -s "Study" -i . -o ./clips` |
+
+## Event-driven clips (no spreadsheet)
+
+When the user wants to cut clips from existing Screenspace events or transcript segments instead of a spreadsheet, use the manifest-driven modes — no `-s` needed:
+
+| Natural language | Command |
+|-----------------|---------|
+| "clips of every change event in the dialog region" | `uv run clipgen.py --ss-clips --ss-clips-detector change --ss-clips-region dialog -i . -o ./clips` |
+| "clips for every segment marked as an insight" | `uv run clipgen.py --transcript-clips --transcript-clips-mark insight -i . -o ./clips` |
+| "clips wherever P01 said 'checkout flow'" | `uv run clipgen.py --transcript-clips --transcript-clips-participant P01 --transcript-clips-text "checkout flow" -i . -o ./clips` |
+
+See `agents/skills/screenspace/SKILL.md` and `agents/skills/transcribe/SKILL.md` for the full filter and clustering reference.

--- a/agents/skills/screenspace/SKILL.md
+++ b/agents/skills/screenspace/SKILL.md
@@ -48,6 +48,42 @@ uv run clipgen.py --ss-list-tasks completed -i INPUT_DIR   # filter by status
 uv run clipgen.py --ss-list-stashes -i INPUT_DIR           # saved region stashes
 ```
 
+## Cut clips from events
+
+Turn the events you generated above into video clips, no UI required:
+
+```
+uv run clipgen.py --ss-clips [filters] [--cluster-gap N] [--clip-pre N --clip-post N] -i INPUT_DIR -o OUTPUT_DIR
+```
+
+Filters (all optional, comma-separated where listed):
+- `--ss-clips-detector change,color` — restrict to specific tool types
+- `--ss-clips-region dialog,header` — restrict to specific regions
+- `--ss-clips-participant P01,P02` — restrict to specific participants
+- `--ss-clips-min-confidence 0.8` — drop low-confidence events
+- `--ss-clips-event-type "login"` — case-insensitive substring on `event_type`
+
+Clustering & padding (defaults shown):
+- `--cluster-gap 5.0` — merge events within N seconds into one clip; `0` = one clip per event
+- `--clip-pre 5.0 --clip-post 5.0` — pad each cluster's start/end with N seconds
+- `--max-clip-duration 0` — when `>0`, split clusters longer than N seconds
+
+Examples:
+
+```
+# Cluster all change events into clips with default 5s gap and 5s pad
+uv run clipgen.py --ss-clips --ss-clips-detector change -i INPUT -o OUTPUT
+
+# One clip per event, no clustering
+uv run clipgen.py --ss-clips --ss-clips-detector change --cluster-gap 0 -i INPUT -o OUTPUT
+
+# High-confidence dialog events for one participant
+uv run clipgen.py --ss-clips --ss-clips-region dialog --ss-clips-participant P01 \
+    --ss-clips-min-confidence 0.8 -i INPUT -o OUTPUT
+```
+
+Generated clips are appended to `clipgen_manifest.json` (synthetic artifact ids using negative cell rows so they never collide with spreadsheet-derived clips). Reruns with the same filters update existing entries idempotently.
+
 ## Export results
 
 ```

--- a/agents/skills/transcribe/SKILL.md
+++ b/agents/skills/transcribe/SKILL.md
@@ -42,6 +42,37 @@ uv run clipgen.py --citations [P01 P03 ...] -i INPUT_DIR -o OUTPUT_DIR
 
 To use a specific Ollama model: `--ollama-model MODEL`
 
+## Step 5: Cut clips from transcript segments or marks
+
+Turn transcript segments into video clips, no UI required:
+
+```
+uv run clipgen.py --transcript-clips [filters] [--cluster-gap N] [--clip-pre N --clip-post N] -i INPUT_DIR -o OUTPUT_DIR
+```
+
+Filters (all optional, comma-separated where listed):
+- `--transcript-clips-participant P01,P02` — restrict to specific participants
+- `--transcript-clips-mark insight,action` — only segments tagged with these mark categories (set via the Transcripts UI)
+- `--transcript-clips-text "checkout"` — case-insensitive substring on segment text
+
+Clustering & padding (defaults shown): same as `--ss-clips` —
+`--cluster-gap 5.0`, `--clip-pre 5.0`, `--clip-post 5.0`, `--max-clip-duration 0`.
+
+Examples:
+
+```
+# Clips for every segment marked as an "insight"
+uv run clipgen.py --transcript-clips --transcript-clips-mark insight -i INPUT -o OUTPUT
+
+# Text-search clips
+uv run clipgen.py --transcript-clips --transcript-clips-text "checkout flow" -i INPUT -o OUTPUT
+
+# One clip per segment, no clustering
+uv run clipgen.py --transcript-clips --transcript-clips-participant P01 --cluster-gap 0 -i INPUT -o OUTPUT
+```
+
+When a mark filter is set, the clip's category is `mark-{category}`; otherwise `transcript`. Clips are appended to `clipgen_manifest.json`.
+
 ## Notes
 
 - `config.DEBUGGING = True` returns stub transcripts without loading the Whisper model — useful for development

--- a/cli.py
+++ b/cli.py
@@ -485,6 +485,106 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         help="Override the auto-generated event label written to the manifest.",
     )
 
+    event_clips = parser.add_argument_group("event-driven clips")
+    event_clips.add_argument(
+        "--ss-clips",
+        action="store_true",
+        help=(
+            "Cut clips from existing Screenspace events (reads screenspace_manifest.json). "
+            "Filter with --ss-clips-detector / --ss-clips-region / --ss-clips-participant / "
+            "--ss-clips-min-confidence / --ss-clips-event-type. Cluster nearby events with "
+            "--cluster-gap and pad with --clip-pre / --clip-post."
+        ),
+    )
+    event_clips.add_argument(
+        "--transcript-clips",
+        action="store_true",
+        help=(
+            "Cut clips from transcript segments or marks (reads transcripts_manifest.json). "
+            "Filter with --transcript-clips-participant / --transcript-clips-mark / "
+            "--transcript-clips-text. Cluster nearby segments with --cluster-gap."
+        ),
+    )
+    event_clips.add_argument(
+        "--ss-clips-detector",
+        type=str,
+        metavar="TYPE",
+        help="Comma-separated detector types to include (e.g. 'change,color').",
+    )
+    event_clips.add_argument(
+        "--ss-clips-region",
+        type=str,
+        metavar="NAME",
+        help="Comma-separated region names to include.",
+    )
+    event_clips.add_argument(
+        "--ss-clips-participant",
+        type=str,
+        metavar="ID",
+        help="Comma-separated participant IDs to include (--ss-clips).",
+    )
+    event_clips.add_argument(
+        "--ss-clips-min-confidence",
+        type=float,
+        metavar="FLOAT",
+        help="Minimum event confidence (0.0-1.0).",
+    )
+    event_clips.add_argument(
+        "--ss-clips-event-type",
+        type=str,
+        metavar="STR",
+        help="Substring match against event_type (case-insensitive).",
+    )
+    event_clips.add_argument(
+        "--transcript-clips-participant",
+        type=str,
+        metavar="ID",
+        help="Comma-separated participant IDs to include (--transcript-clips).",
+    )
+    event_clips.add_argument(
+        "--transcript-clips-mark",
+        type=str,
+        metavar="CATEGORY",
+        help=(
+            "Comma-separated mark categories. When set, only segments with at least "
+            "one matching mark are included."
+        ),
+    )
+    event_clips.add_argument(
+        "--transcript-clips-text",
+        type=str,
+        metavar="STR",
+        help="Substring match against segment text (case-insensitive).",
+    )
+    event_clips.add_argument(
+        "--cluster-gap",
+        type=float,
+        default=5.0,
+        metavar="SECONDS",
+        help="Cluster events whose gap is <= SECONDS into one clip (default: 5.0; 0 disables).",
+    )
+    event_clips.add_argument(
+        "--clip-pre",
+        type=float,
+        default=5.0,
+        metavar="SECONDS",
+        help="Pad each cluster's start by SECONDS (default: 5.0).",
+    )
+    event_clips.add_argument(
+        "--clip-post",
+        type=float,
+        default=5.0,
+        metavar="SECONDS",
+        help="Pad each cluster's end by SECONDS (default: 5.0).",
+    )
+    event_clips.add_argument(
+        "--max-clip-duration",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help="If > 0, cap each clip's duration; longer clusters are split (default: 0 = no cap).",
+    )
+
     run_opts = parser.add_argument_group("run options")
     run_opts.add_argument(
         "-y",
@@ -1551,6 +1651,518 @@ def _run_ss_task(args: argparse.Namespace) -> None:
         utils.info_print(f"Task ended with status={status}.")
 
 
+# ---- Event-driven clip cutting (--ss-clips, --transcript-clips) ----
+
+
+_SS_CLIPS_CELL_COL = 1  # synthetic cell column for --ss-clips artifacts
+_TRANSCRIPT_CLIPS_CELL_COL = 2  # synthetic cell column for --transcript-clips
+
+
+def _split_csv_set(value: str | None) -> set[str] | None:
+    """Parse a comma-separated CLI value into a set of trimmed non-empty tokens.
+
+    Returns None when the option was not supplied (so callers can distinguish
+    "no filter" from "filter rejecting everything").
+    """
+    if value is None:
+        return None
+    items = {tok.strip() for tok in value.split(",")}
+    items.discard("")
+    return items if items else None
+
+
+def _split_study_participant(filename: str) -> tuple[str, str]:
+    """Derive (study, participant) from a {study}_{participant}.<ext> filename stem.
+
+    Falls back to ('', filename_stem) when the basename does not match the
+    convention; downstream code uses the participant for clip metadata only.
+    """
+    stem = Path(filename).stem
+    parts = stem.rsplit("_", 1)
+    if len(parts) == 2 and parts[0]:
+        return (parts[0], parts[1])
+    return ("", stem)
+
+
+def _filter_screenspace_events(
+    events: list[dict[str, Any]],
+    *,
+    detectors: set[str] | None,
+    regions: set[str] | None,
+    participants: set[str] | None,
+    min_confidence: float | None,
+    event_type_substr: str | None,
+) -> list[dict[str, Any]]:
+    """Apply CLI filters to Screenspace events; always drops excluded=True."""
+    needle = event_type_substr.lower() if event_type_substr else None
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        if ev.get("excluded"):
+            continue
+        if detectors and ev.get("detector") not in detectors:
+            continue
+        if regions and ev.get("region") not in regions:
+            continue
+        if participants and ev.get("participant") not in participants:
+            continue
+        if min_confidence is not None:
+            try:
+                conf = float(ev.get("confidence", 0.0))
+            except (TypeError, ValueError):
+                conf = 0.0
+            if conf < min_confidence:
+                continue
+        if needle is not None:
+            label = str(ev.get("event_type", "")).lower()
+            if needle not in label:
+                continue
+        out.append(ev)
+    return out
+
+
+def _filter_transcript_segments(
+    manifest: dict[str, Any],
+    *,
+    participants: set[str] | None,
+    mark_categories: set[str] | None,
+    text_substr: str | None,
+) -> list[tuple[str, dict[str, Any], list[dict[str, Any]]]]:
+    """Return (participant_id, segment, attached_marks) tuples after filtering.
+
+    When ``mark_categories`` is non-empty, only segments referenced by at least
+    one matching mark are kept; the matching marks come along for clip metadata.
+    Otherwise ``attached_marks`` is empty.
+    """
+    needle = text_substr.lower() if text_substr else None
+    marks = manifest.get("marks") or []
+    marks_by_segment: dict[str, list[dict[str, Any]]] = {}
+    for mark in marks:
+        if mark_categories and mark.get("category") not in mark_categories:
+            continue
+        seg_id = mark.get("segment_id")
+        if not seg_id:
+            continue
+        marks_by_segment.setdefault(seg_id, []).append(mark)
+
+    rows: list[tuple[str, dict[str, Any], list[dict[str, Any]]]] = []
+    sources = manifest.get("source_transcripts") or {}
+    for pid, entry in sources.items():
+        if participants and pid not in participants:
+            continue
+        for idx, seg in enumerate(entry.get("segments") or []):
+            seg_id = seg.get("id") or f"{pid}:{idx}"
+            attached = marks_by_segment.get(seg_id, [])
+            if mark_categories and not attached:
+                continue
+            if needle is not None:
+                if needle not in str(seg.get("text", "")).lower():
+                    continue
+            rows.append((pid, seg, attached))
+    return rows
+
+
+def _cluster_groups(
+    keyed_spans: list[tuple[Any, tuple[float, float], int]],
+    *,
+    gap: float,
+    pad_pre: float,
+    pad_post: float,
+    max_duration: float,
+) -> list[tuple[Any, tuple[float, float], list[int]]]:
+    """Group items by ``key`` first, then run utils.cluster_spans within each group.
+
+    Returns a list of (group_key, (cluster_start, cluster_end), member_indices),
+    where ``member_indices`` index into the original ``keyed_spans`` list (not the
+    per-group sublist) — so callers can look up the contributing items directly.
+    """
+    by_key: dict[Any, list[tuple[tuple[float, float], int]]] = {}
+    for key, span, orig_idx in keyed_spans:
+        by_key.setdefault(key, []).append((span, orig_idx))
+
+    out: list[tuple[Any, tuple[float, float], list[int]]] = []
+    for key, items in by_key.items():
+        spans = [span for span, _ in items]
+        local_to_orig = [orig for _, orig in items]
+        clusters = utils.cluster_spans(
+            spans,
+            gap_seconds=gap,
+            pad_pre=pad_pre,
+            pad_post=pad_post,
+            max_duration=max_duration,
+        )
+        for cs, ce, local_members in clusters:
+            members = [local_to_orig[i] for i in local_members]
+            out.append((key, (cs, ce), members))
+    return out
+
+
+def _build_clusters_from_ss_events(
+    events: list[dict[str, Any]],
+    *,
+    gap: float,
+    pad_pre: float,
+    pad_post: float,
+    max_duration: float,
+) -> list[dict[str, Any]]:
+    """Group SS events by (participant, source_video, detector) then cluster.
+
+    Returns a list of cluster dicts: ``{participant, source_video, detector,
+    region, start, end, regions, event_types, member_event_ids}``.
+    """
+    keyed: list[tuple[Any, tuple[float, float], int]] = []
+    for idx, ev in enumerate(events):
+        try:
+            t_in = float(ev.get("time_in", 0.0))
+            t_out = float(ev.get("time_out", t_in))
+        except (TypeError, ValueError):
+            continue
+        if t_out < t_in:
+            t_out = t_in
+        key = (
+            ev.get("participant", ""),
+            ev.get("source_video", ""),
+            ev.get("detector", ""),
+        )
+        keyed.append((key, (t_in, t_out), idx))
+
+    clusters_raw = _cluster_groups(
+        keyed,
+        gap=gap,
+        pad_pre=pad_pre,
+        pad_post=pad_post,
+        max_duration=max_duration,
+    )
+
+    out: list[dict[str, Any]] = []
+    for key, (cs, ce), members in clusters_raw:
+        participant, source_video, detector = key
+        regions = sorted(
+            {events[m].get("region", "") for m in members if events[m].get("region")}
+        )
+        event_types = sorted(
+            {
+                str(events[m].get("event_type", ""))
+                for m in members
+                if events[m].get("event_type")
+            }
+        )
+        out.append(
+            {
+                "participant": participant,
+                "source_video": source_video,
+                "detector": detector,
+                "region": regions[0] if len(regions) == 1 else "",
+                "regions": regions,
+                "event_types": event_types,
+                "start": cs,
+                "end": ce,
+                "member_event_ids": [events[m].get("id", "") for m in members],
+            }
+        )
+    out.sort(
+        key=lambda c: (c["participant"], c["source_video"], c["detector"], c["start"])
+    )
+    return out
+
+
+def _build_clusters_from_transcript_segments(
+    rows: list[tuple[str, dict[str, Any], list[dict[str, Any]]]],
+    transcripts_manifest: dict[str, Any],
+    *,
+    gap: float,
+    pad_pre: float,
+    pad_post: float,
+    max_duration: float,
+) -> list[dict[str, Any]]:
+    """Group filtered (pid, segment, marks) by participant; cluster on segment spans.
+
+    Returns a list of cluster dicts: ``{participant, source_video, start, end,
+    text, mark_categories, member_segment_ids}``.
+    """
+    keyed: list[tuple[Any, tuple[float, float], int]] = []
+    for idx, (pid, seg, _marks) in enumerate(rows):
+        try:
+            s = float(seg.get("start", 0.0))
+            e = float(seg.get("end", s))
+        except (TypeError, ValueError):
+            continue
+        if e < s:
+            e = s
+        keyed.append((pid, (s, e), idx))
+
+    clusters_raw = _cluster_groups(
+        keyed,
+        gap=gap,
+        pad_pre=pad_pre,
+        pad_post=pad_post,
+        max_duration=max_duration,
+    )
+
+    sources = transcripts_manifest.get("source_transcripts") or {}
+    out: list[dict[str, Any]] = []
+    for key, (cs, ce), members in clusters_raw:
+        participant = key
+        text = " ".join(
+            str(rows[m][1].get("text", "")).strip() for m in members
+        ).strip()
+        mark_cats = sorted(
+            {
+                str(mark.get("category", ""))
+                for m in members
+                for mark in rows[m][2]
+                if mark.get("category")
+            }
+        )
+        seg_ids = [rows[m][1].get("id") for m in members if rows[m][1].get("id")]
+        source_file = ""
+        entry = sources.get(participant) or {}
+        if isinstance(entry, dict):
+            source_file = str(entry.get("source_file", "") or "")
+        source_video = Path(source_file).name if source_file else ""
+        out.append(
+            {
+                "participant": participant,
+                "source_video": source_video,
+                "start": cs,
+                "end": ce,
+                "text": text,
+                "mark_categories": mark_cats,
+                "member_segment_ids": seg_ids,
+            }
+        )
+    out.sort(key=lambda c: (c["participant"], c["start"]))
+    return out
+
+
+def _make_synthetic_clip_record(
+    *,
+    cluster_idx: int,
+    cell_col: int,
+    study: str,
+    participant: str,
+    desc: str,
+    category: str,
+    severity: str,
+    start_seconds: float,
+    end_seconds: float,
+    source_filename: str,
+) -> ClipRecord:
+    """Build a ClipRecord with synthetic cell + pre-filled times.
+
+    Uses negative cell rows (unreachable for real spreadsheets) and a per-mode
+    column to namespace artifact ids. The pre-filled ``times`` triggers the
+    fast path in :func:`files.prepare_clip` so the cell value is never read.
+    """
+    from types import SimpleNamespace
+
+    start_ts = utils.seconds_to_timestamp(int(start_seconds), force_hours=True)
+    end_ts = utils.seconds_to_timestamp(
+        max(int(end_seconds), int(start_seconds) + 1), force_hours=True
+    )
+    cell = SimpleNamespace(value="", row=-(cluster_idx + 1), col=cell_col)
+    record: ClipRecord = {
+        "cell": cell,
+        "desc": desc,
+        "study": study,
+        "participant": participant,
+        "category": category,
+        "severity": severity,
+        "times": [(start_ts, end_ts)],
+        "source_filename": source_filename,
+        "cell_annotations": [],
+        "segment_annotations": {},
+    }
+    return record
+
+
+def _truncate_for_filename(text: str, *, limit: int = 60) -> str:
+    """Trim a text snippet for use in a clip description (filename-safe upstream)."""
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
+
+
+def _run_ss_clips(args: argparse.Namespace) -> None:
+    """Cut clips from existing Screenspace events and append to clipgen_manifest.json."""
+    import pipeline
+    import screenspace
+
+    manifest = screenspace.load_screenspace_manifest()
+    raw_events = list(manifest.get("events") or [])
+    if not raw_events:
+        utils.warning_print(
+            "No Screenspace events found.",
+            [
+                "Run --screenspace (UI) or --ss-task to generate events first, "
+                "or check your input/output directory."
+            ],
+        )
+        return
+
+    filtered = _filter_screenspace_events(
+        raw_events,
+        detectors=_split_csv_set(args.ss_clips_detector),
+        regions=_split_csv_set(args.ss_clips_region),
+        participants=_split_csv_set(args.ss_clips_participant),
+        min_confidence=args.ss_clips_min_confidence,
+        event_type_substr=args.ss_clips_event_type,
+    )
+    if not filtered:
+        utils.warning_print("No Screenspace events match the given filters.")
+        return
+
+    clusters = _build_clusters_from_ss_events(
+        filtered,
+        gap=args.cluster_gap,
+        pad_pre=args.clip_pre,
+        pad_post=args.clip_post,
+        max_duration=args.max_clip_duration,
+    )
+    if not clusters:
+        utils.warning_print("No clusters produced from filtered events.")
+        return
+
+    clips_list: list[ClipRecord] = []
+    last_study = ""
+    for idx, cluster in enumerate(clusters):
+        source_video = cluster.get("source_video") or ""
+        if source_video:
+            study, _participant_from_filename = _split_study_participant(source_video)
+        else:
+            study = ""
+        participant = cluster.get("participant") or ""
+        detector = cluster.get("detector") or ""
+        region = cluster.get("region") or ""
+        desc_parts = [detector]
+        if region:
+            desc_parts.append(region)
+        desc = " ".join(p for p in desc_parts if p).strip() or "event"
+        category = f"screenspace-{detector}" if detector else "screenspace"
+        clips_list.append(
+            _make_synthetic_clip_record(
+                cluster_idx=idx,
+                cell_col=_SS_CLIPS_CELL_COL,
+                study=study,
+                participant=participant,
+                desc=desc,
+                category=category,
+                severity="",
+                start_seconds=cluster["start"],
+                end_seconds=cluster["end"],
+                source_filename=source_video,
+            )
+        )
+        last_study = study or last_study
+
+    count, artifacts = pipeline.process_clips(
+        clips_list, output_format="clip", include_severity=False
+    )
+    if artifacts:
+        viewer.save_manifest(
+            artifacts,
+            study=last_study,
+            participant="",
+            worksheet_title="",
+            is_excel=False,
+            mode="ss-clips",
+            output_format="clip",
+        )
+    utils.info_print(
+        f"Generated {count} clip(s) from {len(filtered)} event(s) "
+        f"in {len(clusters)} cluster(s)."
+    )
+
+
+def _run_transcript_clips(args: argparse.Namespace) -> None:
+    """Cut clips from transcript segments/marks and append to clipgen_manifest.json."""
+    import pipeline
+
+    manifest = transcripts.load_transcripts_manifest()
+    if not manifest.get("source_transcripts"):
+        utils.warning_print(
+            "No transcripts found.",
+            [
+                "Run --transcribe (with a clip mode) or --pre-transcribe / --transcripts "
+                "to generate transcripts first."
+            ],
+        )
+        return
+
+    rows = _filter_transcript_segments(
+        manifest,
+        participants=_split_csv_set(args.transcript_clips_participant),
+        mark_categories=_split_csv_set(args.transcript_clips_mark),
+        text_substr=args.transcript_clips_text,
+    )
+    if not rows:
+        utils.warning_print("No transcript segments match the given filters.")
+        return
+
+    clusters = _build_clusters_from_transcript_segments(
+        rows,
+        manifest,
+        gap=args.cluster_gap,
+        pad_pre=args.clip_pre,
+        pad_post=args.clip_post,
+        max_duration=args.max_clip_duration,
+    )
+    if not clusters:
+        utils.warning_print("No clusters produced from filtered segments.")
+        return
+
+    mark_filter = _split_csv_set(args.transcript_clips_mark)
+    clips_list: list[ClipRecord] = []
+    last_study = ""
+    for idx, cluster in enumerate(clusters):
+        source_video = cluster.get("source_video") or ""
+        study = ""
+        if source_video:
+            derived_study, _pid_from_filename = _split_study_participant(source_video)
+            study = derived_study
+        participant = cluster.get("participant") or ""
+        text = cluster.get("text") or ""
+        desc = _truncate_for_filename(text) if text else "transcript"
+        if mark_filter and cluster.get("mark_categories"):
+            primary = cluster["mark_categories"][0]
+            category = f"mark-{primary}"
+        else:
+            category = "transcript"
+        clips_list.append(
+            _make_synthetic_clip_record(
+                cluster_idx=idx,
+                cell_col=_TRANSCRIPT_CLIPS_CELL_COL,
+                study=study,
+                participant=participant,
+                desc=desc,
+                category=category,
+                severity="",
+                start_seconds=cluster["start"],
+                end_seconds=cluster["end"],
+                source_filename=source_video,
+            )
+        )
+        last_study = study or last_study
+
+    count, artifacts = pipeline.process_clips(
+        clips_list, output_format="clip", include_severity=False
+    )
+    if artifacts:
+        viewer.save_manifest(
+            artifacts,
+            study=last_study,
+            participant="",
+            worksheet_title="",
+            is_excel=False,
+            mode="transcript-clips",
+            output_format="clip",
+        )
+    utils.info_print(
+        f"Generated {count} clip(s) from {len(rows)} segment(s) "
+        f"in {len(clusters)} cluster(s)."
+    )
+
+
 # ---- Thinking-agent CLI ----
 
 
@@ -2093,6 +2705,61 @@ _EXCLUSIVE_MODES: tuple[_ModeSpec, ...] = (
             "summarize",
         ),
     ),
+    _ModeSpec(
+        key="ss_clips",
+        truthy=lambda a: bool(getattr(a, "ss_clips", False)),
+        error="--ss-clips cannot be combined with mode, format, or other standalone flags.",
+        hint=(
+            "Use --ss-clips with -i/-o (directories), -v (verbose), "
+            "--cluster-gap / --clip-pre / --clip-post / --max-clip-duration, "
+            "and --ss-clips-* filters."
+        ),
+        selector_attrs=_BASE_SELECTOR_ATTRS + ("highlights",),
+        blocks_modes=(
+            "timeline_viewer",
+            "studio",
+            "insights",
+            "screenspace",
+            "transcripts",
+            "gallery",
+            "pre_transcribe",
+            "export",
+            "ss_task",
+            "ss_list_regions",
+            "ss_list_stashes",
+            "ss_list_tasks",
+            "summarize",
+            "citations",
+        ),
+    ),
+    _ModeSpec(
+        key="transcript_clips",
+        truthy=lambda a: bool(getattr(a, "transcript_clips", False)),
+        error="--transcript-clips cannot be combined with mode, format, or other standalone flags.",
+        hint=(
+            "Use --transcript-clips with -i/-o (directories), -v (verbose), "
+            "--cluster-gap / --clip-pre / --clip-post / --max-clip-duration, "
+            "and --transcript-clips-* filters."
+        ),
+        selector_attrs=_BASE_SELECTOR_ATTRS + ("highlights",),
+        blocks_modes=(
+            "timeline_viewer",
+            "studio",
+            "insights",
+            "screenspace",
+            "transcripts",
+            "gallery",
+            "pre_transcribe",
+            "export",
+            "ss_task",
+            "ss_list_regions",
+            "ss_list_stashes",
+            "ss_list_tasks",
+            "summarize",
+            "citations",
+            "ss_clips",
+        ),
+    ),
 )
 
 
@@ -2211,6 +2878,14 @@ def _dispatch_standalone_mode(
         _run_ss_task(args)
         return True
 
+    # Standalone event-driven clip cutters
+    if getattr(args, "ss_clips", False):
+        _run_ss_clips(args)
+        return True
+    if getattr(args, "transcript_clips", False):
+        _run_transcript_clips(args)
+        return True
+
     # Standalone thinking-agent CLI passes
     if getattr(args, "summarize", None) is not None:
         _run_summarize(args)
@@ -2305,6 +2980,8 @@ def main() -> None:
         or modes["summarize"]
         or modes["citations"]
         or modes["export"]
+        or modes["ss_clips"]
+        or modes["transcript_clips"]
         or pre_transcribe_mode
     )
 

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.117"
+VERSIONNUM: str = "0.10.118"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/files.py
+++ b/files.py
@@ -88,6 +88,28 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
     """
     if config.DEBUGGING:
         ic(clip)
+
+    # Pre-parsed fast path: callers (e.g. --ss-clips, --transcript-clips) build
+    # synthetic clips with timestamps already resolved. Skip the cell-based parse
+    # but still sanitize desc/category for use in filenames.
+    if clip.get("times"):
+        clip["cell_annotations"] = list(clip.get("cell_annotations") or [])
+        clip["segment_annotations"] = dict(clip.get("segment_annotations") or {})
+        raw_desc = clip.get("desc", "")
+        bracket_pos = raw_desc.rfind("]")
+        cleaned_desc = (
+            raw_desc[bracket_pos + 1 :].strip()
+            if bracket_pos >= 0
+            else raw_desc.strip()
+        )
+        clip["desc"] = utils.sanitize_filename(cleaned_desc)
+        clip["category"] = (
+            utils.sanitize_filename(clip["category"])
+            if clip.get("category")
+            else "uncategorized"
+        )
+        return clip
+
     utils.debug_print(
         f"prepare_clip() received clip with cell contents {clip['cell'].value}"
     )

--- a/tests/test_cli_event_clip_args.py
+++ b/tests/test_cli_event_clip_args.py
@@ -1,0 +1,507 @@
+"""Tests for the event-driven clip-cutting CLI flags (--ss-clips, --transcript-clips)."""
+
+import pytest
+
+import cli
+
+# Reuse the comprehensive Namespace factory from the screenspace test file so that
+# any newly added argparse keys flow through one place.
+from test_cli_screenspace_args import _ss_args
+
+
+# ---- Argparse parsing ----
+
+
+def test_parse_ss_clips_minimal(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--ss-clips"])
+    args = cli.parse_arguments()
+    assert args.ss_clips is True
+    assert args.transcript_clips is False
+    # Defaults match the user-confirmed plan choices.
+    assert args.cluster_gap == 5.0
+    assert args.clip_pre == 5.0
+    assert args.clip_post == 5.0
+    assert args.max_clip_duration == 0.0
+
+
+def test_parse_ss_clips_with_filters(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "clipgen.py",
+            "--ss-clips",
+            "--ss-clips-detector",
+            "change,color",
+            "--ss-clips-min-confidence",
+            "0.7",
+            "--ss-clips-region",
+            "dialog",
+            "--cluster-gap",
+            "3",
+            "--clip-pre",
+            "1",
+            "--clip-post",
+            "2",
+        ],
+    )
+    args = cli.parse_arguments()
+    assert args.ss_clips_detector == "change,color"
+    assert args.ss_clips_min_confidence == 0.7
+    assert args.ss_clips_region == "dialog"
+    assert args.cluster_gap == 3.0
+    assert args.clip_pre == 1.0
+    assert args.clip_post == 2.0
+
+
+def test_parse_transcript_clips_with_mark(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "clipgen.py",
+            "--transcript-clips",
+            "--transcript-clips-mark",
+            "insight",
+            "--transcript-clips-text",
+            "checkout",
+        ],
+    )
+    args = cli.parse_arguments()
+    assert args.transcript_clips is True
+    assert args.transcript_clips_mark == "insight"
+    assert args.transcript_clips_text == "checkout"
+
+
+# ---- Conflict validation ----
+
+
+def test_ss_clips_conflicts_with_transcript_clips():
+    args = _ss_args(ss_clips=True, transcript_clips=True)
+    with pytest.raises(SystemExit):
+        cli._validate_mode_conflicts(args)
+
+
+def test_ss_clips_conflicts_with_studio():
+    args = _ss_args(ss_clips=True, studio=True)
+    with pytest.raises(SystemExit):
+        cli._validate_mode_conflicts(args)
+
+
+def test_ss_clips_conflicts_with_ss_task():
+    args = _ss_args(
+        ss_clips=True,
+        ss_task=["color", "P01", "btn"],
+        ss_target_color="#FF0000",
+        ss_tolerance="20,30,30",
+        ss_threshold=0.85,
+    )
+    with pytest.raises(SystemExit):
+        cli._validate_mode_conflicts(args)
+
+
+def test_transcript_clips_conflicts_with_screenspace():
+    args = _ss_args(transcript_clips=True, screenspace=True)
+    with pytest.raises(SystemExit):
+        cli._validate_mode_conflicts(args)
+
+
+def test_ss_clips_alone_validates():
+    args = _ss_args(ss_clips=True)
+    modes = cli._validate_mode_conflicts(args)
+    assert modes["ss_clips"] is True
+    assert modes["transcript_clips"] is False
+
+
+# ---- Filter helpers ----
+
+
+def _ev(**overrides):
+    base = {
+        "id": "ev_1",
+        "source_video": "study_P01.mp4",
+        "participant": "P01",
+        "detector": "change",
+        "event_type": "change: dialog",
+        "time_in": 10.0,
+        "time_out": 10.0,
+        "confidence": 0.9,
+        "metadata": {},
+        "excluded": False,
+        "task_id": "ss_1",
+        "region": "dialog",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_filter_ss_events_drops_excluded():
+    events = [_ev(id="a"), _ev(id="b", excluded=True)]
+    out = cli._filter_screenspace_events(
+        events,
+        detectors=None,
+        regions=None,
+        participants=None,
+        min_confidence=None,
+        event_type_substr=None,
+    )
+    assert [e["id"] for e in out] == ["a"]
+
+
+def test_filter_ss_events_min_confidence():
+    events = [_ev(id="lo", confidence=0.5), _ev(id="hi", confidence=0.95)]
+    out = cli._filter_screenspace_events(
+        events,
+        detectors=None,
+        regions=None,
+        participants=None,
+        min_confidence=0.8,
+        event_type_substr=None,
+    )
+    assert [e["id"] for e in out] == ["hi"]
+
+
+def test_filter_ss_events_detector_and_region():
+    events = [
+        _ev(id="a", detector="change", region="dialog"),
+        _ev(id="b", detector="color", region="dialog"),
+        _ev(id="c", detector="change", region="header"),
+    ]
+    out = cli._filter_screenspace_events(
+        events,
+        detectors={"change"},
+        regions={"dialog"},
+        participants=None,
+        min_confidence=None,
+        event_type_substr=None,
+    )
+    assert [e["id"] for e in out] == ["a"]
+
+
+def test_filter_ss_events_event_type_substr_case_insensitive():
+    events = [_ev(id="a", event_type="Login attempt"), _ev(id="b", event_type="logout")]
+    out = cli._filter_screenspace_events(
+        events,
+        detectors=None,
+        regions=None,
+        participants=None,
+        min_confidence=None,
+        event_type_substr="LOGIN",
+    )
+    assert [e["id"] for e in out] == ["a"]
+
+
+def test_filter_transcript_segments_by_mark_category():
+    manifest = {
+        "source_transcripts": {
+            "P01": {
+                "segments": [
+                    {"id": "P01:0", "start": 0.0, "end": 5.0, "text": "hello"},
+                    {"id": "P01:1", "start": 5.0, "end": 10.0, "text": "world"},
+                ]
+            }
+        },
+        "marks": [
+            {"id": "m1", "segment_id": "P01:0", "category": "insight"},
+            {"id": "m2", "segment_id": "P01:1", "category": "action"},
+        ],
+    }
+    rows = cli._filter_transcript_segments(
+        manifest,
+        participants=None,
+        mark_categories={"insight"},
+        text_substr=None,
+    )
+    assert len(rows) == 1
+    pid, seg, marks = rows[0]
+    assert pid == "P01"
+    assert seg["id"] == "P01:0"
+    assert [m["id"] for m in marks] == ["m1"]
+
+
+def test_filter_transcript_segments_by_text_substr():
+    manifest = {
+        "source_transcripts": {
+            "P01": {
+                "segments": [
+                    {"id": "P01:0", "start": 0.0, "end": 5.0, "text": "Checkout flow"},
+                    {"id": "P01:1", "start": 5.0, "end": 10.0, "text": "Other thing"},
+                ]
+            }
+        },
+        "marks": [],
+    }
+    rows = cli._filter_transcript_segments(
+        manifest,
+        participants=None,
+        mark_categories=None,
+        text_substr="checkout",
+    )
+    assert [r[1]["id"] for r in rows] == ["P01:0"]
+
+
+# ---- Cluster builders ----
+
+
+def test_build_ss_clusters_groups_by_participant_and_detector():
+    events = [
+        _ev(id="a", participant="P01", detector="change", time_in=1.0, time_out=1.0),
+        _ev(id="b", participant="P01", detector="change", time_in=2.0, time_out=2.0),
+        _ev(id="c", participant="P02", detector="change", time_in=1.5, time_out=1.5),
+        _ev(id="d", participant="P01", detector="color", time_in=1.5, time_out=1.5),
+    ]
+    clusters = cli._build_clusters_from_ss_events(
+        events, gap=5.0, pad_pre=0.0, pad_post=0.0, max_duration=0.0
+    )
+    # P01/change merges (a, b); P01/color stays alone; P02/change stays alone.
+    keys = sorted((c["participant"], c["detector"]) for c in clusters)
+    assert keys == [("P01", "change"), ("P01", "color"), ("P02", "change")]
+    p01_change = next(
+        c for c in clusters if c["participant"] == "P01" and c["detector"] == "change"
+    )
+    assert sorted(p01_change["member_event_ids"]) == ["a", "b"]
+
+
+def test_build_ss_clusters_applies_padding():
+    events = [_ev(id="a", time_in=10.0, time_out=10.0)]
+    clusters = cli._build_clusters_from_ss_events(
+        events, gap=0.0, pad_pre=2.0, pad_post=3.0, max_duration=0.0
+    )
+    assert len(clusters) == 1
+    assert clusters[0]["start"] == 8.0
+    assert clusters[0]["end"] == 13.0
+
+
+def test_build_transcript_clusters_groups_by_participant():
+    manifest = {
+        "source_transcripts": {
+            "P01": {
+                "segments": [
+                    {"id": "P01:0", "start": 0.0, "end": 2.0, "text": "alpha"},
+                    {"id": "P01:1", "start": 3.0, "end": 5.0, "text": "beta"},
+                ],
+                "source_file": "/data/study_P01.mp4",
+            },
+            "P02": {
+                "segments": [
+                    {"id": "P02:0", "start": 0.0, "end": 2.0, "text": "gamma"},
+                ],
+                "source_file": "/data/study_P02.mp4",
+            },
+        },
+        "marks": [],
+    }
+    rows = cli._filter_transcript_segments(
+        manifest, participants=None, mark_categories=None, text_substr=None
+    )
+    clusters = cli._build_clusters_from_transcript_segments(
+        rows, manifest, gap=2.0, pad_pre=0.0, pad_post=0.0, max_duration=0.0
+    )
+    by_pid = {c["participant"]: c for c in clusters}
+    assert set(by_pid.keys()) == {"P01", "P02"}
+    # P01's two segments merge with gap=2.0 (gap between them is 1.0).
+    assert by_pid["P01"]["start"] == 0.0
+    assert by_pid["P01"]["end"] == 5.0
+    assert "alpha" in by_pid["P01"]["text"]
+    assert "beta" in by_pid["P01"]["text"]
+    assert by_pid["P01"]["source_video"] == "study_P01.mp4"
+
+
+# ---- Synthetic clip builder ----
+
+
+def test_make_synthetic_clip_record_uses_negative_row_and_padded_times():
+    rec = cli._make_synthetic_clip_record(
+        cluster_idx=0,
+        cell_col=1,
+        study="mystudy",
+        participant="P01",
+        desc="change dialog",
+        category="screenspace-change",
+        severity="",
+        start_seconds=10.0,
+        end_seconds=20.0,
+        source_filename="mystudy_P01.mp4",
+    )
+    assert rec["cell"].row == -1
+    assert rec["cell"].col == 1
+    # Pre-filled times trigger the prepare_clip fast path.
+    assert rec["times"] == [("0:00:10", "0:00:20")]
+    assert rec["source_filename"] == "mystudy_P01.mp4"
+
+
+def test_make_synthetic_clip_record_namespaces_by_cluster_idx():
+    a = cli._make_synthetic_clip_record(
+        cluster_idx=0,
+        cell_col=1,
+        study="s",
+        participant="P01",
+        desc="d",
+        category="c",
+        severity="",
+        start_seconds=0,
+        end_seconds=1,
+        source_filename="s_P01.mp4",
+    )
+    b = cli._make_synthetic_clip_record(
+        cluster_idx=5,
+        cell_col=2,
+        study="s",
+        participant="P01",
+        desc="d",
+        category="c",
+        severity="",
+        start_seconds=0,
+        end_seconds=1,
+        source_filename="s_P01.mp4",
+    )
+    assert a["cell"].row == -1
+    assert b["cell"].row == -6
+    assert a["cell"].col == 1
+    assert b["cell"].col == 2
+
+
+# ---- Smoke dispatch tests ----
+
+
+def test_run_ss_clips_smoke_dispatches_pipeline(monkeypatch):
+    """Wires manifest -> filter -> cluster -> process_clips -> save_manifest."""
+    import pipeline
+    import screenspace
+    import viewer
+
+    fake_events = [
+        {
+            "id": "ev1",
+            "source_video": "study_P01.mp4",
+            "participant": "P01",
+            "detector": "change",
+            "event_type": "change: dialog",
+            "time_in": 10.0,
+            "time_out": 10.0,
+            "confidence": 0.9,
+            "excluded": False,
+            "region": "dialog",
+        }
+    ]
+    monkeypatch.setattr(
+        screenspace,
+        "load_screenspace_manifest",
+        lambda: {"events": fake_events, "regions": {}, "tasks": [], "stashes": []},
+    )
+    captured: dict = {}
+
+    def fake_process(clips_list, output_format="clip", include_severity=False, **kw):
+        captured["clips"] = clips_list
+        captured["output_format"] = output_format
+        return (1, [{"id": "a-1c1s0", "file": "out.mp4"}])
+
+    monkeypatch.setattr(pipeline, "process_clips", fake_process)
+    saved: dict = {}
+
+    def fake_save(artifacts, **kw):
+        saved["artifacts"] = artifacts
+        saved["mode"] = kw.get("mode")
+        return None
+
+    monkeypatch.setattr(viewer, "save_manifest", fake_save)
+
+    args = _ss_args(ss_clips=True)
+    cli._run_ss_clips(args)
+
+    assert len(captured["clips"]) == 1
+    clip = captured["clips"][0]
+    assert clip["participant"] == "P01"
+    assert clip["category"] == "screenspace-change"
+    assert clip["source_filename"] == "study_P01.mp4"
+    assert saved["mode"] == "ss-clips"
+    assert saved["artifacts"][0]["id"] == "a-1c1s0"
+
+
+def test_run_ss_clips_no_events_warns(monkeypatch, capsys):
+    import screenspace
+
+    monkeypatch.setattr(
+        screenspace,
+        "load_screenspace_manifest",
+        lambda: {"events": [], "regions": {}, "tasks": [], "stashes": []},
+    )
+    args = _ss_args(ss_clips=True)
+    cli._run_ss_clips(args)
+    out = capsys.readouterr().out
+    assert "No Screenspace events" in out
+
+
+def test_run_transcript_clips_smoke_dispatches_pipeline(monkeypatch):
+    import pipeline
+    import transcripts
+    import viewer
+
+    fake_manifest = {
+        "source_transcripts": {
+            "P01": {
+                "segments": [
+                    {"id": "P01:0", "start": 0.0, "end": 2.0, "text": "alpha beta"},
+                ],
+                "source_file": "/data/study_P01.mp4",
+            }
+        },
+        "corrections": [],
+        "marks": [],
+    }
+    monkeypatch.setattr(transcripts, "load_transcripts_manifest", lambda: fake_manifest)
+    captured: dict = {}
+
+    def fake_process(clips_list, output_format="clip", include_severity=False, **kw):
+        captured["clips"] = clips_list
+        return (1, [{"id": "a-1c2s0", "file": "out.mp4"}])
+
+    monkeypatch.setattr(pipeline, "process_clips", fake_process)
+    saved: dict = {}
+
+    def fake_save(artifacts, **kw):
+        saved["artifacts"] = artifacts
+        saved["mode"] = kw.get("mode")
+        return None
+
+    monkeypatch.setattr(viewer, "save_manifest", fake_save)
+
+    args = _ss_args(transcript_clips=True)
+    cli._run_transcript_clips(args)
+
+    assert len(captured["clips"]) == 1
+    clip = captured["clips"][0]
+    assert clip["participant"] == "P01"
+    assert clip["category"] == "transcript"
+    assert clip["source_filename"] == "study_P01.mp4"
+    assert saved["mode"] == "transcript-clips"
+
+
+def test_run_transcript_clips_with_mark_filter_uses_mark_category(monkeypatch):
+    import pipeline
+    import transcripts
+    import viewer
+
+    fake_manifest = {
+        "source_transcripts": {
+            "P01": {
+                "segments": [
+                    {"id": "P01:0", "start": 0.0, "end": 2.0, "text": "interesting"},
+                ],
+                "source_file": "/data/study_P01.mp4",
+            }
+        },
+        "marks": [{"id": "m1", "segment_id": "P01:0", "category": "insight"}],
+    }
+    monkeypatch.setattr(transcripts, "load_transcripts_manifest", lambda: fake_manifest)
+    captured: dict = {}
+
+    def fake_process(clips_list, output_format="clip", include_severity=False, **kw):
+        captured["clips"] = clips_list
+        return (1, [{"id": "a-1c2s0", "file": "out.mp4"}])
+
+    monkeypatch.setattr(pipeline, "process_clips", fake_process)
+    monkeypatch.setattr(viewer, "save_manifest", lambda *_a, **_k: None)
+
+    args = _ss_args(transcript_clips=True, transcript_clips_mark="insight")
+    cli._run_transcript_clips(args)
+
+    assert captured["clips"][0]["category"] == "mark-insight"

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -69,6 +69,21 @@ def _ss_args(**overrides):
         "ss_end": None,
         "ss_interval": None,
         "ss_event_label": None,
+        "ss_clips": False,
+        "transcript_clips": False,
+        "ss_clips_detector": None,
+        "ss_clips_region": None,
+        "ss_clips_participant": None,
+        "ss_clips_min_confidence": None,
+        "ss_clips_event_type": None,
+        "transcript_clips_participant": None,
+        "transcript_clips_mark": None,
+        "transcript_clips_text": None,
+        "cluster_gap": 5.0,
+        "clip_pre": 5.0,
+        "clip_post": 5.0,
+        "max_clip_duration": 0.0,
+        "export": False,
     }
     defaults.update(overrides)
     return Namespace(**defaults)

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -183,6 +183,49 @@ def test_process_clips_parallel_generates_all(monkeypatch, make_clip):
     assert run_ffmpeg.call_count == 4
 
 
+def test_process_clips_accepts_pre_parsed_synthetic_clip(monkeypatch):
+    """Synthetic clips (e.g. --ss-clips) skip prepare_clip's cell parse and
+    produce artifacts with deterministic ids derived from the negative cell row."""
+    from types import SimpleNamespace
+
+    from utils import ClipRecord
+
+    cell = SimpleNamespace(value="", row=-1, col=1)
+    clip: ClipRecord = {
+        "cell": cell,
+        "study": "mystudy",
+        "participant": "P01",
+        "category": "screenspace-change",
+        "desc": "change region1",
+        "severity": "",
+        "times": [("0:00:10", "0:00:20")],
+        "source_filename": "mystudy_P01.mp4",
+    }
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+    monkeypatch.setattr(
+        clipgen.files,
+        "get_unique_filename",
+        lambda _template, file_format=None: f"out{file_format or '.mp4'}",
+    )
+    run_ffmpeg = Mock(return_value=True)
+    monkeypatch.setattr(clipgen.video, "run_ffmpeg", run_ffmpeg)
+
+    count, artifacts = clipgen.process_clips([clip], output_format="clip")
+    assert count == 1
+    assert len(artifacts) == 1
+    a = artifacts[0]
+    # Negative-row + col 1 produces stable id namespace; collision-proof vs.
+    # spreadsheet artifacts (which always have positive row/col).
+    assert a["id"] == "a-1c1s0"
+    assert a["cellRow"] == -1
+    assert a["cellCol"] == 1
+    # safe_cell_a1 returns "" for negative rows.
+    assert a["cellA1"] == ""
+    assert run_ffmpeg.call_count == 1
+
+
 def test_resolve_clip_workers(monkeypatch):
     """Auto-detect returns min(4, cpu_count); explicit values pass through."""
     import pipeline

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -65,6 +65,32 @@ def test_discover_clips_excludes_source_videos(tmp_path, monkeypatch):
     assert sorted(clips) == ["study_P01-clip-1.mp4", "study_P01-clip-2.mp4"]
 
 
+def test_prepare_clip_pre_parsed_fast_path_keeps_times_and_sanitizes_desc():
+    # Synthetic clips (e.g. --ss-clips) arrive with times already parsed and a
+    # SimpleNamespace cell. prepare_clip should skip the cell-based parse,
+    # leave times untouched, and still sanitize desc/category for filenames.
+    cell = SimpleNamespace(value="", row=-1, col=1)
+    clip: ClipRecord = {
+        "cell": cell,
+        "study": "study",
+        "participant": "P01",
+        "category": "",
+        "desc": "[ignored-bracket] description / with ?",
+        "times": [("0:00:10", "0:00:20")],
+    }
+    prepared = files.prepare_clip(clip)
+    # Times preserved exactly.
+    assert prepared["times"] == [("0:00:10", "0:00:20")]
+    # Bracketed prefix stripped, special chars removed.
+    assert "ignored-bracket" not in prepared["desc"]
+    assert "?" not in prepared["desc"]
+    # Empty category becomes 'uncategorized'.
+    assert prepared["category"] == "uncategorized"
+    # Annotation containers initialized.
+    assert prepared["cell_annotations"] == []
+    assert prepared["segment_annotations"] == {}
+
+
 def test_prepare_clip_sanitizes_and_sets_defaults(monkeypatch, make_clip):
     raw_clip = make_clip()
     raw_clip["cell"].value = "00:10-00:20"

--- a/tests/test_utils_timestamps.py
+++ b/tests/test_utils_timestamps.py
@@ -40,6 +40,51 @@ def test_convert_clock_pairs_to_relative_uses_baseline_and_skips_invalid():
     assert converted == [("0:02:12", "0:02:45"), ("0:01:00", "0:01:30")]
 
 
+def test_cluster_spans_empty_returns_empty():
+    assert utils.cluster_spans([], gap_seconds=5.0) == []
+
+
+def test_cluster_spans_disabled_yields_one_per_input():
+    spans = [(0.0, 1.0), (10.0, 11.0), (5.0, 6.0)]
+    out = utils.cluster_spans(spans, gap_seconds=0.0)
+    # Sorted by start; one cluster per span, padding zero so identical bounds.
+    assert out == [
+        (0.0, 1.0, [0]),
+        (5.0, 6.0, [2]),
+        (10.0, 11.0, [1]),
+    ]
+
+
+def test_cluster_spans_merges_within_gap():
+    # gap=2.0 means spans with <= 2.0s separation merge.
+    spans = [(0.0, 1.0), (2.5, 3.0), (10.0, 11.0)]
+    out = utils.cluster_spans(spans, gap_seconds=2.0)
+    assert out == [(0.0, 3.0, [0, 1]), (10.0, 11.0, [2])]
+
+
+def test_cluster_spans_pads_and_clamps_low_to_zero():
+    spans = [(2.0, 3.0)]
+    out = utils.cluster_spans(spans, gap_seconds=0.0, pad_pre=10.0, pad_post=4.0)
+    assert out == [(0.0, 7.0, [0])]
+
+
+def test_cluster_spans_splits_on_max_duration():
+    spans = [(0.0, 30.0)]
+    out = utils.cluster_spans(spans, gap_seconds=0.0, max_duration=10.0)
+    assert out == [
+        (0.0, 10.0, [0]),
+        (10.0, 20.0, [0]),
+        (20.0, 30.0, [0]),
+    ]
+
+
+def test_cluster_spans_preserves_member_indices_for_unsorted_input():
+    # Index 1 is the earliest by start; should appear first in the cluster.
+    spans = [(5.0, 6.0), (0.0, 1.0)]
+    out = utils.cluster_spans(spans, gap_seconds=10.0)
+    assert out == [(0.0, 6.0, [1, 0])]
+
+
 def test_parse_cell_annotations_splits_segment_and_cell_annotations():
     # !key should annotate the preceding timestamp and also appear as a cell-level annotation.
     cleaned, segment_annotations, cell_annotations = utils.parse_cell_annotations(

--- a/utils.py
+++ b/utils.py
@@ -758,12 +758,21 @@ def letter_to_index(letter: str) -> int:
 
 
 def safe_cell_a1(row: int | None, col: int | None) -> str:
-    """Convert 1-based row/col to A1 notation, returning '' on failure."""
+    """Convert 1-based row/col to A1 notation, returning '' on failure.
+
+    Returns an empty string when row/col are missing, non-int, or non-positive
+    (e.g. synthetic ClipRecords from --ss-clips / --transcript-clips use negative
+    rows to namespace artifact ids — those produce no spreadsheet A1 reference).
+    """
     import gspread.utils
 
+    if not isinstance(row, int) or not isinstance(col, int):
+        return ""
+    if row < 1 or col < 1:
+        return ""
     try:
-        return gspread.utils.rowcol_to_a1(row, col) if row and col else ""
-    except (TypeError, ValueError):
+        return gspread.utils.rowcol_to_a1(row, col)
+    except Exception:
         return ""
 
 
@@ -1196,6 +1205,58 @@ def convert_clock_pairs_to_relative(
             )
 
     return result
+
+
+def cluster_spans(
+    spans: list[tuple[float, float]],
+    *,
+    gap_seconds: float,
+    pad_pre: float = 0.0,
+    pad_post: float = 0.0,
+    max_duration: float = 0.0,
+) -> list[tuple[float, float, list[int]]]:
+    """Group (start, end) spans whose gap <= gap_seconds, then pad and optionally split.
+
+    Returns a list of (cluster_start, cluster_end, member_indices) tuples, where
+    member_indices are the original indices contributing to that cluster.
+
+    - gap_seconds <= 0 yields one cluster per input span (no merging).
+    - Padding is applied after clustering: cluster_start = max(0, start - pad_pre);
+      cluster_end is not clamped to a video duration (callers may clamp if needed —
+      ffmpeg tolerates an end past EOF).
+    - When max_duration > 0 and a padded cluster exceeds it, the cluster is split
+      into ceil(duration / max_duration) sub-clips that each claim all members.
+    - Input is not mutated; spans are sorted internally by (start, end).
+    """
+    if not spans:
+        return []
+    indexed = sorted(enumerate(spans), key=lambda kv: (kv[1][0], kv[1][1]))
+    groups: list[tuple[float, float, list[int]]] = []
+    cur_start, cur_end = indexed[0][1]
+    cur_members: list[int] = [indexed[0][0]]
+    for orig_idx, (s, e) in indexed[1:]:
+        if gap_seconds <= 0 or s - cur_end > gap_seconds:
+            groups.append((cur_start, cur_end, cur_members))
+            cur_start, cur_end, cur_members = s, e, [orig_idx]
+        else:
+            if e > cur_end:
+                cur_end = e
+            cur_members.append(orig_idx)
+    groups.append((cur_start, cur_end, cur_members))
+
+    out: list[tuple[float, float, list[int]]] = []
+    for s, e, members in groups:
+        ps = max(0.0, s - pad_pre)
+        pe = e + pad_post
+        if max_duration > 0 and (pe - ps) > max_duration:
+            t = ps
+            while t < pe:
+                sub_end = min(t + max_duration, pe)
+                out.append((t, sub_end, list(members)))
+                t = sub_end
+        else:
+            out.append((ps, pe, members))
+    return out
 
 
 # ---- Interactive control flow ----


### PR DESCRIPTION
## Summary

- New `--ss-clips` and `--transcript-clips` standalone CLI modes that read existing event manifests and cut video clips, no spreadsheet or UI required.
- Configurable clustering (`--cluster-gap`, default 5s) merges nearby events into single clips, with `--clip-pre`/`--clip-post` padding (default 5s) and optional `--max-clip-duration` splitting.
- Filter knobs per source: `--ss-clips-detector/-region/-participant/-min-confidence/-event-type` for Screenspace; `--transcript-clips-participant/-mark/-text` for transcripts. Synthetic clips use negative cell rows so artifact ids never collide with spreadsheet-derived clips, making reruns idempotent. Agent skills (screenspace, transcribe, generate) document the new flags.

## Test plan

- [x] \`uv run --extra dev pytest -c tests/pytest.ini\` (743 pass, including new \`tests/test_cli_event_clip_args.py\`)
- [x] \`uv run ruff check\` and \`uv run ruff format --check\`
- [x] \`uv run ty check\`
- [x] \`uv run clipgen.py --help\` shows new flags; conflict matrix (\`--ss-clips --transcript-clips\`, \`--ss-clips --studio\`, etc.) errors as expected
- [ ] Manual: with a populated \`screenspace_manifest.json\`, run \`uv run clipgen.py --ss-clips --ss-clips-detector change\` and verify clips land in output dir + \`clipgen_manifest.json\`
- [ ] Manual: with a populated \`transcripts_manifest.json\` containing marks, run \`uv run clipgen.py --transcript-clips --transcript-clips-mark insight\` and verify