### PR TITLE
fix: backend bug audit — atomicity, cancel races, resource leaks

### DIFF
--- a/ollama_client.py
+++ b/ollama_client.py
@@ -36,10 +36,18 @@ _HEALTH_TIMEOUT = 5  # seconds for connectivity check
 _GENERATE_TIMEOUT = (
     300  # seconds — generous to allow cold model loading + long transcripts
 )
+# Wall-clock deadline for the entire streaming response. urlopen's timeout only
+# applies to connect + first byte, so a slow trickle can stall a worker
+# indefinitely. This bounds total elapsed time end-to-end.
+_GENERATE_DEADLINE = 600  # seconds
 _START_POLL_INTERVAL = 0.5  # seconds between health-check polls after starting server
 _START_TIMEOUT = 10  # seconds to wait for server to become available after starting
 _CANCEL_WATCHER_POLL = 1.0  # seconds; bounds abort latency during long quiet stretches
 _THINK_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
+
+# Serializes _start_server() calls so two threads hitting connection-refused at
+# the same time don't both spawn `ollama serve`.
+_start_server_lock = threading.Lock()
 
 
 def is_available() -> bool:
@@ -151,6 +159,10 @@ def _ollama_install_guidance_lines() -> list[str]:
 def _start_server() -> bool:
     """Attempt to start ``ollama serve`` and wait for it to become available.
 
+    Serialized via ``_start_server_lock`` so concurrent connection-refused
+    retries don't both spawn a server process — the first one to acquire the
+    lock spawns it, the rest see the already-running server when they re-poll.
+
     Returns True if the server is responding after startup, False otherwise.
     """
     if shutil.which("ollama") is None:
@@ -160,23 +172,28 @@ def _start_server() -> bool:
         )
         return False
 
-    utils.info_print("Starting Ollama server...")
-    try:
-        subprocess.Popen(
-            ["ollama", "serve"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except OSError as exc:
-        utils.warning_print(f"Failed to start Ollama: {exc}")
-        return False
-
-    deadline = time.monotonic() + _START_TIMEOUT
-    while time.monotonic() < deadline:
+    with _start_server_lock:
+        # Another thread may have already started the server while we waited.
         if is_available():
-            utils.info_print("Ollama server started.")
             return True
-        time.sleep(_START_POLL_INTERVAL)
+
+        utils.info_print("Starting Ollama server...")
+        try:
+            subprocess.Popen(
+                ["ollama", "serve"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            utils.warning_print(f"Failed to start Ollama: {exc}")
+            return False
+
+        deadline = time.monotonic() + _START_TIMEOUT
+        while time.monotonic() < deadline:
+            if is_available():
+                utils.info_print("Ollama server started.")
+                return True
+            time.sleep(_START_POLL_INTERVAL)
 
     utils.warning_print("Ollama server did not start within timeout.")
     return False
@@ -227,6 +244,8 @@ def _do_generate(
     parts: list[str] = []
     done_event = threading.Event()
     watcher: threading.Thread | None = None
+    deadline = time.monotonic() + _GENERATE_DEADLINE
+    deadline_exceeded = False
     if cancel_event is not None:
 
         def _watch() -> None:
@@ -244,17 +263,26 @@ def _do_generate(
         if cancel_event is not None and cancel_event.is_set():
             return None
         while True:
+            if time.monotonic() >= deadline:
+                deadline_exceeded = True
+                _shutdown_response_socket(resp)
+                return None
             try:
                 line = resp.readline()
             except (OSError, ValueError, AttributeError):
-                # Raised when the watcher shuts down the socket mid-read.
-                # http.client may surface this as AttributeError on Python
-                # 3.13+ when the chunked-encoding state machine tries to
-                # advance past a closed fp.
+                # Raised when the watcher shuts down the socket mid-read, or
+                # when we shut it down above on deadline. http.client may
+                # surface this as AttributeError on Python 3.13+ when the
+                # chunked-encoding state machine tries to advance past a
+                # closed fp.
                 return None
             if not line:
                 break
             if cancel_event is not None and cancel_event.is_set():
+                return None
+            if time.monotonic() >= deadline:
+                deadline_exceeded = True
+                _shutdown_response_socket(resp)
                 return None
             try:
                 chunk = json.loads(line.decode("utf-8"))
@@ -273,6 +301,11 @@ def _do_generate(
             pass
         if watcher is not None:
             watcher.join(timeout=0.5)
+        if deadline_exceeded:
+            utils.warning_print(
+                f"Ollama generate exceeded {_GENERATE_DEADLINE}s deadline "
+                f"(model: {body.get('model')}); aborting."
+            )
 
     if cancel_event is not None and cancel_event.is_set():
         return None

--- a/pipeline.py
+++ b/pipeline.py
@@ -295,6 +295,10 @@ def _run_clip_pipeline(
     When *parallel* is True and there are at least 2 clips, a ThreadPoolExecutor
     is used to run ``per_clip_fn`` concurrently (same worker count as
     ``_resolve_clip_workers()``).  Results are collected in original order.
+
+    On cancellation, any per-clip slots that did not complete are dropped from
+    the returned list — callers receive only successful results and can iterate
+    them without defensive ``None`` checks.
     """
     if not clips_list:
         utils.warning_print(empty_warning)
@@ -407,6 +411,10 @@ def _run_clip_pipeline(
 
     if missing_videos:
         utils.standard_print(f"* Missing source video files: {len(missing_videos)}")
+    # Drop slots from cancelled futures in the parallel path so callers get a
+    # list of completed results only (the sequential path naturally produces
+    # the same shape via early-break + append).
+    results = [r for r in results if r is not None]
     return (results, missing_videos)
 
 
@@ -973,10 +981,7 @@ def process_reel(
 
     # If cancelled, clean up any partial clip files and bail out
     if cancel_flag and cancel_flag():
-        for item in all_results:
-            if item is None:
-                continue
-            segment_paths, _ = item
+        for segment_paths, _ in all_results:
             for entry in segment_paths:
                 try:
                     Path(entry[0]).unlink(missing_ok=True)

--- a/screenspace.py
+++ b/screenspace.py
@@ -575,6 +575,15 @@ def scan_video_frames(
     - ``max_region_dim``: downscale extracted region to this max dimension
     """
     full_frame = region is None
+    # Reject zero-dimension regions early so ffmpeg's crop filter doesn't
+    # produce empty frames downstream (which would crash cv2.cvtColor /
+    # cv2.GaussianBlur with an opaque shape mismatch).
+    if not full_frame and region is not None:
+        if region.get("w", 0) <= 0 or region.get("h", 0) <= 0:
+            utils.warning_print(
+                f"Skipping scan: region has zero width or height ({region})"
+            )
+            return
     if cv_scale is None:
         cv_scale = config.SCREENSPACE_CV_RESOLUTION_SCALE
 
@@ -1901,7 +1910,13 @@ def check_frame_for_tool(
     For **change** and **flow** tools *prev_frame* is required (the frame
     immediately before the candidate timestamp).  If it is ``None`` the
     check is skipped (returns ``(False, None)``).
+
+    Degenerate regions (width or height ≤ 0, e.g. a 1-px user draw rounded
+    to zero pixels on a small preview) are treated as a non-match here so
+    downstream cv2 ops never see empty arrays.
     """
+    if region.get("w", 0) <= 0 or region.get("h", 0) <= 0:
+        return False, None
     if tool_type == "color":
         pixels = extract_region(frame, region)
         target = parameters.get("target_color", {"h": 0, "s": 0, "v": 0})

--- a/server.py
+++ b/server.py
@@ -39,6 +39,7 @@ import re
 import sys
 import threading
 import webbrowser
+from collections import OrderedDict
 from contextlib import contextmanager
 from pathlib import Path
 from collections.abc import Iterator
@@ -69,10 +70,17 @@ _worksheet: Any = None
 _sheet_context: spreadsheet.SheetContext | None = None
 _generated_artifacts: list[dict[str, Any]] = []
 _generated_reels: list[dict[str, Any]] = []
-_thumbnail_cache: dict[tuple, bytes] = {}
+# Bounded LRU so long sessions don't grow unbounded; entries are JPEG bytes
+# (tens of KB each), so a few hundred is plenty.
+_THUMBNAIL_CACHE_MAX = 256
+_thumbnail_cache: "OrderedDict[tuple, bytes]" = OrderedDict()
+# A second concurrent /api/generate or /api/reel call would clobber the
+# shared cancel event; reject with 409 instead while one is in flight.
 _reel_cancel_event = threading.Event()
-# Single in-flight job assumed; a second /api/generate clears this.
 _generate_cancel_event = threading.Event()
+_busy_lock = threading.Lock()
+_generate_in_progress = False
+_reel_in_progress = False
 
 # Snapshot config defaults before any settings file is loaded.
 # Deep-copied so dict-valued defaults are not aliased to live config state.
@@ -107,6 +115,44 @@ def _coerce_mark_categories(value: Any) -> dict[str, dict[str, str]] | None:
             return None
         cleaned[key] = {"label": label, "color": color}
     return cleaned
+
+
+def _thumbnail_cache_put(key: tuple, value: bytes) -> None:
+    """Insert into the thumbnail cache with simple LRU eviction."""
+    _thumbnail_cache[key] = value
+    while len(_thumbnail_cache) > _THUMBNAIL_CACHE_MAX:
+        _thumbnail_cache.popitem(last=False)
+
+
+def _try_claim_busy(slot: str) -> bool:
+    """Atomically reserve the single-job slot for *slot* ('generate'|'reel').
+
+    Returns True on success (caller must call ``_release_busy`` when done) or
+    False if another request is already holding the slot.
+    """
+    global _generate_in_progress, _reel_in_progress  # noqa: PLW0603
+    with _busy_lock:
+        if slot == "generate":
+            if _generate_in_progress:
+                return False
+            _generate_in_progress = True
+            return True
+        if slot == "reel":
+            if _reel_in_progress:
+                return False
+            _reel_in_progress = True
+            return True
+    return False
+
+
+def _release_busy(slot: str) -> None:
+    """Release the single-job slot for *slot* ('generate'|'reel')."""
+    global _generate_in_progress, _reel_in_progress  # noqa: PLW0603
+    with _busy_lock:
+        if slot == "generate":
+            _generate_in_progress = False
+        elif slot == "reel":
+            _reel_in_progress = False
 
 
 @contextmanager
@@ -186,7 +232,7 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
     if jpeg_bytes is None:
         return jsonify({"ok": False, "error": "Thumbnail extraction failed"}), 404
 
-    _thumbnail_cache[cache_key] = jpeg_bytes
+    _thumbnail_cache_put(cache_key, jpeg_bytes)
     return Response(
         jpeg_bytes,
         mimetype="image/jpeg",
@@ -318,7 +364,13 @@ def api_sheet_refresh() -> FlaskResponse:
 
 
 def _save_manifest_quiet() -> None:
-    """Save manifest after generate/reel; swallow errors so the caller still succeeds."""
+    """Save manifest after generate/reel.
+
+    Narrow exception handling: filesystem and serialization errors are logged
+    (the manifest writer already handles atomicity), but other exceptions
+    bubble up so they aren't lost silently — those are real bugs we want to
+    see, not transient I/O issues.
+    """
     try:
         artifacts = _generated_artifacts
         reels = _generated_reels
@@ -337,7 +389,7 @@ def _save_manifest_quiet() -> None:
             is_excel=pipeline.is_excel_worksheet(_worksheet) if _worksheet else False,
             mode="studio",
         )
-    except Exception as e:
+    except (OSError, TypeError, ValueError) as e:
         utils.warning_print(f"Failed to save manifest: {e}")
 
 
@@ -557,10 +609,16 @@ def api_generate() -> FlaskResponse:
     if output_format not in ("clip", "screen", "gif"):
         return jsonify({"ok": False, "error": f"Invalid format: {output_format}"}), 400
 
+    if not _try_claim_busy("generate"):
+        return jsonify(
+            {"ok": False, "error": "A clip generation is already in progress"}
+        ), 409
+
     try:
         cell_input = ", ".join(cell_strings)
         cell_specs = spreadsheet.parse_cell_specifications(cell_input)
         if not cell_specs:
+            _release_busy("generate")
             return jsonify(
                 {"ok": False, "error": "Could not parse cell specifications"}
             ), 400
@@ -573,6 +631,7 @@ def api_generate() -> FlaskResponse:
             skip_prompts=True,
         )
     except Exception as e:
+        _release_busy("generate")
         return jsonify({"ok": False, "error": str(e)}), 500
 
     def stream() -> Any:
@@ -701,8 +760,16 @@ def api_generate() -> FlaskResponse:
                 yield json.dumps({"cancelled": True}) + "\n"
             _save_manifest_quiet()
 
+    def stream_with_busy_release() -> Any:
+        try:
+            yield from stream()
+        finally:
+            _release_busy("generate")
+
     return Response(
-        stream(), mimetype="application/x-ndjson", headers={"X-Accel-Buffering": "no"}
+        stream_with_busy_release(),
+        mimetype="application/x-ndjson",
+        headers={"X-Accel-Buffering": "no"},
     )
 
 
@@ -784,6 +851,11 @@ def api_reel() -> FlaskResponse:
         except (ValueError, TypeError):
             pass
 
+    if not _try_claim_busy("reel"):
+        return jsonify(
+            {"ok": False, "error": "A reel build is already in progress"}
+        ), 409
+
     with _override_config(**overrides):
         try:
             reel_input = ", ".join(cell_strings)
@@ -847,6 +919,8 @@ def api_reel() -> FlaskResponse:
 
         except Exception as e:
             return jsonify({"ok": False, "error": str(e)}), 500
+        finally:
+            _release_busy("reel")
 
 
 @studio_bp.route("/api/viewer", methods=["POST"])
@@ -1347,6 +1421,11 @@ def api_reel_direct() -> FlaskResponse:
     clip_paths: list[str] = []
     temp_clips: list[str] = []
 
+    if not _try_claim_busy("reel"):
+        return jsonify(
+            {"ok": False, "error": "A reel build is already in progress"}
+        ), 409
+
     _reel_cancel_event.clear()
 
     with _override_config(**overrides):
@@ -1373,8 +1452,11 @@ def api_reel_direct() -> FlaskResponse:
                 fd, tmp_path = tempfile.mkstemp(
                     suffix=config.FILEFORMAT, dir=str(output_dir)
                 )
-                os.close(fd)
+                # Track for cleanup BEFORE os.close(fd) or any other call
+                # that could raise; otherwise the tmp file is on disk but
+                # not in temp_clips, so the finally block won't unlink it.
                 temp_clips.append(tmp_path)
+                os.close(fd)
 
                 ok = video.run_ffmpeg(
                     video_path,
@@ -1428,6 +1510,7 @@ def api_reel_direct() -> FlaskResponse:
                     Path(tmp).unlink(missing_ok=True)
                 except OSError:
                     pass
+            _release_busy("reel")
 
 
 @studio_bp.route("/api/reel/cancel", methods=["POST"])

--- a/server.py
+++ b/server.py
@@ -1543,7 +1543,7 @@ def _init_studio_state(worksheet: Any) -> None:
     _worksheet = worksheet
     _sheet_context = spreadsheet.build_sheet_context(worksheet)
     _generated_artifacts, _generated_reels = viewer._load_manifest_both()
-    _thumbnail_cache = {}
+    _thumbnail_cache = OrderedDict()
 
     if _sheet_context is None:
         utils.error_print("Could not load spreadsheet data for Studio.")

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -537,7 +537,7 @@ def find_participant_column(
 
 
 def _make_clip_record(
-    ctx: SheetContext, row_idx: int, col_idx: int, cell_value: str
+    ctx: SheetContext, row_idx: int, col_idx: int, cell_value: Any
 ) -> ClipRecord:
     """Build one clip record dict for a cell at (row_idx, col_idx).
 
@@ -549,8 +549,12 @@ def _make_clip_record(
     - category: Category label from the same row (category column).
     'times' is added later when timestamps are resolved to [start, end] ranges.
     """
+    # Excel cells may yield numbers, datetimes, or None; gspread always returns
+    # strings. Coerce here so downstream timestamp parsing (which calls .lower())
+    # never sees a non-string.
+    cell_value_str = "" if cell_value is None else str(cell_value)
     # gspread Cell uses 1-based coordinates; convert from 0-based list indices
-    cell = gspread.cell.Cell(row_idx + 1, col_idx + 1, cell_value)
+    cell = gspread.cell.Cell(row_idx + 1, col_idx + 1, cell_value_str)
     # observation_cell.col is 1-based; convert to 0-based for sheet_data
     desc_col = ctx.observation_cell.col - 1
     category_col = ctx.category_cell.col - 1
@@ -558,23 +562,25 @@ def _make_clip_record(
     participant_row = ctx.id_cell.row - 1
     desc = ""
     if 0 <= desc_col < len(ctx.sheet_data[row_idx]):
-        desc = ctx.sheet_data[row_idx][desc_col]
+        desc = str(ctx.sheet_data[row_idx][desc_col] or "")
     participant = ""
     if 0 <= participant_row < len(ctx.sheet_data) and col_idx < len(
         ctx.sheet_data[participant_row]
     ):
         participant = utils.normalize_participant_id(
-            ctx.sheet_data[participant_row][col_idx]
+            str(ctx.sheet_data[participant_row][col_idx] or "")
         )
     timestamp_baseline = ""
     if ctx.baseline_row_idx is not None:
         if 0 <= ctx.baseline_row_idx < len(ctx.sheet_data) and col_idx < len(
             ctx.sheet_data[ctx.baseline_row_idx]
         ):
-            timestamp_baseline = ctx.sheet_data[ctx.baseline_row_idx][col_idx].strip()
+            timestamp_baseline = str(
+                ctx.sheet_data[ctx.baseline_row_idx][col_idx] or ""
+            ).strip()
     category = ""
     if 0 <= category_col < len(ctx.sheet_data[row_idx]):
-        category = ctx.sheet_data[row_idx][category_col]
+        category = str(ctx.sheet_data[row_idx][category_col] or "")
     severity = ""
     if ctx.severity_cell is not None:
         severity_col = ctx.severity_cell.col - 1

--- a/transcripts.py
+++ b/transcripts.py
@@ -258,14 +258,18 @@ def save_transcripts_manifest(
 ) -> Path | None:
     """Write the transcripts manifest to disk.
 
-    Assigns segment IDs (``"{participant}:{index}"``) at storage time.
+    Assigns a segment ID (``"{participant}:{index}"``) when a segment doesn't
+    already have one, but never overwrites an existing id — so marks and
+    corrections that reference ``seg["id"]`` keep pointing at the same
+    segment even when later segments are added, edited, or reordered.
     *marks* defaults to ``None`` which preserves whatever marks are already on
     disk (load → merge → save).  Pass an explicit list to overwrite.
     Returns the manifest path on success, or ``None`` on failure.
     """
     for participant_id, entry in source_transcripts.items():
         for idx, seg in enumerate(entry.get("segments", [])):
-            seg["id"] = f"{participant_id}:{idx}"
+            if not seg.get("id"):
+                seg["id"] = f"{participant_id}:{idx}"
 
     # When marks is None, preserve existing marks from disk
     if marks is None:

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1111,10 +1111,17 @@ def _run_agent(agent_key: str, participant: str, force: bool = False) -> None:
         return
     if not force and not _agent_enabled(agent):
         return
-    if _is_generating(participant, agent_key):
-        return
 
     cancel_event = threading.Event()
+    # Atomically check-and-claim the in-flight slot so two near-simultaneous
+    # chain triggers (e.g. user click + auto-chain from a completed
+    # dependency) can't both spawn a thread for the same participant.
+    with _manifest_lock:
+        if _is_generating(participant, agent_key):
+            return
+        _agent_in_flight[agent_key].add(participant)
+        _agent_cancel_events[agent_key][participant] = cancel_event
+
     # If a Stop just scheduled an unload for this model, cancel it — the
     # next request would only force a reload.
     model = _agent_model(agent_key)
@@ -1158,20 +1165,19 @@ def _run_agent(agent_key: str, participant: str, force: bool = False) -> None:
                 f"{agent_key} generation failed for {participant}: {exc}"
             )
         finally:
-            _agent_in_flight[agent_key].discard(participant)
-            _agent_cancel_events[agent_key].pop(participant, None)
-            _agent_threads[agent_key].discard(t)
+            with _manifest_lock:
+                _agent_in_flight[agent_key].discard(participant)
+                _agent_cancel_events[agent_key].pop(participant, None)
+                _agent_threads[agent_key].discard(t)
 
-    # Register the event before starting the thread so a fast Stop click can
-    # never miss it.
-    _agent_in_flight[agent_key].add(participant)
-    _agent_cancel_events[agent_key][participant] = cancel_event
+    # Slot claim happened above under _manifest_lock; just spawn the thread.
     t = threading.Thread(
         target=_run,
         daemon=True,
         name=f"{agent['thread_name_prefix']}-{participant}",
     )
-    _agent_threads[agent_key].add(t)
+    with _manifest_lock:
+        _agent_threads[agent_key].add(t)
     t.start()
 
 

--- a/utils.py
+++ b/utils.py
@@ -531,17 +531,26 @@ def save_json_manifest(
 ) -> Path | None:
     """Write *data* as JSON to *filename* in the output directory.
 
-    Creates parent dirs.  Returns the path on success, ``None`` on failure.
-    Logs a warning on write failure using *warn_label*.
+    Writes via a sibling .tmp file and ``os.replace()`` so a crash or ENOSPC
+    mid-write leaves the previous manifest intact rather than corrupted.
+    Creates parent dirs. Returns the path on success, ``None`` on failure.
+    Logs a warning on write/serialization failure using *warn_label*.
     """
+    import os as _os
+
     path = Path(get_effective_output_dir()) / filename
+    tmp = path.with_suffix(path.suffix + ".tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
+        payload = json.dumps(data, ensure_ascii=False, indent=2)
+        tmp.write_text(payload, encoding="utf-8")
+        _os.replace(tmp, path)
         return path
-    except OSError as exc:
+    except (OSError, TypeError, ValueError) as exc:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
         if warn_label:
             warning_print(f"Could not write {warn_label}: {exc}")
         return None
@@ -1197,10 +1206,10 @@ def convert_clock_pairs_to_relative(
             f"Ignoring invalid baseline timestamp '{baseline}'{cell_info}.",
             [
                 "Baseline must use clock format like HH:MM:SS or MM:SS.",
-                "Timestamps in this column will be treated as relative.",
+                f"Dropping {len(pairs)} clock-style segment(s) in this column.",
             ],
         )
-        return pairs
+        return []
 
     result: list[tuple[str, str]] = []
     skipped: list[str] = []
@@ -1223,9 +1232,11 @@ def convert_clock_pairs_to_relative(
         )
 
     if skipped:
-        # Only show detailed skipped clock-based segment warnings at verbose verbosity.
-        if getattr(config, "VERBOSITY", config.STANDARD) >= config.VERBOSE:
-            cell_info = f" in cell {cell_ref}" if cell_ref else ""
+        cell_info = f" in cell {cell_ref}" if cell_ref else ""
+        # Standard verbosity: short summary so users notice silent drops.
+        # Verbose: full list and explanation.
+        verbosity = getattr(config, "VERBOSITY", config.STANDARD)
+        if verbosity >= config.VERBOSE:
             details = [f"    '{s}'" for s in skipped]
             details.append(
                 "  These segments were before the baseline, invalid, or zero/negative length."
@@ -1233,6 +1244,12 @@ def convert_clock_pairs_to_relative(
             warning_print(
                 f"Skipped {len(skipped)} clock-based timestamp segment(s){cell_info} when converting to relative:",
                 details,
+            )
+        else:
+            warning_print(
+                f"Skipped {len(skipped)} clock-based timestamp segment(s){cell_info} "
+                "(before baseline, invalid, or zero/negative length). "
+                "Re-run with verbose verbosity for the full list.",
             )
 
     return result


### PR DESCRIPTION
## Summary

Audit of the Python backend (server, pipeline, screenspace, transcripts, Ollama, manifests) surfaced a set of real bugs ranging from data-loss risks to silent silent failures. This PR fixes all of them. Each commit is one bug area:

- **utils**: atomic manifest writes (tmp + `os.replace`); catch `TypeError`/`ValueError` from `json.dumps`; surface clock-baseline skips at standard verbosity; drop pairs (not return as-is) when baseline is unparseable.
- **pipeline**: drop `None` slots from cancelled parallel results so callers don't have to defensively check.
- **ollama**: wall-clock deadline (`_GENERATE_DEADLINE = 600s`) so slow trickling responses can't hang a worker; serialize `_start_server` with a lock.
- **transcripts**: stop renumbering segment IDs on every save — marks/corrections that reference `seg["id"]` stay stable.
- **screenspace**: reject zero-width/zero-height regions at scan entry and in multitool `check_frame_for_tool` so cv2 ops never see empty arrays.
- **server**: 409 instead of clobbering the singleton cancel event on a concurrent `/api/generate` or `/api/reel`; LRU-bounded thumbnail cache; tighter `_save_manifest_quiet` exception handling; track tempfile path before `os.close(fd)` so a mid-step failure doesn't leak it.
- **transcripts-server**: atomic check-and-set for `_is_generating`+`_agent_in_flight` so two near-simultaneous chain triggers can't double-spawn a thread.
- **spreadsheet**: coerce cell values to `str` in `_make_clip_record` so an Excel cell that yields a number/datetime/None doesn't crash downstream timestamp parsing.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run ty check` clean
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — all 754 tests pass
- [ ] Manual: open Studio, kick off `/api/generate`, fire a second one — expect 409 instead of broken cancel button on the first
- [ ] Manual: run a Screenspace scan with a normally-sized region (sanity check that the zero-dim guard doesn't false-positive)
- [ ] Manual: re-transcribe a participant who already has marks — marks should remain pointing at the same content (note: this is the case where IDs are already assigned; truly fresh re-transcription still allocates new positional IDs since the old segments are gone)