### PR TITLE
frontend: wire remaining layout tokens + Passes 5-7 prep

### DIFF
--- a/assets/web/gallery.css
+++ b/assets/web/gallery.css
@@ -28,7 +28,7 @@ body {
 /* Header */
 
 #pageHeader {
-  padding: var(--space-5) var(--space-5) var(--space-3);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-3);
   max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -104,8 +104,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }

--- a/assets/web/insights-builder.css
+++ b/assets/web/insights-builder.css
@@ -23,7 +23,7 @@ body {
 /* ---- Header ---- */
 
 #builderHeader {
-  padding: var(--space-5) var(--space-5) var(--space-2);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-2);
   max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -151,8 +151,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
@@ -1018,7 +1018,7 @@ body {
 
 /* ---- Responsive ---- */
 
-@media (max-width: 768px) {
+@media (max-width: 768px) /* --bp-tablet */ {
   #builderHeader,
   #builderLayout {
     margin-left: var(--space-2);

--- a/assets/web/insights-builder.js
+++ b/assets/web/insights-builder.js
@@ -652,11 +652,9 @@
       }
     }
 
-    // Position
-    var rect = e.currentTarget.getBoundingClientRect();
-    popover.style.top = Math.min(rect.bottom + 4, window.innerHeight - 160) + "px";
-    popover.style.left = Math.min(rect.left, window.innerWidth - 170) + "px";
+    // Position — make popover measurable first so offsetWidth/Height read correctly.
     popover.classList.remove("hidden");
+    positionPopoverAnchored(popover, e.currentTarget.getBoundingClientRect());
   }
 
   function onPopoverBucketClick(e) {

--- a/assets/web/insights-viewer.css
+++ b/assets/web/insights-viewer.css
@@ -25,7 +25,7 @@ body {
 /* ---- Header ---- */
 
 #viewerHeader {
-  padding: var(--space-5) var(--space-5) var(--space-3);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-3);
   max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -91,8 +91,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }

--- a/assets/web/metadata.css
+++ b/assets/web/metadata.css
@@ -64,8 +64,8 @@
 /* Icons via mask-image */
 .md-icon {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: currentColor;
   mask-size: contain;
   mask-repeat: no-repeat;
@@ -195,8 +195,8 @@
 
 .md-section-chevron {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: var(--color-text-dim);
   mask-image: url("icons/chevron-down.svg");
   -webkit-mask-image: url("icons/chevron-down.svg");
@@ -580,8 +580,8 @@
 
 .md-outlier-icon {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: var(--sev-high);
   mask-image: url("icons/exclamation-triangle.svg");
   -webkit-mask-image: url("icons/exclamation-triangle.svg");

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -35,8 +35,8 @@ body {
  * Used in tooltip headers, multitool step badges, and result rows. */
 .ss-task-icon {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: currentColor;
   mask-size: contain;
   mask-repeat: no-repeat;
@@ -60,7 +60,7 @@ body {
 
 #ssHeader {
   flex-shrink: 0;
-  padding: var(--space-5) var(--space-5) var(--space-3);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-3);
   max-width: var(--layout-max-width);
   width: 100%;
   margin: var(--space-5) auto 0;
@@ -152,8 +152,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
@@ -650,8 +650,8 @@ body {
 
 .amplitude-btn-icon {
   display: block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: currentColor;
   mask-image: url("/screenspace/icons/signal.svg");
   mask-size: contain;
@@ -963,8 +963,8 @@ body {
 
 .scan-mode-fast-icon {
   display: inline-block;
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-xs);
+  height: var(--icon-size-xs);
   background: var(--color-warning, #f59e0b);
   mask-size: contain;
   mask-repeat: no-repeat;
@@ -1102,8 +1102,8 @@ body {
 }
 
 .model-view-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: currentColor;
   mask-image: url("/screenspace/icons/eye.svg");
   mask-size: contain;
@@ -1377,8 +1377,8 @@ body {
 
 .multitool-operator-icon {
   display: inline-block;
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-xs);
+  height: var(--icon-size-xs);
   background-color: currentColor;
   -webkit-mask-image: url("/screenspace/icons/plus.svg");
           mask-image: url("/screenspace/icons/plus.svg");
@@ -1680,8 +1680,8 @@ body {
 
 .ss-template-icon-btn__glyph {
   display: block;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   flex-shrink: 0;
   background-color: currentColor;
   mask-size: contain;
@@ -1902,8 +1902,8 @@ body.panel-dragging #bottomPanel {
 }
 
 .rp-tab-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background: currentColor;
   mask-size: contain;
   -webkit-mask-size: contain;
@@ -1925,8 +1925,8 @@ body.panel-dragging #bottomPanel {
 }
 
 .rp-tab-chevron {
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-xs);
+  height: var(--icon-size-xs);
   background: currentColor;
   mask-image: url("/screenspace/icons/chevron-down.svg");
   -webkit-mask-image: url("/screenspace/icons/chevron-down.svg");
@@ -2429,8 +2429,8 @@ body.panel-dragging #bottomPanel {
 }
 
 .rp-icon-btn-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background: currentColor;
   mask-size: contain;
   -webkit-mask-size: contain;
@@ -2884,7 +2884,7 @@ html[data-theme="dark"] .stash-card-name:focus {
 
 /* Responsive */
 
-@media (max-width: 768px) {
+@media (max-width: 768px) /* --bp-tablet */ {
   #ssHeader,
   #ssMain,
   #panelDivider,

--- a/assets/web/settings-modal.css
+++ b/assets/web/settings-modal.css
@@ -323,8 +323,8 @@
 
 .settings-trigger-icon {
   display: inline-block;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   background-color: currentColor;
   -webkit-mask-image: url("icons/cog-6-tooth.svg");
   mask-image: url("icons/cog-6-tooth.svg");

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -38,8 +38,8 @@ html {
 .cg-icon--bars-3      { mask-image: url(icons/bars-3.svg);      -webkit-mask-image: url(icons/bars-3.svg); }
 .cg-icon--squares-2x2 { mask-image: url(icons/squares-2x2.svg); -webkit-mask-image: url(icons/squares-2x2.svg); }
 .cg-icon--confirm {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   vertical-align: text-bottom;
   margin-right: 4px;
 }
@@ -59,7 +59,7 @@ body {
 
 #studioHeader {
   flex-shrink: 0;
-  padding: var(--space-5) var(--space-5) var(--space-3);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-3);
   max-width: var(--layout-max-width);
   width: 100%;
   margin: var(--space-5) auto 0;
@@ -146,8 +146,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
@@ -234,6 +234,7 @@ body {
 
 #sheetPreview {
   flex: 0 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   max-width: var(--layout-max-width);
@@ -512,8 +513,8 @@ body {
 }
 
 .filter-clear .cg-icon {
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-xs);
+  height: var(--icon-size-xs);
 }
 
 #sheetLoading {
@@ -2054,7 +2055,7 @@ html[data-theme="dark"] .log-panel {
 
 /* ---- Responsive ---- */
 
-@media (max-width: 768px) {
+@media (max-width: 768px) /* --bp-tablet */ {
   #studioHeader,
   #sheetPreview,
   #panelDivider,

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -25,10 +25,8 @@
  * SIDEBAR:    --sidebar-width-default | --sidebar-width-wide
  * CARD WIDTH: --card-width-queue | --card-width-stash | --card-width-preview
  * PANEL:      --bottom-panel-height
- * ICON SIZE:  --icon-size-xs (12px) | --icon-size-sm (14px) | --icon-size-md (16px) | --icon-size-lg (20px)
- *
- * NOTE: layout/sidebar/card-width/panel/icon-size tokens are seeded with current
- *   values; no consumers yet (they're tunable in the dev token-tweak widget).
+ * ICON SIZE:  --icon-size-xs (12px) | --icon-size-sm (14px) | --icon-size-md (16px) | --icon-size-lg (20px) | --icon-size-xl (24px)
+ * BREAKPOINT: --bp-tablet (768px) — documentation/JS-read only, see note below
  */
 
 :root {
@@ -172,6 +170,14 @@
   --icon-size-sm: 14px;
   --icon-size-md: 16px;
   --icon-size-lg: 20px;
+  --icon-size-xl: 24px;
+
+  /* Breakpoints — for documentation + JS reads only. CSS @media queries
+   * cannot consume var() in their conditions; tweaking the dev widget will
+   * not change layout breakpoints, only any JS that reads this value. Each
+   * @media (max-width: 768px) site carries a "--bp-tablet" comment marker
+   * so a grep finds them via the token name. */
+  --bp-tablet: 768px;
 }
 
 /* Dark theme — OS preference (applies when user hasn't manually toggled) */
@@ -418,8 +424,8 @@ body:not(.cg-grid-bg-on) {
 }
 .frontend-switcher-chevron {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   align-self: center;
   background-color: currentColor;
   mask-image: url("icons/chevron-down.svg");

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -35,7 +35,7 @@ body {
 
 #trHeader {
   flex-shrink: 0;
-  padding: var(--space-5) var(--space-5) var(--space-3);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-3);
   max-width: var(--layout-max-width);
   width: 100%;
   margin: var(--space-5) auto 0;
@@ -188,8 +188,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
@@ -430,8 +430,8 @@ body {
 }
 
 .player-btn-icon {
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   display: inline-block;
   background: currentColor;
   mask-size: contain;
@@ -607,8 +607,8 @@ body {
 }
 
 .summary-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   flex-shrink: 0;
   background: var(--color-text-dim);
   mask-image: url(icons/sparkles.svg);
@@ -641,8 +641,8 @@ body {
 }
 
 .summary-chevron {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background: var(--color-text-dim);
   mask-image: url(icons/chevron-down.svg);
   -webkit-mask-image: url(icons/chevron-down.svg);
@@ -721,8 +721,8 @@ body {
 }
 
 .summary-action-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background: var(--color-text-dim);
   mask-size: contain;
   -webkit-mask-size: contain;
@@ -1066,8 +1066,8 @@ body {
 
 .segment-copy-icon {
   display: block;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: currentColor;
   mask-image: url(icons/clipboard.svg);
   -webkit-mask-image: url(icons/clipboard.svg);
@@ -1229,8 +1229,8 @@ body {
   position: absolute;
   inset: 0;
   margin: auto;
-  width: 14px;
-  height: 14px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   background-color: currentColor;
   mask-size: contain;
   mask-repeat: no-repeat;
@@ -1283,8 +1283,8 @@ body {
 
 .pill-chevron {
   display: inline-block;
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-xs);
+  height: var(--icon-size-xs);
   background-color: currentColor;
   color: var(--color-text-dim);
   mask-size: contain;

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2958,9 +2958,7 @@
   }
 
   function _positionPillOptions(pane, wrap) {
-    var rect = wrap.getBoundingClientRect();
-    pane.style.top = rect.bottom + 4 + "px";
-    pane.style.left = rect.left + "px";
+    positionPopoverAnchored(pane, wrap.getBoundingClientRect());
   }
 
   function _closeOpenPaneInDom() {

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -309,6 +309,23 @@ var positionTooltipAnchored = function (tooltipEl, anchorRect) {
   tooltipEl.style.top = top + "px";
 };
 
+// Position a popover element bottom-left aligned with an anchor rect, flipping
+// above if there's no room below, and clamping to the viewport with 4px
+// margins. Reads the popover's actual offsetWidth/Height — the popover must
+// be in the DOM and visible (not display:none) before calling.
+var positionPopoverAnchored = function (popoverEl, anchorRect) {
+  var w = popoverEl.offsetWidth;
+  var h = popoverEl.offsetHeight;
+  var top = anchorRect.bottom + 4;
+  if (top + h > window.innerHeight - 4) top = anchorRect.top - h - 4;
+  if (top < 4) top = 4;
+  var left = anchorRect.left;
+  if (left + w > window.innerWidth - 4) left = window.innerWidth - w - 4;
+  if (left < 4) left = 4;
+  popoverEl.style.left = left + "px";
+  popoverEl.style.top = top + "px";
+};
+
 // ---- Debounce / escaping / color / toast (shared across Studio tabs + web UIs) ----
 
 var debounce = function (fn, ms) {

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -29,7 +29,7 @@ body {
 /* Header */
 
 #pageHeader {
-  padding: var(--space-5) var(--space-5) var(--space-3);
+  padding: var(--space-5) var(--layout-padding-x) var(--space-3);
   max-width: var(--layout-max-width);
   margin: var(--space-5) auto 0;
   background: var(--color-panel-bg);
@@ -128,8 +128,8 @@ body {
 
 .theme-toggle-icon {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
   border-radius: var(--radius-full);
   transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
 }
@@ -811,6 +811,7 @@ body {
 
 #detailPane {
   flex: 1;
+  min-width: 0;
   padding: var(--space-5) var(--space-5);
   overflow-y: auto;
   max-height: calc(100vh - 200px);
@@ -1324,7 +1325,7 @@ html[data-theme="dark"] .artifact-marker.selected {
 
 /* Responsive */
 
-@media (max-width: 768px) {
+@media (max-width: 768px) /* --bp-tablet */ {
   #layout {
     flex-direction: column;
     border-radius: 0 0 var(--radius-lg) var(--radius-lg);


### PR DESCRIPTION
## Summary

- Wires the unused tokens from Pass 1 (`--layout-padding-x`, `--icon-size-{xs,sm,md,lg}`) onto consumers across 7 UIs and 10 CSS files; adds `--icon-size-xl: 24px` to complete the ladder.
- Pass 5: adds defensive `min-width: 0` to `#detailPane` (viewer) and `#sheetPreview` (studio) so flex children with overflow can shrink.
- Pass 6: adds documentation-only `--bp-tablet: 768px` token + `/* --bp-tablet */` markers next to each `@media (max-width: 768px)` site (var() can't appear in @media conditions, so this is grep-as-source-of-truth).
- Pass 7: extracts `positionPopoverAnchored()` in utils.js; replaces hand-rolled popover positioning in `insights-builder.js` (artifact-add popover) and `transcripts.js` (pill options menu), gaining viewport clamping + flip-above behavior.

No visual change at the current 1120px column. Plan: [plans/FRONTEND-PLAN.md](../blob/master/plans/FRONTEND-PLAN.md).

## Test plan

- [x] `uvx ruff check && uvx ruff format --check` — clean
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 759/759 passing
- [ ] Visual: open Studio/Viewer/Insights Builder/Screenspace/Transcripts at 1120px and confirm pixel-identical to master
- [ ] Dev widget: verify `--layout-padding-x`, `--icon-size-*`, and `--bp-tablet` show up in the live token-tweak panel
- [ ] Pass 5: resize browser to ~1000px and confirm viewer detail pane no longer pushes the sidebar off-screen
- [ ] Pass 7: open insights-builder artifact-add popover near the right/bottom edge and the transcripts pill options near the right edge — both stay on-screen