### PR TITLE
frontend: Pass 2-4 token migration across web UIs

### DIFF
--- a/assets/web/gallery.css
+++ b/assets/web/gallery.css
@@ -29,7 +29,7 @@ body {
 
 #pageHeader {
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -139,7 +139,7 @@ body {
 /* Gallery Info */
 
 #galleryInfo {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   padding: var(--space-3) var(--space-5);
   background: var(--color-panel-bg);
@@ -154,7 +154,7 @@ body {
 /* Gallery Grid */
 
 #galleryGrid {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   padding: var(--space-4) var(--space-5) var(--space-6);
   background: var(--color-panel-bg);
@@ -206,7 +206,7 @@ body {
 /* Empty State */
 
 #emptyState {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: var(--space-6) auto;
   text-align: center;
   color: var(--color-text-dim);

--- a/assets/web/insights-builder.css
+++ b/assets/web/insights-builder.css
@@ -8,11 +8,6 @@
   padding: 0;
 }
 
-/* Page-specific variables — shared tokens are in tokens.css */
-:root {
-  --sidebar-width: 420px;
-}
-
 html {
   font-size: 16px;
 }
@@ -29,7 +24,7 @@ body {
 
 #builderHeader {
   padding: var(--space-5) var(--space-5) var(--space-2);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -193,7 +188,7 @@ body {
 #builderLayout {
   display: flex;
   min-height: calc(100vh - 200px);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto var(--space-8);
   background: var(--color-panel-bg);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
@@ -206,7 +201,7 @@ body {
 /* ---- Media Library Sidebar ---- */
 
 #mediaLibrary {
-  width: var(--sidebar-width);
+  width: var(--sidebar-width-wide);
   min-width: 280px;
   max-width: 50%;
   display: flex;
@@ -793,7 +788,7 @@ body {
 /* ---- Inline preview cards (in buckets) ---- */
 
 .preview-card {
-  width: 200px;
+  width: var(--card-width-preview);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);

--- a/assets/web/insights-viewer.css
+++ b/assets/web/insights-viewer.css
@@ -26,7 +26,7 @@ body {
 
 #viewerHeader {
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 900px;
+  max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -126,7 +126,7 @@ body {
 /* ---- Content ---- */
 
 #content {
-  max-width: 900px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
@@ -277,7 +277,7 @@ body {
 }
 
 .detail-artifact-card {
-  width: 220px;
+  width: var(--card-width-preview);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -329,7 +329,7 @@ body {
 /* ---- Footer ---- */
 
 #viewerFooter {
-  max-width: 900px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   padding: var(--space-4) var(--space-5);
   background: var(--color-panel-bg);

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -61,7 +61,7 @@ body {
 #ssHeader {
   flex-shrink: 0;
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -187,7 +187,7 @@ body {
 /* Main content */
 
 #ssMain {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: 0 auto;
   background: var(--color-panel-bg);
@@ -1761,7 +1761,7 @@ body {
 /* Panel divider */
 
 #panelDivider {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: 0 auto;
   height: 12px;
@@ -1799,7 +1799,7 @@ body {
 /* Bottom panel */
 
 #bottomPanel {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: 0 auto;
   background: var(--color-panel-bg);
@@ -1813,7 +1813,7 @@ body {
   gap: var(--space-5);
   flex-shrink: 0;
   margin-bottom: var(--space-5);
-  height: 400px;
+  height: var(--bottom-panel-height);
   min-height: 120px;
   overflow: hidden;
   transition:

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -49,6 +49,14 @@
 
   var REGION_COLOR_COUNT = 8;
 
+  // Re-reads each call so dev-token-tweak widget overrides take effect live.
+  function bottomPanelHeightFromToken() {
+    var v = getComputedStyle(document.documentElement)
+      .getPropertyValue("--bottom-panel-height")
+      .trim();
+    return parseInt(v, 10) || 400;
+  }
+
   var state = {
     participants: [],
     selectedParticipant: null,
@@ -78,8 +86,8 @@
     eventSource: null,
     queuePaused: false,
     timelineDragging: false,
-    panelHeight: 340,
-    panelHeightBeforeCollapse: 340,
+    panelHeight: bottomPanelHeightFromToken(),
+    panelHeightBeforeCollapse: bottomPanelHeightFromToken(),
     bottomCollapsed: false,
     previewMaxWidth: 100,
     taskFilter: null,
@@ -6375,7 +6383,7 @@
       // --- Restore ---
       state.bottomCollapsed = false;
       var maxH = Math.round(window.innerHeight * 0.6);
-      var targetH = Math.min(state.panelHeightBeforeCollapse || 340, maxH);
+      var targetH = Math.min(state.panelHeightBeforeCollapse || bottomPanelHeightFromToken(), maxH);
 
       document.body.classList.add("bottom-animating");
       document.body.classList.remove("bottom-collapsed");

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -60,7 +60,7 @@ body {
 #studioHeader {
   flex-shrink: 0;
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -236,7 +236,7 @@ body {
   flex: 0 1 auto;
   display: flex;
   flex-direction: column;
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: 0 auto;
   background: var(--color-panel-bg);
@@ -548,7 +548,7 @@ body {
 /* Panel divider (resizable handle between sheet preview and bottom panel) */
 
 #panelDivider {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: 0 auto;
   height: 12px;
@@ -870,7 +870,7 @@ col.col-participant-col {
 /* Drop areas */
 
 #dropAreas {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
@@ -952,7 +952,7 @@ col.col-participant-col {
 
 .queue-card {
   flex-shrink: 0;
-  width: 140px;
+  width: var(--card-width-queue);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -1064,7 +1064,7 @@ col.col-participant-col {
 /* Reel timeline */
 
 #reelArea {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto var(--space-5);
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
@@ -1137,7 +1137,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 /* Stashed reels */
 
 #stashedReelsArea {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto var(--space-5);
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);
@@ -1178,7 +1178,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 
 .stash-card {
   flex-shrink: 0;
-  width: 160px;
+  width: var(--card-width-stash);
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -1273,7 +1273,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 /* Stashed artifacts */
 
 #stashedArtifactsArea {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   background: var(--color-panel-bg);
   border: 1px solid var(--color-panel-border);

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -151,7 +151,7 @@
   --z-overlay: 2000;
   --z-toast: 3000;
 
-  /* Layout (no consumers yet — Pass 2 migrates 1120px sites to var(--layout-max-width)) */
+  /* Layout */
   --layout-max-width: 1120px;
   --layout-padding-x: var(--space-5);
 
@@ -159,12 +159,12 @@
   --sidebar-width-default: 340px;
   --sidebar-width-wide: 420px;
 
-  /* Card widths (Pass 3 migrates studio queue/stash/preview cards) */
+  /* Card widths */
   --card-width-queue: 140px;
   --card-width-stash: 160px;
   --card-width-preview: 200px;
 
-  /* Bottom panel height (Pass 4 wires this through screenspace.css + screenspace.js) */
+  /* Bottom panel height (consumed by screenspace.css + screenspace.js) */
   --bottom-panel-height: 400px;
 
   /* Icon sizes */

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -36,7 +36,7 @@ body {
 #trHeader {
   flex-shrink: 0;
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -347,7 +347,7 @@ body {
 /* Main content */
 
 #trMain {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   width: 100%;
   margin: 0 auto;
   background: var(--color-panel-bg);

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -30,7 +30,7 @@ body {
 
 #pageHeader {
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -164,7 +164,7 @@ body {
 
 #timelinePane {
   padding: var(--space-5) var(--space-5) var(--space-3);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
@@ -455,7 +455,7 @@ body {
 #layout {
   display: flex;
   min-height: calc(100vh - 200px);
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto var(--space-8);
   background: var(--color-panel-bg);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
@@ -465,7 +465,7 @@ body {
 }
 
 #sidebar {
-  width: 340px;
+  width: var(--sidebar-width-default);
   min-width: 260px;
   border-right: 1px solid var(--color-border);
   padding: var(--space-4);
@@ -1142,7 +1142,7 @@ html[data-theme="dark"] .artifact-marker.selected {
 /* ---- Participant timeline viewer ---- */
 
 #playerPane {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto;
   background: var(--color-panel-bg);
   border-left: 1px solid var(--color-panel-border);
@@ -1226,7 +1226,7 @@ html[data-theme="dark"] .artifact-marker.selected {
 }
 
 #participantTimelines {
-  max-width: 1120px;
+  max-width: var(--layout-max-width);
   margin: 0 auto var(--space-8);
   background: var(--color-panel-bg);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);


### PR DESCRIPTION
## Summary
Wires consumers for the layout/card/sidebar/bottom-panel tokens added in Pass 1 (plans/FRONTEND-PLAN.md). Pass 2 swaps 28 `max-width` sites to `var(--layout-max-width)`; Pass 3 swaps 7 hardcoded card/sidebar widths to tokens (and drops insights-builder's local `--sidebar-width` var); Pass 4 wires `--bottom-panel-height` through `screenspace.css` and `screenspace.js` (via a small `getComputedStyle` helper, mirroring the existing `refreshThemeColors` pattern), eliminating the prior 400/340 mismatch. After this, the redesign sprint can retune layout dimensions by flipping a handful of tokens — live via the dev token-tweak widget or in `tokens.css`. Two deliberate visible changes in insights-viewer: main containers widen 900→1120px, and `.detail-artifact-card` shrinks 220→200px (both align with user-decision #5 in the plan).

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 759 passed
- [ ] Open Studio, drag `--layout-max-width` slider in dev token-tweak widget; main column responds
- [ ] Open Screenspace, drag `--bottom-panel-height` slider; bottom panel resizes live
- [ ] Open Insights Viewer; confirm 1120px width and 200px detail cards
- [ ] Spot-check Viewer/Gallery/Transcripts/Insights Builder/Convergence at 1120px viewport — pixel-identical to before