### PR TITLE
fix(web): frontend bug audit v2 — participant races, polling pauses, formula injection

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -43,6 +43,9 @@
   var _cvFrameCache = {};
   var _cvFramePreviewEl = null;
   var _cvHoverDebounce = null;
+  // Bumped on every preview show so a slow fetch can't paint over a newer
+  // hover (would otherwise display participant A's frame under B's label).
+  var _cvPreviewSeq = 0;
 
   // --- Utilities ---
 
@@ -85,6 +88,7 @@
     var img = preview.querySelector("img");
     var lbl = preview.querySelector(".cv-frame-preview-label");
     var url = cvFrameUrl(event.source, event.participant, event.start);
+    var seq = ++_cvPreviewSeq;
 
     var cached = _cvFrameCache[url];
     if (cached && cached !== "error" && cached !== "loading") {
@@ -107,13 +111,13 @@
             try { URL.revokeObjectURL(prev); } catch (_) {}
           }
           _cvFrameCache[url] = objUrl;
-          if (!preview.classList.contains("hidden") && img.parentNode) {
+          if (seq === _cvPreviewSeq && !preview.classList.contains("hidden") && img.parentNode) {
             img.src = objUrl;
           }
         })
         .catch(function () {
           _cvFrameCache[url] = "error";
-          cvHideFramePreview();
+          if (seq === _cvPreviewSeq) cvHideFramePreview();
         });
     }
 

--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -1497,6 +1497,12 @@
 
   function csvEscape(val) {
     var s = String(val == null ? "" : val);
+    // Defang spreadsheet formula triggers — Excel/Numbers/Sheets evaluate any
+    // cell beginning with =/+/-/@/tab/CR. User-authored fields (observation,
+    // category, severity) flow into these CSVs, so the leading sigil is the
+    // attacker's only entrypoint. Prefixing with a single quote neutralises
+    // the formula while displaying intuitively.
+    if (/^[=+\-@\t\r]/.test(s)) s = "'" + s;
     if (s.indexOf(",") >= 0 || s.indexOf('"') >= 0 || s.indexOf("\n") >= 0) {
       return '"' + s.replace(/"/g, '""') + '"';
     }

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1320,6 +1320,11 @@
       _cachedOverlayRect = null;
       if (r.w > 5 && r.h > 5) {
         state.pendingRegion = r;
+      } else if (r.w > 0 || r.h > 0) {
+        // Drop the draw silently for click-without-drag (zero size), but
+        // surface a hint when the user actually dragged a too-small box —
+        // otherwise the picker just snaps closed with no feedback.
+        showToast("Region too small — drag a larger area");
       }
       flushOverlayRender();
       updateRegionButtons();
@@ -5462,11 +5467,13 @@
     count.textContent = "(" + filtered.length + ")";
     updateTaskFilterButtons();
     if (state.tasks.length === 0) {
-      container.innerHTML = '<div class="panel-empty">No tasks yet. Configure a workflow and click Run.</div>';
+      container.innerHTML = "";
+      container.appendChild(el("div", "panel-empty", "No tasks yet. Configure a workflow and click Run."));
       return;
     }
     if (filtered.length === 0) {
-      container.innerHTML = '<div class="panel-empty">No ' + state.taskFilter + ' tasks.</div>';
+      container.innerHTML = "";
+      container.appendChild(el("div", "panel-empty", "No " + state.taskFilter + " tasks."));
       return;
     }
     var frag = document.createDocumentFragment();
@@ -6573,7 +6580,7 @@
             setRightPaneTab(stored.rightPaneTab);
           }
           if (stored.activeWorkflow) {
-            var wfTab = qs('.wf-tab[data-type="' + stored.activeWorkflow + '"]');
+            var wfTab = qs('.wf-tab[data-type="' + CSS.escape(stored.activeWorkflow) + '"]');
             if (wfTab) wfTab.click();
           }
         }

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1462,7 +1462,8 @@
   }
 
   function updateSingleCellClass(participant, row) {
-    var td = qs('.ts-cell[data-participant="' + participant + '"][data-row="' + row + '"]');
+    var td = qs('.ts-cell[data-participant="' + CSS.escape(participant) +
+                '"][data-row="' + CSS.escape(row) + '"]');
     if (!td) return;
     var inArt = findInQueue(state.artifactQueue, participant, row) >= 0;
     var inReel = findInQueue(state.reelQueue, participant, row) >= 0;
@@ -2707,20 +2708,27 @@
     var list = qs("#artifactsList");
     var items = state.artifactQueue.slice();
 
-    // Separate spreadsheet and intake items
-    var sheetItems = [];
-    var intakeItems = [];
-    for (var ci = 0; ci < items.length; ci++) {
-      if (isIntakeSource(items[ci].source)) {
-        intakeItems.push(items[ci]);
-      } else {
-        sheetItems.push(items[ci]);
-      }
-    }
-
+    // Capture the queue cards before any async work so per-item result
+    // markers don't drift onto the wrong card if the queue re-renders mid
+    // request. allCards is in DOM order, which matches state.artifactQueue.
     var allCards = list.querySelectorAll(".queue-card");
     for (var i = 0; i < allCards.length; i++) {
       setCardQueued(allCards[i]);
+    }
+
+    // Separate spreadsheet and intake items, keeping each split's card
+    // element parallel to its item array so the resolve handler can match
+    // by index against the captured card list (immune to later re-renders).
+    var sheetItems = [];
+    var intakeItems = [];
+    var intakeCardEls = [];
+    for (var ci = 0; ci < items.length; ci++) {
+      if (isIntakeSource(items[ci].source)) {
+        intakeItems.push(items[ci]);
+        intakeCardEls.push(allCards[ci]);
+      } else {
+        sheetItems.push(items[ci]);
+      }
     }
 
     var totalSuccess = 0;
@@ -2781,7 +2789,8 @@
         var participant = data.cell.substring(0, dot);
         var row = data.cell.substring(dot + 1);
         var cards = list.querySelectorAll(
-          '[data-participant="' + participant + '"][data-row="' + row + '"]'
+          '[data-participant="' + CSS.escape(participant) +
+          '"][data-row="' + CSS.escape(row) + '"]'
         );
         if (data.ok) {
           for (var ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], true);
@@ -2858,10 +2867,10 @@
 
       apiPost("api/generate-intake", { items: intakePayload, format: format })
         .then(function (data) {
-          var intakeCards = list.querySelectorAll('[data-source="screenspace"], [data-source="transcript"]');
           if (data.ok && data.results) {
             for (var ri = 0; ri < data.results.length; ri++) {
               var res = data.results[ri];
+              var card = intakeCardEls[ri];
               if (res.ok) {
                 totalSuccess++;
                 if (res.artifact) {
@@ -2869,18 +2878,19 @@
                   state.generatedArtifacts.push(res.artifact);
                   updateViewerButton();
                 }
-                if (intakeCards[ri]) setCardResult(intakeCards[ri], true);
+                if (card) setCardResult(card, true);
               } else {
                 totalFail++;
-                if (intakeCards[ri]) setCardResult(intakeCards[ri], false);
+                if (card) setCardResult(card, false);
               }
             }
           }
           finishBranch();
         })
         .catch(function () {
-          var intakeCards = list.querySelectorAll('[data-source="screenspace"], [data-source="transcript"]');
-          for (var j = 0; j < intakeCards.length; j++) setCardResult(intakeCards[j], false);
+          for (var j = 0; j < intakeCardEls.length; j++) {
+            if (intakeCardEls[j]) setCardResult(intakeCardEls[j], false);
+          }
           totalFail += intakeItems.length;
           finishBranch();
         });

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -65,6 +65,11 @@
   var _hadActiveTranscriptionLastPoll = false;
   var MODEL_FAIL_GRACE_MS = 10000;
 
+  // Bumped on every participant switch so per-participant fetches that resolve
+  // late (`loadTranscript`, `loadSummary`, summary/citations polls) can detect
+  // they're stale and bail before clobbering the active participant's UI.
+  var _participantReqVer = 0;
+
   // ---- Helpers (showToast: 2500ms hide; shared default in utils.js is 3000ms) ----
 
   var _utilsShowToast = window.showToast;
@@ -508,6 +513,7 @@
 
 
   function selectParticipant(pid) {
+    _participantReqVer++;
     state.selectedParticipant = pid;
     setStoredUIStateField("transcripts", "selectedParticipant", pid);
     renderPills();
@@ -603,7 +609,9 @@
   // ---- Transcript loading ----
 
   function loadTranscript(pid) {
+    var ver = _participantReqVer;
     return apiGet("api/transcript/" + pid).then(function (data) {
+      if (ver !== _participantReqVer) return;
       if (!data.ok) {
         state.segments = [];
         renderSegments();
@@ -633,8 +641,10 @@
 
   function loadSummary(pid) {
     var section = qs("#summarySection");
+    var ver = _participantReqVer;
 
     apiGet("api/summary/" + pid).then(function (data) {
+      if (ver !== _participantReqVer) return;
       if (data.ok && data.summary) {
         _stopSummaryPoll();
         renderSummary(data.summary);
@@ -658,6 +668,7 @@
         section.classList.add("hidden");
       }
     }).catch(function () {
+      if (ver !== _participantReqVer) return;
       // Ollama unavailable or no summary — stay hidden
       section.classList.add("hidden");
     });
@@ -665,12 +676,14 @@
 
   function _startSummaryPoll(pid) {
     _stopSummaryPoll();
+    var ver = _participantReqVer;
     _summaryPollTimer = setInterval(function () {
-      if (state.selectedParticipant !== pid) {
+      if (ver !== _participantReqVer || state.selectedParticipant !== pid) {
         _stopSummaryPoll();
         return;
       }
       apiGet("api/summary/" + pid).then(function (data) {
+        if (ver !== _participantReqVer) return;
         if (data.ok && data.summary) {
           _stopSummaryPoll();
           renderSummary(data.summary);
@@ -691,6 +704,7 @@
           qs("#summarySection").classList.add("hidden");
         }
       }).catch(function () {
+        if (ver !== _participantReqVer) return;
         _stopSummaryPoll();
         qs("#summarySection").classList.add("hidden");
       });
@@ -852,8 +866,11 @@
   function _startCitationsPoll(pid) {
     _stopCitationsPoll();
     var started = Date.now();
+    var ver = _participantReqVer;
     _citationsPollTimer = setInterval(function () {
-      if (state.selectedParticipant !== pid || Date.now() - started > _CITATIONS_POLL_TIMEOUT) {
+      if (ver !== _participantReqVer ||
+          state.selectedParticipant !== pid ||
+          Date.now() - started > _CITATIONS_POLL_TIMEOUT) {
         _stopCitationsPoll();
         state.citationsGenerating = false;
         var status = qs("#summaryContent .citations-status");
@@ -861,6 +878,7 @@
         return;
       }
       apiGet("api/citations/" + pid).then(function (data) {
+        if (ver !== _participantReqVer) return;
         if (data.ok && data.citations) {
           _stopCitationsPoll();
           state.summaryCitations = data.citations;
@@ -873,6 +891,7 @@
           if (status) status.remove();
         }
       }).catch(function () {
+        if (ver !== _participantReqVer) return;
         _stopCitationsPoll();
         state.citationsGenerating = false;
         var status = qs("#summaryContent .citations-status");
@@ -2272,8 +2291,13 @@
     popover.style.left = (rect.left + window.scrollX - 4) + "px";
     popover.classList.remove("hidden");
 
-    // Close on outside click (deferred so this click doesn't trigger it)
-    setTimeout(function () {
+    // Close on outside click (deferred so this click doesn't trigger it).
+    // Track the timeout so a fast hideMarkPopover (e.g. Esc within the same
+    // tick) cancels the pending attach instead of leaving a permanently
+    // attached listener after the deferred .addEventListener fires.
+    if (_popoverAttachTimer) clearTimeout(_popoverAttachTimer);
+    _popoverAttachTimer = setTimeout(function () {
+      _popoverAttachTimer = null;
       document.addEventListener("click", _popoverOutsideClick);
     }, 0);
   }
@@ -2285,9 +2309,15 @@
     }
   }
 
+  var _popoverAttachTimer = null;
+
   function hideMarkPopover() {
     var popover = qs("#markPopover");
     if (popover) popover.classList.add("hidden");
+    if (_popoverAttachTimer) {
+      clearTimeout(_popoverAttachTimer);
+      _popoverAttachTimer = null;
+    }
     document.removeEventListener("click", _popoverOutsideClick);
   }
 
@@ -3477,11 +3507,16 @@
     initTranscriptSettings();
     initTopNavActions();
 
-    // Pause polling when tab is hidden; resume when visible
+    // Pause every poller when tab is hidden; resume what was active on focus.
+    // Without this, summary/citations/model-hint pollers (1.5–3 s cadence)
+    // keep hammering the backend from background tabs.
     document.addEventListener("visibilitychange", function () {
       if (document.hidden) {
         stopPolling();
         stopXrefPolling();
+        stopModelHintPoll();
+        _stopSummaryPoll();
+        _stopCitationsPoll();
       } else {
         pollTaskStatus();
         startXrefPolling();
@@ -3490,6 +3525,9 @@
         // poll already gave up (or summary completed after we stopped polling)
         // the manifest result would only surface on a full page reload. This
         // catches the common "user goes to another tab, comes back" case.
+        // loadSummary re-arms the summary/citations polls if generation is
+        // still in flight, and the transcribe-status poll re-arms the
+        // model-hint poll on the next active task transition.
         if (state.selectedParticipant) loadSummary(state.selectedParticipant);
       }
     });


### PR DESCRIPTION
## Summary

Second pass on the frontend bug audit. Picks up the issues that survived #297. Plan file (with verification notes) lives at `~/.claude/plans/system-instruction-you-are-working-refactored-donut.md`.

**High severity**
- **H1** — `transcripts.js` stale-participant race: `loadTranscript` / `loadSummary` / both pollers now bump and check `_participantReqVer` so a slow fetch for participant A can't clobber B's segments / summary when the user switches mid-flight.
- **H2** — `transcripts.js` pollers ignored `document.hidden`: extends the existing `visibilitychange` handler to also stop the model-hint, summary, and citations pollers (was only stopping `pollTaskStatus` + xref).
- **H3** — `studio.js` intake card index race: capture intake queue cards at submit time and match results by stable index against the captured array, instead of re-querying the DOM at resolve time. No more wrong-card success / failure markers when the user reorders the queue mid-generation.

**Medium**
- **M1** — `convergence.js`: per-call generation counter in `cvShowFramePreview` so a slow fetch can't paint A's frame under B's label on rapid hover sweeps.
- **M2** — `transcripts.js`: track + cancel the deferred outside-click `setTimeout` in `showMarkPopover` so a fast Esc / re-open can't leave a permanently-attached document listener.
- **M3** — `screenspace.js`: replace the only `innerHTML`+variable pattern in `renderTaskList` (`state.taskFilter`) with `el()` construction.
- **M4** — `metadata.js`: defang CSV formula injection in `csvEscape` (prefix `=`/`+`/`-`/`@`/tab/CR with `'`).
- **M5/M6** — wrap dynamic `data-participant` / `data-row` / `data-type` substitutions in `CSS.escape` (`studio.js:1465`, `studio.js:2791`, `screenspace.js:6578`).

**Low**
- **L1** — `screenspace.js`: surface a \"Region too small\" toast when the user drags a tiny non-zero region; previously dropped silently.

5 files changed, +88 / -23. No backend or test churn.

## Test plan
- [ ] `uv run ruff format --check` / `uv run ruff check` / `uv run ty check` — all pass locally.
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` — 755 passed locally.
- [ ] Manual: open transcripts, click rapidly between two participants with non-trivial transcripts, confirm displayed segments / summary always match the highlighted pill (widen the race in DevTools by throttling network).
- [ ] Manual: open transcripts, switch to another tab, confirm Flask request log falls silent within ~3 s; refocus, polling resumes.
- [ ] Manual: queue several intake events in Studio, kick off generate, remove a queued card before the response lands, confirm the remaining cards show correct success / failure markers.
- [ ] Manual: hover-sweep convergence event markers under \"Slow 3G\" throttling, confirm preview image and label always agree.
- [ ] Manual: open / close a mark popover repeatedly via Esc, confirm DevTools \"Event Listeners\" shows a single document-level click listener.
- [ ] Manual: add a row with Observation `=HYPERLINK(\"x\")`, export metadata CSV, confirm Excel displays it literally.
- [ ] Manual: shove `'\"]/*` into `localStorage[\"screenspace\"].activeWorkflow`, reload the page, confirm the picker still renders.
- [ ] Manual: draw a tiny screenspace region, confirm the toast appears.