### PR TITLE
fix(web): frontend bug audit — blob leaks, inline SVGs, tooltip XSS

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -102,6 +102,10 @@
         })
         .then(function (blob) {
           var objUrl = URL.createObjectURL(blob);
+          var prev = _cvFrameCache[url];
+          if (prev && prev !== "error" && prev !== "loading") {
+            try { URL.revokeObjectURL(prev); } catch (_) {}
+          }
           _cvFrameCache[url] = objUrl;
           if (!preview.classList.contains("hidden") && img.parentNode) {
             img.src = objUrl;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1321,8 +1321,10 @@
       if (e.button !== 0) return;
       if (state.videoPlaying) pauseVideo();
       if (state.pipetteActive) {
-        var pos = canvasCoords(qs("#frameCanvas"), e);
-        var frameCtx = qs("#frameCanvas").getContext("2d");
+        var frameCanvas = qs("#frameCanvas");
+        if (!frameCanvas) { deactivatePipette(); return; }
+        var pos = canvasCoords(frameCanvas, e);
+        var frameCtx = frameCanvas.getContext("2d");
         var pixel = frameCtx.getImageData(pos.x, pos.y, 1, 1).data;
         var hsv = rgbToHsv(pixel[0], pixel[1], pixel[2]);
         if (state._mtPipetteStep !== undefined && state._mtPipetteStep >= 0) {
@@ -1347,6 +1349,10 @@
       _cachedOverlayRect = overlay.getBoundingClientRect();
       pos = canvasCoords(overlay, e, _cachedOverlayRect);
       var displayW = _cachedOverlayRect.width || overlay.width;
+      // Bail if the overlay has no usable size (e.g. hidden / display:none
+      // container). Without this, `s` becomes NaN and propagates into hit
+      // testing and any region coords stored downstream.
+      if (!displayW || !overlay.width) return;
       var s = overlay.width / displayW;
       var ctx = overlay.getContext("2d");
       var tHit = templateOverlayBounds();
@@ -6813,7 +6819,12 @@
           // TODO: fire-and-forget blob preload; needs apiGetBlob helper to migrate.
           fetch(url)
             .then(function (r) { return r.blob(); })
-            .then(function (blob) { _preloadedFrames[p.id] = URL.createObjectURL(blob); })
+            .then(function (blob) {
+              if (_preloadedFrames[p.id]) {
+                try { URL.revokeObjectURL(_preloadedFrames[p.id]); } catch (_) {}
+              }
+              _preloadedFrames[p.id] = URL.createObjectURL(blob);
+            })
             .catch(function () {});
         });
         if (state.participants.length > 0) {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3473,6 +3473,10 @@
           })
           .then(function (blob) {
             var objUrl = URL.createObjectURL(blob);
+            var prev = _ssThumbCache[entry.url];
+            if (prev && prev !== "error" && prev !== "loading") {
+              try { URL.revokeObjectURL(prev); } catch (_) {}
+            }
             _ssThumbCache[entry.url] = objUrl;
             if (entry.img.parentNode) entry.img.src = objUrl;
           })

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1551,12 +1551,24 @@
     var cat = (mark && MARK_CATEGORIES[mark.category]) || MARK_CATEGORIES.bookmark || { label: "Mark", color: "#888" };
     var snippet = (seg.text || "").trim().slice(0, 80);
     if ((seg.text || "").length > 80) snippet += "…";
-    var extra = (seg.marks && seg.marks.length > 1) ? ' <span style="opacity:.7">+' + (seg.marks.length - 1) + ' more</span>' : "";
-    var label = mark && mark.label ? ' — ' + escapeHtml(mark.label) : "";
-    tip.innerHTML = '<span class="tr-tooltip-cat" style="color:' + (mark && mark.color || cat.color) + '">'
-      + escapeHtml(cat.label) + '</span>'
-      + escapeHtml(formatTime(seg.start)) + label + extra
-      + '<br>' + escapeHtml(snippet);
+    var extraCount = (seg.marks && seg.marks.length > 1) ? (seg.marks.length - 1) : 0;
+    var label = mark && mark.label ? " — " + mark.label : "";
+    tip.textContent = "";
+    var catSpan = el("span", "tr-tooltip-cat", cat.label);
+    // Set color via property API rather than string-interpolating into a
+    // style attribute — mark.color comes from a stash/manifest file and a
+    // crafted value (e.g. `red" onmouseover=...`) would otherwise break out.
+    catSpan.style.color = (mark && mark.color) || cat.color || "";
+    tip.appendChild(catSpan);
+    tip.appendChild(document.createTextNode(formatTime(seg.start) + label));
+    if (extraCount > 0) {
+      tip.appendChild(document.createTextNode(" "));
+      var extraSpan = el("span", "", "+" + extraCount + " more");
+      extraSpan.style.opacity = ".7";
+      tip.appendChild(extraSpan);
+    }
+    tip.appendChild(document.createElement("br"));
+    tip.appendChild(document.createTextNode(snippet));
     tip.classList.remove("hidden");
     var tipRect = tip.getBoundingClientRect();
     var x = clientX + 12;

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -49,7 +49,7 @@ var clipgenApplyConfig = function (payload) {
   if (typeof payload.defaultDuration === "number") {
     CLIPGEN_CONFIG.defaultDuration = payload.defaultDuration;
   }
-  if (Array.isArray(payload.severity) && payload.severity.length) {
+  if (Array.isArray(payload.severity)) {
     CLIPGEN_CONFIG.severity = payload.severity;
   }
   if (Array.isArray(payload.annotationKeyphrases)) {

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -350,18 +350,26 @@ body {
   outline-offset: 2px;
 }
 
-.track-expand-btn svg {
+/* The exported timeline viewer is a single self-contained .html file with
+   no `icons/` route, so we embed icon path data as inline data URLs
+   (matches the .brand-mark pattern in tokens.css). The path data here
+   mirrors assets/icons/chevron-down.svg. */
+.track-expand-icon {
+  --track-expand-icon-svg: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill-rule='evenodd' clip-rule='evenodd' d='M4.21967 6.21967C4.51256 5.92678 4.98744 5.92678 5.28033 6.21967L8 8.93934L10.7197 6.21967C11.0126 5.92678 11.4874 5.92678 11.7803 6.21967C12.0732 6.51256 12.0732 6.98744 11.7803 7.28033L8.53033 10.5303C8.23744 10.8232 7.76256 10.8232 7.46967 10.5303L4.21967 7.28033C3.92678 6.98744 3.92678 6.51256 4.21967 6.21967Z'/></svg>");
+  display: block;
   width: 16px;
   height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  background-color: currentColor;
+  mask-image: var(--track-expand-icon-svg);
+  -webkit-mask-image: var(--track-expand-icon-svg);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
   transition: transform var(--duration-normal) ease;
 }
 
-.track-expand-btn.expanded svg {
+.track-expand-btn.expanded .track-expand-icon {
   transform: rotate(180deg);
 }
 
@@ -981,11 +989,21 @@ body {
   background: rgba(0, 0, 0, 0.12);
 }
 
-.video-play-overlay svg {
+/* Inline data URL — the exported timeline viewer has no icons/ route.
+   Path data mirrors assets/icons/play.svg. */
+.video-play-overlay-icon {
+  --video-play-icon-svg: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3 3.73241C3 2.54878 4.30673 1.83146 5.30531 2.46692L12.0114 6.73441C12.9376 7.32384 12.9376 8.67597 12.0114 9.2654L5.30532 13.5329C4.30673 14.1684 3 13.451 3 12.2674V3.73241Z'/></svg>");
+  display: block;
   width: 56px;
   height: 56px;
-  color: white;
+  background-color: white;
   filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4));
+  mask-image: var(--video-play-icon-svg);
+  -webkit-mask-image: var(--video-play-icon-svg);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
 }
 
 .video-play-overlay.hidden {
@@ -1049,7 +1067,7 @@ body {
     transition: opacity var(--duration-fast), box-shadow var(--duration-normal);
   }
 
-  .track-expand-btn svg {
+  .track-expand-icon {
     transition: none;
   }
 

--- a/assets/web/viewer.html
+++ b/assets/web/viewer.html
@@ -35,7 +35,7 @@
     <div class="timeline-track-wrap">
       <div id="timelineTrack"></div>
       <button class="track-expand-btn" type="button" aria-label="Expand tracks" aria-expanded="false" title="Expand tracks">
-        <svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+        <span class="track-expand-icon"></span>
       </button>
     </div>
     <div class="timeline-track-wrap screenspace-track-wrap hidden" id="screenspaceTrackWrap">

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -155,6 +155,9 @@
         canvas.toBlob(function (blob) {
           if (!blob) { mediaEl.classList.remove("thumb-pending"); finish(); return; }
           var url = URL.createObjectURL(blob);
+          if (_thumbCache[artifact.id]) {
+            try { URL.revokeObjectURL(_thumbCache[artifact.id]); } catch (_) {}
+          }
           _thumbCache[artifact.id] = url;
           var img = document.createElement("img");
           img.src = url;
@@ -472,6 +475,9 @@
           canvas.toBlob(function (blob) {
             if (!blob) { markerEl.classList.remove("filmstrip-loading"); finish(); return; }
             var url = URL.createObjectURL(blob);
+            if (_thumbCache[artifact.id]) {
+              try { URL.revokeObjectURL(_thumbCache[artifact.id]); } catch (_) {}
+            }
             _thumbCache[artifact.id] = url;
             if (_filmstripEnabled && markerEl.classList.contains("filmstrip-loading")) {
               markerEl.style.backgroundImage = "url(" + url + ")";
@@ -1562,9 +1568,7 @@
     overlay.className = "video-play-overlay";
     overlay.type = "button";
     overlay.setAttribute("aria-label", "Play video");
-    overlay.innerHTML = '<svg width="56" height="56" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">' +
-      '<path d="M3 3.73241C3 2.54878 4.30673 1.83146 5.30531 2.46692L12.0114 6.73441C12.9376 7.32384 12.9376 8.67597 12.0114 9.2654L5.30532 13.5329C4.30673 14.1684 3 13.451 3 12.2674V3.73241Z"/>' +
-      '</svg>';
+    overlay.appendChild(el("span", "video-play-overlay-icon"));
 
     var timeBadge = el("span", "video-time-badge", "--:--");
 
@@ -1873,7 +1877,7 @@
       expandBtn.setAttribute("aria-label", "Expand tracks");
       expandBtn.setAttribute("aria-expanded", "false");
       expandBtn.title = "Expand tracks";
-      expandBtn.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>';
+      expandBtn.appendChild(el("span", "track-expand-icon"));
       expandBtn.addEventListener("click", (function (t) {
         return function () { toggleTrackExpand(t); };
       })(track));


### PR DESCRIPTION
## Summary

Six bug fixes from a frontend audit pass:

- **Blob-URL leaks (4 cache sites)** — `_thumbCache` (viewer, both single-frame and filmstrip generators), `_ssThumbCache` (studio screenspace queue), `_cvFrameCache` (convergence hover preview), and `_preloadedFrames` (screenspace per-participant) now revoke the prior URL before reassigning the same key. Stops unbounded memory growth in long-lived tabs.
- **Hardcoded inline SVG path data in viewer** — the play overlay and track-expand chevron in `viewer.js`/`viewer.html` are now `mask-image` spans driven by inline `data:` URLs (matches the `.brand-mark` pattern in `tokens.css`; exported timeline viewers are self-contained `.html` with no `icons/` route).
- **`clipgenApplyConfig` empty severity** — dropped `&& payload.severity.length` in `utils.js` so an empty server payload no longer silently keeps stale JS defaults (now consistent with the other `Array` overlay branches).
- **Style-attribute injection in transcript tooltip** — `transcripts.js` now constructs the tooltip via DOM API and applies `mark.color` through `style.color`, so a crafted manifest can't break out of the attribute.
- **Screenspace canvas null-deref + NaN coords** — `screenspace.js` null-checks `#frameCanvas` before `.getContext("2d")`, and bails out of overlay hit-testing when display width is zero (was producing `NaN` coords that propagated into stored region data).

## Test plan

- [x] `uv run --extra dev pytest tests/` — all 685 pass
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [ ] Manual: open Studio with a sheet → load many clips, toggle filmstrip mode, scroll sidebar → take heap snapshots, confirm Blob count is bounded
- [ ] Manual: open exported timeline viewer (`--viewer`) standalone from disk → confirm play overlay and track-expand chevron render in both light and dark mode
- [ ] Manual: in Screenspace, hide the canvas container during pipette/region drawing → confirm no `NaN` coords or crashes