### PR TITLE
fix: frame-accurate seek so Screenspace preview matches analysis

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ from icecream import ic
 REENCODING: bool = False
 AUDIO_NORMALIZE: bool = False
 FILEFORMAT: str = ".mp4"
-VERSIONNUM: str = "0.10.120"
+VERSIONNUM: str = "0.10.121"
 TITLECARDS_ENABLED: bool = (
     False  # use --titlecards / --no-titlecards to override per run
 )

--- a/screenspace.py
+++ b/screenspace.py
@@ -692,10 +692,11 @@ def _ffmpeg_pipe_frames(
         out_h += out_h % 2
         filters.append(f"scale={out_w}:{out_h}")
 
-    cmd: list[str] = ["ffmpeg"]
-    if start_seconds > 0:
-        cmd += ["-ss", str(start_seconds)]
-    cmd += ["-i", video_path]
+    # Two-stage seek so each yielded frame's synthetic ts (computed below as
+    # start_seconds + frame_idx * interval_seconds) lines up with the actual
+    # decoded PTS instead of the nearest preceding key-frame.
+    pre_seek, post_seek = video.accurate_seek_args(max(0.0, start_seconds))
+    cmd: list[str] = ["ffmpeg", *pre_seek, "-i", video_path, *post_seek]
     if end_seconds > start_seconds:
         cmd += ["-t", str(end_seconds - start_seconds)]
     cmd += [

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -210,7 +210,7 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
         ), 404
 
     width = request.args.get("w", 0, type=int)
-    cache_key = (video_path, round(ts, 2), width)
+    cache_key = (video_path, round(ts, 3), width)
     cached = _frame_cache.get(cache_key)
     if cached is not None:
         return Response(
@@ -220,7 +220,7 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
         )
 
     if width > 0:
-        jpeg_bytes = video.extract_thumbnail_bytes(video_path, int(ts), width=width)
+        jpeg_bytes = video.extract_thumbnail_bytes(video_path, ts, width=width)
     else:
         frame = video.extract_frame_at_timestamp(video_path, ts)
         if frame is None:

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1539,6 +1539,36 @@ class TestFfmpegPipeFrames:
         )
         assert frames == []
 
+    def test_uses_two_stage_seek_for_far_start(self, monkeypatch):
+        """Analysis pipe should two-stage seek so synthetic ts == decoded PTS."""
+        captured: dict = {}
+
+        def fake_popen(cmd, *a, **kw):
+            captured["cmd"] = list(cmd)
+            proc = mock.MagicMock()
+            proc.stdout = io.BytesIO(b"")
+            proc.terminate = mock.MagicMock()
+            proc.wait = mock.MagicMock()
+            return proc
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        list(
+            screenspace._ffmpeg_pipe_frames(
+                "/fake.mp4",
+                1.0,
+                start_seconds=15.0,
+                end_seconds=20.0,
+                frame_width=4,
+                frame_height=2,
+            )
+        )
+        cmd = captured["cmd"]
+        i_idx = cmd.index("-i")
+        assert "-ss" in cmd[:i_idx], "expected fast pre-input seek"
+        assert "-ss" in cmd[i_idx + 2 :], "expected accurate post-input seek"
+
 
 class TestScanViaFfmpegPipe:
     def test_returns_false_when_no_ffmpeg(self, monkeypatch):

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -585,6 +585,100 @@ def test_extract_frame_at_timestamp_debug_mode(monkeypatch):
     assert frame.shape == (1080, 1920, 3)
 
 
+# ---- accurate_seek_args ----
+
+
+def test_accurate_seek_args_zero_returns_empty_lists():
+    pre, post = video.accurate_seek_args(0.0)
+    assert pre == []
+    assert post == []
+
+
+def test_accurate_seek_args_within_preseek_window_skips_pre():
+    """For ts within the preseek window, the entire seek goes after -i."""
+    ts = video.FFMPEG_PRESEEK_SECONDS / 2
+    pre, post = video.accurate_seek_args(ts)
+    assert pre == []
+    assert post == ["-ss", str(ts)]
+
+
+def test_accurate_seek_args_splits_for_far_target():
+    """For ts beyond the preseek window, we get a fast pre + small post."""
+    ts = video.FFMPEG_PRESEEK_SECONDS + 12.345
+    pre, post = video.accurate_seek_args(ts)
+    assert pre == ["-ss", str(ts - video.FFMPEG_PRESEEK_SECONDS)]
+    assert post == ["-ss", str(video.FFMPEG_PRESEEK_SECONDS)]
+
+
+# ---- two-stage seek wiring in extract_frame_at_timestamp ----
+
+
+def _captured_run(captured: dict):
+    def _run(*args, **kwargs):
+        captured["cmd"] = list(args[0])
+        return subprocess.CompletedProcess(args, 0, stdout=b"")
+
+    return _run
+
+
+def test_extract_frame_at_timestamp_uses_two_stage_seek(monkeypatch):
+    """Far targets get -ss before -i AND -ss after -i (frame-accurate)."""
+    monkeypatch.setattr(
+        video,
+        "probe_video_properties",
+        lambda _: {"width": 320, "height": 240, "fps": 30.0, "duration": 60.0},
+    )
+    captured: dict = {}
+    monkeypatch.setattr(video.subprocess, "run", _captured_run(captured))
+
+    video.extract_frame_at_timestamp("/fake.mp4", 12.5)
+    cmd = captured["cmd"]
+    i_idx = cmd.index("-i")
+    pre = cmd[:i_idx]
+    post = cmd[i_idx + 2 :]
+    assert "-ss" in pre, "expected fast pre-input seek"
+    assert "-ss" in post, "expected accurate post-input seek"
+
+
+def test_extract_frame_at_timestamp_post_only_seek_for_near_target(monkeypatch):
+    """For ts inside the preseek window, only post-input -ss is emitted."""
+    monkeypatch.setattr(
+        video,
+        "probe_video_properties",
+        lambda _: {"width": 320, "height": 240, "fps": 30.0, "duration": 60.0},
+    )
+    captured: dict = {}
+    monkeypatch.setattr(video.subprocess, "run", _captured_run(captured))
+
+    video.extract_frame_at_timestamp("/fake.mp4", 0.5)
+    cmd = captured["cmd"]
+    i_idx = cmd.index("-i")
+    assert "-ss" not in cmd[:i_idx]
+    assert "-ss" in cmd[i_idx + 2 :]
+
+
+# ---- two-stage seek + float ts in extract_thumbnail_bytes ----
+
+
+def test_extract_thumbnail_bytes_preserves_float_timestamp(monkeypatch, tmp_path):
+    """The float timestamp must reach ffmpeg without int() truncation."""
+    fake = tmp_path / "video.mp4"
+    fake.write_bytes(b"x")
+    captured: dict = {}
+    monkeypatch.setattr(video.subprocess, "run", _captured_run(captured))
+
+    video.extract_thumbnail_bytes(str(fake), 12.75, width=200)
+    cmd = captured["cmd"]
+    seek_values = [cmd[i + 1] for i, a in enumerate(cmd) if a == "-ss"]
+    assert seek_values, "expected at least one -ss flag"
+    assert any("12.75" in str(v) or "10.75" in str(v) for v in seek_values), (
+        f"float seconds should appear in either pre- or post-seek (got {seek_values})"
+    )
+    # And no integer-truncated whole-second-only command.
+    i_idx = cmd.index("-i")
+    assert "-ss" in cmd[i_idx + 2 :]
+
+
 # -- cancel_flag forwarding --
 
 

--- a/video.py
+++ b/video.py
@@ -22,8 +22,30 @@ import utils
 
 INVALID_END_TIMESTAMP = None
 
+# Two-stage ffmpeg seek window. We pre-seek (fast, key-frame-aligned) to
+# `target - FFMPEG_PRESEEK_SECONDS` and then seek the rest accurately after
+# `-i`. This keeps long-video performance while landing on the exact frame
+# the caller asked for, instead of the nearest preceding key-frame.
+FFMPEG_PRESEEK_SECONDS = 2.0
+
 _file_duration_cache: dict[str, int] = {}
 _video_properties_cache: dict[str, dict[str, Any]] = {}
+
+
+def accurate_seek_args(timestamp_seconds: float) -> tuple[list[str], list[str]]:
+    """Return ``(pre_input_args, post_input_args)`` for a frame-accurate seek.
+
+    Splits a seek into a fast pre-input ``-ss`` near the target plus a small
+    accurate post-input ``-ss`` for the residual. Callers splice the lists
+    around ``-i <video>``. For ``timestamp <= FFMPEG_PRESEEK_SECONDS`` the
+    pre-input list is empty and the full seek is post-input.
+    """
+    if timestamp_seconds <= 0:
+        return [], []
+    if timestamp_seconds <= FFMPEG_PRESEEK_SECONDS:
+        return [], ["-ss", str(timestamp_seconds)]
+    pre = timestamp_seconds - FFMPEG_PRESEEK_SECONDS
+    return ["-ss", str(pre)], ["-ss", str(FFMPEG_PRESEEK_SECONDS)]
 
 
 def _ffmpeg_install_guidance_lines() -> list[str]:
@@ -477,15 +499,17 @@ def extract_screenshot(
 
 def extract_thumbnail_bytes(
     input_file: str,
-    start_seconds: int,
+    start_seconds: float,
     *,
     width: int = 200,
 ) -> bytes | None:
     """Extract a small JPEG thumbnail frame from a video at *start_seconds*.
 
-    Uses fast input seeking (``-ss`` before ``-i``) so performance is
-    independent of file size.  Returns raw JPEG bytes on success or
-    ``None`` on any failure.
+    Uses two-stage seeking (fast pre-input ``-ss`` near the target, then a
+    small accurate ``-ss`` after ``-i``) so the returned thumbnail matches
+    the requested timestamp instead of snapping to the nearest preceding
+    key-frame. Returns raw JPEG bytes on success or ``None`` on any
+    failure.
     """
     if config.DEBUGGING:
         ic(input_file, start_seconds, width)
@@ -494,15 +518,16 @@ def extract_thumbnail_bytes(
     if not Path(input_file).is_file():
         return None
 
+    pre_seek, post_seek = accurate_seek_args(max(0.0, start_seconds))
     cmd = [
         "ffmpeg",
         "-y",
         "-loglevel",
         config.FFMPEG_LOGLEVEL,
-        "-ss",
-        str(max(0, start_seconds)),
+        *pre_seek,
         "-i",
         input_file,
+        *post_seek,
         "-vframes",
         "1",
         "-vf",
@@ -836,6 +861,9 @@ def extract_frame_at_timestamp(
 ) -> Any | None:
     """Extract a single video frame at the given timestamp via ffmpeg.
 
+    Uses two-stage seeking (fast pre-input ``-ss`` near the target, then a
+    small accurate ``-ss`` after ``-i``) so the returned frame is the one
+    at ``timestamp_seconds`` rather than the nearest preceding key-frame.
     Returns a BGR numpy array (H x W x 3) or None if extraction fails.
     Requires ffprobe to determine resolution and ffmpeg to decode the frame.
     """
@@ -849,12 +877,13 @@ def extract_frame_at_timestamp(
         return None
 
     width, height = props["width"], props["height"]
+    pre_seek, post_seek = accurate_seek_args(max(0.0, timestamp_seconds))
     cmd = [
         "ffmpeg",
-        "-ss",
-        str(timestamp_seconds),
+        *pre_seek,
         "-i",
         video_path,
+        *post_seek,
         "-frames:v",
         "1",
         "-pix_fmt",


### PR DESCRIPTION
## Summary

- Switched ffmpeg single-frame extraction to a two-stage seek (fast pre-input `-ss` + small accurate post-input `-ss`) in `extract_frame_at_timestamp`, `extract_thumbnail_bytes`, and Screenspace's `_ffmpeg_pipe_frames`. This eliminates keyframe-snap drift (up to ~2 s on H.264) so the click-to-preview frame matches what OCR/analysis actually saw.
- Dropped the `int(ts)` truncation on the thumbnail path and tightened the in-memory frame cache key from `round(ts, 2)` → `round(ts, 3)` for sub-50 ms granularity.
- Added unit tests asserting the two-stage seek shape for both video helpers and the analysis pipe; bumped patch version.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 758 passed
- [x] `uv run ruff check --fix` and `uv run ruff format` clean
- [x] `uv run ty check` clean
- [ ] Manual: run an OCR task in `--screenspace`; click each result and confirm the detected text sits inside the region overlay (instead of adjacent to it)