### PR TITLE
build(macos): produce unsigned .app bundle alongside CLI binary

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: macos-latest
             artifact_name: clipgen-macos
-            dist_path: dist/clipgen
+            dist_path: dist/clipgen.app
           - os: windows-latest
             artifact_name: clipgen-windows
             dist_path: dist/clipgen.exe
@@ -71,4 +71,12 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}-${{ steps.suffix.outputs.suffix }}
           path: ${{ matrix.dist_path }}
+          if-no-files-found: error
+
+      - name: Upload macOS raw binary
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v6
+        with:
+          name: clipgen-macos-bin-${{ steps.suffix.outputs.suffix }}
+          path: dist/clipgen
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -95,7 +95,15 @@ pip install pyinstaller
 pyinstaller --clean --noconfirm build/clipgen.spec
 ```
 
-Output: `dist/clipgen` (macOS) or `dist/clipgen.exe` (Windows).
+Output: `dist/clipgen` and `dist/clipgen.app` (macOS), or `dist/clipgen.exe` (Windows). Double-clicking `clipgen.app` opens Terminal at the interactive CLI prompt; the raw binary inside is at `clipgen.app/Contents/MacOS/clipgen-bin`.
+
+The macOS build is **unsigned** (no paid Apple Developer account). When downloaded from GitHub, macOS quarantines the app and Gatekeeper blocks the first launch. To clear the quarantine attribute, run:
+
+```shell
+xattr -dr com.apple.quarantine clipgen.app
+```
+
+Alternatively, right-click the `.app` in Finder and choose **Open** once to bypass Gatekeeper for that build.
 
 ## AI disclosure
 

--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -69,3 +69,38 @@ exe = EXE(
     entitlements_file=None,
     icon=("clipgen.icns" if sys.platform == "darwin" else "clipgen.ico"),
 )
+
+if sys.platform == "darwin":
+    import stat
+    from pathlib import Path
+
+    _version = (Path(SPECPATH) / "VERSION").read_text().strip()
+    app = BUNDLE(
+        exe,
+        name="clipgen.app",
+        icon="clipgen.icns",
+        bundle_identifier="se.signalresearch.clipgen",
+        version=_version,
+        info_plist={
+            "CFBundleShortVersionString": _version,
+            "CFBundleVersion": _version,
+            "NSHighResolutionCapable": True,
+            "LSMinimumSystemVersion": "11.0",
+        },
+    )
+
+    # PyInstaller writes the CLI binary to Contents/MacOS/clipgen. clipgen is a
+    # console app, so double-clicking the .app would silently launch the binary
+    # with no visible terminal. Move the real binary aside and put a tiny
+    # shell launcher in its place that opens Terminal pointing at it.
+    _macos_dir = Path(DISTPATH) / "clipgen.app" / "Contents" / "MacOS"
+    _real_bin = _macos_dir / "clipgen-bin"
+    _launcher = _macos_dir / "clipgen"
+    if _launcher.exists() and not _real_bin.exists():
+        _launcher.rename(_real_bin)
+        _launcher.write_text(
+            '#!/bin/bash\n'
+            'DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+            'open -a Terminal "$DIR/clipgen-bin"\n'
+        )
+        _launcher.chmod(_launcher.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)


### PR DESCRIPTION
## Summary

- `build/clipgen.spec` gains a darwin-guarded `BUNDLE` that emits `dist/clipgen.app` next to the existing one-file `dist/clipgen` binary, stamped with `build/VERSION` in `Info.plist`. A post-BUNDLE step renames the bundled binary to `clipgen-bin` and replaces `Contents/MacOS/clipgen` with a tiny shell launcher that opens Terminal — so double-clicking the `.app` actually drops into the interactive CLI instead of silently launching a console app with no visible terminal.
- `.github/workflows/build-binaries.yml` now uploads `dist/clipgen.app` as the primary macOS artifact and adds a second macOS-only upload for the raw `dist/clipgen` binary. Windows builds are unchanged.
- `README.md` documents the new `.app` output and the unsigned-build Gatekeeper bypass (`xattr -dr com.apple.quarantine clipgen.app` or right-click → Open). No code signing or notarization — out of scope without a paid Apple Developer account.

## Test plan

- [ ] Trigger `build-binaries` via `workflow_dispatch` and confirm both `clipgen-macos-<sha>` (`.app`) and `clipgen-macos-bin-<sha>` (raw binary) artifacts appear; Windows artifact unchanged.
- [ ] Local macOS: `uv run pyinstaller --clean --noconfirm build/clipgen.spec` produces `dist/clipgen` and `dist/clipgen.app`; `plutil -p dist/clipgen.app/Contents/Info.plist` shows the `build/VERSION` value.
- [ ] Double-click `dist/clipgen.app` in Finder → Terminal opens and clipgen runs in interactive mode.
- [ ] `./dist/clipgen.app/Contents/MacOS/clipgen-bin --help` prints CLI help (bundled binary still callable directly).
- [ ] Download the CI artifact, run `xattr -dr com.apple.quarantine clipgen.app`, double-click → launches without the Gatekeeper warning.