### PR TITLE
fix(backend): tighten lock boundaries and concurrency in server endpoints

### DIFF
--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -1545,24 +1545,24 @@ def api_export_events() -> FlaskResponse:
 @screenspace_bp.route("/api/events/<event_id>/exclude", methods=["PUT"])
 def api_event_exclude(event_id: str) -> FlaskResponse:
     """Set an event as excluded."""
-    for e in _manifest.get("events", []):
-        if e["id"] == event_id:
-            with _manifest_lock:
+    with _manifest_lock:
+        for e in _manifest.get("events", []):
+            if e["id"] == event_id:
                 e["excluded"] = True
                 _do_persist(drain_events=False)
-            return jsonify({"ok": True})
+                return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Event not found"}), 404
 
 
 @screenspace_bp.route("/api/events/<event_id>/include", methods=["PUT"])
 def api_event_include(event_id: str) -> FlaskResponse:
     """Set an event as included."""
-    for e in _manifest.get("events", []):
-        if e["id"] == event_id:
-            with _manifest_lock:
+    with _manifest_lock:
+        for e in _manifest.get("events", []):
+            if e["id"] == event_id:
                 e["excluded"] = False
                 _do_persist(drain_events=False)
-            return jsonify({"ok": True})
+                return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Event not found"}), 404
 
 

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -136,9 +136,6 @@ def validate_spreadsheet_headers(
     return (id_cell, observation_cell, category_cell)
 
 
-_BASELINE_ROW_CACHE: dict[int, int | None] = {}
-
-
 def _detect_baseline_row(sheet_data: list[list[str]]) -> int | None:
     """Detect the sheet-wide baseline row marked by a 'Baseline time' label.
 
@@ -146,23 +143,13 @@ def _detect_baseline_row(sheet_data: list[list[str]]) -> int | None:
     (case-insensitive). That row is treated as the baseline row: each non-empty
     cell in that row provides the baseline timestamp for its column.
     """
-    cache_key = id(sheet_data)
-    if cache_key in _BASELINE_ROW_CACHE:
-        return _BASELINE_ROW_CACHE[cache_key]
-
-    baseline_row_idx: int | None = None
     for row_idx, row in enumerate(sheet_data):
         for value in row:
             if not value:
                 continue
             if str(value).strip().lower().startswith("baseline time"):
-                baseline_row_idx = row_idx
-                break
-        if baseline_row_idx is not None:
-            break
-
-    _BASELINE_ROW_CACHE[cache_key] = baseline_row_idx
-    return baseline_row_idx
+                return row_idx
+    return None
 
 
 def get_num_participants(header_row: list[str], id_cell: Any, col_count: int) -> int:
@@ -542,7 +529,7 @@ def find_participant_column(
         Column index (0-based) if found, None otherwise
     """
     normalized_target = utils.normalize_participant_id(participant_id).lower()
-    for col_idx in range(id_cell.col - 1, len(header_row)):
+    for col_idx in range(id_cell.col, len(header_row)):
         header_value = utils.normalize_participant_id(header_row[col_idx]).strip()
         if header_value.lower() == normalized_target:
             return col_idx

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -44,6 +44,11 @@ class Agent(TypedDict):
                           this agent. None of the attributes currently
                           differ per-agent, but keeping them separate means
                           future agents can have their own toggle.
+      model_config_key:   Name of the ``config`` attribute (str) holding the
+                          Ollama model name this agent runs against. Read by
+                          the orchestrator for cancel-after-stop unload
+                          scheduling so future agents that use a different
+                          model unload the right one.
       manifest_field:     Where the result lands in
                           ``source_transcripts[participant][manifest_field]``.
       depends_on:         Other agent keys whose ``manifest_field`` must be
@@ -61,6 +66,7 @@ class Agent(TypedDict):
 
     key: str
     enabled_config_key: str
+    model_config_key: str
     manifest_field: str
     depends_on: list[str]
     thread_name_prefix: str
@@ -329,6 +335,7 @@ AGENTS: list[Agent] = [
     Agent(
         key="summary",
         enabled_config_key="OLLAMA_SUMMARY_ENABLED",
+        model_config_key="OLLAMA_SUMMARY_MODEL",
         manifest_field="summary",
         depends_on=[],
         thread_name_prefix="summary",
@@ -337,6 +344,7 @@ AGENTS: list[Agent] = [
     Agent(
         key="citations",
         enabled_config_key="OLLAMA_SUMMARY_ENABLED",
+        model_config_key="OLLAMA_SUMMARY_MODEL",
         manifest_field="citations",
         depends_on=["summary"],
         thread_name_prefix="citations",

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -127,6 +127,14 @@ def _is_generating(participant: str, agent_key: str) -> bool:
     return participant in _agent_in_flight.get(agent_key, set())
 
 
+def _agent_model(agent_key: str) -> str | None:
+    """Look up the Ollama model name configured for *agent_key*."""
+    agent = thinking_agents.get_agent(agent_key)
+    if agent is None:
+        return None
+    return getattr(config, agent["model_config_key"], None)
+
+
 def _step_state_transcription(entry: dict[str, Any]) -> str:
     # Only the persisted result is known here; live running/queued/failed for
     # Whisper is merged in on the frontend from /api/transcribe/status.
@@ -360,12 +368,13 @@ def api_summary(participant: str) -> FlaskResponse:
     """Return AI-generated summary, generation status, or 404."""
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
-    if not entry or not entry.get("summary"):
-        if _is_generating(participant, "summary"):
-            return jsonify({"ok": False, "generating": True})
-        return jsonify({"ok": False}), 404
-    resp: dict[str, Any] = {"ok": True, "summary": entry["summary"]}
-    citations = entry.get("citations")
+        if not entry or not entry.get("summary"):
+            if _is_generating(participant, "summary"):
+                return jsonify({"ok": False, "generating": True})
+            return jsonify({"ok": False}), 404
+        summary = entry["summary"]
+        citations = entry.get("citations")
+    resp: dict[str, Any] = {"ok": True, "summary": summary}
     if citations:
         resp["citations"] = citations
     resp["citations_generating"] = _is_generating(participant, "citations")
@@ -383,9 +392,8 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
         return jsonify({"ok": True, "generating": True})
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
-    if not entry or not entry.get("segments"):
-        return jsonify({"ok": False, "error": "No transcript found"}), 404
-    with _manifest_lock:
+        if not entry or not entry.get("segments"):
+            return jsonify({"ok": False, "error": "No transcript found"}), 404
         entry["summary"] = ""
         entry.pop("citations", None)
     _persist_manifest()
@@ -408,7 +416,9 @@ def api_summary_stop(participant: str) -> FlaskResponse:
     if event is not None:
         event.set()
     _agent_in_flight["summary"].discard(participant)
-    _schedule_model_unload(config.OLLAMA_SUMMARY_MODEL)
+    model = _agent_model("summary")
+    if model:
+        _schedule_model_unload(model)
     return jsonify({"ok": True, "running": False})
 
 
@@ -436,9 +446,9 @@ def api_citations(participant: str) -> FlaskResponse:
     """Return citation refs for a participant's summary, or generation status."""
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
-    if not entry:
-        return jsonify({"ok": False}), 404
-    citations = entry.get("citations") if entry else None
+        if not entry:
+            return jsonify({"ok": False}), 404
+        citations = entry.get("citations")
     if citations:
         return jsonify({"ok": True, "citations": citations})
     if _is_generating(participant, "citations"):
@@ -456,9 +466,10 @@ def api_citations_regenerate(participant: str) -> FlaskResponse:
         return jsonify({"ok": True, "generating": True})
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
-    if not entry or not entry.get("summary") or not entry.get("segments"):
-        return jsonify({"ok": False, "error": "No summary or transcript found"}), 404
-    with _manifest_lock:
+        if not entry or not entry.get("summary") or not entry.get("segments"):
+            return jsonify(
+                {"ok": False, "error": "No summary or transcript found"}
+            ), 404
         entry.pop("citations", None)
     _persist_manifest()
     _run_agent("citations", participant, force=True)
@@ -480,7 +491,9 @@ def api_citations_stop(participant: str) -> FlaskResponse:
     if event is not None:
         event.set()
     _agent_in_flight["citations"].discard(participant)
-    _schedule_model_unload(config.OLLAMA_SUMMARY_MODEL)
+    model = _agent_model("citations")
+    if model:
+        _schedule_model_unload(model)
     return jsonify({"ok": True, "running": False})
 
 
@@ -1104,7 +1117,9 @@ def _run_agent(agent_key: str, participant: str, force: bool = False) -> None:
     cancel_event = threading.Event()
     # If a Stop just scheduled an unload for this model, cancel it — the
     # next request would only force a reload.
-    _cancel_pending_unload(config.OLLAMA_SUMMARY_MODEL)
+    model = _agent_model(agent_key)
+    if model:
+        _cancel_pending_unload(model)
 
     def _run() -> None:
         try:
@@ -1120,11 +1135,19 @@ def _run_agent(agent_key: str, participant: str, force: bool = False) -> None:
             # Stop click, drop the result and skip the chain advance.
             if cancel_event.is_set():
                 return
+            committed = False
             if result is not None:
                 with _manifest_lock:
+                    # Re-check the cancel event inside the lock so a Stop that
+                    # arrives between the snapshot read above and this commit
+                    # cannot race past us and leave a stale result behind.
+                    if cancel_event.is_set():
+                        return
                     entry = _manifest.get("source_transcripts", {}).get(participant)
                     if entry is not None:
                         entry[agent["manifest_field"]] = result
+                        committed = True
+            if committed:
                 _persist_manifest()
                 # Chain into the next eligible agent (e.g. summary → citations).
                 # Propagate *force* so a manual run cascades through disabled

--- a/video.py
+++ b/video.py
@@ -165,19 +165,21 @@ def run_ffmpeg_process(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            while proc.poll() is None:
+            # Drain pipes via communicate() in a polling loop. Reading them
+            # only after proc.poll() returns can deadlock once ffmpeg fills
+            # the OS pipe buffer (~64 KB). Per Python docs, retrying after
+            # TimeoutExpired does not lose output.
+            while True:
                 if cancel_flag():
                     utils.terminate_subprocess(proc)
                     return None
                 try:
-                    proc.wait(timeout=0.5)
+                    out, err = proc.communicate(timeout=0.5)
                 except subprocess.TimeoutExpired:
                     continue
-            stdout = proc.stdout.read() if proc.stdout else ""
-            stderr = proc.stderr.read() if proc.stderr else ""
-            return subprocess.CompletedProcess(
-                ffmpeg_command, proc.returncode, stdout, stderr
-            )
+                return subprocess.CompletedProcess(
+                    ffmpeg_command, proc.returncode, out, err
+                )
         return subprocess.run(ffmpeg_command, encoding="utf-8", capture_output=True)
     except FileNotFoundError:
         utils.error_print(


### PR DESCRIPTION
## Summary

Eight bugs surfaced by a backend audit, all fixed in one PR:

- **transcripts (HIGH):** Collapse the lock-validate-unlock-relock pattern in `api_summary_regenerate`, `api_citations_regenerate`, and `api_citations` into a single critical section so mutations cannot land on an entry that was deleted between locks. `api_summary` now also reads both summary and citations under the lock.
- **transcripts (MED):** Re-check `cancel_event` inside `_manifest_lock` before writing an agent result so a Stop click that races the model cannot leave a stale summary/citations behind.
- **screenspace (HIGH):** Move event-list iteration in `api_event_exclude` / `api_event_include` inside `_manifest_lock` so they match the bulk variants and cannot observe torn state during concurrent appends.
- **spreadsheet (HIGH):** Drop the `id()`-keyed `_BASELINE_ROW_CACHE`. CPython reuses memory addresses after GC, so a sheet refresh could pick up a stale baseline row index. The scan runs once per context build — losing the cache costs nothing.
- **spreadsheet (LOW):** `find_participant_column` now starts at `id_cell.col` instead of `id_cell.col - 1` so the ID column itself is no longer searched for participant prefixes.
- **thinking-agents (LOW):** Added a `model_config_key` to the `Agent` shape; the citations stop endpoint now unloads the agent's actual model via the registry, so a future agent that runs on a different model will Just Work.
- **video (MED):** Rewrote the cancellable `run_ffmpeg_process` branch to drain stdout/stderr via `communicate(timeout=...)` in a polling loop, removing the latent OS-pipe-buffer deadlock when ffmpeg writes more than ~64 KB before exit.

The original audit report is at `/Users/Henrik/.claude/plans/system-instruction-you-are-working-shimmying-moler.md`. False positives ruled out during verification (mostly spreadsheet 1-based/0-based "off-by-ones" that turn out to be correct identities) are listed at the end of that file.

## Test plan

- [x] `uv run ruff check --fix && uv run ruff format` — no diffs
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 753 passed
- [ ] Manual: `--studio`, exercise summary/citations regenerate + stop under rapid clicks
- [ ] Manual: `--screenspace`, exclude/include events while a long-running task is producing events
- [ ] Manual: refresh a Studio worksheet (`/api/sheet/refresh`) and confirm baseline times still resolve correctly
- [ ] Manual: cancel a long ffmpeg cut and confirm clean termination