### PR TITLE
fix(web): raise subheader z-index so popovers escape sibling chrome

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -2332,7 +2332,7 @@ body.panel-dragging #bottomPanel {
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1);
-  z-index: 50;
+  z-index: var(--z-dropdown);
 }
 
 .rp-switcher-panel.hidden {
@@ -2821,7 +2821,7 @@ body.panel-dragging #bottomPanel {
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1);
-  z-index: 50;
+  z-index: var(--z-dropdown);
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -581,7 +581,11 @@ html[data-theme="light"] .cg-logo {
   top: 48px;
   left: 0;
   right: 0;
-  z-index: calc(var(--z-dropdown) - 1);
+  /* Matches .topnav so popovers anchored inside a subheader (e.g. the
+   * Transcripts search dropdown) escape the subheader's stacking context
+   * above sibling chrome like #trPillBar. Subheaders never physically
+   * overlap the topnav, so sharing z:100 is safe. */
+  z-index: var(--z-dropdown);
 }
 @supports not (backdrop-filter: blur(1px)) {
   .subheader,


### PR DESCRIPTION
## Summary

- The Transcripts search dropdown rendered behind the participant pill bar. Root cause: `#trSubheader` (position:fixed, z:99) created a stacking context, and `#trPillBar` (also z:99, later in DOM) occluded any descendant popover extending downward.
- Lift the shared subheader rule (`.subheader, #studioSubheader, #ssSubheader, #trSubheader` in `tokens.css`) from `calc(var(--z-dropdown) - 1)` to `var(--z-dropdown)`. Subheaders never overlap the topnav physically, so sharing z:100 is safe — and any future popover anchored inside a subheader gets the same protection.
- Swap two raw `z-index: 50` values in `screenspace.css` (`.rp-switcher-panel`, `.rp-export-menu`) to `var(--z-dropdown)` for token consistency.

## Test plan

- [ ] Open Transcripts, type in the search box, confirm the dropdown overlays the pill bar instead of disappearing behind it.
- [ ] Open Studio and Screenspace, confirm the chrome strip (topnav + subheader) still looks unchanged.
- [ ] In Screenspace, exercise the run-picker, results-tab switcher panel, and export menu — confirm they still open and layer correctly.