### PR TITLE
fix(cli): rename -y/--yes to --no-input and harden non-interactive guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ uv run clipgen.py
 clipgen can also be launched noninteractively, meaning you can script it as part of your workflows. For example:
 
 ```shell
-uv run clipgen.py -R -H                # Highlight reel of the most severe issues
-uv run clipgen.py -b -y                # Batch: all clips in study
-uv run clipgen.py -l 5+7+12 -y         # Lines: rows 5, 7, 12
-uv run clipgen.py -r 5-12 -y           # Range: rows 5–12
-uv run clipgen.py -C "Onboarding" -y   # Category
-uv run clipgen.py --gif -b -y          # GIFs instead of clips
+uv run clipgen.py -R -H                       # Highlight reel of the most severe issues
+uv run clipgen.py -b --no-input               # Batch: all clips in study
+uv run clipgen.py -l 5+7+12 --no-input        # Lines: rows 5, 7, 12
+uv run clipgen.py -r 5-12 --no-input          # Range: rows 5–12
+uv run clipgen.py -C "Onboarding" --no-input  # Category
+uv run clipgen.py --gif -b --no-input         # GIFs instead of clips
 ```
 
 Run `uv run clipgen.py --help` for the full flag reference.

--- a/agents/skills/generate/SKILL.md
+++ b/agents/skills/generate/SKILL.md
@@ -33,7 +33,7 @@
 
 ## Other useful flags
 
-- `-y` — skip confirmation prompts (good for agent automation)
+- `--no-input` — non-interactive mode: skip confirmation prompts and fail fast on prompts that would block on stdin (good for agent automation)
 - `--manifest` — write `clipgen_manifest.json` alongside artifacts
 - `--viewer` — generate `clips_viewer.html` timeline viewer
 - `--transcribe` — generate transcript files alongside artifacts
@@ -49,7 +49,7 @@ Source videos must be named `{study}_{participant}.mp4` — e.g. `mystudy_P01.mp
 |-----------------|---------|
 | "clips for P01 and P03" | `uv run clipgen.py -p P01+P03 -s "Study" -i . -o ./clips` |
 | "screenshots of rows 3 through 7" | `uv run clipgen.py --screen -r 3-7 -s "Study" -i . -o ./clips` |
-| "everything, no prompts" | `uv run clipgen.py -b -y -s "Study" -i . -o ./clips` |
+| "everything, no prompts" | `uv run clipgen.py -b --no-input -s "Study" -i . -o ./clips` |
 | "highlight reel, 2 minutes" | `uv run clipgen.py -H 120 -s "Study" -i . -o ./clips` |
 | "annotated clips only" | `uv run clipgen.py -k -s "Study" -i . -o ./clips` |
 | "critical and high severity" | `uv run clipgen.py -S Critical,High -s "Study" -i . -o ./clips` |

--- a/cli.py
+++ b/cli.py
@@ -82,7 +82,7 @@ Examples:
   python clipgen.py -b -s "Study Name"     Batch mode with specific spreadsheet
   python clipgen.py -s excel               Use the only .xlsx in cwd (fails if 0 or many)
   python clipgen.py -s ./notes.xlsx        Batch with local Excel workbook
-  python clipgen.py -l 5 -y                Line mode, skip confirmation prompts
+  python clipgen.py -l 5 --no-input        Line mode, non-interactive (no prompts)
   python clipgen.py -b -v                  Batch mode with verbose output
   python clipgen.py -R "11, 13-16, P01, \\"Observations\\""  Reel mode - one combined video
   python clipgen.py -T P01                 Chronologic mode - chronological reel for participant P01
@@ -239,7 +239,7 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         metavar="ID",
         default=None,
         help="Run the summary thinking agent over already-transcribed participants. "
-        "No IDs = all transcribed. Existing summaries are kept unless -y is passed.",
+        "No IDs = all transcribed. Existing summaries are kept unless --no-input is passed.",
     )
     transcription.add_argument(
         "--citations",
@@ -247,7 +247,7 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
         metavar="ID",
         default=None,
         help="Run the citation thinking agent over participants that already have a summary. "
-        "No IDs = all eligible. Existing citations are kept unless -y is passed.",
+        "No IDs = all eligible. Existing citations are kept unless --no-input is passed.",
     )
 
     ai_opts = parser.add_argument_group("AI models")
@@ -616,10 +616,10 @@ Note: Non-interactive mode (using -b, -l, -r, -C, -c, -p, -k, -S, -M, -R, or -T)
 
     run_opts = parser.add_argument_group("run options")
     run_opts.add_argument(
-        "-y",
-        "--yes",
+        "--no-input",
+        dest="no_input",
         action="store_true",
-        help="Skip confirmation prompts (auto-confirm)",
+        help="Non-interactive mode: skip confirmation prompts and fail fast on prompts that would block on stdin (for programmatic use)",
     )
     run_opts.add_argument(
         "-v",
@@ -897,7 +897,7 @@ def _generate_cli_clips(
     cli_mode_args: CliModeArgs,
 ) -> list[ClipRecord]:
     """Resolve CLI arguments into a list of clip records."""
-    skip_prompts = args.yes
+    skip_prompts = args.no_input
     mixed_selectors = getattr(args, "mixed", None)
     output_format = "screen" if args.screen else "gif" if args.gif else "clip"
 
@@ -2382,8 +2382,10 @@ def _run_summarize(args: argparse.Namespace) -> None:
             utils.warning_print(f"{pid}: no transcript entry; skipping.")
             skipped += 1
             continue
-        if entry.get("summary") and not args.yes:
-            utils.info_print(f"{pid}: summary already present; skip (-y to overwrite).")
+        if entry.get("summary") and not args.no_input:
+            utils.info_print(
+                f"{pid}: summary already present; skip (--no-input to overwrite)."
+            )
             skipped += 1
             continue
         utils.info_print(f"Summarizing {pid}...")
@@ -2428,9 +2430,9 @@ def _run_citations(args: argparse.Namespace) -> None:
             utils.warning_print(f"{pid}: no summary yet; run --summarize first.")
             skipped += 1
             continue
-        if entry.get("citations") and not args.yes:
+        if entry.get("citations") and not args.no_input:
             utils.info_print(
-                f"{pid}: citations already present; skip (-y to overwrite)."
+                f"{pid}: citations already present; skip (--no-input to overwrite)."
             )
             skipped += 1
             continue
@@ -3116,6 +3118,7 @@ def main() -> None:
     setup_encoding()
 
     args = parse_arguments()
+    utils.NO_INPUT_MODE = bool(getattr(args, "no_input", False))
     if config.DEBUGGING:
         ic(args)
 

--- a/clipgen.py
+++ b/clipgen.py
@@ -281,6 +281,15 @@ def _handle_spreadsheet_command(
 
 def select_spreadsheet(gspread_client: Any, doc_list: list[str]) -> Any:
     """Interactive spreadsheet selection. Returns the selected worksheet."""
+    if utils.NO_INPUT_MODE:
+        utils.error_print(
+            "Spreadsheet selection requires -s in non-interactive mode.",
+            [
+                "Pass -s <name|url|index|./file.xlsx>",
+                "Or omit --no-input to select interactively.",
+            ],
+        )
+        sys.exit(2)
     consecutive_open_failures = 0
     utils.print_mode_heading("Spreadsheet selection", "mode.spreadsheet")
 
@@ -1109,6 +1118,15 @@ def _dispatch_interactive_mode(
 
 def run_interactive_mode(worksheet: Any) -> None:
     """Execute interactive mode - main processing loop."""
+    if utils.NO_INPUT_MODE:
+        utils.error_print(
+            "No CLI mode flag provided; cannot enter interactive mode under --no-input.",
+            [
+                "Pass one of: -b, -l, -r, -c, -p, -k, -S, -M, -R, -T, -H, --highlights",
+                "Or a UI flag: --studio, --screenspace, --transcripts",
+            ],
+        )
+        sys.exit(2)
     viewer.INTERACTIVE_ARTIFACTS.clear()
     viewer.INTERACTIVE_REELS.clear()
 

--- a/excel_io.py
+++ b/excel_io.py
@@ -148,6 +148,15 @@ def select_excel_file() -> ExcelSheetAdapter | None:
         utils.standard_print(f"Opening Excel file: {Path(paths[0]).name}")
         return open_excel_workbook(paths[0])
     # Multiple files: list and prompt
+    if utils.NO_INPUT_MODE:
+        utils.error_print(
+            "Multiple .xlsx files in current directory; cannot pick one in non-interactive mode.",
+            [
+                f"Found: {', '.join(Path(p).name for p in paths)}",
+                "Pass -s ./path/to/file.xlsx explicitly.",
+            ],
+        )
+        return None
     utils.info_print("Excel files in current directory:")
     for i, p in enumerate(paths, 1):
         utils.info_print(f"  {i}. {Path(p).name}")
@@ -197,6 +206,14 @@ def prompt_for_excel_fallback() -> ExcelSheetAdapter | None:
     credentials troubleshooting, or an empty input to cancel. Returns the
     opened ExcelSheetAdapter, or None if the user cancelled.
     """
+    if utils.NO_INPUT_MODE:
+        utils.error_print(
+            "Google authentication failed and the Excel fallback prompt is interactive.",
+            [
+                "Pass -s ./path/to/file.xlsx to use a local Excel file in non-interactive mode."
+            ],
+        )
+        return None
     utils.info_print(
         "No Google credentials available — you can work with a local Excel file instead."
     )

--- a/pipeline.py
+++ b/pipeline.py
@@ -101,7 +101,7 @@ def _check_source_video(
     # Sort by similarity descending, then file size descending as tiebreaker
     candidates.sort(key=lambda c: (c[0], c[1]), reverse=True)
 
-    if candidates and candidates[0][0] >= 0.7:
+    if candidates and candidates[0][0] >= 0.7 and not utils.NO_INPUT_MODE:
         best_ratio, best_size, best_path = candidates[0]
         size_gb = best_size / 1_000_000_000
         # Pause progress bar so the prompt is visible and input is rendered

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -822,7 +822,7 @@ def generate_list(
         line_numbers: List of line numbers for 'line' mode
         range_start: Start line for 'range' mode
         range_end: End line for 'range' mode
-        skip_prompts: If True, skip confirmation prompts (CLI -y flag, for batch/keyword)
+        skip_prompts: If True, skip confirmation prompts (CLI --no-input flag, for batch/keyword)
         cell_specs: List of (participant_id, row_number) tuples for 'cell' mode
         participant_id: Participant ID(s) for 'participant' mode (comma/plus-separated string)
         reel_input: Reel selector string for 'reel' mode

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -23,7 +23,7 @@ def _base_args(**overrides):
         "highlights": None,
         "screen": False,
         "gif": False,
-        "yes": False,
+        "no_input": False,
         "verbose": False,
         "spreadsheet": None,
         "viewer": False,
@@ -166,7 +166,7 @@ def test_run_cli_mode_rejects_reel_with_gif():
     "args_overrides,parsed_kwargs,mode,gen_kwargs,process_attr,process_kwargs",
     [
         (
-            {"batch": True, "yes": True},
+            {"batch": True, "no_input": True},
             {},
             "batch",
             {"skip_prompts": True},
@@ -174,7 +174,7 @@ def test_run_cli_mode_rejects_reel_with_gif():
             {"output_format": "clip", "include_severity": False},
         ),
         (
-            {"lines": "5", "screen": True, "yes": True},
+            {"lines": "5", "screen": True, "no_input": True},
             {"line_numbers": [5]},
             "line",
             {"line_numbers": [5], "skip_prompts": True},
@@ -182,7 +182,7 @@ def test_run_cli_mode_rejects_reel_with_gif():
             {"output_format": "screen", "include_severity": False},
         ),
         (
-            {"category": "Observations,Onboarding", "yes": True},
+            {"category": "Observations,Onboarding", "no_input": True},
             {},
             "category",
             {"skip_prompts": True, "categories": ["Observations", "Onboarding"]},
@@ -190,7 +190,7 @@ def test_run_cli_mode_rejects_reel_with_gif():
             {"output_format": "clip", "include_severity": False},
         ),
         (
-            {"reel": "11, P01.5", "yes": True},
+            {"reel": "11, P01.5", "no_input": True},
             {},
             "reel",
             {"reel_input": "11, P01.5", "skip_prompts": True},

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -24,7 +24,7 @@ def _args(**overrides):
         highlights=None,
         screen=False,
         gif=False,
-        yes=False,
+        no_input=False,
         verbose=False,
         spreadsheet=None,
         viewer=False,

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -24,7 +24,7 @@ def _ss_args(**overrides):
         "highlights": None,
         "screen": False,
         "gif": False,
-        "yes": False,
+        "no_input": False,
         "verbose": False,
         "spreadsheet": None,
         "viewer": False,

--- a/tests/test_cli_thinking_agents_args.py
+++ b/tests/test_cli_thinking_agents_args.py
@@ -23,7 +23,7 @@ def _agent_args(**overrides):
         "highlights": None,
         "screen": False,
         "gif": False,
-        "yes": False,
+        "no_input": False,
         "verbose": False,
         "spreadsheet": None,
         "viewer": False,
@@ -177,7 +177,7 @@ def test_summarize_specific_ids_only(monkeypatch):
     assert "summary" not in final.get("P01", {})
 
 
-def test_summarize_skips_existing_without_yes(monkeypatch, capsys):
+def test_summarize_skips_existing_without_no_input(monkeypatch, capsys):
     saved = []
 
     def fake_save(source_transcripts, corrections, marks=None):
@@ -193,7 +193,7 @@ def test_summarize_skips_existing_without_yes(monkeypatch, capsys):
 
     monkeypatch.setattr(thinking_agents, "summarize_transcript", lambda segs: "NEW")
 
-    args = _agent_args(summarize=["P01"], yes=False)
+    args = _agent_args(summarize=["P01"], no_input=False)
     cli._run_summarize(args)
 
     out = capsys.readouterr().out
@@ -202,7 +202,7 @@ def test_summarize_skips_existing_without_yes(monkeypatch, capsys):
     assert manifest["source_transcripts"]["P01"]["summary"] == "old"
 
 
-def test_summarize_overwrites_with_yes(monkeypatch):
+def test_summarize_overwrites_with_no_input(monkeypatch):
     saved = []
 
     def fake_save(source_transcripts, corrections, marks=None):
@@ -218,7 +218,7 @@ def test_summarize_overwrites_with_yes(monkeypatch):
 
     monkeypatch.setattr(thinking_agents, "summarize_transcript", lambda segs: "NEW")
 
-    args = _agent_args(summarize=["P01"], yes=True)
+    args = _agent_args(summarize=["P01"], no_input=True)
     cli._run_summarize(args)
 
     assert saved[-1]["P01"]["summary"] == "NEW"

--- a/tests/test_no_input_guards.py
+++ b/tests/test_no_input_guards.py
@@ -1,0 +1,127 @@
+"""Tests for --no-input flag parsing and the targeted blocking-prompt guards."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import cli
+import clipgen
+import excel_io
+import utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_no_input_mode():
+    """Ensure NO_INPUT_MODE doesn't leak between tests."""
+    utils.NO_INPUT_MODE = False
+    yield
+    utils.NO_INPUT_MODE = False
+
+
+# ---- Argparse rename ----
+
+
+def test_no_input_long_flag_parses(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--no-input"])
+    args = cli.parse_arguments()
+    assert args.no_input is True
+
+
+def test_no_input_default_false(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py"])
+    args = cli.parse_arguments()
+    assert args.no_input is False
+
+
+def test_short_y_flag_is_rejected(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "-y"])
+    with pytest.raises(SystemExit) as exc:
+        cli.parse_arguments()
+    assert exc.value.code == 2
+
+
+def test_long_yes_flag_is_rejected(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["clipgen.py", "--yes"])
+    with pytest.raises(SystemExit) as exc:
+        cli.parse_arguments()
+    assert exc.value.code == 2
+
+
+# ---- utils.suggest_close_match guard ----
+
+
+def test_suggest_close_match_returns_none_under_no_input(monkeypatch):
+    # Sanity: without NO_INPUT_MODE, the prompt is reached.
+    monkeypatch.setattr(utils, "read_user_input", lambda _prompt: "n")
+    assert utils.suggest_close_match("foobar", ["foobaz"]) is None
+
+    utils.NO_INPUT_MODE = True
+
+    def _fail(_prompt):
+        raise AssertionError("read_user_input must not be called under NO_INPUT_MODE")
+
+    monkeypatch.setattr(utils, "read_user_input", _fail)
+    assert utils.suggest_close_match("foobar", ["foobaz"]) is None
+
+
+# ---- clipgen.select_spreadsheet guard ----
+
+
+def test_select_spreadsheet_exits_under_no_input(monkeypatch):
+    utils.NO_INPUT_MODE = True
+
+    def _fail(_prompt):
+        raise AssertionError("read_user_input must not be called under NO_INPUT_MODE")
+
+    monkeypatch.setattr(utils, "read_user_input", _fail)
+    with pytest.raises(SystemExit) as exc:
+        clipgen.select_spreadsheet(MagicMock(), ["doc1", "doc2"])
+    assert exc.value.code == 2
+
+
+# ---- clipgen.run_interactive_mode guard ----
+
+
+def test_run_interactive_mode_exits_under_no_input(monkeypatch):
+    utils.NO_INPUT_MODE = True
+
+    def _fail(_prompt):
+        raise AssertionError("read_user_input must not be called under NO_INPUT_MODE")
+
+    monkeypatch.setattr(utils, "read_user_input", _fail)
+    with pytest.raises(SystemExit) as exc:
+        clipgen.run_interactive_mode(MagicMock())
+    assert exc.value.code == 2
+
+
+# ---- excel_io guards ----
+
+
+def test_prompt_for_excel_fallback_returns_none_under_no_input(monkeypatch):
+    utils.NO_INPUT_MODE = True
+
+    def _fail(_prompt):
+        raise AssertionError("read_user_input must not be called under NO_INPUT_MODE")
+
+    monkeypatch.setattr(utils, "read_user_input", _fail)
+    assert excel_io.prompt_for_excel_fallback() is None
+
+
+def test_select_excel_file_returns_none_under_no_input_with_multiple(monkeypatch):
+    utils.NO_INPUT_MODE = True
+    monkeypatch.setattr(excel_io, "list_excel_in_cwd", lambda: ["./a.xlsx", "./b.xlsx"])
+
+    def _fail(_prompt):
+        raise AssertionError("read_user_input must not be called under NO_INPUT_MODE")
+
+    monkeypatch.setattr(utils, "read_user_input", _fail)
+    assert excel_io.select_excel_file() is None
+
+
+def test_select_excel_file_opens_single_match_under_no_input(monkeypatch):
+    """Single-file branch should still work in non-interactive mode."""
+    utils.NO_INPUT_MODE = True
+    monkeypatch.setattr(excel_io, "list_excel_in_cwd", lambda: ["./only.xlsx"])
+    sentinel = object()
+    monkeypatch.setattr(excel_io, "open_excel_workbook", lambda _path: sentinel)
+    assert excel_io.select_excel_file() is sentinel

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,13 @@ from icecream import ic
 import config
 
 
+# ---- Non-interactive mode flag ----
+# Set to True from cli.py when --no-input is passed. Targeted guards in
+# clipgen.py / excel_io.py / pipeline.py / video.py / utils.suggest_close_match
+# read this flag to fail fast (or skip) instead of blocking on stdin.
+NO_INPUT_MODE: bool = False
+
+
 # ---- Shared type definitions ----
 
 
@@ -1351,6 +1358,8 @@ def suggest_close_match(
         return None
     original = lower_to_original[matches[0]]
     display = original.strip()
+    if NO_INPUT_MODE:
+        return None
     yn = read_user_input(f"{prompt_prefix} '{display}'? [y/n]\n>> ")
     if yn.strip().lower() == "y":
         return original

--- a/video.py
+++ b/video.py
@@ -348,11 +348,16 @@ def run_ffmpeg(
     if config.DEBUGGING:
         ic(duration, duration_seconds)
     if duration > config.MAX_CLIP_DURATION_SECONDS:
-        yn = utils.read_user_input(
-            f"The generated video will be {duration}s ({duration // 60}m {duration % 60}s), over 10 minutes long. Generate anyway? [y/n]\n>> "
-        )
-        if yn != "y":
-            return False
+        if utils.NO_INPUT_MODE:
+            utils.warning_print(
+                f"Generating long clip ({duration}s, > {config.MAX_CLIP_DURATION_SECONDS}s) in non-interactive mode."
+            )
+        else:
+            yn = utils.read_user_input(
+                f"The generated video will be {duration}s ({duration // 60}m {duration % 60}s), over 10 minutes long. Generate anyway? [y/n]\n>> "
+            )
+            if yn != "y":
+                return False
 
     utils.verbose_print(f"Cutting {input_file} from {start_pos} to {end_pos}.")
     if config.DEBUGGING:


### PR DESCRIPTION
## Summary
- Rename the `-y` / `--yes` CLI flag to `--no-input` (no short form). `args.yes` becomes `args.no_input`. Argparse rejects the old spellings.
- Add a `utils.NO_INPUT_MODE` flag (set from `args.no_input` in `cli.main()`) and wire targeted guards at the seven blocking-prompt spots so programmatic users get clean errors or sensible defaults instead of hanging on stdin: `select_spreadsheet`, `suggest_close_match`, both Excel selection paths in `excel_io.py`, the source-video fuzzy match in `pipeline.py`, the long-clip warning in `video.py`, and the `run_interactive_mode` entry.
- New `tests/test_no_input_guards.py` covers parsing of `--no-input`, rejection of `-y` / `--yes`, and each runtime guard. Existing `_base_args` test fixtures and two thinking-agent test names updated for the rename. README and `agents/skills/generate/SKILL.md` examples updated.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 753 pass
- [x] `uv run ruff format --check` / `uv run ruff check` — clean
- [x] `uv run --extra dev ty check` — clean
- [x] `uv run clipgen.py --help` shows `--no-input`; no `-y`/`--yes`
- [x] `uv run clipgen.py -y` → argparse "unrecognized arguments: -y"
- [x] `uv run clipgen.py --no-input` → exits 2 with the spreadsheet-selection guard message