### PR TITLE
perf(web): defensive drag-perf cleanups + disable RAF grid-bg & token-tweak

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -914,6 +914,13 @@ col.col-participant-col {
   background-color: var(--color-cell-hover);
 }
 
+/* Cheap insurance: most browsers suppress :hover during HTML5 drag, but with
+ * many cells in the grid this guarantees no per-cell repaint cost. */
+body.dragging .ts-cell:hover {
+  background-color: inherit;
+  transition: none;
+}
+
 .ts-cell.selected {
   background-color: var(--color-cell-selected);
 }
@@ -1139,6 +1146,13 @@ col.col-participant-col {
   background-color: var(--color-selected);
 }
 
+/* During drag, skip the color transition. An instant flip is invisible to
+ * the user and avoids per-frame repaint cost beneath the floating nav's
+ * (now-suspended) backdrop-filter. */
+body.dragging .drop-target {
+  transition: none;
+}
+
 .drop-target-empty {
   display: flex;
   align-items: center;
@@ -1209,8 +1223,12 @@ col.col-participant-col {
   position: relative;
   transition: box-shadow var(--duration-fast), border-color var(--duration-fast);
   user-select: none;
-  will-change: transform;
 }
+
+/* No will-change on .queue-card. The original always-on rule promoted every
+ * card to its own composited layer; HTML5 drag never transforms the source
+ * card, so the hint was misapplied. With many cards, the layer count alone
+ * was saturating the compositor during drag. */
 
 .queue-card:active {
   cursor: grabbing;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -226,24 +226,52 @@
     return result;
   }
 
+  // Cached once — `--radius` lives on :root in tokens.css and isn't expected to
+  // change at runtime. Avoids a getComputedStyle call inside setCardDragImage,
+  // which is on the dragstart hot path.
+  var _cardDragImageRadius = null;
+  function getCardDragImageRadius() {
+    if (_cardDragImageRadius !== null) return _cardDragImageRadius;
+    var raw = getComputedStyle(document.documentElement).getPropertyValue("--radius").trim();
+    _cardDragImageRadius = raw ? "calc(" + raw + " - 2px)" : "4px";
+    return _cardDragImageRadius;
+  }
+
   function setCardDragImage(ev, card) {
     var clone = card.cloneNode(true);
-    var computed = window.getComputedStyle(card);
+    var rect = card.getBoundingClientRect();
     clone.style.position = "absolute";
     clone.style.top = "-9999px";
     clone.style.left = "-9999px";
-    clone.style.width = card.offsetWidth + "px";
+    clone.style.width = rect.width + "px";
     clone.style.zIndex = "-1";
     // Some Chromium versions render the drag-image bitmap without honoring the
     // class-driven border-radius / overflow clip, leaving square corners on
     // an otherwise rounded card. Pin them inline on the clone so the snapshot
     // captures the rounding.
-    clone.style.borderRadius = computed.borderRadius;
+    clone.style.borderRadius = getCardDragImageRadius();
     clone.style.overflow = "hidden";
     document.body.appendChild(clone);
-    var rect = card.getBoundingClientRect();
     ev.dataTransfer.setDragImage(clone, ev.clientX - rect.left, ev.clientY - rect.top);
     setTimeout(function () { document.body.removeChild(clone); }, 0);
+  }
+
+  // Single capture-phase gate: while a drag is in flight, `body.dragging` is
+  // set so CSS can suspend expensive effects (backdrop-filter on the floating
+  // nav, drop-target transitions, hover paint, etc.). Centralized here instead
+  // of patched into every dragstart handler — see studio.css / topnav.css /
+  // tokens.css for the matching rules.
+  function bindDragGate() {
+    function clear() { document.body.classList.remove("dragging"); }
+    document.addEventListener("dragstart", function () {
+      document.body.classList.add("dragging");
+    }, true);
+    document.addEventListener("dragend", clear, true);
+    document.addEventListener("drop", clear, true);
+    window.addEventListener("blur", clear);
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) clear();
+    });
   }
 
   // ---- Filtering ----
@@ -1635,7 +1663,9 @@
     target.addEventListener("dragover", function (ev) {
       ev.preventDefault();
       ev.dataTransfer.dropEffect = "copy";
-      target.classList.add("drag-over");
+      // dragover fires ~60Hz; skip the no-op write when the class is already
+      // applied so we don't churn the attribute / invalidate style.
+      if (!target.classList.contains("drag-over")) target.classList.add("drag-over");
     });
     target.addEventListener("dragleave", function (ev) {
       if (!target.contains(ev.relatedTarget)) {
@@ -4301,6 +4331,7 @@
     initPreviewTabs();
     initDropTargets();
     initWheelScroll();
+    bindDragGate();
     bindReelReorder();
     bindButtons();
     loadStoredBottomHeight();

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -596,6 +596,18 @@ body:not(.cg-grid-bg-on) {
   #trSubheader { background: var(--bg); }
 }
 
+/* See body.dragging .topnav in topnav.css — same rationale: backdrop-filter
+ * over an animating drop-target background is the primary compositor cost
+ * during drag. */
+body.dragging .subheader,
+body.dragging #studioSubheader,
+body.dragging #ssSubheader,
+body.dragging #trSubheader {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  background: var(--bg);
+}
+
 .subheader-left {
   display: flex;
   align-items: center;

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -31,6 +31,17 @@
   .topnav { background: var(--bg); }
 }
 
+/* During an active drag, swap the glass nav for a solid bar. The 14px blur is
+ * GPU-rasterized but invalidated whenever any pixel beneath the strip
+ * repaints — including drop-target color flips on every dragover — which
+ * starves the compositor and visibly lags the OS-rendered drag image. The
+ * gate is `body.dragging`, set by bindDragGate() in studio.js. */
+body.dragging .topnav {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  background: var(--bg);
+}
+
 .topnav-left,
 .topnav-right {
   flex: 1 1 0;

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -11,14 +11,17 @@
 // ---- Feature flags ----
 
 // Animated canvas dot-grid background (grid-bg.js). When false, falls back to
-// the static CSS line-grid defined in tokens.css.
-var CLIPGEN_ANIMATED_BG = true;
+// the static CSS line-grid defined in tokens.css. Disabled: the full-viewport
+// canvas repaints every frame (RAF loop with ambient shimmer + drag-wake
+// pulses), which combined with the floating-nav backdrop-filter strips
+// saturates the compositor and visibly lags drag operations.
+var CLIPGEN_ANIMATED_BG = false;
 
 // Live token-tweak debug widget (dev-token-tweak.js). When false, the widget
 // script bails on load and never mounts. Flip to false during a build, or
 // when not iterating on the redesign. The widget never ships in exports
 // either way — viewer.py strips data-dev-only tags during inlining.
-var CLIPGEN_DEV_TOKEN_TWEAK = true;
+var CLIPGEN_DEV_TOKEN_TWEAK = false;
 
 // ---- Canonical config (mirror of config.py via utils.get_frontend_config)
 //


### PR DESCRIPTION
## Summary

Investigated reported card-drag stutter in Studio — the actual symptom turned out to be system-side (reproduces on \`about:blank\` with a tiny draggable element too), so this is a bundle of small defensive cleanups rather than a hero fix. Each item was a pre-existing misapplication or always-on cost worth removing regardless:

- Single \`body.dragging\` gate (capture-phase listeners) so CSS can scope drag-only effects without patching every dragstart/dragend handler.
- Suspend topnav + subheader \`backdrop-filter: blur(14px)\` during drag, skip drop-target color transitions, drop the redundant \`classList.add("drag-over")\` write that fires on every dragover.
- Remove always-on \`will-change: transform\` from \`.queue-card\` (HTML5 drag never transforms the source card; the hint promoted every card to its own composited layer for nothing); cache \`--radius\` in \`setCardDragImage\` instead of a \`getComputedStyle\` per dragstart; neutralize \`.ts-cell:hover\` during drag.
- Disable \`CLIPGEN_ANIMATED_BG\` (full-viewport canvas RAF loop with drag-wake pulses — real continuous cost) and \`CLIPGEN_DEV_TOKEN_TWEAK\` (debug widget, off by default).

## Test plan

- [x] \`uv run ruff format --check\` / \`uv run ruff check --fix\` / \`uv run ty check\` — all green
- [x] \`uv run --extra dev pytest -c tests/pytest.ini\` — 734 passed
- [ ] Smoke-test in Studio: drag artifact card, reel card, screenspace intake, transcript intake, sheet cell, reel reorder — all four entry points still work
- [ ] Verify static CSS line-grid renders correctly with \`CLIPGEN_ANIMATED_BG = false\`
- [ ] Verify backdrop-filter reappears on dragend (open Elements, drag, drop, confirm \`body.dragging\` clears)