### PR TITLE
test: parametrize event-clip CLI + data-export tests (-20 LOC, fewer functions)

### DIFF
--- a/tests/test_cli_event_clip_args.py
+++ b/tests/test_cli_event_clip_args.py
@@ -74,41 +74,41 @@ def test_parse_transcript_clips_with_mark(monkeypatch):
 # ---- Conflict validation ----
 
 
-def test_ss_clips_conflicts_with_transcript_clips():
-    args = _ss_args(ss_clips=True, transcript_clips=True)
-    with pytest.raises(SystemExit):
-        cli._validate_mode_conflicts(args)
-
-
-def test_ss_clips_conflicts_with_studio():
-    args = _ss_args(ss_clips=True, studio=True)
-    with pytest.raises(SystemExit):
-        cli._validate_mode_conflicts(args)
-
-
-def test_ss_clips_conflicts_with_ss_task():
-    args = _ss_args(
-        ss_clips=True,
-        ss_task=["color", "P01", "btn"],
-        ss_target_color="#FF0000",
-        ss_tolerance="20,30,30",
-        ss_threshold=0.85,
-    )
-    with pytest.raises(SystemExit):
-        cli._validate_mode_conflicts(args)
-
-
-def test_transcript_clips_conflicts_with_screenspace():
-    args = _ss_args(transcript_clips=True, screenspace=True)
-    with pytest.raises(SystemExit):
-        cli._validate_mode_conflicts(args)
-
-
-def test_ss_clips_alone_validates():
-    args = _ss_args(ss_clips=True)
-    modes = cli._validate_mode_conflicts(args)
-    assert modes["ss_clips"] is True
-    assert modes["transcript_clips"] is False
+@pytest.mark.parametrize(
+    "args_overrides,expects_exit",
+    [
+        ({"ss_clips": True, "transcript_clips": True}, True),
+        ({"ss_clips": True, "studio": True}, True),
+        (
+            {
+                "ss_clips": True,
+                "ss_task": ["color", "P01", "btn"],
+                "ss_target_color": "#FF0000",
+                "ss_tolerance": "20,30,30",
+                "ss_threshold": 0.85,
+            },
+            True,
+        ),
+        ({"transcript_clips": True, "screenspace": True}, True),
+        ({"ss_clips": True}, False),
+    ],
+    ids=[
+        "ss_clips_with_transcript_clips",
+        "ss_clips_with_studio",
+        "ss_clips_with_ss_task",
+        "transcript_clips_with_screenspace",
+        "ss_clips_alone",
+    ],
+)
+def test_clip_mode_conflicts(args_overrides, expects_exit):
+    args = _ss_args(**args_overrides)
+    if expects_exit:
+        with pytest.raises(SystemExit):
+            cli._validate_mode_conflicts(args)
+    else:
+        modes = cli._validate_mode_conflicts(args)
+        assert modes["ss_clips"] is True
+        assert modes["transcript_clips"] is False
 
 
 # ---- Filter helpers ----
@@ -133,60 +133,56 @@ def _ev(**overrides):
     return base
 
 
-def test_filter_ss_events_drops_excluded():
-    events = [_ev(id="a"), _ev(id="b", excluded=True)]
-    out = cli._filter_screenspace_events(
-        events,
-        detectors=None,
-        regions=None,
-        participants=None,
-        min_confidence=None,
-        event_type_substr=None,
-    )
-    assert [e["id"] for e in out] == ["a"]
+_NO_FILTERS = dict(
+    detectors=None,
+    regions=None,
+    participants=None,
+    min_confidence=None,
+    event_type_substr=None,
+)
 
 
-def test_filter_ss_events_min_confidence():
-    events = [_ev(id="lo", confidence=0.5), _ev(id="hi", confidence=0.95)]
-    out = cli._filter_screenspace_events(
-        events,
-        detectors=None,
-        regions=None,
-        participants=None,
-        min_confidence=0.8,
-        event_type_substr=None,
-    )
-    assert [e["id"] for e in out] == ["hi"]
-
-
-def test_filter_ss_events_detector_and_region():
-    events = [
-        _ev(id="a", detector="change", region="dialog"),
-        _ev(id="b", detector="color", region="dialog"),
-        _ev(id="c", detector="change", region="header"),
-    ]
-    out = cli._filter_screenspace_events(
-        events,
-        detectors={"change"},
-        regions={"dialog"},
-        participants=None,
-        min_confidence=None,
-        event_type_substr=None,
-    )
-    assert [e["id"] for e in out] == ["a"]
-
-
-def test_filter_ss_events_event_type_substr_case_insensitive():
-    events = [_ev(id="a", event_type="Login attempt"), _ev(id="b", event_type="logout")]
-    out = cli._filter_screenspace_events(
-        events,
-        detectors=None,
-        regions=None,
-        participants=None,
-        min_confidence=None,
-        event_type_substr="LOGIN",
-    )
-    assert [e["id"] for e in out] == ["a"]
+@pytest.mark.parametrize(
+    "events,filter_overrides,expected_ids",
+    [
+        (
+            [_ev(id="a"), _ev(id="b", excluded=True)],
+            {},
+            ["a"],
+        ),
+        (
+            [_ev(id="lo", confidence=0.5), _ev(id="hi", confidence=0.95)],
+            {"min_confidence": 0.8},
+            ["hi"],
+        ),
+        (
+            [
+                _ev(id="a", detector="change", region="dialog"),
+                _ev(id="b", detector="color", region="dialog"),
+                _ev(id="c", detector="change", region="header"),
+            ],
+            {"detectors": {"change"}, "regions": {"dialog"}},
+            ["a"],
+        ),
+        (
+            [
+                _ev(id="a", event_type="Login attempt"),
+                _ev(id="b", event_type="logout"),
+            ],
+            {"event_type_substr": "LOGIN"},
+            ["a"],
+        ),
+    ],
+    ids=[
+        "drops_excluded",
+        "min_confidence",
+        "detector_and_region",
+        "event_type_substr",
+    ],
+)
+def test_filter_ss_events(events, filter_overrides, expected_ids):
+    out = cli._filter_screenspace_events(events, **{**_NO_FILTERS, **filter_overrides})
+    assert [e["id"] for e in out] == expected_ids
 
 
 def test_filter_transcript_segments_by_mark_category():
@@ -510,44 +506,49 @@ def test_run_transcript_clips_with_mark_filter_uses_mark_category(monkeypatch):
 # ---- --transcript-mark argparse + conflict ----
 
 
-def test_parse_transcript_mark_minimal(monkeypatch):
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "clipgen.py",
-            "--transcript-mark",
-            "checkout",
-            "--transcript-mark-category",
-            "insight",
-        ],
-    )
+@pytest.mark.parametrize(
+    "argv_extra,expected_attrs",
+    [
+        (
+            [
+                "--transcript-mark",
+                "checkout",
+                "--transcript-mark-category",
+                "insight",
+            ],
+            {
+                "transcript_mark": "checkout",
+                "transcript_mark_category": "insight",
+                "transcript_mark_participant": None,
+                "transcript_mark_label": None,
+            },
+        ),
+        (
+            [
+                "--transcript-mark",
+                "checkout flow",
+                "--transcript-mark-category",
+                "pain_point",
+                "--transcript-mark-participant",
+                "P01,P02",
+                "--transcript-mark-label",
+                "follow up",
+            ],
+            {
+                "transcript_mark": "checkout flow",
+                "transcript_mark_category": "pain_point",
+                "transcript_mark_participant": "P01,P02",
+                "transcript_mark_label": "follow up",
+            },
+        ),
+    ],
+    ids=["minimal", "with_filters"],
+)
+def test_parse_transcript_mark(monkeypatch, argv_extra, expected_attrs):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", *argv_extra])
     args = cli.parse_arguments()
-    assert args.transcript_mark == "checkout"
-    assert args.transcript_mark_category == "insight"
-    assert args.transcript_mark_participant is None
-    assert args.transcript_mark_label is None
-
-
-def test_parse_transcript_mark_with_filters(monkeypatch):
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "clipgen.py",
-            "--transcript-mark",
-            "checkout flow",
-            "--transcript-mark-category",
-            "pain_point",
-            "--transcript-mark-participant",
-            "P01,P02",
-            "--transcript-mark-label",
-            "follow up",
-        ],
-    )
-    args = cli.parse_arguments()
-    assert args.transcript_mark == "checkout flow"
-    assert args.transcript_mark_category == "pain_point"
-    assert args.transcript_mark_participant == "P01,P02"
-    assert args.transcript_mark_label == "follow up"
+    for attr, expected in expected_attrs.items():
+        assert getattr(args, attr) == expected
 
 
 def test_transcript_mark_conflicts_with_transcript_clips():
@@ -610,24 +611,42 @@ def _mark_manifest():
     }
 
 
-def test_run_transcript_mark_creates_marks_for_matches(monkeypatch, no_running_server):
+@pytest.mark.parametrize(
+    "args_overrides,expected_seg_ids",
+    [
+        (
+            dict(transcript_mark="checkout", transcript_mark_category="insight"),
+            ["P01:0", "P02:0"],
+        ),
+        (
+            dict(
+                transcript_mark="checkout",
+                transcript_mark_category="insight",
+                transcript_mark_participant="P01",
+            ),
+            ["P01:0"],
+        ),
+    ],
+    ids=["all_participants", "participant_filter"],
+)
+def test_run_transcript_mark_creates_marks(
+    monkeypatch, no_running_server, args_overrides, expected_seg_ids
+):
     import transcripts
 
     manifest = _mark_manifest()
     monkeypatch.setattr(transcripts, "load_transcripts_manifest", lambda: manifest)
     saved: dict = {}
+    monkeypatch.setattr(
+        transcripts,
+        "save_transcripts_manifest",
+        lambda src, corr, marks=None: saved.update({"marks": marks}),
+    )
 
-    def fake_save(source_transcripts, corrections, marks=None):
-        saved["marks"] = marks
-        return None
-
-    monkeypatch.setattr(transcripts, "save_transcripts_manifest", fake_save)
-
-    args = _ss_args(transcript_mark="checkout", transcript_mark_category="insight")
+    args = _ss_args(**args_overrides)
     cli._run_transcript_mark(args)
 
-    seg_ids = sorted(m["segment_id"] for m in saved["marks"])
-    assert seg_ids == ["P01:0", "P02:0"]
+    assert sorted(m["segment_id"] for m in saved["marks"]) == expected_seg_ids
     assert all(m["category"] == "insight" for m in saved["marks"])
     assert all(m["label"] is None for m in saved["marks"])
 
@@ -680,28 +699,6 @@ def test_run_transcript_mark_updates_existing_in_place(monkeypatch, no_running_s
     assert by_seg["P02:0"]["category"] == "insight"
     # No duplicates.
     assert len(saved["marks"]) == 3
-
-
-def test_run_transcript_mark_participant_filter(monkeypatch, no_running_server):
-    import transcripts
-
-    manifest = _mark_manifest()
-    monkeypatch.setattr(transcripts, "load_transcripts_manifest", lambda: manifest)
-    saved: dict = {}
-    monkeypatch.setattr(
-        transcripts,
-        "save_transcripts_manifest",
-        lambda src, corr, marks=None: saved.update({"marks": marks}),
-    )
-
-    args = _ss_args(
-        transcript_mark="checkout",
-        transcript_mark_category="insight",
-        transcript_mark_participant="P01",
-    )
-    cli._run_transcript_mark(args)
-
-    assert [m["segment_id"] for m in saved["marks"]] == ["P01:0"]
 
 
 def test_run_transcript_mark_invalid_category_does_not_save(

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -141,47 +141,45 @@ def transcripts_manifest():
 # ---- Screenspace events builder -----------------------------------------
 
 
-def test_screenspace_events_default_excludes_marked(screenspace_manifest):
-    rows = data_export.build_screenspace_events(screenspace_manifest)
-    assert all(not r["excluded"] for r in rows)
-    assert len(rows) == 9
-    detectors = {r["detector"] for r in rows}
-    assert detectors == {
-        "color",
-        "change",
-        "similarity",
-        "text",
-        "numbers",
-        "template",
-        "flow",
-        "scene",
-        "inactivity",
-    }
+_ALL_DETECTORS = {
+    "color",
+    "change",
+    "similarity",
+    "text",
+    "numbers",
+    "template",
+    "flow",
+    "scene",
+    "inactivity",
+}
 
 
-def test_screenspace_events_include_excluded(screenspace_manifest):
-    rows = data_export.build_screenspace_events(
-        screenspace_manifest, include_excluded=True
-    )
-    assert len(rows) == 10
-    excluded_rows = [r for r in rows if r["excluded"]]
-    assert len(excluded_rows) == 1
-
-
-def test_screenspace_events_filters_participant(screenspace_manifest):
-    rows = data_export.build_screenspace_events(
-        screenspace_manifest, include_excluded=True, participants=["P02"]
-    )
-    assert len(rows) == 1
-    assert rows[0]["participant"] == "P02"
-
-
-def test_screenspace_events_filters_detector(screenspace_manifest):
-    rows = data_export.build_screenspace_events(
-        screenspace_manifest, detectors=["change", "flow"]
-    )
-    assert len(rows) == 2
-    assert {r["detector"] for r in rows} == {"change", "flow"}
+@pytest.mark.parametrize(
+    "kwargs,expected_count,expected_detectors,expected_participants,expected_excluded_count",
+    [
+        ({}, 9, _ALL_DETECTORS, None, 0),
+        ({"include_excluded": True}, 10, None, None, 1),
+        ({"include_excluded": True, "participants": ["P02"]}, 1, None, {"P02"}, None),
+        ({"detectors": ["change", "flow"]}, 2, {"change", "flow"}, None, None),
+    ],
+    ids=["default", "include_excluded", "participant_filter", "detector_filter"],
+)
+def test_screenspace_events_filters(
+    screenspace_manifest,
+    kwargs,
+    expected_count,
+    expected_detectors,
+    expected_participants,
+    expected_excluded_count,
+):
+    rows = data_export.build_screenspace_events(screenspace_manifest, **kwargs)
+    assert len(rows) == expected_count
+    if expected_detectors is not None:
+        assert {r["detector"] for r in rows} == expected_detectors
+    if expected_participants is not None:
+        assert {r["participant"] for r in rows} == expected_participants
+    if expected_excluded_count is not None:
+        assert sum(1 for r in rows if r["excluded"]) == expected_excluded_count
 
 
 def test_screenspace_events_metadata_hoisted(screenspace_manifest):
@@ -267,37 +265,23 @@ def test_insights_builder_handles_missing_subsections():
 # ---- Transcript segments builder ----------------------------------------
 
 
-def test_transcript_segments_one_row_per_segment(transcripts_manifest):
+def test_build_transcript_segments(transcripts_manifest):
+    """One row per segment, with participant metadata, mark joins, and duration."""
     rows = data_export.build_transcript_segments(transcripts_manifest)
-    assert len(rows) == 3
     by_id = {r["segment_id"]: r for r in rows}
-    assert "P01:0" in by_id
-    assert "P01:1" in by_id
-    assert "P02:0" in by_id
 
+    assert len(rows) == 3
+    assert set(by_id) == {"P01:0", "P01:1", "P02:0"}
 
-def test_transcript_segments_carries_participant_metadata(transcripts_manifest):
-    rows = data_export.build_transcript_segments(transcripts_manifest)
     for r in rows:
         assert r["language"] == "en"
         assert r["model"] == "base"
-        if r["participant"] == "P01":
-            assert r["source_file"] == "study_P01.mp4"
+    assert by_id["P01:0"]["source_file"] == "study_P01.mp4"
 
+    assert by_id["P01:1"]["mark_categories"] == ["pain_point"]
+    assert by_id["P01:1"]["mark_labels"] == ["confused"]
+    assert by_id["P01:0"]["mark_categories"] == []
 
-def test_transcript_segments_joins_marks(transcripts_manifest):
-    rows = data_export.build_transcript_segments(transcripts_manifest)
-    by_id = {r["segment_id"]: r for r in rows}
-    marked = by_id["P01:1"]
-    unmarked = by_id["P01:0"]
-    assert marked["mark_categories"] == ["pain_point"]
-    assert marked["mark_labels"] == ["confused"]
-    assert unmarked["mark_categories"] == []
-
-
-def test_transcript_segments_duration(transcripts_manifest):
-    rows = data_export.build_transcript_segments(transcripts_manifest)
-    by_id = {r["segment_id"]: r for r in rows}
     assert by_id["P01:0"]["duration"] == pytest.approx(5.0, abs=1e-6)
     assert by_id["P02:0"]["duration"] == pytest.approx(4.5, abs=1e-6)
 
@@ -348,48 +332,47 @@ def _write_manifest(tmp_path: Path, filename: str, content: dict) -> None:
     (tmp_path / filename).write_text(json.dumps(content), encoding="utf-8")
 
 
-def test_bundle_writes_all_three(
-    tmp_path, screenspace_manifest, insights_manifest, transcripts_manifest
+_EMPTY_SS_MANIFEST = {"regions": {}, "tasks": [], "events": [], "stashes": []}
+
+
+@pytest.mark.parametrize(
+    "manifest_specs,expected_count,expected_name_substrs",
+    [
+        (
+            ["screenspace", "insights", "transcripts"],
+            6,
+            {"screenspace_events", "insights", "transcripts"},
+        ),
+        (["screenspace"], 2, {"screenspace_events"}),
+        ([], 0, set()),
+        (["screenspace_empty"], 0, set()),
+    ],
+    ids=["all_three", "skips_missing", "no_manifests", "skips_empty"],
+)
+def test_bundle_writer(
+    tmp_path,
+    screenspace_manifest,
+    insights_manifest,
+    transcripts_manifest,
+    manifest_specs,
+    expected_count,
+    expected_name_substrs,
 ):
-    _write_manifest(
-        tmp_path, config.SCREENSPACE_MANIFEST_FILENAME, screenspace_manifest
-    )
-    _write_manifest(tmp_path, config.INSIGHTS_MANIFEST_FILENAME, insights_manifest)
-    _write_manifest(
-        tmp_path, config.TRANSCRIPTS_MANIFEST_FILENAME, transcripts_manifest
-    )
+    fixture_map = {
+        "screenspace": (config.SCREENSPACE_MANIFEST_FILENAME, screenspace_manifest),
+        "screenspace_empty": (config.SCREENSPACE_MANIFEST_FILENAME, _EMPTY_SS_MANIFEST),
+        "insights": (config.INSIGHTS_MANIFEST_FILENAME, insights_manifest),
+        "transcripts": (config.TRANSCRIPTS_MANIFEST_FILENAME, transcripts_manifest),
+    }
+    for spec in manifest_specs:
+        filename, content = fixture_map[spec]
+        _write_manifest(tmp_path, filename, content)
 
     written = data_export.write_export_bundle(tmp_path)
+    assert len(written) == expected_count
     names = {p.name for p in written}
-    assert "clipgen_export_screenspace_events.json" in names
-    assert "clipgen_export_screenspace_events.csv" in names
-    assert "clipgen_export_insights.json" in names
-    assert "clipgen_export_insights.csv" in names
-    assert "clipgen_export_transcripts.json" in names
-    assert "clipgen_export_transcripts.csv" in names
-    assert len(written) == 6
-
-
-def test_bundle_skips_missing_manifests(tmp_path, screenspace_manifest):
-    _write_manifest(
-        tmp_path, config.SCREENSPACE_MANIFEST_FILENAME, screenspace_manifest
-    )
-    written = data_export.write_export_bundle(tmp_path)
-    assert len(written) == 2
-    assert all("screenspace_events" in p.name for p in written)
-
-
-def test_bundle_returns_empty_when_no_manifests(tmp_path):
-    assert data_export.write_export_bundle(tmp_path) == []
-
-
-def test_bundle_skips_empty_manifest(tmp_path):
-    _write_manifest(
-        tmp_path,
-        config.SCREENSPACE_MANIFEST_FILENAME,
-        {"regions": {}, "tasks": [], "events": [], "stashes": []},
-    )
-    assert data_export.write_export_bundle(tmp_path) == []
+    for substr in expected_name_substrs:
+        assert any(substr in n for n in names), f"missing {substr!r} in {names}"
 
 
 def test_bundle_csv_has_data_rows(tmp_path, screenspace_manifest):


### PR DESCRIPTION
Conservative extension of the test-suite consolidation work shipped in PR #264, targeting the two files most likely to yield similar wins. `tests/test_cli_event_clip_args.py`: 13 repetitive functions collapse into 4 parametrized tests covering conflict validation, the `_filter_screenspace_events` helper, `--transcript-mark` argparse, and the `_run_transcript_mark` dispatch. `tests/test_data_export.py`: 4 screenspace-event-filter tests and 4 bundle-writer tests collapse into parametrized blocks; the 4 transcript-segments tests merge into a single function asserting count/metadata/marks/duration on the shared fixture. Net −20 LOC, 0 test cases lost (collapsed transcript-segment functions reduce the reported count by 3 but every original assertion still runs); CSV/JSON serialization tests left alone because the audit flagged them as heterogeneous enough that parametrization would harm readability.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 751 passed (was 754; the −3 reflects the transcript-segment merge, not lost coverage)
- [x] `uv run ruff check --fix && uv run ruff format` — clean