### PR TITLE
fix(studio): render persisted collapsed bottom panel at zero height

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -692,6 +692,13 @@ body.bottom-collapsed #panelDivider .divider-handle {
   background: var(--color-accent);
 }
 
+/* When the page boots with a persisted collapse state, no inline max-height is
+ * set on #bottomPanel — without this rule the panel reverts to its natural
+ * content height (toolbars + ghost text), which reads as "half collapsed". */
+body.bottom-collapsed:not(.bottom-animating) #bottomPanel {
+  max-height: 0;
+}
+
 body.bottom-animating #dropAreas,
 body.bottom-animating #reelArea,
 body.bottom-animating #stashedArtifactsArea {


### PR DESCRIPTION
## Summary
When Studio loaded with `collapsed: true` from localStorage, the bottom panel fell back to its natural content height (~112px) instead of fully collapsing — toolbars stayed visible and drag-to-resize was blocked (drag is disabled by design when collapsed), so the panel looked stuck until a double-click toggle. Adds `body.bottom-collapsed:not(.bottom-animating) #bottomPanel { max-height: 0 }`; the `:not(.bottom-animating)` guard keeps the rule out of the way during JS-driven transitions, which manage inline `max-height` themselves.

## Test plan
- [ ] Collapse the bottom panel, reload Studio — panel loads fully collapsed (only the divider visible).
- [ ] Double-click the divider — panel uncollapses with the existing animation.
- [ ] Drag the divider — resize still works.
- [ ] Double-click again — collapses with animation, then reload to confirm the persisted state still renders at zero height.