### PR TITLE
feat(transcripts): add collapse toggle to hide top-docked video player

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -472,6 +472,16 @@ body {
   -webkit-mask-image: url(icons/tv.svg);
 }
 
+.player-icon-collapse {
+  mask-image: url(icons/chevron-up.svg);
+  -webkit-mask-image: url(icons/chevron-up.svg);
+  transition: transform var(--duration-fast);
+}
+
+#videoSection.video-collapsed .player-icon-collapse {
+  transform: rotate(180deg);
+}
+
 .player-speed-btn {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
@@ -569,6 +579,15 @@ body {
 
 #videoSection.pip #videoControls {
   padding: var(--space-1) var(--space-2);
+}
+
+#videoSection.video-collapsed #videoFrame,
+#videoSection.video-collapsed #timelineRow {
+  display: none;
+}
+
+#videoSection.pip #videoCollapseBtn {
+  display: none;
 }
 
 /* ── AI Summary ─────────────────────────────────────────────── */

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -64,6 +64,9 @@
         <button id="videoPipBtn" class="player-btn" title="Toggle picture-in-picture" aria-label="Toggle picture-in-picture" aria-pressed="true">
           <span class="player-btn-icon player-icon-pip"></span>
         </button>
+        <button id="videoCollapseBtn" class="player-btn" title="Hide video" aria-label="Hide video" aria-expanded="true">
+          <span class="player-btn-icon player-icon-collapse"></span>
+        </button>
         <span id="videoTime" class="player-time">0:00 / 0:00</span>
       </div>
       <div id="timelineRow">

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -57,6 +57,7 @@
     ccEnabled: false,
     pipActive: false,
     pipEnabled: true,
+    videoCollapsed: false,
   };
 
   var _transcriptionWarmupPosted = false;
@@ -1333,6 +1334,11 @@
       pipBtn.classList.toggle("active", state.pipEnabled);
       pipBtn.setAttribute("aria-pressed", state.pipEnabled ? "true" : "false");
     }
+    var collapseBtn = qs("#videoCollapseBtn");
+    if (collapseBtn) {
+      collapseBtn.title = state.videoCollapsed ? "Show video" : "Hide video";
+      collapseBtn.setAttribute("aria-expanded", state.videoCollapsed ? "false" : "true");
+    }
   }
 
   function applyPlaybackRate() {
@@ -1571,6 +1577,9 @@
     // gives the user the documented default (off).
     var stored = getStoredUIState("transcripts");
     state.ccEnabled = !!(stored && stored.ccEnabled);
+    state.videoCollapsed = !!(stored && stored.videoCollapsed);
+    var section = qs("#videoSection");
+    if (section) section.classList.toggle("video-collapsed", state.videoCollapsed);
 
     qs("#videoPlayBtn").addEventListener("click", function () {
       if (video.paused) video.play();
@@ -1602,6 +1611,13 @@
       if (!state.pipEnabled && state.pipActive && typeof _setPipActive === "function") {
         _setPipActive(false);
       }
+      updatePlayerButtons();
+    });
+    qs("#videoCollapseBtn").addEventListener("click", function () {
+      state.videoCollapsed = !state.videoCollapsed;
+      var sec = qs("#videoSection");
+      if (sec) sec.classList.toggle("video-collapsed", state.videoCollapsed);
+      setStoredUIStateField("transcripts", "videoCollapsed", state.videoCollapsed);
       updatePlayerButtons();
     });
 


### PR DESCRIPTION
## Summary
- Adds a chevron button in the Transcripts player controls that folds the video frame and timeline away, leaving only the controls bar visible (audio keeps playing).
- State persists per-user via the existing `getStoredUIState`/`setStoredUIStateField` helpers; the toggle is hidden while `#videoSection` is in PiP mode so the two affordances stay orthogonal.

## Test plan
- [ ] Launch \`uv run clipgen.py --screenspace -i DIR -o DIR\`, open http://127.0.0.1:8089/transcripts/, select a participant.
- [ ] Click the new chevron next to the PiP button → frame + timeline collapse, chevron flips, audio still plays.
- [ ] Reload the page → collapsed state restored.
- [ ] Scroll the transcript past ~140px → PiP activates and the chevron disappears; scroll back to top → chevron returns in the top dock.