### PR TITLE
fix(studio): expand Find Highlights clips into segments before queueing

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2821,7 +2821,10 @@
         if (data.ok && data.clips && data.clips.length > 0) {
           state.reelQueue = [];
           for (var i = 0; i < data.clips.length; i++) {
-            state.reelQueue.push(data.clips[i]);
+            var entries = expandCellToSegments(data.clips[i]);
+            for (var ei = 0; ei < entries.length; ei++) {
+              state.reelQueue.push(entries[ei]);
+            }
           }
           renderReelQueue();
           updateCellClasses();


### PR DESCRIPTION
## Summary
- Find Highlights pushed raw `{participant, row, desc, timestamp}` records straight into `state.reelQueue`, but `renderReelQueue` expects `start` / `end` — so thumbnails resolved to `/api/thumbnail/<p>/undefined` (400) and durations rendered as `NaN`.
- Route highlights through the same `expandCellToSegments` helper used by drag-drop and bulk intake, so the queue gets per-segment entries with `start`, `end`, `segIdx`, `segTotal` and renders correctly.

## Test plan
- [ ] `uv run clipgen.py --studio`, click **Find Highlights**, confirm cards show thumbnails and durations.
- [ ] Multi-segment cells render as `Pxx.row (1/2)`, `(2/2)` like a regular drag.
- [ ] Server log: no `GET /api/thumbnail/.../undefined` 400s.
- [ ] `uv run --extra dev pytest tests/test_studio_api.py` (no API change, should still pass).