### PR TITLE
feat(screenspace): per-task amplitude graph toggle on timeline

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -648,6 +648,26 @@ body {
   margin: 0 var(--space-1);
 }
 
+.amplitude-btn-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+  background-color: currentColor;
+  mask-image: url("/screenspace/icons/signal.svg");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-image: url("/screenspace/icons/signal.svg");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  flex-shrink: 0;
+}
+
+#amplitudeGraphBtn.active {
+  color: var(--color-accent);
+}
+
 .marker-info {
   font-size: var(--text-xs);
   font-family: var(--font-mono);

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -73,6 +73,7 @@
         <button id="zoomInBtn" class="btn btn-small btn-icon"></button>
         <button id="zoomOutBtn" class="btn btn-small btn-icon"></button>
         <button id="zoomResetBtn" class="btn btn-small">Reset</button>
+        <button id="amplitudeGraphBtn" class="btn btn-small btn-icon" title="Toggle amplitude graph" aria-label="Toggle amplitude graph"><span class="amplitude-btn-icon"></span></button>
         <span class="timeline-sep"></span>
         <button id="setInBtn" class="btn btn-small">Set In</button>
         <button id="setOutBtn" class="btn btn-small">Set Out</button>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -115,6 +115,7 @@
     overlayLayerSpec: {},
     rightPaneTab: "queue",
     resultsSwitcherOpen: false,
+    amplitudeGraphEnabled: false,
   };
 
   var _timelineHitRects = [];
@@ -1911,6 +1912,12 @@
   function initTimeline() {
     qs("#zoomInBtn").appendChild(svgPlusIcon());
     qs("#zoomOutBtn").appendChild(svgMinusIcon());
+
+    var storedTimeline = getStoredUIState("screenspace");
+    if (storedTimeline.amplitudeGraphEnabled === true) {
+      state.amplitudeGraphEnabled = true;
+      qs("#amplitudeGraphBtn").classList.add("active");
+    }
     var canvas = qs("#timelineCanvas");
     sizeTimelineCanvas();
     window.addEventListener("resize", function () {
@@ -2062,6 +2069,12 @@
       updateMarkerInfo();
       renderTimeline();
     });
+    qs("#amplitudeGraphBtn").addEventListener("click", function () {
+      state.amplitudeGraphEnabled = !state.amplitudeGraphEnabled;
+      this.classList.toggle("active", state.amplitudeGraphEnabled);
+      setStoredUIStateField("screenspace", "amplitudeGraphEnabled", state.amplitudeGraphEnabled);
+      renderTimeline();
+    });
   }
 
   function clampTimelineOffset() {
@@ -2183,11 +2196,48 @@
       }
     }
 
-    // Result markers from completed and running tasks
-    var resultY = 24;
+    // Optional amplitude band: per-task-type event-density curves above the
+    // result markers. Drawn before markers so markers stay on top visually.
+    var ampOn = state.amplitudeGraphEnabled;
+    var AMP_BAND_H = 22;
+    var AMP_BAND_GAP = 2;
+    var resultY = ampOn ? 24 + AMP_BAND_H + AMP_BAND_GAP : 24;
     var resultH = h - resultY - 6;
     var focused = focusedTaskId();
     _timelineHitRects = [];
+
+    if (ampOn) {
+      var seriesByType = {};
+      state.tasks.forEach(function (task) {
+        if (!task.result || task.status === "cancelled") return;
+        if (task.participant && task.participant !== state.selectedParticipant) return;
+        if (task.type === "timelapse") return;
+        if (!seriesByType[task.type]) {
+          seriesByType[task.type] = { key: task.type, color: taskTypeColor(task.type), timestamps: [] };
+        }
+        var dst = seriesByType[task.type].timestamps;
+        var results = task.result || [];
+        for (var ri = 0; ri < results.length; ri++) {
+          var r = results[ri];
+          var ts = r.timestamp !== undefined ? r.timestamp : r.start;
+          if (ts !== undefined) dst.push(ts);
+        }
+      });
+      var seriesList = Object.keys(seriesByType).map(function (k) { return seriesByType[k]; });
+      var focusedTask = focused ? findTask(focused) : null;
+      var dimKey = focusedTask ? focusedTask.type : null;
+      drawAmplitudeBands(ctx, {
+        x: 0,
+        y: 24,
+        w: w,
+        h: AMP_BAND_H,
+        visStart: visStart,
+        visEnd: visEnd,
+        series: seriesList,
+        binPx: 2,
+        dimKey: dimKey,
+      });
+    }
 
     // Build excluded-timestamp lookup per task from cached events
     var excludedByTask = {};

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -730,3 +730,106 @@ var setStoredUIStateField = function (page, field, value) {
     window.localStorage.setItem(UI_STATE_STORAGE_KEY, JSON.stringify(all));
   } catch (_) {}
 };
+
+// ---- Canvas helpers (timeline overlays) ----
+
+// Draw stacked per-series amplitude bands inside a canvas rect.
+//
+// Pure: no DOM lookups, no global state. Each timeline page (screenspace,
+// viewer, transcripts, convergence) builds a `series` array from its own
+// event shape and calls this helper from inside its renderTimeline().
+//
+// opts:
+//   x, y, w, h         band rect on the canvas (pixels, integer)
+//   visStart, visEnd   visible time window (seconds)
+//   series             [{ key, color, timestamps: number[] }, ...]
+//                      `key` is used for dim comparison; `color` is "#rrggbb";
+//                      `timestamps` are seconds (already filtered to visible scope
+//                      is fine but not required — out-of-window samples are skipped)
+//   binPx              column width in pixels for binning (default 2)
+//   dimKey             optional series key to keep at full opacity; all other series
+//                      render at reduced alpha. Pass null/undefined for no dimming.
+//
+// Each series is normalized against its OWN peak so quiet types still show
+// shape. Curves are drawn back-to-front so dimKey paints last when set.
+var drawAmplitudeBands = function (ctx, opts) {
+  var x = opts.x, y = opts.y, w = opts.w, h = opts.h;
+  var visStart = opts.visStart, visEnd = opts.visEnd;
+  var series = opts.series || [];
+  var binPx = opts.binPx || 2;
+  var dimKey = opts.dimKey;
+
+  if (w <= 0 || h <= 0 || series.length === 0) return;
+  var visLen = visEnd - visStart;
+  if (!(visLen > 0)) return;
+
+  var numBins = Math.max(1, Math.ceil(w / binPx));
+  var binSec = visLen / numBins;
+
+  // Bin each series and remember its own max
+  var binned = [];
+  for (var s = 0; s < series.length; s++) {
+    var ts = series[s].timestamps || [];
+    var bins = new Array(numBins);
+    for (var b = 0; b < numBins; b++) bins[b] = 0;
+    var maxCount = 0;
+    for (var i = 0; i < ts.length; i++) {
+      var t = ts[i];
+      if (t < visStart || t >= visEnd) continue;
+      var idx = Math.floor((t - visStart) / binSec);
+      if (idx < 0) idx = 0;
+      else if (idx >= numBins) idx = numBins - 1;
+      var c = bins[idx] + 1;
+      bins[idx] = c;
+      if (c > maxCount) maxCount = c;
+    }
+    binned.push({ key: series[s].key, color: series[s].color, bins: bins, max: maxCount });
+  }
+
+  // Order: dimmed series first, focused series last (paints on top)
+  var order = [];
+  for (var k = 0; k < binned.length; k++) {
+    if (dimKey && binned[k].key !== dimKey) order.push(k);
+  }
+  for (var k2 = 0; k2 < binned.length; k2++) {
+    if (!dimKey || binned[k2].key === dimKey) order.push(k2);
+  }
+
+  var baselineY = y + h;
+  for (var oi = 0; oi < order.length; oi++) {
+    var ser = binned[order[oi]];
+    if (ser.max <= 0) continue;
+    var dimmed = dimKey && ser.key !== dimKey;
+    var fillAlpha = dimmed ? 0.05 : 0.18;
+    var strokeAlpha = dimmed ? 0.25 : 1.0;
+
+    // Build the area path along bin tops
+    ctx.beginPath();
+    ctx.moveTo(x, baselineY);
+    for (var bi = 0; bi < numBins; bi++) {
+      var norm = ser.bins[bi] / ser.max;
+      var py = baselineY - norm * h;
+      var px = x + bi * binPx;
+      ctx.lineTo(px, py);
+      ctx.lineTo(px + binPx, py);
+    }
+    ctx.lineTo(x + numBins * binPx, baselineY);
+    ctx.closePath();
+    ctx.fillStyle = hexToRgba(ser.color, fillAlpha);
+    ctx.fill();
+
+    ctx.beginPath();
+    var started = false;
+    for (var bi2 = 0; bi2 < numBins; bi2++) {
+      var n2 = ser.bins[bi2] / ser.max;
+      var py2 = baselineY - n2 * h;
+      var px2 = x + bi2 * binPx;
+      if (!started) { ctx.moveTo(px2, py2); started = true; }
+      else ctx.lineTo(px2, py2);
+      ctx.lineTo(px2 + binPx, py2);
+    }
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = strokeAlpha === 1.0 ? ser.color : hexToRgba(ser.color, strokeAlpha);
+    ctx.stroke();
+  }
+};

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.120"
+VERSIONNUM: str = "0.10.121"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )


### PR DESCRIPTION
## Summary

- Adds an optional amplitude band on the Screenspace timeline showing event-density curves per task type, toggled by a new toolbar button (off by default, persisted to localStorage).
- Each per-type curve is normalized against its own peak so quiet types still show shape; the focused task's type paints last/full-opacity while others dim.
- Bin + draw logic is extracted as a pure `drawAmplitudeBands(ctx, opts)` in `utils.js` so the viewer/transcripts/convergence timelines can adopt it via small adapters later.

## Test plan

- [x] `uvx ruff check` and `uvx ruff format --check` clean
- [x] `pytest tests/test_screenspace.py tests/test_screenspace_api.py` (219 passed)
- [ ] Manual: launch `--screenspace`, load a participant with mixed task types, toggle the button on/off, verify focus dimming, theme toggle, and reload-persistence