### PR TITLE
fix + refactor: Start overlay audit sweep

### DIFF
--- a/assets/web/primitives.css
+++ b/assets/web/primitives.css
@@ -11,6 +11,7 @@
  *   .clip-card            16/10 thumb + caption (Screenspace Intake source events)
  *   .transcript-card      same anatomy with timeRange + clamped text (Transcript Intake)
  *   .cg-btn               base button: ghost / solid / bare; sm / md / lg
+ *   .skeleton-grid        responsive skeleton row layout (pair with .skeleton cells)
  *
  * All transitions: var(--duration-instant) ease-out on bg/border/color only. Hit targets ≥28px.
  */
@@ -696,4 +697,31 @@
   .cg-swim-cluster-band {
     transition: none;
   }
+}
+
+/* ---- SkeletonGrid ---------------------------------------------------------
+ *
+ * Responsive table-skeleton row layout. Pairs with the `.skeleton` shimmer
+ * class defined in tokens.css. Studio uses this for the "no spreadsheet"
+ * placeholder; Screenspace/Transcripts can reuse it for their own pre-load
+ * states. Cells are rendered by `buildSkeletonGrid(target, cols, rows)` in
+ * utils.js, which appends `<div class="skeleton skeleton-cell [is-header]">`
+ * nodes — keep the JS helper and these classes in sync.
+ */
+
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: 56px 2.2fr 1.2fr repeat(6, 1fr);
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.skeleton-cell {
+  height: 26px;
+  border-radius: var(--radius-sm);
+}
+
+.skeleton-cell.is-header {
+  height: 30px;
+  opacity: 0.85;
 }

--- a/assets/web/start-overlay.css
+++ b/assets/web/start-overlay.css
@@ -18,7 +18,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 32px;
+  padding: var(--space-6);
   font-family: var(--font-sans);
   color: var(--fg);
   --host-blur: 0px;
@@ -167,7 +167,7 @@
   height: 720px;
   pointer-events: none;
   background:
-    radial-gradient(circle at 25% 25%, rgba(45, 107, 255, 0.22) 0%, rgba(45, 107, 255, 0.08) 28%, transparent 60%),
+    radial-gradient(circle at 25% 25%, var(--color-accent-highlight) 0%, rgba(45, 107, 255, 0.08) 28%, transparent 60%),
     radial-gradient(circle at 35% 35%, rgba(125, 211, 224, 0.10) 0%, transparent 55%);
   z-index: 0;
 }
@@ -496,7 +496,7 @@
   border-color: var(--accent);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.25),
-    0 0 0 3px rgba(45, 107, 255, 0.18);
+    0 0 0 3px var(--color-selected);
   background: #0d0f13;
 }
 
@@ -806,7 +806,7 @@
   background: #0d0f13;
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.25),
-    0 0 0 3px rgba(45, 107, 255, 0.18);
+    0 0 0 3px var(--color-selected);
 }
 
 .start-overlay .sheet-picker__label {
@@ -997,7 +997,7 @@
   height: 17px;
   padding: 0 5px;
   border-radius: 999px;
-  background: rgba(45, 107, 255, 0.18);
+  background: var(--color-selected);
   color: #9ec0ff;
   font-size: 10px;
   font-weight: 600;

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -49,6 +49,7 @@
     persistEnabled: true,
     googlePollTimer: null,
     googlePollDeadline: 0,
+    confirmInFlight: false,
     activeTab: "google",    // 'google' | 'excel' | 'none'
     extrasTab: "tools",     // 'tools' | 'updates' | 'about'
     changelogLoaded: false,
@@ -223,7 +224,10 @@
     });
 
     on(document, "click", function (e) {
-      if (!root) return;
+      // Bail when the overlay isn't open — the listener stays bound for the
+      // page's lifetime (mount() is once-per-page; close() just hides),
+      // so guard explicitly to avoid pointless work on every page click.
+      if (!root || !state.open) return;
       closeRecentsIfOutside(e);
       closePickersIfOutside(e);
     });
@@ -946,6 +950,12 @@
   // ---- Open / dismiss flows ----
 
   function confirm() {
+    // Guard against re-entry: the click handler disables the button, but the
+    // Cmd/Ctrl+Enter shortcut bypasses that path. Two simultaneous flights
+    // would race the server-side _swap_worksheet.
+    if (state.confirmInFlight) return;
+    state.confirmInFlight = true;
+
     var inputVal = (els.inputDir.value || "").trim();
     var outputVal = (els.outputDir.value || "").trim();
 
@@ -967,6 +977,11 @@
         })
       : Promise.resolve({ ok: true, body: {} });
 
+    function releaseConfirm() {
+      state.confirmInFlight = false;
+      els.confirmBtn.disabled = false;
+    }
+
     els.confirmBtn.disabled = true;
     dirsPromise.then(function (res) {
       if (!res.ok) {
@@ -976,13 +991,13 @@
         if (!errors.input && !errors.output && typeof showToast === "function") {
           showToast("Folder error");
         }
-        els.confirmBtn.disabled = false;
+        releaseConfirm();
         return;
       }
       var skipSpreadsheet = state.activeTab === "none" || !state.selection;
       if (skipSpreadsheet) {
         recordSession(inputVal, outputVal, null).finally(function () {
-          els.confirmBtn.disabled = false;
+          releaseConfirm();
           close();
         });
         return;
@@ -996,18 +1011,22 @@
           return r.json().then(function (j) { return { ok: r.ok, body: j }; });
         })
         .then(function (res2) {
-          els.confirmBtn.disabled = false;
           if (!res2.ok || !res2.body.ok) {
+            releaseConfirm();
             markSheetError((res2.body && res2.body.error) || "Could not open spreadsheet");
             return;
           }
           // Hard reload so all three frontends re-fetch their data.
+          // Don't release the in-flight flag — the page is about to unmount.
           window.location.reload();
         })
         .catch(function (err) {
-          els.confirmBtn.disabled = false;
+          releaseConfirm();
           markSheetError("Open failed: " + err.message);
         });
+    }).catch(function (err) {
+      releaseConfirm();
+      console.error("Confirm dirs failed", err);
     });
   }
 

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -23,6 +23,12 @@
   var INTRO_VEIL_ALPHA = 0.55;
   var CASCADE_BASE_MS = 220;
   var CASCADE_STEP_MS = 80;
+  // Google-auth poll lifecycle: the server's /api/spreadsheets/google/auth
+  // launches an OAuth flow in a daemon thread; we poll /api/spreadsheets/google
+  // until it reports `authenticated`, an `auth_error`, or we exceed the budget.
+  var GOOGLE_POLL_TIMEOUT_MS = 90 * 1000;
+  var GOOGLE_POLL_INTERVAL_MS = 1500;
+  var GOOGLE_POLL_RETRY_MS = 2500;
 
   function sessionDismissed() {
     try { return sessionStorage.getItem(DISMISSED_KEY) === "1"; } catch (_) { return false; }
@@ -744,36 +750,49 @@
       });
   }
 
-  function pollGoogleAuth() {
-    state.googlePollDeadline = Date.now() + 90 * 1000;
-    function tick() {
-      apiGet("/api/spreadsheets/google").then(function (g) {
-        if (g.authenticated && !g.auth_error) {
-          state.googleSheets = g.sheets || [];
-          els.googleStatus.textContent = state.googleSheets.length
-            ? state.googleSheets.length + " spreadsheets available"
-            : "No spreadsheets found in your account";
-          renderGoogleList(state.googleSheets);
-          setHidden(els.googlePicker, false);
-          state.googlePollTimer = null;
-          return;
-        }
-        if (g.auth_error) {
-          renderGoogleConnectCTA(false, g.auth_error);
-          state.googlePollTimer = null;
-          return;
-        }
-        if (Date.now() > state.googlePollDeadline) {
-          renderGoogleConnectCTA(false, "Sign-in timed out — try again.");
-          state.googlePollTimer = null;
-          return;
-        }
-        state.googlePollTimer = setTimeout(tick, 1500);
-      }).catch(function () {
-        state.googlePollTimer = setTimeout(tick, 2500);
-      });
+  function stopGooglePoll() {
+    if (state.googlePollTimer) {
+      clearTimeout(state.googlePollTimer);
+      state.googlePollTimer = null;
     }
-    tick();
+  }
+
+  function onGooglePollSuccess(sheets) {
+    state.googleSheets = sheets || [];
+    els.googleStatus.textContent = state.googleSheets.length
+      ? state.googleSheets.length + " spreadsheets available"
+      : "No spreadsheets found in your account";
+    renderGoogleList(state.googleSheets);
+    setHidden(els.googlePicker, false);
+  }
+
+  function pollGoogleAuth() {
+    stopGooglePoll();
+    state.googlePollDeadline = Date.now() + GOOGLE_POLL_TIMEOUT_MS;
+    pollGoogleAuthOnce();
+  }
+
+  function pollGoogleAuthOnce() {
+    apiGet("/api/spreadsheets/google").then(function (g) {
+      if (g.authenticated && !g.auth_error) {
+        state.googlePollTimer = null;
+        onGooglePollSuccess(g.sheets);
+        return;
+      }
+      if (g.auth_error) {
+        state.googlePollTimer = null;
+        renderGoogleConnectCTA(false, g.auth_error);
+        return;
+      }
+      if (Date.now() > state.googlePollDeadline) {
+        state.googlePollTimer = null;
+        renderGoogleConnectCTA(false, "Sign-in timed out — try again.");
+        return;
+      }
+      state.googlePollTimer = setTimeout(pollGoogleAuthOnce, GOOGLE_POLL_INTERVAL_MS);
+    }).catch(function () {
+      state.googlePollTimer = setTimeout(pollGoogleAuthOnce, GOOGLE_POLL_RETRY_MS);
+    });
   }
 
   function renderGoogleList(sheets) {
@@ -1059,10 +1078,7 @@
     if (!root) return;
     state.open = false;
     markDismissed();
-    if (state.googlePollTimer) {
-      clearTimeout(state.googlePollTimer);
-      state.googlePollTimer = null;
-    }
+    stopGooglePoll();
     // Animate the panel and backdrop out, then hide.
     if (els.panel) els.panel.classList.remove("is-in");
     root.style.setProperty("--host-blur", "0px");

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -617,23 +617,8 @@ body[data-active-tab]:not([data-active-tab="sheet"]) #studioSidebar {
   box-sizing: border-box;
 }
 
-.skeleton-grid {
-  display: grid;
-  grid-template-columns: 56px 2.2fr 1.2fr repeat(6, 1fr);
-  gap: var(--space-2);
-  width: 100%;
-}
-
-.skeleton-cell {
-  height: 26px;
-  border-radius: var(--radius-sm);
-}
-
-.skeleton-cell.is-header {
-  height: 30px;
-  opacity: 0.85;
-}
-
+/* .skeleton-grid and .skeleton-cell live in primitives.css; the
+ * studio-specific "no spreadsheet" empty state just dims the grid. */
 #sheetLoading.is-empty .skeleton-grid {
   opacity: 0.45;
 }

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -826,24 +826,7 @@
   }
 
   function populateSheetSkeleton() {
-    var grid = qs("#sheetLoading .skeleton-grid");
-    if (!grid) return;
-    var cols = 9;
-    var rows = 4;
-    var frag = document.createDocumentFragment();
-    for (var i = 0; i < cols; i++) {
-      var th = document.createElement("div");
-      th.className = "skeleton skeleton-cell is-header";
-      frag.appendChild(th);
-    }
-    for (var r = 0; r < rows; r++) {
-      for (var c = 0; c < cols; c++) {
-        var cell = document.createElement("div");
-        cell.className = "skeleton skeleton-cell";
-        frag.appendChild(cell);
-      }
-    }
-    grid.appendChild(frag);
+    buildSkeletonGrid(qs("#sheetLoading .skeleton-grid"), 9, 4);
   }
 
   // ---- Data loading ----

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -75,6 +75,25 @@ var el = function (tag, cls, text) {
   return e;
 };
 
+// Populate a container with a skeleton table: `cols` header cells plus
+// `rows × cols` body cells. Pairs with the `.skeleton-grid` / `.skeleton-cell`
+// CSS in primitives.css (and the shimmer in tokens.css). Target should
+// already have class `skeleton-grid`; the helper appends cells via a single
+// DocumentFragment.
+var buildSkeletonGrid = function (target, cols, rows) {
+  if (!target) return;
+  var frag = document.createDocumentFragment();
+  for (var i = 0; i < cols; i++) {
+    frag.appendChild(el("div", "skeleton skeleton-cell is-header"));
+  }
+  for (var r = 0; r < rows; r++) {
+    for (var c = 0; c < cols; c++) {
+      frag.appendChild(el("div", "skeleton skeleton-cell"));
+    }
+  }
+  target.appendChild(frag);
+};
+
 // True when an animated artifact's filename should render via <video> rather
 // than <img>. Used by the gallery and viewer so they agree which extensions
 // are looping video. Keep as the single source of truth.

--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -29,11 +29,13 @@ excludes = [
     "pytest", "_pytest", "py", "pluggy", "iniconfig",
     # Torch submodules clipgen never uses
     "tensorboard", "torch.distributed",
-    # GUI toolkit pulled in transitively — clipgen is CLI-only
-    "tkinter", "_tkinter",
     # Other unused transitive dependencies
     "matplotlib", "IPython", "notebook", "jupyter",
 ]
+# tkinter is intentionally NOT excluded: utils.open_native_folder_picker
+# uses tkinter.filedialog as the non-macOS fallback for the Start overlay's
+# Browse button. Excluding it silently breaks the Browse flow on Windows/Linux
+# frozen builds.
 
 a = Analysis(
     ["../clipgen.py"],

--- a/changelog.py
+++ b/changelog.py
@@ -33,10 +33,14 @@ def load_entries(limit: int = 20) -> list[dict[str, Any]]:
     """Return up to *limit* changelog entries in file order (newest first)."""
     path = _changelog_path()
     if not path.is_file():
+        utils.warning_print(
+            f"CHANGELOG.md not found at {path}; Start overlay 'Recent updates' will be empty."
+        )
         return []
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError:
+    except OSError as exc:
+        utils.warning_print(f"Could not read CHANGELOG.md at {path}: {exc}")
         return []
     entries: list[dict[str, Any]] = []
     current: dict[str, Any] | None = None

--- a/cli.py
+++ b/cli.py
@@ -744,6 +744,31 @@ def get_runtime_working_dir() -> str:
 # ---- Google authentication ----
 
 
+def _try_silent_google_auth() -> Any | None:
+    """Reuse a cached gspread token without ever launching the OAuth flow.
+
+    Returns a gspread client when both ``credentials.json`` and the cached
+    ``authorized_user.json`` exist (and load); otherwise returns ``None``
+    without printing or prompting. Used by the frozen-binary launch path so
+    a previously-authenticated user is not forced through "Connect Google"
+    on every double-click — but a fresh install lands silently on the Start
+    overlay's Connect CTA rather than blocking on an interactive flow.
+    """
+    try:
+        import gspread
+        from gspread.auth import DEFAULT_AUTHORIZED_USER_FILENAME
+    except Exception:
+        return None
+    if not Path("credentials.json").is_file():
+        return None
+    if not Path(DEFAULT_AUTHORIZED_USER_FILENAME).is_file():
+        return None
+    try:
+        return gspread.oauth(credentials_filename="credentials.json")
+    except Exception:
+        return None
+
+
 def authenticate_google() -> Any | None:
     """Authenticate with Google Sheets API.
 
@@ -3102,7 +3127,15 @@ def _dispatch_standalone_mode(
         import server
 
         _maybe_apply_persisted_dirs(args)
-        server.start_combined_server(worksheet=None, default_page=web_mode)
+        # Silent best-effort reuse of the cached Google token (frozen .app
+        # double-clicks land here; without this, every launch forces the user
+        # back through "Connect Google" even when their token is still good).
+        gspread_client = _try_silent_google_auth()
+        server.start_combined_server(
+            worksheet=None,
+            default_page=web_mode,
+            gspread_client=gspread_client,
+        )
         return True
 
     # Standalone gallery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,11 @@ dev = ["pytest"]
 [tool.setuptools]
 packages = []
 py-modules = [
-    "cli", "clipgen", "config", "excel_io", "files", "google_api",
-    "insights", "insights_server", "interactive", "ollama_client", "screenspace",
-    "screenspace_server", "server", "spreadsheet", "titlecards",
-    "transcripts", "utils", "video", "viewer",
+    "changelog", "cli", "clipgen", "config", "data_export", "excel_io",
+    "files", "google_api", "interactive", "ollama_client", "pipeline",
+    "screenspace", "screenspace_preview", "screenspace_server", "server",
+    "spreadsheet", "start_settings", "thinking_agents", "titlecards",
+    "transcripts", "transcripts_server", "utils", "video", "viewer",
 ]
 
 [tool.uv]

--- a/server.py
+++ b/server.py
@@ -41,6 +41,7 @@ import threading
 import webbrowser
 from collections import OrderedDict
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from collections.abc import Iterator
 from typing import Any
@@ -89,12 +90,19 @@ _reel_in_progress = False
 # Serializes load → mutate → save for the stash manifests so concurrent
 # stash CRUD requests don't drop each other's writes.
 _stash_lock = threading.Lock()
-# Cached gspread client for the Start overlay's Google Sheets picker.
-# Populated lazily by /api/spreadsheets/google/auth.
-_gspread_client: Any = None
-_gspread_auth_in_flight: bool = False
-_gspread_auth_lock = threading.Lock()
-_gspread_auth_error: str = ""
+
+
+# Cached gspread client + threaded-auth state for the Start overlay's Google
+# Sheets picker. Populated lazily by /api/spreadsheets/google/auth.
+@dataclass
+class _GoogleAuthState:
+    client: Any = None
+    in_flight: bool = False
+    error: str = ""
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_google_auth = _GoogleAuthState()
 
 # Snapshot config defaults before any settings file is loaded.
 # Deep-copied so dict-valued defaults are not aliased to live config state.
@@ -340,6 +348,7 @@ def api_sheet() -> FlaskResponse:
             "titlecardsEnabled": config.TITLECARDS_ENABLED,
             "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
             "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
+            "defaultDuration": config.DEFAULT_DURATION_SECONDS,
             "config": utils.get_frontend_config(),
             "participants": participants,
             "rows": rows,
@@ -1732,22 +1741,16 @@ def _swap_worksheet(new_worksheet: Any) -> None:
         raise
 
 
-def start_combined_server(
+def build_combined_app(
     worksheet: Any = None,
-    port: int | None = None,
     default_page: str = "studio",
     gspread_client: Any = None,
-) -> None:
-    """Start a combined Studio + Screenspace + Transcripts server on one port.
+) -> Flask:
+    """Build the combined Studio + Screenspace + Transcripts Flask app.
 
-    All three blueprints are always registered. When *worksheet* is ``None``,
-    sheet-dependent Studio routes return ``sheet_loaded: false`` placeholder
-    responses; the frontend's Start overlay lets the user pick a spreadsheet
-    via ``POST /api/spreadsheets/open``.
-
-    If *gspread_client* is supplied (the CLI's auth already happened upstream),
-    the Google Sheets list endpoint reports authenticated and skips the
-    "Connect Google" CTA in the Start overlay.
+    Same setup as :func:`start_combined_server` but stops short of
+    ``app.run`` so tests (and any embedding caller) can hold the live
+    ``Flask`` instance and exercise routes via ``app.test_client()``.
     """
     import screenspace_server
     import start_settings
@@ -1759,10 +1762,10 @@ def start_combined_server(
     # Seed the meta + recent-projects rail for CLI launches that already
     # have a worksheet — the runtime /api/spreadsheets/open path handles
     # both of these itself.
-    global _active_sheet_meta, _gspread_client
+    global _active_sheet_meta
     _active_sheet_meta = _derive_sheet_meta(worksheet)
     if gspread_client is not None:
-        _gspread_client = gspread_client
+        _google_auth.client = gspread_client
     if _active_sheet_meta is not None:
         start_settings.record_project_session(
             str(utils.get_effective_input_dir()),
@@ -1936,21 +1939,20 @@ def start_combined_server(
 
     @combined.route("/api/spreadsheets/google", methods=["GET"])
     def api_spreadsheets_google() -> Response:
-        global _gspread_auth_error
-        if _gspread_client is None:
+        if _google_auth.client is None:
             return jsonify(
                 {
                     "ok": True,
                     "authenticated": False,
-                    "auth_in_flight": _gspread_auth_in_flight,
-                    "auth_error": _gspread_auth_error,
+                    "auth_in_flight": _google_auth.in_flight,
+                    "auth_error": _google_auth.error,
                     "sheets": [],
                 }
             )
         import google_api
 
         try:
-            names = google_api.get_all_spreadsheets(_gspread_client)
+            names = google_api.get_all_spreadsheets(_google_auth.client)
         except Exception as exc:
             return jsonify(
                 {
@@ -1973,31 +1975,32 @@ def start_combined_server(
 
     @combined.route("/api/spreadsheets/google/auth", methods=["POST"])
     def api_spreadsheets_google_auth() -> FlaskResponse:
-        global _gspread_auth_in_flight, _gspread_client, _gspread_auth_error
-        with _gspread_auth_lock:
-            if _gspread_auth_in_flight:
+        with _google_auth.lock:
+            if _google_auth.in_flight:
                 return jsonify({"ok": True, "started": False, "in_flight": True})
-            if _gspread_client is not None:
+            if _google_auth.client is not None:
                 return jsonify({"ok": True, "started": False, "authenticated": True})
-            _gspread_auth_in_flight = True
-            _gspread_auth_error = ""
+            _google_auth.in_flight = True
+            _google_auth.error = ""
 
         def _run_auth() -> None:
-            global _gspread_auth_in_flight, _gspread_client, _gspread_auth_error
             try:
                 import cli as _cli
 
                 client = _cli.authenticate_google()
                 if client is None:
-                    _gspread_auth_error = (
+                    _google_auth.error = (
                         "Google authentication failed — check credentials.json."
                     )
                 else:
-                    _gspread_client = client
+                    _google_auth.client = client
             except Exception as exc:
-                _gspread_auth_error = str(exc)
+                # Daemon-thread exceptions otherwise vanish; surface to logs
+                # so a misconfigured credentials.json is debuggable.
+                utils.error_print(f"Google auth thread failed: {exc}")
+                _google_auth.error = str(exc)
             finally:
-                _gspread_auth_in_flight = False
+                _google_auth.in_flight = False
 
         threading.Thread(target=_run_auth, daemon=True).start()
         return jsonify({"ok": True, "started": True, "in_flight": True}), 202
@@ -2026,7 +2029,7 @@ def start_combined_server(
                 new_ws = excel_io.open_excel_workbook(id_or_path)
                 label = Path(id_or_path).name
             else:
-                if _gspread_client is None:
+                if _google_auth.client is None:
                     return jsonify(
                         {
                             "ok": False,
@@ -2043,12 +2046,12 @@ def start_combined_server(
                     "https://"
                 ):
                     new_ws = _clipgen.open_spreadsheet_by_url(
-                        _gspread_client, id_or_path
+                        _google_auth.client, id_or_path
                     )
                 else:
-                    doc_list = google_api.get_all_spreadsheets(_gspread_client)
+                    doc_list = google_api.get_all_spreadsheets(_google_auth.client)
                     new_ws = _clipgen.open_spreadsheet_by_name(
-                        _gspread_client, doc_list, id_or_path
+                        _google_auth.client, doc_list, id_or_path
                     )
                 if new_ws is not None:
                     parent = getattr(new_ws, "spreadsheet", None)
@@ -2238,6 +2241,31 @@ def start_combined_server(
             }
         )
 
+    return combined
+
+
+def start_combined_server(
+    worksheet: Any = None,
+    port: int | None = None,
+    default_page: str = "studio",
+    gspread_client: Any = None,
+) -> None:
+    """Start a combined Studio + Screenspace + Transcripts server on one port.
+
+    All three blueprints are always registered. When *worksheet* is ``None``,
+    sheet-dependent Studio routes return ``sheet_loaded: false`` placeholder
+    responses; the frontend's Start overlay lets the user pick a spreadsheet
+    via ``POST /api/spreadsheets/open``.
+
+    If *gspread_client* is supplied (the CLI's auth already happened upstream),
+    the Google Sheets list endpoint reports authenticated and skips the
+    "Connect Google" CTA in the Start overlay.
+    """
+    combined = build_combined_app(
+        worksheet=worksheet,
+        default_page=default_page,
+        gspread_client=gspread_client,
+    )
     port = port or config.SERVER_PORT
     url = f"http://127.0.0.1:{port}/{default_page}/"
 

--- a/server.py
+++ b/server.py
@@ -267,7 +267,6 @@ def api_sheet() -> FlaskResponse:
                 "titlecardsEnabled": config.TITLECARDS_ENABLED,
                 "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
                 "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
-                "defaultDuration": config.DEFAULT_DURATION_SECONDS,
                 "config": utils.get_frontend_config(),
                 "participants": [],
                 "rows": [],
@@ -341,7 +340,6 @@ def api_sheet() -> FlaskResponse:
             "titlecardsEnabled": config.TITLECARDS_ENABLED,
             "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
             "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
-            "defaultDuration": config.DEFAULT_DURATION_SECONDS,
             "config": utils.get_frontend_config(),
             "participants": participants,
             "rows": rows,
@@ -1687,21 +1685,51 @@ def _spreadsheet_label() -> str:
 def _swap_worksheet(new_worksheet: Any) -> None:
     """Replace the active worksheet and refresh all three blueprints' state.
 
-    Used by ``/api/spreadsheets/open`` and ``/api/spreadsheets/close`` so the
-    user can pick or clear a spreadsheet from the frontend at runtime.
+    Atomic: if any of the three init steps fails, the prior state is restored
+    so Studio / Screenspace / Transcripts don't end up pointing at different
+    sheets. Used by ``/api/spreadsheets/open`` and ``/api/spreadsheets/close``.
     """
     import screenspace_server
     import transcripts_server
 
-    _init_studio_state(new_worksheet)
-    screenspace_server._init_screenspace_state(
-        sheet_context=_sheet_context,
-        participant_list=_resolve_participants(),
-    )
-    transcripts_server._init_transcripts_state(
-        sheet_context=_sheet_context,
-        participant_list=_resolve_participants(),
-    )
+    global _worksheet, _sheet_context, _generated_artifacts, _generated_reels
+    prev_worksheet = _worksheet
+    prev_sheet_context = _sheet_context
+    prev_artifacts = _generated_artifacts
+    prev_reels = _generated_reels
+    try:
+        _init_studio_state(new_worksheet)
+        screenspace_server._init_screenspace_state(
+            sheet_context=_sheet_context,
+            participant_list=_resolve_participants(),
+        )
+        transcripts_server._init_transcripts_state(
+            sheet_context=_sheet_context,
+            participant_list=_resolve_participants(),
+        )
+    except Exception:
+        _worksheet = prev_worksheet
+        _sheet_context = prev_sheet_context
+        _generated_artifacts = prev_artifacts
+        _generated_reels = prev_reels
+        # Best-effort: re-pin the two sister blueprints to the restored state.
+        # If these themselves throw, swallow — the studio state is already
+        # consistent and the original exception is what we want to surface.
+        try:
+            screenspace_server._init_screenspace_state(
+                sheet_context=_sheet_context,
+                participant_list=_resolve_participants(),
+            )
+        except Exception:
+            pass
+        try:
+            transcripts_server._init_transcripts_state(
+                sheet_context=_sheet_context,
+                participant_list=_resolve_participants(),
+            )
+        except Exception:
+            pass
+        raise
 
 
 def start_combined_server(
@@ -2078,7 +2106,7 @@ def start_combined_server(
         return jsonify({"ok": True, "path": path})
 
     @combined.route("/api/sessions/record", methods=["POST"])
-    def api_sessions_record() -> Response:
+    def api_sessions_record() -> FlaskResponse:
         """Record an "Open workspace" session — used by the no-spreadsheet path.
 
         The Google/Excel paths already record via api_spreadsheets_open after a
@@ -2088,15 +2116,40 @@ def start_combined_server(
         import start_settings
 
         data = request.get_json(silent=True) or {}
-        input_dir = (data.get("input") or "").strip()
-        output_dir = (data.get("output") or "").strip()
+        input_raw = data.get("input")
+        output_raw = data.get("output")
+        if input_raw is not None and not isinstance(input_raw, str):
+            return jsonify({"ok": False, "error": "input must be a string"}), 400
+        if output_raw is not None and not isinstance(output_raw, str):
+            return jsonify({"ok": False, "error": "output must be a string"}), 400
+        input_dir = (input_raw or "").strip()
+        output_dir = (output_raw or "").strip()
+
         spreadsheet_payload = data.get("spreadsheet")
         spreadsheet_dict: dict[str, Any] | None = None
-        if isinstance(spreadsheet_payload, dict):
+        if spreadsheet_payload is not None:
+            if not isinstance(spreadsheet_payload, dict):
+                return jsonify(
+                    {"ok": False, "error": "spreadsheet must be an object or null"}
+                ), 400
+            ss_type = (spreadsheet_payload.get("type") or "").strip()
+            ss_id = (spreadsheet_payload.get("id_or_path") or "").strip()
+            ss_label = (spreadsheet_payload.get("label") or "").strip()
+            if ss_type not in ("google", "excel"):
+                return jsonify(
+                    {
+                        "ok": False,
+                        "error": "spreadsheet.type must be 'google' or 'excel'",
+                    }
+                ), 400
+            if not ss_id:
+                return jsonify(
+                    {"ok": False, "error": "spreadsheet.id_or_path is required"}
+                ), 400
             spreadsheet_dict = {
-                "type": spreadsheet_payload.get("type") or "",
-                "id_or_path": spreadsheet_payload.get("id_or_path") or "",
-                "label": spreadsheet_payload.get("label") or "",
+                "type": ss_type,
+                "id_or_path": ss_id,
+                "label": ss_label or ss_id,
             }
         start_settings.record_project_session(
             input_dir or str(utils.get_effective_input_dir()),

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -123,13 +123,18 @@ def test_web_mode_without_spreadsheet_dispatches_standalone(
 
     captured = {}
 
-    def fake_start(*, worksheet=None, port=None, default_page="studio"):
+    def fake_start(
+        *, worksheet=None, port=None, default_page="studio", gspread_client=None
+    ):
         captured["worksheet"] = worksheet
         captured["default_page"] = default_page
+        captured["gspread_client"] = gspread_client
 
     monkeypatch.setattr(server, "start_combined_server", fake_start)
     # Skip persisted-dir application in this isolated test
     monkeypatch.setattr(cli, "_maybe_apply_persisted_dirs", lambda _args: None)
+    # Force the silent-auth helper to return None (no cached token to reuse).
+    monkeypatch.setattr(cli, "_try_silent_google_auth", lambda: None)
 
     args = _base_args(**{flag: True})
     result = cli._dispatch_standalone_mode(args, cli_mode=False, gallery_arg=None)
@@ -137,6 +142,7 @@ def test_web_mode_without_spreadsheet_dispatches_standalone(
     assert result is True
     assert captured["worksheet"] is None
     assert captured["default_page"] == expected_default_page
+    assert captured["gspread_client"] is None
 
 
 def test_studio_with_spreadsheet_does_not_short_circuit(monkeypatch):

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -1,0 +1,399 @@
+"""Integration tests for Start-overlay endpoints on the combined Flask app.
+
+Exercises the routes registered directly on ``combined`` (not on a blueprint):
+
+* ``GET  /api/changelog``
+* ``GET  /api/dirs``           ``POST /api/dirs``
+* ``POST /api/folder-picker``
+* ``POST /api/sessions/record``
+* ``GET  /api/spreadsheets/google``
+* ``POST /api/spreadsheets/google/auth``
+
+We build the live app via :func:`server.build_combined_app` and drive it
+through ``test_client``. State globals (``_google_auth``, ``config.INPUT_DIR``,
+etc.) are reset around each test so order doesn't matter.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("flask")
+
+import config  # noqa: E402
+import server  # noqa: E402
+import start_settings  # noqa: E402
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    """Combined Flask app with the worksheet unset and dirs pinned to tmp."""
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    out_dir.mkdir()
+
+    # Pin config dirs so /api/dirs sees a known starting point.
+    monkeypatch.setattr(config, "INPUT_DIR", str(in_dir), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(out_dir), raising=False)
+
+    # Persist Start settings to tmp so tests don't touch the user's real file.
+    monkeypatch.setattr(
+        start_settings, "_settings_path", lambda: tmp_path / "start.json"
+    )
+
+    # Reset Google-auth state between tests.
+    monkeypatch.setattr(server, "_google_auth", server._GoogleAuthState())
+
+    return server.build_combined_app(worksheet=None, default_page="studio")
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------- /api/changelog --------------------------------------------------
+
+
+def test_changelog_returns_entries(client):
+    """Happy-path: real CHANGELOG.md parses into a non-empty entries list."""
+    resp = client.get("/api/changelog")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert isinstance(body["entries"], list)
+    # The repo ships a populated CHANGELOG.md; if entries is empty, the
+    # parser regex drifted from the file format.
+    assert body["entries"], "CHANGELOG.md present but no entries parsed"
+    first = body["entries"][0]
+    assert {"version", "date", "tool", "title", "body"} <= set(first)
+
+
+def test_changelog_handles_missing_file(client, monkeypatch):
+    """A missing CHANGELOG.md returns ok with an empty list (warning logged)."""
+    import changelog
+
+    monkeypatch.setattr(changelog, "_changelog_path", lambda: Path("/nope/missing.md"))
+    resp = client.get("/api/changelog")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True, "entries": []}
+
+
+# ---------- /api/dirs (GET + POST) ------------------------------------------
+
+
+def test_dirs_get_returns_current(client, tmp_path):
+    resp = client.get("/api/dirs")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["input"] == str(tmp_path / "in")
+    assert body["output"] == str(tmp_path / "out")
+
+
+def test_dirs_post_updates_both(client, tmp_path):
+    new_in = tmp_path / "alt_in"
+    new_in.mkdir()
+    new_out = tmp_path / "alt_out"  # doesn't exist yet — POST should mkdir
+    resp = client.post(
+        "/api/dirs",
+        data=json.dumps({"input": str(new_in), "output": str(new_out)}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["input"] == str(new_in)
+    assert body["output"] == str(new_out)
+    assert new_out.is_dir()  # Output dir auto-created
+
+
+def test_dirs_post_rejects_nonexistent_input(client, tmp_path):
+    bogus = tmp_path / "definitely_not_here"
+    resp = client.post(
+        "/api/dirs",
+        data=json.dumps({"input": str(bogus)}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "input" in body["errors"]
+
+
+def test_dirs_post_rejects_output_under_file(client, tmp_path):
+    """If the path points at an existing file (not a dir), mkdir fails."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    resp = client.post(
+        "/api/dirs",
+        data=json.dumps({"output": str(blocker / "child")}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "output" in body["errors"]
+
+
+# ---------- /api/folder-picker ---------------------------------------------
+
+
+def test_folder_picker_returns_chosen_path(client, monkeypatch):
+    """The route returns whatever utils.open_native_folder_picker returns."""
+    import utils
+
+    monkeypatch.setattr(
+        utils, "open_native_folder_picker", lambda initial="": "/picked"
+    )
+    resp = client.post(
+        "/api/folder-picker",
+        data=json.dumps({"initial": "/start"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True, "path": "/picked"}
+
+
+def test_folder_picker_returns_null_on_cancel(client, monkeypatch):
+    import utils
+
+    monkeypatch.setattr(utils, "open_native_folder_picker", lambda initial="": None)
+    resp = client.post(
+        "/api/folder-picker",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True, "path": None}
+
+
+# ---------- /api/sessions/record -------------------------------------------
+
+
+def test_sessions_record_happy_path(client, tmp_path):
+    payload = {
+        "input": str(tmp_path / "in"),
+        "output": str(tmp_path / "out"),
+        "spreadsheet": {
+            "type": "excel",
+            "id_or_path": str(tmp_path / "book.xlsx"),
+            "label": "book.xlsx",
+        },
+    }
+    resp = client.post(
+        "/api/sessions/record",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+    saved = start_settings.load_start_settings()
+    assert saved["recent_projects"], "Session record didn't persist"
+    entry = saved["recent_projects"][0]
+    assert entry["input"] == payload["input"]
+    assert entry["output"] == payload["output"]
+    assert entry["spreadsheet"]["type"] == "excel"
+
+
+def test_sessions_record_no_sheet_path(client, tmp_path):
+    """Spreadsheet omitted → still records a session with spreadsheet=None."""
+    resp = client.post(
+        "/api/sessions/record",
+        data=json.dumps(
+            {"input": str(tmp_path / "in"), "output": str(tmp_path / "out")}
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    saved = start_settings.load_start_settings()
+    assert saved["recent_projects"][0]["spreadsheet"] is None
+
+
+def test_sessions_record_rejects_non_string_input(client):
+    resp = client.post(
+        "/api/sessions/record",
+        data=json.dumps({"input": 42, "output": "/some/where"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "input" in body["error"]
+
+
+def test_sessions_record_rejects_bad_spreadsheet_type(client, tmp_path):
+    resp = client.post(
+        "/api/sessions/record",
+        data=json.dumps(
+            {
+                "input": str(tmp_path / "in"),
+                "output": str(tmp_path / "out"),
+                "spreadsheet": {"type": "csv", "id_or_path": "/x"},
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "google" in body["error"] and "excel" in body["error"]
+
+
+def test_sessions_record_rejects_non_dict_spreadsheet(client, tmp_path):
+    resp = client.post(
+        "/api/sessions/record",
+        data=json.dumps(
+            {
+                "input": str(tmp_path / "in"),
+                "output": str(tmp_path / "out"),
+                "spreadsheet": "not-a-dict",
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+
+
+def test_sessions_record_rejects_missing_spreadsheet_id(client, tmp_path):
+    resp = client.post(
+        "/api/sessions/record",
+        data=json.dumps(
+            {
+                "input": str(tmp_path / "in"),
+                "output": str(tmp_path / "out"),
+                "spreadsheet": {"type": "google", "id_or_path": "  "},
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "id_or_path" in body["error"]
+
+
+# ---------- /api/spreadsheets/google + /auth -------------------------------
+
+
+def test_google_list_unauthenticated(client):
+    """No cached client → authenticated=False, no in-flight flag."""
+    resp = client.get("/api/spreadsheets/google")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["authenticated"] is False
+    assert body["auth_in_flight"] is False
+    assert body["sheets"] == []
+
+
+def test_google_list_authenticated(client, monkeypatch):
+    """With a cached client, names come from google_api.get_all_spreadsheets."""
+    server._google_auth.client = object()  # stand-in
+    import google_api
+
+    monkeypatch.setattr(
+        google_api, "get_all_spreadsheets", lambda _c: ["Alpha", "Beta"]
+    )
+    resp = client.get("/api/spreadsheets/google")
+    body = resp.get_json()
+    assert body["authenticated"] is True
+    assert [s["name"] for s in body["sheets"]] == ["Alpha", "Beta"]
+
+
+def test_google_list_surfaces_api_error(client, monkeypatch):
+    server._google_auth.client = object()
+    import google_api
+
+    def _boom(_c):
+        raise RuntimeError("rate limited")
+
+    monkeypatch.setattr(google_api, "get_all_spreadsheets", _boom)
+    resp = client.get("/api/spreadsheets/google")
+    body = resp.get_json()
+    assert body["authenticated"] is True
+    assert "rate limited" in body["auth_error"]
+    assert body["sheets"] == []
+
+
+def test_google_auth_short_circuits_when_already_authenticated(client):
+    """POST /auth returns authenticated=True without spawning a thread."""
+    server._google_auth.client = object()
+    resp = client.post("/api/spreadsheets/google/auth", json={})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["started"] is False
+    assert body["authenticated"] is True
+
+
+def test_google_auth_short_circuits_when_in_flight(client):
+    server._google_auth.in_flight = True
+    resp = client.post("/api/spreadsheets/google/auth", json={})
+    body = resp.get_json()
+    assert body["started"] is False
+    assert body["in_flight"] is True
+
+
+def test_google_auth_runs_handler_when_idle(client, monkeypatch):
+    """When no client and no flight, the thread runs cli.authenticate_google."""
+    import threading
+
+    # Force the spawned thread to run inline so we can assert end state.
+    def fake_thread(target, daemon=True):
+        target()
+
+        class _Joined:
+            def start(self_inner):
+                pass
+
+        return _Joined()
+
+    monkeypatch.setattr(threading, "Thread", fake_thread)
+
+    sentinel = object()
+    import cli
+
+    monkeypatch.setattr(cli, "authenticate_google", lambda: sentinel)
+
+    resp = client.post("/api/spreadsheets/google/auth", json={})
+    assert resp.status_code == 202
+    body = resp.get_json()
+    assert body["started"] is True
+    # After the (synchronous) thread ran, state should reflect success.
+    assert server._google_auth.client is sentinel
+    assert server._google_auth.in_flight is False
+    assert server._google_auth.error == ""
+
+
+def test_google_auth_records_thread_error(client, monkeypatch):
+    import threading
+
+    def fake_thread(target, daemon=True):
+        target()
+
+        class _Joined:
+            def start(self_inner):
+                pass
+
+        return _Joined()
+
+    monkeypatch.setattr(threading, "Thread", fake_thread)
+
+    import cli
+
+    def _explode():
+        raise RuntimeError("creds missing")
+
+    monkeypatch.setattr(cli, "authenticate_google", _explode)
+
+    client.post("/api/spreadsheets/google/auth", json={})
+    assert server._google_auth.client is None
+    assert "creds missing" in server._google_auth.error
+    assert server._google_auth.in_flight is False

--- a/utils.py
+++ b/utils.py
@@ -1627,20 +1627,20 @@ def open_native_folder_picker(initial_dir: str = "") -> str | None:
 
     if sys.platform == "darwin":
         prompt = "Select a folder for clipgen"
-        # AppleScript strings break on " and \. Sanitised paths are good
-        # enough — if a path contains either, just skip seeding the dialog's
-        # initial location.
         safe_initial = ""
-        if initial_dir and '"' not in initial_dir and "\\" not in initial_dir:
+        if initial_dir:
             try:
                 if Path(initial_dir).is_dir():
                     safe_initial = initial_dir
             except OSError:
                 pass
         if safe_initial:
+            # Escape backslashes first, then double quotes, for safe embedding
+            # in an AppleScript double-quoted string literal.
+            escaped = safe_initial.replace("\\", "\\\\").replace('"', '\\"')
             script = (
                 f'set chosenFolder to choose folder with prompt "{prompt}" '
-                f'default location POSIX file "{safe_initial}"\n'
+                f'default location POSIX file "{escaped}"\n'
                 "return POSIX path of chosenFolder"
             )
         else:


### PR DESCRIPTION
## Summary

Audit of the Start overlay feature (PRs #312–#316) split into two commits:
the bug-fix sweep first, the cleanup/refactor second.

### 1. `fix(start): audit sweep — atomicity, validation, frozen-binary, packaging`
Twelve verified findings; B6 + B12 were false alarms after investigation, ten land as code.
- **B1** `build/clipgen.spec`: stop excluding `tkinter` so the folder-picker Tkinter fallback actually works on frozen Windows/Linux builds.
- **B2** `start-overlay.js`: `state.confirmInFlight` guard so Cmd/Ctrl+Enter can't race the disabled-button flight.
- **B3** `server._swap_worksheet`: snapshot prior state + roll back on init failure so Studio/Screenspace/Transcripts can't end up pointing at different sheets.
- **B4** `cli`: silent reuse of cached gspread token in the frozen no-args launch path — no more re-`Connect Google` on every `.app` double-click. New `_try_silent_google_auth()` helper.
- **B5** `server.api_sheet`: drop the duplicate top-level `defaultDuration` (canonical copy already flows through `utils.get_frontend_config()`).
- **B7** `server.api_sessions_record`: reject non-string paths, non-dict spreadsheets, bad `type` values, missing `id_or_path`.
- **B8** `start-overlay.js`: guard the document-level click listener on `state.open` (mirrors the existing keydown guard).
- **B9** `changelog.load_entries`: `utils.warning_print` when `CHANGELOG.md` is missing so PyInstaller spec regressions are detectable.
- **B10** `pyproject.toml`: complete the `py-modules` list — add `changelog`, `start_settings`, `data_export`, `pipeline`, `thinking_agents`, `screenspace_preview`, `transcripts_server`; drop stale `insights`/`insights_server`.
- **B11** `utils.open_native_folder_picker`: proper AppleScript escaping (escape `\\` first, then `"`) so legitimate paths aren't silently skipped.

### 2. `refactor(start): consolidate auth state, tokenize overlay, share ghost grid, test endpoints`
- **R1** `server.py`: five Google-auth globals → one `_GoogleAuthState` dataclass; `_run_auth` exceptions now go through `utils.error_print` instead of vanishing.
- **R2** `start-overlay.js`: poll constants hoisted; `pollGoogleAuth` split into `pollGoogleAuthOnce` / `onGooglePollSuccess` / `stopGooglePoll`; `close()` calls `stopGooglePoll()`.
- **R3** `start-overlay.css`: exact-match raw values → tokens (`--space-6`, `--color-selected`, `--color-accent-highlight`). Other raw values left per the file's own "intentional local-only" header note.
- **R4** ghost grid extracted: `.skeleton-grid` + `.skeleton-cell` → `primitives.css`; new `buildSkeletonGrid(target, cols, rows)` helper in `utils.js`; `studio.js` now uses it.
- **Test refactor**: `start_combined_server` split into `build_combined_app()` (returns the live Flask app) + a thin `start_combined_server()` wrapper that adds the run loop, so tests can drive the live app via `test_client`.
- **Coverage**: new `tests/test_start_endpoints.py` adds 21 integration tests for the previously-untested Start overlay endpoints (`/api/changelog`, `/api/dirs`, `/api/folder-picker`, `/api/sessions/record`, `/api/spreadsheets/google`, `/api/spreadsheets/google/auth`).

805 tests pass (up from 784); `ruff check`, `ruff format --check`, `ty check` all green.

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean (pre-existing pytest unresolved-import noise unchanged)
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 805 pass
- [ ] Manual smoke: double-click bundled `.app` with a cached Google token → lands in Studio, "Recently used" rail populated, Connect Google CTA not shown
- [ ] Manual smoke: open Start overlay, hammer Cmd+Enter while a previous `/api/spreadsheets/open` is in flight → only one request fires
- [ ] Manual smoke: Studio with no spreadsheet → ghost grid renders the same as before the refactor