### PR TITLE
docs: trim AGENTS.md duplications and clarify ARCHITECTURE.md/CLOUD.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Source video filenames follow `{study}_{participant}.mp4` (e.g. `mystudy_P01.mp4
 
 ## Development tools
 
-- **uv** – Use `uv run` instead of `python` to run scripts (e.g. `uv run clipgen.py`). Use `uv add` to add dependencies.
+- **uv** – Always use `uv run` instead of `python` to run scripts (e.g. `uv run clipgen.py`). This ensures the correct venv is used, including in worktrees that don't yet have a `.venv`. Use `uv add` to add dependencies.
 - **Ruff** – Linting and formatting. A `PostToolUse` hook in `.claude/settings.json` automatically runs `uv run ruff check --fix` and `uv run ruff format` on every edited/written file. You can also run these manually: `uv run ruff check --fix` and `uv run ruff format`.
 - **ty** – Use `uv run ty check` for type checking.
 
@@ -73,15 +73,11 @@ Required columns: **ID**, **Observation**, **Category**. Participant columns fol
 
 ## Version
 
-- The version is stored as `VERSIONNUM` in [config.py](config.py).
-- **When making substantive code changes** (bug fixes or features), increment the **last segment only** (patch) in `config.py`, e.g. `0.9.0` → `0.9.1`. Do not bump for docs-only, comment-only, or refactor-only changes unless they affect user-visible behavior.
+Bump the patch (last) segment of `VERSIONNUM` in [config.py](config.py) for substantive changes (bug fixes, features). Skip for docs-only, comment-only, or refactor-only changes that don't affect user-visible behavior. See [agents/skills/bump/SKILL.md](agents/skills/bump/SKILL.md).
 
 ## Testing notes
 
-- Run the test suite from the project root with `uv run --extra dev pytest -c tests/pytest.ini`. The `dev` optional extra (tests/CI only) supplies pytest; default `uv sync` does not install it.
-- Tests cover: CLI argument parsing, CLI mode dispatch, clip pipeline, file/artifact handling, Google/Excel adapters, insights data model, insights API, manifest operations, selectors, spreadsheet generation, studio API, titlecards, transcripts, timestamp utilities, video commands, viewer data, and viewer inlining.
-- Every new CLI mode, flag, or selector should include at least one smoke test in the same PR.
-- With `config.DEBUGGING = True`, icecream is enabled, [video.py](video.py) does not invoke ffmpeg, and [transcripts.py](transcripts.py) returns stub results without loading a Whisper model.
+See [agents/skills/test/SKILL.md](agents/skills/test/SKILL.md) for the command, fixtures, and coverage areas. Every new CLI mode, flag, or selector should include at least one smoke test in the same PR.
 
 ## Project learnings for agents
 
@@ -107,8 +103,7 @@ Required columns: **ID**, **Observation**, **Category**. Participant columns fol
 - Manifest-driven state persistence: JSON manifest files (clipgen, insights, screenspace, stashes, settings) follow the pattern of load-on-startup, save-after-mutations.
 - No hardcoded version numbers in evergreen docs (CLAUDE.md, README.md). Reference `VERSIONNUM` in `config.py` instead.
 - **Icons**: Prefer SVG icons from `assets/icons/` (316 Heroicons outline, kebab-case names like `pencil-square.svg`) over crafting new inline SVG paths or using text/emoji glyphs in web UIs. **Never define SVG path data in JavaScript.** Use the CSS `mask-image` pattern to reference `.svg` files: create a `<span>` with `mask-image: url("icons/icon-name.svg")` and `background-color: currentColor`. See `XREF_BADGES` in `utils.js` and `.xref-badge-icon` in `tokens.css` for the canonical example. Icon routes already exist per blueprint (`/screenspace/icons/`, `/transcripts/icons/`, etc.).
-- **Linting/formatting**: Run `uv run ruff check --fix && uv run ruff format` after editing Python files. Run `uv run ty check` for type checking.
-- **Pre-commit format gate**: Before every `git commit`, run `uv run ruff format --check` on all modified `.py` files. If any would be reformatted, run `uv run ruff format` on them before committing. This catches files missed by the per-file PostToolUse hook (e.g. in worktrees where the hook is absent). The most common CI lint failure by far is unformatted Python code.
+- **Pre-commit check**: Before every `git commit`, run [agents/skills/check/SKILL.md](agents/skills/check/SKILL.md). Unformatted Python is the most common CI failure (the per-file PostToolUse hook is absent in worktrees).
 - Commit early and commit often, so we can roll back changes more easily.
 - If a problem is reoccurring and survives fix attempts, check git logs for clues.
 - Never edit .gitignore automatically, always confirm changes to this file with the user.
@@ -118,12 +113,8 @@ Required columns: **ID**, **Observation**, **Category**. Participant columns fol
 ### Learned Workspace Facts
 
 - Baseline time row placement in the spreadsheet layer is tied to header/`id_cell` row math (e.g. offsets from `id_cell.row`); changing that offset without aligning tests and sheet layout has broken baseline timestamp handling before.
-- When making substantive code changes (fixes or features), increment the patch (last number) of VERSIONNUM in config.py.
-- Interactive prompts use a keyword-aware helper: `quit`/`exit` exit the program, `top` returns to spreadsheet selection, and `back` returns to mode selection (or spreadsheet selection when already at mode selection).
 - Textual-based TUI support (tui.py, TEXTUAL_TUI) has been removed; prefer CLI prompts and the HTML timeline viewer for interactive features.
 - Browse mode scrolling is controlled via `BROWSE_LINES_TO_SCROLL` in `config.py`, with a default of 5 rows per up/down step.
-- Always use `uv run` to execute Python commands (e.g. `uv run clipgen.py`). This ensures the correct venv is used, even in worktrees where no `.venv` exists yet.
-- **Running tests:** from the project root, `uv run --extra dev pytest -c tests/pytest.ini`. Pytest is only in the optional `dev` extra (`pyproject.toml`); `uv sync` alone does not install it, intentionally, so runtime installs stay lean. Do not use ad-hoc `pip install pytest` — use this command so versions match `uv.lock`.
 - Be careful about using the `generate_list()`, `sheet.find()`, `sheet.get_all_values()` methods as they are API calls to Google Sheets and are heavily rate-limited. Repeatedly calling the Google API will lead to rate-limiting without warnings, which can appear as bugs (e.g. silently skipping timestamps) and make development difficult.
 - CI uses `uv pip install --torch-backend cpu` to avoid downloading ~2.5GB of CUDA/nvidia packages (tests never use CUDA). This override is CI-only (in `tests.yml`), not in `pyproject.toml`, so end-user installs still get GPU-capable torch. If Linux end users emerge and report CUDA issues, check that the CI-only approach hasn't leaked into project config.
 - Timelapse produces a single output file, not per-frame timeline events. It does not need icon/color entries in Viewer's `SS_DETECTOR_COLORS`/`SS_DETECTOR_ICON_PATHS` maps.
@@ -187,12 +178,6 @@ Patterns distilled from recurring post-review and post-merge fixes across the pr
 #### Integration
 
 - **Data contract completeness**: When creating records consumed by the frontend (artifacts, events, tasks), include all fields the renderer expects — even optional ones. Missing fields cause empty/broken cards.
-- **New flags in mode detection**: When adding a CLI flag, verify it appears in the mode-detection logic (`cli.py`), not just in argparse definition.
+- **New flags in mode detection**: When adding a CLI flag, verify it appears in the mode-detection logic (`cli.py`), not just in argparse definition. See [agents/skills/new-mode/SKILL.md](agents/skills/new-mode/SKILL.md) for the full checklist.
 - **Bundled/frozen paths**: Use `utils.get_bundled_assets_root()` for asset resolution, never raw `Path(__file__).parent`. Test that asset paths resolve in both source and PyInstaller environments.
-- **No duplicated constants between Python and JS.** Any value that lives in `config.py` (or a Python helper) and that the frontend also needs — severity labels, default clip duration, annotation keyphrases (`!key`), ignored timestamp tokens (`x`) — must flow through `utils.get_frontend_config()`, not be hardcoded in JS. When adding a new one:
-  1. Extend `get_frontend_config()` in `utils.py`.
-  2. Confirm every consumer already embeds `"config": utils.get_frontend_config()` (server.py `/api/sheet`, insights_server.py `/api/artifacts`, viewer.py `finalize_timeline_data` / gallery / insights viewer). Add it if missing.
-  3. Add the default to `CLIPGEN_CONFIG` in `assets/web/utils.js` and extend `clipgenApplyConfig` to copy the new key.
-  4. Add an assertion in `tests/test_shared_constants.py` that the JS default matches the Python value.
-
-  Why: severity tables, `!key`, `x`, and the 60s default each previously drifted across 3–5 JS files (`studio.js`, `viewer.js`, `insights-builder.js`, `metadata.js`, `transcripts.js`) because they were independently hardcoded. Renaming `!key` in `config.py` would update the backend silently while the frontend kept stripping the old token. Same risk class as `MARK_CATEGORIES` (already guarded by `test_shared_constants.py`).
+- **No duplicated constants between Python and JS.** Any value that lives in `config.py` (or a Python helper) and that the frontend also needs — severity labels, default clip duration, annotation keyphrases (`!key`), ignored timestamp tokens (`x`) — must flow through `utils.get_frontend_config()`, not be hardcoded in JS. Why: severity tables, `!key`, `x`, and the 60s default each previously drifted across 3–5 JS files (`studio.js`, `viewer.js`, `insights-builder.js`, `metadata.js`, `transcripts.js`) because they were independently hardcoded. Renaming `!key` in `config.py` would update the backend silently while the frontend kept stripping the old token. Procedure for adding a new mirrored constant: [agents/skills/sync-constants/SKILL.md](agents/skills/sync-constants/SKILL.md).

--- a/agents/ARCHITECTURE.md
+++ b/agents/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 | File | Role |
 | ------ | ------ |
-| [clipgen.py](clipgen.py) | Entry point (`python clipgen.py`), spreadsheet opening helpers, interactive mode dispatch; delegates to pipeline.py for processing |
+| [clipgen.py](clipgen.py) | Entry point (`uv run clipgen.py`), spreadsheet opening helpers, interactive mode dispatch; delegates to pipeline.py for processing |
 | [pipeline.py](pipeline.py) | Clip processing pipeline: process_clips, process_reel, compute_reel_id, regenerate_from_manifest, is_excel_worksheet |
 | [viewer.py](viewer.py) | Timeline viewer: artifact record building, data finalization, HTML generation with inlined CSS/JS |
 | [cli.py](cli.py) | CLI argument parsing, CLI mode detection, setup, Google auth, worksheet selection, CLI mode dispatch, `main()` |
@@ -10,6 +10,7 @@
 | [interactive.py](interactive.py) | Interactive prompt helpers for all modes (line/range/cell/category/participant selection, browse mode); keeps generation functions pure |
 | [video.py](video.py) | ffmpeg/ffprobe operations: cut clips, screenshots, GIFs, concatenate reels, optional filesize compression |
 | [transcripts.py](transcripts.py) | Transcription via faster-whisper: `transcribe_video()`, segment filtering, write/read transcript files (Markdown/SRT/VTT) |
+| [transcripts_server.py](transcripts_server.py) | Transcripts Flask blueprint and thinking-agent orchestrator: `_next_eligible_agent()`, `_run_agent()`, `_run_agent_chain()`, `_agent_in_flight` tracking, REST endpoints |
 | [ollama_client.py](ollama_client.py) | Ollama HTTP transport: `is_available()`, `list_models()`, `generate()`, auto-start of `ollama serve`. Pure transport — no prompt or response-parsing logic lives here. |
 | [thinking_agents.py](thinking_agents.py) | Registry of Ollama-powered "thinking agents" that reason over transcripts (summary, citations). Owns prompts, model selection, response parsing, and the `AGENTS` list. New agents are added by appending an `Agent` entry — no orchestrator edits needed. |
 | [titlecards.py](titlecards.py) | Titlecard/endcard generation: `build_titlecard_frame()`, `build_endcard_frame()`, `wrap_clip_with_cards()` — prepends a title card and appends an endcard in a single FFmpeg encode pass |
@@ -19,42 +20,44 @@
 | [google_api.py](google_api.py) | Google Sheets auth, worksheet selection by priority, spreadsheet listing/search |
 | [excel_io.py](excel_io.py) | Excel adapter: `ExcelSheetAdapter` mimics gspread Worksheet interface for local .xlsx |
 | [server.py](server.py) | Combined Flask server for Studio + Insights + Screenspace; registers blueprints per active mode, `start_combined_server()` handles all three on one port |
-| [screenspace.py](screenspace.py) | Screenspace analysis engine: image analysis primitives, eleven analysis tools (color, change, similarity, text, numbers, timelapse, template, flow, scene, inactivity + multitool chaining), background task queue worker (`ScreenspaceWorker`), manifest persistence |
+| [screenspace.py](screenspace.py) | Screenspace analysis engine: image analysis primitives, ten analysis tools (color, change, similarity, text, numbers, timelapse, template, flow, scene, inactivity) plus a `multitool` chaining mode, background task queue worker (`ScreenspaceWorker`), manifest persistence |
 | [screenspace_server.py](screenspace_server.py) | Screenspace Flask REST API: region CRUD, video frame extraction, task queue management, results retrieval |
 | [insights.py](insights.py) | Insights data model: CRUD operations for insight records, insights manifest read/write |
 | [insights_server.py](insights_server.py) | Insights Flask REST API: insight CRUD, artifact browsing, sprite sheet generation, viewer export |
 | [data_export.py](data_export.py) | Analysis-ready JSON+CSV export from Screenspace, Insights, and Transcripts manifests; powers `--export` CLI flag and `/screenspace/api/export/events` endpoint |
 | [assets/web/](assets/web/) | Static HTML/JS/CSS templates: timeline viewer (`viewer.html/js/css`), gallery (`gallery.html/js/css`), studio (`studio.html/js/css`), insights (`insights-builder.html/js/css`), insights viewer (`insights-viewer.html/js/css`), screenspace (`screenspace.html/js/css`). Shared utilities and constants live in `utils.js` (loaded before each page's main script) |
 
-## Timeline HTML Viewer
+> Subsystem internals (data contracts, key function signatures, merge/dedup rules) live in each module's docstring. The sections below describe how each subsystem is launched and how it fits into the overall flow; for internals, open the referenced module.
 
-Opt-in via `--viewer` or interactive `viewer`. Injects `window.CLIPGEN_DATA` into `assets/web/viewer.html` replacing `<!-- CLIPGEN_DATA_HERE -->`. Data contract, key functions, filmstrip mode, and gallery variant are documented in the [viewer.py](viewer.py) module docstring.
+## Timeline HTML Viewer ([viewer.py](viewer.py))
 
-## Gallery HTML Viewer
+Opt-in via `--viewer` or interactive `viewer`. Injects `window.CLIPGEN_DATA` into `assets/web/viewer.html` replacing `<!-- CLIPGEN_DATA_HERE -->`.
 
-Opt-in via `--gallery [VIDEO]` or interactive `gv`/`gallery`. Uses the same injection pattern as the timeline viewer but with `assets/web/gallery.html`. Key functions and data contract are documented in the [viewer.py](viewer.py) module docstring.
+## Gallery HTML Viewer ([viewer.py](viewer.py))
 
-## Studio Web Interface
+Opt-in via `--gallery [VIDEO]` or interactive `gv`/`gallery`. Uses the same injection pattern as the timeline viewer but with `assets/web/gallery.html`.
 
-Opt-in via `--studio`; requires a spreadsheet. Starts a Flask app via `start_combined_server()` in [server.py](server.py) at `config.SERVER_PORT` (8089), serving `assets/web/studio.html`. API endpoints, module-level state, and key function signatures are documented in the [server.py](server.py) module docstring.
+## Studio Web Interface ([server.py](server.py))
+
+Opt-in via `--studio`; requires a spreadsheet. Starts a Flask app via `start_combined_server()` at `config.SERVER_PORT` (8089), serving `assets/web/studio.html`.
 
 ## Insights ([insights.py](insights.py), [insights_server.py](insights_server.py))
 
-Opt-in via `--insights`; no spreadsheet required — reads from `clipgen_manifest.json`. Served at `/insights/` by the same Flask server as Studio. Insight record shape and CRUD function signatures are in the [insights.py](insights.py) module docstring. Flask API endpoints are in the [insights_server.py](insights_server.py) module docstring. The exported `insights_viewer.html` is generated by `finalize_insights_viewer_data()` / `generate_insights_viewer()` in [viewer.py](viewer.py). The frontend source file is `assets/web/insights-builder.{html,js,css}`.
+Opt-in via `--insights`; no spreadsheet required — reads from `clipgen_manifest.json`. Served at `/insights/` by the same Flask server as Studio. The exported `insights_viewer.html` is generated by `finalize_insights_viewer_data()` / `generate_insights_viewer()` in [viewer.py](viewer.py). The frontend source file is `assets/web/insights-builder.{html,js,css}`.
 
 ## Screenspace ([screenspace.py](screenspace.py), [screenspace_server.py](screenspace_server.py))
 
-Opt-in via `--screenspace` or interactive `ss`/`screenspace`; no spreadsheet required. Served at `/screenspace/` by the combined Flask server. Analysis tool descriptions (color/change/similarity/text/numbers/timelapse/template/flow/scene/inactivity) and API endpoints are documented in the [screenspace.py](screenspace.py) and [screenspace_server.py](screenspace_server.py) module docstrings.
+Opt-in via `--screenspace` or interactive `ss`/`screenspace`; no spreadsheet required. Served at `/screenspace/` by the combined Flask server.
 
-## Artifact Manifest
+## Artifact Manifest ([viewer.py](viewer.py))
 
-Opt-in via `--manifest` or `config.MANIFEST_ENABLED`. Writes `clipgen_manifest.json` alongside artifacts. Key functions (`save_manifest`, `load_manifest_artifacts`, `load_manifest_reels`) and merge/dedup behavior are documented in the [viewer.py](viewer.py) module docstring. Consumed by Insights, `--regenerate`, and standalone `--viewer`.
+Opt-in via `--manifest` or `config.MANIFEST_ENABLED`. Writes `clipgen_manifest.json` alongside artifacts. Key functions: `save_manifest`, `load_manifest_artifacts`, `load_manifest_reels`. Consumed by Insights, `--regenerate`, and standalone `--viewer`.
 
-### Transcription ([transcripts.py](transcripts.py))
+## Transcription ([transcripts.py](transcripts.py))
 
-Opt-in via `--transcribe` or `config.TRANSCRIBE_ENABLED`. Uses faster-whisper; model is lazy-loaded and cached per session. Data types, key function signatures, and pipeline integration details are documented in the [transcripts.py](transcripts.py) module docstring.
+Opt-in via `--transcribe` or `config.TRANSCRIBE_ENABLED`. Uses faster-whisper; model is lazy-loaded and cached per session.
 
-## Local AI: Ollama thinking-agent pipeline
+## Local AI: Ollama thinking-agent pipeline ([ollama_client.py](ollama_client.py), [thinking_agents.py](thinking_agents.py), [transcripts_server.py](transcripts_server.py))
 
 Two layers, kept strictly separate:
 
@@ -65,14 +68,8 @@ Two layers, kept strictly separate:
 
 Results are written into `source_transcripts[participant][manifest_field]` in `transcripts_manifest.json`. In-flight tracking is keyed per-agent via `_agent_in_flight[agent_key]`, surfaced to the frontend through generic `_is_generating(participant, agent_key)` checks at the API endpoints.
 
-**Adding a new agent** (e.g. keyword extractor, pain-point tagger):
-
-1. Add an `OLLAMA_<NAME>_ENABLED` toggle (and any `_MODEL` keys) to [config.py](config.py).
-2. Write a `run` callable in [thinking_agents.py](thinking_agents.py) that takes the transcript entry dict and returns the value to store (or `None` to skip).
-3. Append an `Agent` entry to `AGENTS` (respect topological order — dependencies before dependents).
-
-No edits to [transcripts_server.py](transcripts_server.py) or [ollama_client.py](ollama_client.py) are needed — the orchestrator picks up the new agent automatically. If the UI should surface the new result, add one endpoint or extend the existing response shape.
+**Adding a new agent**: see [agents/skills/new-thinking-agent/SKILL.md](skills/new-thinking-agent/SKILL.md). The orchestrator picks up new agents from the `AGENTS` list automatically — no edits to [transcripts_server.py](transcripts_server.py) or [ollama_client.py](ollama_client.py) are needed.
 
 ## Titlecards ([titlecards.py](titlecards.py))
 
-Opt-in via `config.TITLECARDS_ENABLED` or `--titlecards` / `--no-titlecards`. Prepends a title card (first source frame + text overlay) to each clip. Key functions and config knobs are documented in the [titlecards.py](titlecards.py) module docstring.
+Opt-in via `config.TITLECARDS_ENABLED` or `--titlecards` / `--no-titlecards`. Prepends a title card (first source frame + text overlay) to each clip.

--- a/agents/CLOUD.md
+++ b/agents/CLOUD.md
@@ -2,7 +2,7 @@
 
 ## Environment overview
 
-clipgen is a self-contained Python CLI tool with no databases or Docker services. System dependencies (`ffmpeg`, `ffprobe`, Python 3.12) are pre-installed on the VM. The update script handles `uv` installation and Python dependency sync only.
+clipgen is a self-contained Python CLI tool with no databases or Docker services. System dependencies (`ffmpeg`, `ffprobe`, Python 3.12) are pre-installed on the VM; only `uv` and Python packages need to be installed at session start.
 
 ## Dependency installation
 
@@ -22,11 +22,13 @@ clipgen is a self-contained Python CLI tool with no databases or Docker services
 | Run Insights UI | `uv run clipgen.py --insights -i DIR -o DIR` (reads from manifest) |
 | Run Studio UI | `uv run clipgen.py --studio` (requires a spreadsheet) |
 
+`--no-sync` on the tests command is a cloud-specific optimization: it relies on the prior `uv pip install ".[dev]" --torch-backend cpu` step having already installed pytest and CPU torch, and skips the lockfile resolution that would otherwise re-pull the (much larger) GPU torch packages. Locally — where you have not done the cpu-only install — use AGENTS.md's `uv run --extra dev pytest ...` instead.
+
 All web UIs serve on `http://127.0.0.1:8089`. The Flask server starts automatically when launching `--studio`, `--screenspace`, or `--insights`.
 
 ## Gotchas
 
 - `uv run` auto-creates `.venv` if missing; always prefer `uv run` over activating the venv manually.
-- The first `uv run clipgen.py` invocation after a CPU-only pip install may re-resolve and download GPU torch packages via `uv.lock`. To avoid this, use `uv run --no-sync` after the initial `uv pip install ".[dev]" --torch-backend cpu` setup, or run commands that don't trigger a full sync (like `uvx` for ruff/ty).
+- The first `uv run clipgen.py` invocation after a CPU-only pip install may re-resolve and download GPU torch packages via `uv.lock`. To avoid this: use `uv run --no-sync` for any command after the initial `uv pip install ".[dev]" --torch-backend cpu`, or use `uvx` (which doesn't trigger a sync) for tools like ruff and ty.
 - Google Sheets integration requires OAuth credentials not available in Cloud Agent VMs. Use local Excel files or mocked tests instead.
 - DBus errors in the Flask server log are harmless — they come from Chrome attempting DBus connections in the headless VM environment.


### PR DESCRIPTION
## Summary

- **AGENTS.md**: removed within-file repeats (version-bump, uv-run, test command, debug flag, interactive keywords, linting) so each fact has one canonical home; replaced 5 procedural sections (Version, Testing notes, Pre-commit format gate, mode-detection bullet, constants-mirroring 7-step checklist) with pointers to the canonical `agents/skills/*/SKILL.md` so they can't drift.
- **ARCHITECTURE.md**: clarity pass — `clipgen.py` row uses `uv run`, `transcripts_server.py` added to the file table (was referenced in prose but missing), tool-count phrasing tightened, `### Transcription` promoted to `##`, all section headings now carry `([file.py])` breadcrumbs, the "documented in module docstring" boilerplate hoisted to one global note, and "Adding a new agent" steps replaced with a pointer to `new-thinking-agent` skill.
- **CLOUD.md**: vague "update script" sentence replaced with a concrete environment description, the `--no-sync` test command now has a footnote explaining how it differs from AGENTS.md's `--extra dev` (cloud has the cpu-only install pre-done), and the long Gotchas sentence is split for readability.

All stable domain content (clip record, conventions, modes, performance principles, frontend/backend/ty/integration code-review checklists) is preserved verbatim. Net: 30 insertions / 46 deletions across three docs.

## Test plan

- [ ] Skim AGENTS.md, ARCHITECTURE.md, CLOUD.md for coherence
- [ ] Verify each new skill pointer (`bump`, `test`, `check`, `sync-constants`, `new-mode`, `new-thinking-agent`) resolves to an existing file under `agents/skills/`
- [ ] Confirm no stable fact was dropped without a replacement (cross-check the diff)