### PR TITLE
fix: backend bug audit — sweep across 11 verified findings

### DIFF
--- a/excel_io.py
+++ b/excel_io.py
@@ -5,6 +5,7 @@ Provides a sheet adapter that matches the gspread Worksheet interface
 so spreadsheet.py and clipgen can use local Excel files the same way as Google Sheets.
 """
 
+import datetime as _datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -12,6 +13,32 @@ import openpyxl
 
 import config
 import utils
+
+
+def _cell_to_str(v: Any) -> str:
+    """Convert an openpyxl cell value to a downstream-safe string.
+
+    Time-like cells (``datetime.time``, ``datetime.datetime``,
+    ``datetime.timedelta``) are formatted as ``HH:MM:SS`` so timestamp
+    parsing downstream behaves the same way it does for Google Sheets,
+    which always returns strings. The default ``str()`` on a
+    ``datetime.datetime`` prefixes the Excel epoch date (``1899-12-30``)
+    and produces unparseable output; this normalizes those away.
+    """
+    if v is None:
+        return ""
+    if isinstance(v, str):
+        return v.strip()
+    if isinstance(v, _datetime.datetime):
+        return v.strftime("%H:%M:%S")
+    if isinstance(v, _datetime.time):
+        return v.strftime("%H:%M:%S")
+    if isinstance(v, _datetime.timedelta):
+        total = int(v.total_seconds())
+        h, rem = divmod(total, 3600)
+        m, s = divmod(rem, 60)
+        return f"{h:02d}:{m:02d}:{s:02d}"
+    return str(v)
 
 
 class _CellLike(NamedTuple):
@@ -44,12 +71,7 @@ class ExcelSheetAdapter:
         rows: list[list[str]] = []
         max_col = 0
         for row in self._ws.iter_rows(values_only=True):
-            str_row = [
-                (str(v).strip() if isinstance(v, str) else str(v))
-                if v is not None
-                else ""
-                for v in row
-            ]
+            str_row = [_cell_to_str(v) for v in row]
             rows.append(str_row)
             max_col = max(max_col, len(str_row))
         # Pad rows to same length

--- a/files.py
+++ b/files.py
@@ -2,6 +2,7 @@
 """File and filename operations for clipgen."""
 
 import re
+import unicodedata
 from pathlib import Path
 
 import gspread
@@ -10,6 +11,26 @@ from icecream import ic
 import config
 import utils
 from utils import ClipRecord
+
+
+def _safe_truncate(text: str, max_chars: int) -> str:
+    """Truncate to ``max_chars`` code points, then drop trailing combining marks.
+
+    Plain ``text[:n]`` can split a grapheme cluster (e.g. emoji + skin-tone
+    modifier, or letter + combining accent), leaving an orphan combining
+    character. Drop those at the truncation boundary so the visible glyph
+    survives intact.
+    """
+    if max_chars <= 0:
+        return ""
+    truncated = text[:max_chars]
+    # Trim trailing combining marks / joiners that would render orphaned.
+    while truncated and (
+        unicodedata.category(truncated[-1]) in ("Mn", "Mc", "Me")
+        or truncated[-1] in ("‍", "️")
+    ):
+        truncated = truncated[:-1]
+    return truncated
 
 
 def get_unique_filename(filename: str, file_format: str | None = None) -> str:
@@ -36,12 +57,12 @@ def get_unique_filename(filename: str, file_format: str | None = None) -> str:
         base = name
     # Truncate base if needed (reserve space for extension)
     max_base = config.MAX_FILENAME_LENGTH - len(file_extension)
-    base = base[:max_base]
+    base = _safe_truncate(base, max_base)
     candidate = directory / (base + file_extension)
     counter = 1
     while candidate.is_file():
         suffix = f"-{counter}"
-        truncated_base = base[: max_base - len(suffix)]
+        truncated_base = _safe_truncate(base, max_base - len(suffix))
         candidate = directory / (truncated_base + suffix + file_extension)
         counter += 1
     return str(candidate)

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -240,26 +240,27 @@ def _do_generate(
         data=data,
         headers={"Content-Type": "application/json"},
     )
-    resp = urllib.request.urlopen(req, timeout=_GENERATE_TIMEOUT)
     parts: list[str] = []
     done_event = threading.Event()
     watcher: threading.Thread | None = None
     deadline = time.monotonic() + _GENERATE_DEADLINE
     deadline_exceeded = False
-    if cancel_event is not None:
-
-        def _watch() -> None:
-            while not done_event.is_set():
-                if cancel_event.wait(timeout=_CANCEL_WATCHER_POLL):
-                    _shutdown_response_socket(resp)
-                    return
-
-        watcher = threading.Thread(
-            target=_watch, daemon=True, name="ollama-cancel-watcher"
-        )
-        watcher.start()
-
+    resp: Any = None
     try:
+        resp = urllib.request.urlopen(req, timeout=_GENERATE_TIMEOUT)
+        if cancel_event is not None:
+
+            def _watch() -> None:
+                while not done_event.is_set():
+                    if cancel_event.wait(timeout=_CANCEL_WATCHER_POLL):
+                        _shutdown_response_socket(resp)
+                        return
+
+            watcher = threading.Thread(
+                target=_watch, daemon=True, name="ollama-cancel-watcher"
+            )
+            watcher.start()
+
         if cancel_event is not None and cancel_event.is_set():
             return None
         while True:
@@ -295,10 +296,11 @@ def _do_generate(
                 break
     finally:
         done_event.set()
-        try:
-            resp.close()
-        except Exception:
-            pass
+        if resp is not None:
+            try:
+                resp.close()
+            except Exception:
+                pass
         if watcher is not None:
             watcher.join(timeout=0.5)
         if deadline_exceeded:

--- a/screenspace.py
+++ b/screenspace.py
@@ -721,7 +721,9 @@ def _ffmpeg_pipe_frames(
     ]
 
     frame_size = out_w * out_h * 3
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # stderr → DEVNULL: we only read stdout, so a PIPE'd stderr could fill
+    # its 64 KB OS buffer on a chatty codec error and deadlock ffmpeg.
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     assert proc.stdout is not None  # guaranteed by stdout=PIPE
     frame_idx = 0
     try:
@@ -1395,7 +1397,9 @@ def generate_timelapse(
     # Use Popen with -progress to get real-time encoding updates
     cmd += ["-progress", "pipe:1"]
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # stderr → DEVNULL: only stdout (progress lines) is read, so a PIPE'd
+        # stderr could fill its 64 KB OS buffer and deadlock ffmpeg.
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
         assert proc.stdout is not None  # guaranteed by stdout=PIPE
     except (FileNotFoundError, OSError):
         return None

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -47,6 +47,7 @@ import math
 import queue as queue_mod
 import threading
 import uuid
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypeGuard, cast
@@ -127,7 +128,11 @@ _worker: "screenspace.ScreenspaceWorker | None" = None
 _output_dir: str = ""
 _participants: list[dict[str, Any]] = []
 _video_metadata_cache: dict[str, dict[str, Any]] = {}
-_frame_cache: dict[tuple[str, float, int], bytes] = {}
+# Bounded LRU so long scrub sessions don't grow unbounded; entries are
+# JPEG bytes (tens of KB each), so a few hundred is plenty.
+_FRAME_CACHE_MAX = 256
+_frame_cache: "OrderedDict[tuple[str, float, int], bytes]" = OrderedDict()
+_frame_cache_lock = threading.Lock()
 
 # ---- SSE (Server-Sent Events) client registry ----
 
@@ -318,7 +323,11 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
 
     width = request.args.get("w", 0, type=int)
     cache_key = (video_path, round(ts, 3), width)
-    cached = _frame_cache.get(cache_key)
+    with _frame_cache_lock:
+        cached = _frame_cache.get(cache_key)
+        if cached is not None:
+            # Refresh LRU recency.
+            _frame_cache.move_to_end(cache_key)
     if cached is not None:
         return Response(
             cached,
@@ -342,7 +351,10 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     if jpeg_bytes is None:
         return jsonify({"ok": False, "error": "Could not extract frame"}), 400
 
-    _frame_cache[cache_key] = jpeg_bytes
+    with _frame_cache_lock:
+        _frame_cache[cache_key] = jpeg_bytes
+        while len(_frame_cache) > _FRAME_CACHE_MAX:
+            _frame_cache.popitem(last=False)
     return Response(
         jpeg_bytes,
         mimetype="image/jpeg",

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -128,6 +128,7 @@ _worker: "screenspace.ScreenspaceWorker | None" = None
 _output_dir: str = ""
 _participants: list[dict[str, Any]] = []
 _video_metadata_cache: dict[str, dict[str, Any]] = {}
+_video_metadata_cache_lock = threading.Lock()
 # Bounded LRU so long scrub sessions don't grow unbounded; entries are
 # JPEG bytes (tens of KB each), so a few hundred is plenty.
 _FRAME_CACHE_MAX = 256
@@ -588,8 +589,10 @@ def api_preview_layers() -> FlaskResponse:
 @screenspace_bp.route("/api/video/info/<participant>")
 def api_video_info(participant: str) -> FlaskResponse:
     """Return video metadata (duration, resolution, fps)."""
-    if participant in _video_metadata_cache:
-        return jsonify({"ok": True, "info": _video_metadata_cache[participant]})
+    with _video_metadata_cache_lock:
+        cached_info = _video_metadata_cache.get(participant)
+    if cached_info is not None:
+        return jsonify({"ok": True, "info": cached_info})
 
     video_path = _find_participant_video(participant)
     if video_path is None:
@@ -616,7 +619,8 @@ def api_video_info(participant: str) -> FlaskResponse:
         "nb_frames": props.get("nb_frames", 0) or 0,
         "video_codec": props.get("video_codec") or "",
     }
-    _video_metadata_cache[participant] = info
+    with _video_metadata_cache_lock:
+        _video_metadata_cache[participant] = info
 
     return jsonify({"ok": True, "info": info})
 

--- a/server.py
+++ b/server.py
@@ -81,6 +81,9 @@ _generate_cancel_event = threading.Event()
 _busy_lock = threading.Lock()
 _generate_in_progress = False
 _reel_in_progress = False
+# Serializes load → mutate → save for the stash manifests so concurrent
+# stash CRUD requests don't drop each other's writes.
+_stash_lock = threading.Lock()
 
 # Snapshot config defaults before any settings file is loaded.
 # Deep-copied so dict-valued defaults are not aliased to live config state.
@@ -1173,53 +1176,58 @@ def _handle_stash_crud(load_fn: Any, save_fn: Any, id_prefix: str) -> FlaskRespo
 
     data = request.get_json(silent=True) or {}
     action = data.get("action", "create")
-    stashes = load_fn()
 
-    if action == "create":
-        items = data.get("items", [])
-        if not items:
-            return jsonify({"ok": False, "error": "No items to stash"}), 400
-        name = data.get("name", "")
-        total_duration = data.get("totalDuration") or sum(
-            item.get("segDuration", 0) for item in items
-        )
-        stash = {
-            "id": f"{id_prefix}_{uuid.uuid4().hex[:8]}",
-            "name": name or f"Stash {len(stashes) + 1}",
-            "items": items,
-            "count": len(items),
-            "totalDuration": total_duration,
-            "createdAt": datetime.now(timezone.utc).isoformat(),
-        }
-        stashes.append(stash)
-        save_fn(stashes)
-        return jsonify({"ok": True, "stash": stash})
+    # Serialize the load → mutate → save cycle so two concurrent stash
+    # POSTs can't both read the same list, both append, and have the
+    # second save overwrite the first.
+    with _stash_lock:
+        stashes = load_fn()
 
-    if action == "update":
-        stash_id = data.get("id")
-        if not stash_id:
-            return jsonify({"ok": False, "error": "No stash ID"}), 400
-        for s in stashes:
-            if s["id"] == stash_id:
-                name = data.get("name")
-                if name is not None:
-                    s["name"] = name
-                save_fn(stashes)
-                return jsonify({"ok": True, "stash": s})
-        return jsonify({"ok": False, "error": "Stash not found"}), 404
+        if action == "create":
+            items = data.get("items", [])
+            if not items:
+                return jsonify({"ok": False, "error": "No items to stash"}), 400
+            name = data.get("name", "")
+            total_duration = data.get("totalDuration") or sum(
+                item.get("segDuration", 0) for item in items
+            )
+            stash = {
+                "id": f"{id_prefix}_{uuid.uuid4().hex[:8]}",
+                "name": name or f"Stash {len(stashes) + 1}",
+                "items": items,
+                "count": len(items),
+                "totalDuration": total_duration,
+                "createdAt": datetime.now(timezone.utc).isoformat(),
+            }
+            stashes.append(stash)
+            save_fn(stashes)
+            return jsonify({"ok": True, "stash": stash})
 
-    if action == "delete":
-        stash_id = data.get("id")
-        if not stash_id:
-            return jsonify({"ok": False, "error": "No stash ID"}), 400
-        for i, s in enumerate(stashes):
-            if s["id"] == stash_id:
-                stashes.pop(i)
-                save_fn(stashes)
-                return jsonify({"ok": True})
-        return jsonify({"ok": False, "error": "Stash not found"}), 404
+        if action == "update":
+            stash_id = data.get("id")
+            if not stash_id:
+                return jsonify({"ok": False, "error": "No stash ID"}), 400
+            for s in stashes:
+                if s["id"] == stash_id:
+                    name = data.get("name")
+                    if name is not None:
+                        s["name"] = name
+                    save_fn(stashes)
+                    return jsonify({"ok": True, "stash": s})
+            return jsonify({"ok": False, "error": "Stash not found"}), 404
 
-    return jsonify({"ok": False, "error": f"Unknown action: {action}"}), 400
+        if action == "delete":
+            stash_id = data.get("id")
+            if not stash_id:
+                return jsonify({"ok": False, "error": "No stash ID"}), 400
+            for i, s in enumerate(stashes):
+                if s["id"] == stash_id:
+                    stashes.pop(i)
+                    save_fn(stashes)
+                    return jsonify({"ok": True})
+            return jsonify({"ok": False, "error": "Stash not found"}), 404
+
+        return jsonify({"ok": False, "error": f"Unknown action: {action}"}), 400
 
 
 @studio_bp.route("/api/stashes", methods=["GET"])

--- a/server.py
+++ b/server.py
@@ -371,11 +371,13 @@ def _save_manifest_quiet() -> None:
     bubble up so they aren't lost silently — those are real bugs we want to
     see, not transient I/O issues.
     """
+    # Snapshot the shared lists before serializing so a concurrent intake or
+    # generate-worker extend can't surface as a partially-saved manifest.
+    artifacts = list(_generated_artifacts)
+    reels = list(_generated_reels)
+    if not artifacts and not reels:
+        return
     try:
-        artifacts = _generated_artifacts
-        reels = _generated_reels
-        if not artifacts and not reels:
-            return
         study = ""
         if artifacts:
             study = artifacts[0].get("study", "")
@@ -1106,8 +1108,10 @@ def api_manifest() -> FlaskResponse:
         reels = viewer.load_manifest_reels()
         return jsonify({"ok": True, "artifacts": artifacts, "reels": reels})
 
-    artifacts = _generated_artifacts
-    reels = _generated_reels
+    # Snapshot the shared lists so a worker thread extending mid-export
+    # can't produce a partial/aliased manifest snapshot.
+    artifacts = list(_generated_artifacts)
+    reels = list(_generated_reels)
     if not artifacts and not reels:
         return jsonify(
             {

--- a/tests/test_utils_timestamps.py
+++ b/tests/test_utils_timestamps.py
@@ -40,6 +40,31 @@ def test_convert_clock_pairs_to_relative_uses_baseline_and_skips_invalid():
     assert converted == [("0:02:12", "0:02:45"), ("0:01:00", "0:01:30")]
 
 
+def test_convert_clock_pairs_to_relative_handles_post_midnight_wraparound():
+    # Baseline at 22:00, segment at 01:30 the next morning → +3:30:00 from start.
+    pairs = [("01:30:00", "01:32:00")]
+    baseline = "22:00"
+    converted = utils.convert_clock_pairs_to_relative(pairs, baseline)
+    assert converted == [("3:30:00", "3:32:00")]
+
+
+def test_convert_clock_pairs_to_relative_handles_midnight_crossing_span():
+    # Baseline 23:30, span 23:55-00:05 should yield 0:25:00-0:35:00.
+    pairs = [("23:55:00", "00:05:00")]
+    baseline = "23:30"
+    converted = utils.convert_clock_pairs_to_relative(pairs, baseline)
+    assert converted == [("0:25:00", "0:35:00")]
+
+
+def test_convert_clock_pairs_to_relative_rejects_unreasonable_pre_baseline():
+    # Baseline 08:00, segment at 07:00 is more likely a typo than a 23-hour
+    # overnight recording; should be skipped, not wrapped.
+    pairs = [("07:00:00", "07:05:00")]
+    baseline = "08:00"
+    converted = utils.convert_clock_pairs_to_relative(pairs, baseline)
+    assert converted == []
+
+
 def test_cluster_spans_empty_returns_empty():
     assert utils.cluster_spans([], gap_seconds=5.0) == []
 

--- a/transcripts.py
+++ b/transcripts.py
@@ -146,6 +146,16 @@ def _load_model(model_name: str | None = None) -> Any:
             )
             return None
 
+        # Drop the previous model before loading a new one so we don't
+        # double-hold ~1-2 GB of weights (per CPU/GPU) until the next GC
+        # cycle. gc.collect() prods CUDA/MPS allocator cleanup as well.
+        if _cached_model is not None:
+            import gc
+
+            _cached_model = None
+            _cached_model_name = None
+            gc.collect()
+
         def _do_load() -> Any:
             return WhisperModel(model_name, compute_type=config.TRANSCRIBE_COMPUTE_TYPE)
 

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -342,19 +342,23 @@ def api_edit_segment(participant: str) -> FlaskResponse:
 def api_vtt(participant: str) -> FlaskResponse:
     """Serve transcript as WebVTT for <track> subtitle support."""
     with _manifest_lock:
-        src = _manifest.get("source_transcripts", {})
-        entry = src.get(participant)
-    if not entry or not entry.get("segments"):
-        return Response("WEBVTT\n", content_type="text/vtt")
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+        if not entry or not entry.get("segments"):
+            return Response("WEBVTT\n", content_type="text/vtt")
+        # Snapshot under the lock so a concurrent edit/transcribe can't mutate
+        # corrections or segments mid-iteration.
+        segments_snapshot = list(entry["segments"])
+        corrections_snapshot = list(_manifest.get("corrections", []))
+        language = entry.get("language", "")
+        source_file = entry.get("source_file", "")
+        model = entry.get("model", "")
 
-    corrections = _manifest.get("corrections", [])
-    corrected = transcripts.apply_corrections(entry["segments"], corrections)
-
+    corrected = transcripts.apply_corrections(segments_snapshot, corrections_snapshot)
     result = transcripts.TranscriptResult(
         segments=corrected,
-        language=entry.get("language", ""),
-        source_file=entry.get("source_file", ""),
-        model=entry.get("model", ""),
+        language=language,
+        source_file=source_file,
+        model=model,
     )
     vtt_text = transcripts._format_vtt(result)
     return Response(vtt_text, content_type="text/vtt")

--- a/utils.py
+++ b/utils.py
@@ -1211,6 +1211,13 @@ def convert_clock_pairs_to_relative(
         )
         return []
 
+    # Overnight recordings: segments after midnight will be < baseline_seconds.
+    # If the resulting wraparound offset is within a reasonable recording
+    # window (<= 12 hours), treat it as a day rollover; otherwise reject as
+    # a typo / pre-baseline entry.
+    seconds_per_day = 24 * config.SECONDS_PER_HOUR
+    wrap_window = 12 * config.SECONDS_PER_HOUR
+
     result: list[tuple[str, str]] = []
     skipped: list[str] = []
     for start_str, end_str in pairs:
@@ -1221,6 +1228,14 @@ def convert_clock_pairs_to_relative(
             continue
         start_rel = start_s - baseline_seconds
         end_rel = end_s - baseline_seconds
+        if start_rel < 0:
+            wrapped = start_rel + seconds_per_day
+            if 0 <= wrapped <= wrap_window:
+                start_rel = wrapped
+                end_rel = end_rel + seconds_per_day
+        elif end_rel < start_rel:
+            # Span crosses midnight while baseline was pre-midnight.
+            end_rel += seconds_per_day
         if start_rel < 0 or end_rel <= 0 or end_rel <= start_rel:
             skipped.append(f"{start_str}-{end_str}")
             continue


### PR DESCRIPTION
## Summary

Follow-up sweep to #309. Eleven verified backend issues, one fix per commit, ordered by impact.

### High impact

- **`api_vtt` lock extension** — `transcripts_server.py` was reading `corrections` and iterating `entry["segments"]` outside `_manifest_lock`. A concurrent `api_edit_segment` or transcribe write could mutate state mid-render. Snapshot both lists + entry metadata under the lock.
- **`api_manifest` / `_save_manifest_quiet` snapshotting** — `server.py` was passing `_generated_artifacts` / `_generated_reels` by reference to the manifest serializer while worker threads extended them. Replace with `list(...)` shallow copies.
- **`_frame_cache` bounded LRU** — `screenspace_server.py` had an unbounded dict for JPEG frame bytes; long scrub sessions leaked memory monotonically. Switch to `OrderedDict` LRU capped at 256, gated by a lock.

### Medium impact

- **ffmpeg stderr → DEVNULL** — Two `Popen` sites in `screenspace.py` PIPE'd stderr but never drained it. A chatty codec error could fill the 64 KB buffer and deadlock ffmpeg. Redirect to DEVNULL (stderr was unused).
- **Excel datetime formatting** — `excel_io.py` used bare `str()` on cell values; `datetime.datetime` cells stringify with the Excel epoch date prefix and won't parse downstream. Format time-like values as `HH:MM:SS`.
- **`_video_metadata_cache` lock** — Same race shape as `_frame_cache`, smaller blast radius. Add a dedicated lock.
- **Post-midnight clock segments** — `convert_clock_pairs_to_relative` silently dropped valid overnight segments (baseline 22:00, segment 01:30). Detect day rollover when the wrapped offset lies within a 12-hour window; also handle spans that cross midnight while the baseline is pre-midnight.

### Lower impact

- **Stash CRUD serialization** — `_handle_stash_crud` did unsynchronized load → mutate → save on the stash JSON files, so two concurrent stash POSTs could drop one. New `_stash_lock` serializes the cycle.
- **WhisperModel release on swap** — Drop the previous `_cached_model` + run `gc.collect()` before constructing the new one so the allocator releases ~1-2 GB of weights promptly on model swap.
- **Filename truncation grapheme safety** — `_safe_truncate` strips orphan combining marks / ZWJ left behind by a mid-cluster slice.
- **Ollama `urlopen` inside try/finally** — Moved the urlopen call and watcher start into the try block so any exception between them and the original try would still trigger `resp.close()`.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 758 passed (added 3 new tests for the post-midnight clock case)
- [ ] Manual: open Studio, generate clips, click Export Manifest mid-run — manifest should serialize a clean snapshot
- [ ] Manual: open Transcripts, edit segments while another tab fetches `/api/vtt/<participant>` — VTT should stay consistent
- [ ] Manual: open Screenspace, scrub a long video timeline — frame cache should stabilize at 256 entries