### PR TITLE
refactor(screenspace): drop sidebar video details (redundant with navbar)

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -433,12 +433,6 @@ body {
   letter-spacing: -0.005em;
 }
 
-.ss-info-sub {
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
-  color: var(--color-text-dim);
-}
-
 .ss-info-notes {
   resize: vertical;
   min-height: 4.5rem;

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -49,24 +49,6 @@
               <span class="ss-info-collapse-icon"></span>
             </button>
           </div>
-          <section class="ss-info-section" data-section="details">
-            <button class="ss-info-section-header" type="button" aria-expanded="true">
-              <span class="ss-info-section-chevron"></span>
-              <span>Details</span>
-            </button>
-            <div class="ss-info-section-body">
-              <div class="ss-info-block">
-                <div class="ss-info-label">Duration</div>
-                <div id="ssInfoDuration" class="ss-info-value">&mdash;</div>
-                <div id="ssInfoFrames" class="ss-info-sub">&mdash;</div>
-              </div>
-              <div class="ss-info-block">
-                <div class="ss-info-label">Video</div>
-                <div id="ssInfoResolution" class="ss-info-value">&mdash;</div>
-                <div id="ssInfoCodec" class="ss-info-sub">&mdash;</div>
-              </div>
-            </div>
-          </section>
           <div class="ss-info-block">
             <div class="ss-info-label">Notes</div>
             <textarea id="ssInfoNotes" class="ss-info-notes" rows="4" spellcheck="false" autocomplete="off" placeholder="Notes for this participant&hellip;"></textarea>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -818,7 +818,6 @@
         if (data.info.width && data.info.height) parts.push(data.info.width + "x" + data.info.height);
         if (data.info.fps) parts.push(Math.round(data.info.fps) + "fps");
         qs("#videoInfo").textContent = parts.join(" \u00b7 ");
-        renderInfoVideo(data.info);
         renderTimeline();
         // Preload video source for instant playback
         qs("#videoPlayer").src = videoStreamUrl(pid);
@@ -848,24 +847,9 @@
   function setInfoParticipant(pid) {
     var el = qs("#ssInfoParticipant");
     if (el) el.textContent = pid || "\u2014";
-    qs("#ssInfoDuration").textContent = "\u2014";
-    qs("#ssInfoFrames").textContent = "\u2014";
-    qs("#ssInfoResolution").textContent = "\u2014";
-    qs("#ssInfoCodec").textContent = "\u2014";
     qs("#ssInfoNotes").value = "";
     qs("#ssInfoIssuesBlock").classList.add("hidden");
     qs("#ssInfoIssues").innerHTML = "";
-  }
-
-  function renderInfoVideo(info) {
-    qs("#ssInfoDuration").textContent = info.duration ? formatDuration(info.duration) : "\u2014";
-    qs("#ssInfoFrames").textContent = info.nb_frames
-      ? info.nb_frames.toLocaleString() + " frames"
-      : "";
-    qs("#ssInfoResolution").textContent = info.width && info.height
-      ? info.width + "\u00d7" + info.height
-      : "\u2014";
-    qs("#ssInfoCodec").textContent = info.video_codec || "";
   }
 
   function renderInfoNotes(notes) {


### PR DESCRIPTION
## Summary
- Removes the Screenspace sidebar's "Details" section (Duration, Frames, Resolution, Codec) — the navbar already shows `duration · WxH · FPSfps` next to the participant dropdown.
- Drops the now-unused `renderInfoVideo()` function, its call site, the four reset lines in `setInfoParticipant()`, and the orphaned `.ss-info-sub` CSS rule. The `api/video/info/` fetch and `state.videoInfo` assignment stay — still drive timeline math and playback bounds.

## Test plan
- [ ] Open Screenspace, select a participant: sidebar shows Participant + Notes (+ Top issues), no Details block.
- [ ] Navbar still shows `duration · WxH · FPSfps`.
- [ ] Timeline renders with correct duration; arrow-key stepping and play/pause respect video bounds.
- [ ] Switching participants resets the sidebar and refreshes the navbar without console errors.