### PR TITLE
fix: frontend bug audit — listener/timer leaks, scroll preservation, blob lifecycle

### DIFF
--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -155,9 +155,9 @@
   }
 
   function navigateLightbox(delta) {
-    var next = state.lightboxIndex + delta;
-    if (next < 0) next = state.artifacts.length - 1;
-    if (next >= state.artifacts.length) next = 0;
+    var len = state.artifacts.length;
+    if (!len) return;
+    var next = ((state.lightboxIndex + delta) % len + len) % len;
     openLightbox(next);
   }
 })();

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -981,6 +981,7 @@ body {
 
 #amplitudeGraphBtn.active {
   color: var(--color-accent);
+  background: var(--color-accent-highlight);
 }
 
 .marker-info {

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -2420,6 +2420,10 @@ body.panel-dragging #bottomPanel {
   overflow-y: auto;
 }
 
+#taskList.drag-over-append .task-card:last-of-type {
+  border-bottom: 2px solid var(--color-accent);
+}
+
 .task-card {
   display: flex;
   align-items: center;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -6197,7 +6197,7 @@
   // ---- Keyboard shortcuts ----
 
   function initKeyboard() {
-    document.addEventListener("keydown", function (e) {
+    function onKeyDown(e) {
       // Don't capture when typing in inputs
       if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.tagName === "SELECT") return;
 
@@ -6255,15 +6255,22 @@
         }
         hideRegionNameModal();
       }
-    });
+    }
 
-    document.addEventListener("keyup", function (e) {
+    function onKeyUp(e) {
       if (e.key === "b" || e.key === "B") {
         if (state.overlayBlinkActive) {
           state.overlayBlinkActive = false;
           renderOverlay();
         }
       }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+    window.addEventListener("pagehide", function () {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
     });
 
     // Defensive: clear blink state on window blur so a held key doesn't get

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -147,6 +147,13 @@
   }
   var _lastPollFingerprint = "";
   var _preloadedFrames = {};
+
+  window.addEventListener("pagehide", function () {
+    Object.keys(_preloadedFrames).forEach(function (pid) {
+      try { URL.revokeObjectURL(_preloadedFrames[pid]); } catch (_) {}
+      delete _preloadedFrames[pid];
+    });
+  });
   var _participantRequestVersion = 0;
   var _frameRequestVersion = 0;
   var _resultsRequestVersion = 0;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5602,8 +5602,10 @@
 
       frag.appendChild(card);
     });
+    var prevScrollTop = container.scrollTop;
     container.innerHTML = "";
     container.appendChild(frag);
+    container.scrollTop = prevScrollTop;
     updateResultsCrumb();
   }
 
@@ -5910,6 +5912,7 @@
 
   function renderResults() {
     var container = qs("#resultsList");
+    var prevResultsScrollTop = container.scrollTop;
     var countEl = qs("#resultCount") || { textContent: "" };
     var actionsEl = qs("#resultsActions");
     var results = state.selectedTaskResults;
@@ -6199,6 +6202,7 @@
       frag.appendChild(row);
     });
     container.appendChild(frag);
+    container.scrollTop = prevResultsScrollTop;
   }
 
   // ---- Keyboard shortcuts ----

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1070,13 +1070,13 @@
 
     qs("#framePrev").addEventListener("click", function () {
       if (!state.videoInfo) return;
-      var ts = clamp(state.currentTimestamp - FRAME_STEP, 0, state.videoInfo.duration);
+      var ts = clamp(state.currentTimestamp - FRAME_STEP, 0, Math.max(0, state.videoInfo.duration - 0.001));
       loadFrame(ts);
     });
 
     qs("#frameNext").addEventListener("click", function () {
       if (!state.videoInfo) return;
-      var ts = clamp(state.currentTimestamp + FRAME_STEP, 0, state.videoInfo.duration);
+      var ts = clamp(state.currentTimestamp + FRAME_STEP, 0, Math.max(0, state.videoInfo.duration - 0.001));
       loadFrame(ts);
     });
   }
@@ -6214,10 +6214,10 @@
 
       if (e.key === "ArrowLeft") {
         e.preventDefault();
-        if (state.videoInfo) loadFrame(clamp(state.currentTimestamp - FRAME_STEP, 0, state.videoInfo.duration));
+        if (state.videoInfo) loadFrame(clamp(state.currentTimestamp - FRAME_STEP, 0, Math.max(0, state.videoInfo.duration - 0.001)));
       } else if (e.key === "ArrowRight") {
         e.preventDefault();
-        if (state.videoInfo) loadFrame(clamp(state.currentTimestamp + FRAME_STEP, 0, state.videoInfo.duration));
+        if (state.videoInfo) loadFrame(clamp(state.currentTimestamp + FRAME_STEP, 0, Math.max(0, state.videoInfo.duration - 0.001)));
       } else if (e.key === " ") {
         e.preventDefault();
         if (state.videoPlaying) {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5693,6 +5693,13 @@
     }
   }
 
+  document.addEventListener("dragend", function () {
+    var stepsDiv = document.querySelector(".multitool-steps");
+    if (stepsDiv) clearMultitoolDragIndicators(stepsDiv);
+    var taskListEl = qs("#taskList");
+    if (taskListEl) clearDragIndicators(taskListEl);
+  });
+
   document.addEventListener("visibilitychange", function () {
     if (document.hidden) {
       stopSSE();

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1681,8 +1681,11 @@
     chipsEl.addEventListener("scroll", updateRegionChipsOverflow);
   }
 
+  var _regionNameModalPrevFocus = null;
+
   function showRegionNameModal() {
     var r = state.pendingRegion;
+    _regionNameModalPrevFocus = document.activeElement;
     qs("#regionNameInput").value = "";
     qs("#regionDescInput").value = "";
     qs("#regionCoords").textContent = r ? (r.x + ", " + r.y + " \u2014 " + r.w + "\u00d7" + r.h + " px") : "";
@@ -1692,6 +1695,10 @@
 
   function hideRegionNameModal() {
     qs("#regionNameModal").classList.add("hidden");
+    if (_regionNameModalPrevFocus && typeof _regionNameModalPrevFocus.focus === "function") {
+      try { _regionNameModalPrevFocus.focus(); } catch (_) {}
+    }
+    _regionNameModalPrevFocus = null;
   }
 
   function updateRegionButtons() {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3118,6 +3118,7 @@
   function clearMultitoolDragIndicators(container) {
     var cards = container.querySelectorAll(".multitool-step.drag-over");
     for (var i = 0; i < cards.length; i++) cards[i].classList.remove("drag-over");
+    container.classList.remove("drag-over-append");
   }
 
   function taskToMultitoolStep(task) {
@@ -3282,6 +3283,8 @@
         var insertIdx = getMultitoolDropIndex(stepsDiv, e.clientY);
         if (insertIdx < cards.length) {
           cards[insertIdx].classList.add("drag-over");
+        } else {
+          stepsDiv.classList.add("drag-over-append");
         }
       }
     });
@@ -5107,12 +5110,17 @@
       clearDragIndicators(taskListEl);
       if (insertIdx < cards.length) {
         cards[insertIdx].classList.add("drag-over");
+      } else {
+        taskListEl.classList.add("drag-over-append");
       }
     });
 
     taskListEl.addEventListener("dragleave", function (e) {
       var card = e.target.closest(".task-card");
       if (card) card.classList.remove("drag-over");
+      if (!taskListEl.contains(e.relatedTarget)) {
+        taskListEl.classList.remove("drag-over-append");
+      }
     });
 
     taskListEl.addEventListener("drop", function (e) {
@@ -5212,6 +5220,7 @@
   function clearDragIndicators(container) {
     var cards = container.querySelectorAll(".task-card.drag-over");
     for (var i = 0; i < cards.length; i++) cards[i].classList.remove("drag-over");
+    container.classList.remove("drag-over-append");
   }
 
   function setInputValue(selector, value) {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -139,6 +139,12 @@
   var _overlayRaf = 0;
   var _playheadRaf = 0;
   var _cachedOverlayRect = null;
+  var _cachedTimelineRect = null;
+
+  function getTimelineRect(canvas) {
+    if (!_cachedTimelineRect) _cachedTimelineRect = canvas.getBoundingClientRect();
+    return _cachedTimelineRect;
+  }
   var _lastPollFingerprint = "";
   var _preloadedFrames = {};
   var _participantRequestVersion = 0;
@@ -2154,8 +2160,13 @@
     sizeTimelineCanvas();
     window.addEventListener("resize", function () {
       _cachedOverlayRect = null;
+      _cachedTimelineRect = null;
       sizeTimelineCanvas();
     });
+    window.addEventListener("scroll", function () {
+      _cachedOverlayRect = null;
+      _cachedTimelineRect = null;
+    }, true);
 
     canvas.addEventListener("click", function (e) {
       if (state.timelineDragging) return;
@@ -2318,6 +2329,7 @@
 
   function sizeTimelineCanvas() {
     var canvas = qs("#timelineCanvas");
+    _cachedTimelineRect = null;
     var rect = canvas.getBoundingClientRect();
     canvas.width = Math.floor(rect.width);
     canvas.height = TIMELINE_CANVAS_HEIGHT;
@@ -2331,7 +2343,7 @@
   function timelineXToTime(event) {
     if (!state.videoInfo) return null;
     var canvas = qs("#timelineCanvas");
-    var rect = canvas.getBoundingClientRect();
+    var rect = getTimelineRect(canvas);
     var frac = (event.clientX - rect.left) / rect.width;
     frac = clamp(frac, 0, 1);
     var dur = state.videoInfo.duration;
@@ -2567,7 +2579,7 @@
 
   function hitTestTimeline(clientX, clientY) {
     var canvas = qs("#timelineCanvas");
-    var rect = canvas.getBoundingClientRect();
+    var rect = getTimelineRect(canvas);
     var mx = clientX - rect.left;
     var my = clientY - rect.top;
     for (var i = _timelineHitRects.length - 1; i >= 0; i--) {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3103,7 +3103,7 @@
     }
 
     var duration = parseInt(qs("#highlightsDuration").value, 10);
-    if (!duration || duration < 1) duration = 180;
+    if (!Number.isFinite(duration) || duration < 1) duration = 180;
 
     drawer.classList.remove("open");
     btn.style.minWidth = "";

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -255,7 +255,9 @@
     clone.style.overflow = "hidden";
     document.body.appendChild(clone);
     ev.dataTransfer.setDragImage(clone, ev.clientX - rect.left, ev.clientY - rect.top);
-    setTimeout(function () { document.body.removeChild(clone); }, 0);
+    requestAnimationFrame(function () {
+      if (clone.parentNode) clone.parentNode.removeChild(clone);
+    });
   }
 
   // Transparent 1×1 image used to suppress the browser's default drag preview

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -994,6 +994,8 @@
   function renderGrid() {
     var d = state.sheetData;
     var grid = qs("#sheetGrid");
+    var prevScrollTop = grid.scrollTop;
+    var prevScrollLeft = grid.scrollLeft;
     grid.innerHTML = "";
 
     var showSeverity = hasSeverityData(d.rows);
@@ -1102,6 +1104,8 @@
     tbody.id = "gridTbody";
     table.appendChild(tbody);
     grid.appendChild(table);
+    grid.scrollTop = prevScrollTop;
+    grid.scrollLeft = prevScrollLeft;
 
     applyGridFilters();
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3264,6 +3264,7 @@
   var _confirmCleanup = null;
 
   function showConfirm(title, message, onYes, onNo) {
+    if (_confirmCleanup) _confirmCleanup();
     qs("#confirmTitle").textContent = title;
     qs("#confirmMessage").textContent = message;
     qs("#confirmOverlay").classList.remove("hidden");

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -4660,8 +4660,19 @@
     initTranscriptIntake();
     pollIntakeStatus();
     pollTrIntakeStatus();
-    state.intakeStatusTimer = setInterval(pollIntakeStatus, 5000);
-    state.trIntakeStatusTimer = setInterval(pollTrIntakeStatus, 5000);
+    if (!document.hidden) {
+      state.intakeStatusTimer = setInterval(pollIntakeStatus, 5000);
+      state.trIntakeStatusTimer = setInterval(pollTrIntakeStatus, 5000);
+    }
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) {
+        if (state.intakeStatusTimer) { clearInterval(state.intakeStatusTimer); state.intakeStatusTimer = null; }
+        if (state.trIntakeStatusTimer) { clearInterval(state.trIntakeStatusTimer); state.trIntakeStatusTimer = null; }
+      } else {
+        if (!state.intakeStatusTimer) { pollIntakeStatus(); state.intakeStatusTimer = setInterval(pollIntakeStatus, 5000); }
+        if (!state.trIntakeStatusTimer) { pollTrIntakeStatus(); state.trIntakeStatusTimer = setInterval(pollTrIntakeStatus, 5000); }
+      }
+    });
     // Start intake event polls immediately so the sub-tab counter badges
     // populate on page load and update live regardless of which sub-tab the
     // user is currently viewing. Visibility-change handlers in

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -3109,6 +3109,7 @@
       if (floating && floating.contains(e.target)) return;
       closePillOptions();
     });
+    window.addEventListener("pagehide", closePillOptions);
   }
 
   function initPillWheelScroll() {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1446,9 +1446,10 @@
     var cssH = canvas.offsetHeight;
     ctx.clearRect(0, 0, cssW, cssH);
 
-    var surfaceAlt = getCSSVar("--color-surface-alt", "#f1ece4");
-    var border = getCSSVar("--color-border", "#e0ddd7");
-    var textDim = getCSSVar("--color-text-dim", "#6b7280");
+    var isDark = (document.documentElement.getAttribute("data-theme") || "").toLowerCase() === "dark";
+    var surfaceAlt = getCSSVar("--color-surface-alt", isDark ? "#1f2937" : "#f1ece4");
+    var border = getCSSVar("--color-border", isDark ? "#374151" : "#e0ddd7");
+    var textDim = getCSSVar("--color-text-dim", isDark ? "#9ca3af" : "#6b7280");
 
     ctx.fillStyle = surfaceAlt;
     ctx.fillRect(0, 0, cssW, cssH);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -516,6 +516,7 @@
     _participantReqVer++;
     _stopSummaryPoll();
     _stopCitationsPoll();
+    hideMarkPopover();
     state.selectedParticipant = pid;
     setStoredUIStateField("transcripts", "selectedParticipant", pid);
     renderPills();
@@ -2298,6 +2299,7 @@
     // tick) cancels the pending attach instead of leaving a permanently
     // attached listener after the deferred .addEventListener fires.
     if (_popoverAttachTimer) clearTimeout(_popoverAttachTimer);
+    document.removeEventListener("click", _popoverOutsideClick);
     _popoverAttachTimer = setTimeout(function () {
       _popoverAttachTimer = null;
       document.addEventListener("click", _popoverOutsideClick);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -514,6 +514,8 @@
 
   function selectParticipant(pid) {
     _participantReqVer++;
+    _stopSummaryPoll();
+    _stopCitationsPoll();
     state.selectedParticipant = pid;
     setStoredUIStateField("transcripts", "selectedParticipant", pid);
     renderPills();

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1724,6 +1724,9 @@
         renderTimeline();
       });
       _timelineResizeObs.observe(qs("#timelineCanvasWrapper"));
+      window.addEventListener("pagehide", function () {
+        if (_timelineResizeObs) { _timelineResizeObs.disconnect(); _timelineResizeObs = null; }
+      });
     } else {
       window.addEventListener("resize", function () {
         sizeTimelineCanvas();

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2486,7 +2486,9 @@
       });
     });
 
+    var prevScrollTop = container.scrollTop;
     container.innerHTML = html;
+    container.scrollTop = prevScrollTop;
     container.classList.remove("hidden");
 
     // Attach click handlers

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -30,6 +30,13 @@
   var _thumbObserver = null;
   var _thumbCache = {};
 
+  window.addEventListener("pagehide", function () {
+    Object.keys(_thumbCache).forEach(function (id) {
+      try { URL.revokeObjectURL(_thumbCache[id]); } catch (_) {}
+      delete _thumbCache[id];
+    });
+  });
+
   var _filmstripEnabled = false;
   var _filmstripObserver = null;
   var _filmstripThumbQueue = [];

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1580,12 +1580,12 @@
 
     var timeBadge = el("span", "video-time-badge", "--:--");
 
-    var proportion = seekProportion != null ? seekProportion : 0;
+    var proportion = seekProportion != null ? Math.max(0, Math.min(1, seekProportion)) : 0;
 
     vid.onloadedmetadata = function () {
       var dur = vid.duration;
       if (!dur || !isFinite(dur)) return;
-      var seekTime = dur * Math.max(0, Math.min(1, proportion));
+      var seekTime = dur * proportion;
       vid.currentTime = seekTime;
       timeBadge.textContent = formatTime(seekTime) + " / " + formatTime(dur);
     };

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -238,6 +238,7 @@
   function cardScrubMove(mediaEl, ev) {
     if (!_cardScrub) return;
     if (!mediaEl || mediaEl !== _cardScrub.mediaEl) return;
+    if (!mediaEl.isConnected) { cardScrubLeave(); return; }
     var vid = _cardScrub.videoEl;
     if (!vid.duration || !isFinite(vid.duration)) return;
     if (vid.readyState < 1) return;


### PR DESCRIPTION
## Summary
Bug-audit sweep across `assets/web/`. Each fix is a discrete commit; verified false positives from the audit are listed below.

**HIGH impact**
- viewer: revoke cached thumbnail blob URLs on `pagehide` (`_thumbCache` was append-only across the session).
- studio: dismiss any prior confirm modal before opening a new one (stacked yes/no listeners fired both callbacks).
- transcripts: kill summary/citations poll timers synchronously on participant switch (callback-based version check could let one stale request through).
- studio: pause intake status pollers when the tab is hidden (event pollers already paused; the two 5s status pollers never did).
- screenspace: show insertion indicator when dragging past the last card in multitool/task lists.
- screenspace: cache timeline canvas `getBoundingClientRect()` for 60Hz hot paths.

**MEDIUM impact**
- viewer: bail card-scrub when media element is detached (`isConnected` guard).
- studio: rAF (not `setTimeout(0)`) for drag-image clone cleanup.
- screenspace: document-level `dragend` safety net for orphan `.drag-over`/`.drag-over-append` classes.
- screenspace: detach document keyboard listeners on `pagehide`.
- transcripts: defensively detach popover outside-click listener; close popover on participant switch.
- transcripts: close pill-options on `pagehide` (frees reposition listeners).
- transcripts: theme-aware fallback colors for canvas (dark-mode no longer renders with light-theme defaults if tokens are absent).
- screenspace: revoke preloaded frame blob URLs on `pagehide`.
- transcripts: preserve scroll across search-results rebuild.
- screenspace: preserve scroll across task list and results rebuilds.
- studio: preserve scroll across sheet-grid rebuild.

**LOW impact**
- gallery: safe modulo for lightbox wrap-around.
- studio: `Number.isFinite` instead of falsy check for highlights duration.
- viewer: clamp seek proportion to [0,1] at entry.
- transcripts: disconnect timeline `ResizeObserver` on `pagehide`.
- screenspace: more visible amplitude toggle active state.
- screenspace: keep frame-step seeks below exact video duration (browser seek-to-duration quirk).
- screenspace: restore focus when region-name modal closes.

**Verified false positives** (no commits — audit was wrong):
- viewer filmstrip concurrency (already implemented correctly).
- viewer `--color-task-*` tokens (`viewer.py` inlines `tokens.css` in standalone exports).
- screenspace polling on `visibilitychange` (already wired).
- screenspace `taskTypeColor` (already reads `--color-task-*` via `DETECTOR_COLORS` + `refreshDetectorColors()`).
- screenspace inline SVG paths (none present).
- screenspace `video.play()` rejection handling (already caught).
- transcripts `renderSegments` active-class loss (`activeClass` is rebuilt from `state.activeSegmentIndex`).
- transcripts streaming marks race (single-threaded JS makes the proposed race impossible).
- viewer `.filter-severity-wrap.hidden` CSS (no global `.hidden` rule in viewer.css to shadow it).
- studio queue card listeners (`innerHTML = ""` GCs the listeners with the nodes).
- transcripts Space-in-input (already guarded).
- screenspace timeline wheel `preventDefault` (already at top of handler).
- screenspace HSV clamping (already clamped in the assignment expression).

## Test plan
- [x] `uv run ruff check && uv run ruff format` — clean
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 755 passed
- [ ] Manual: open Viewer, scrub long session, verify blob count stays bounded
- [ ] Manual: stack two `showConfirm` dialogs, verify only the latest callback fires
- [ ] Manual: switch transcript participants rapidly while summary/citations generating, verify no cross-contamination
- [ ] Manual: drag a multitool step or queued task to the end of the list, verify tail indicator
- [ ] Manual: scroll the screenspace task list, trigger a poll, verify scroll position holds
- [ ] Manual: scroll studio sheet grid, apply a filter, verify position holds
- [ ] Manual: dark-mode transcripts canvas should not render with light fallbacks if tokens fail to resolve