### PR TITLE
refactor: introduce AgentOrchestrator + AnalysisTool strategy classes

### DIFF
--- a/screenspace.py
+++ b/screenspace.py
@@ -35,7 +35,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 import cv2
 import numpy as np
@@ -1921,177 +1921,10 @@ def check_frame_for_tool(
     """
     if region.get("w", 0) <= 0 or region.get("h", 0) <= 0:
         return False, None
-    if tool_type == "color":
-        pixels = extract_region(frame, region)
-        target = parameters.get("target_color", {"h": 0, "s": 0, "v": 0})
-        tol = parameters.get("tolerance", {"h": 10, "s": 50, "v": 50})
-        matched, conf = color_matches(pixels, target, tol)
-        if matched:
-            return True, {"_confidence": conf}
+    tool = TOOLS.get(tool_type)
+    if tool is None:
         return False, None
-
-    elif tool_type == "change":
-        if prev_frame is None:
-            return False, None
-        pixels = extract_region(frame, region)
-        prev_pixels = extract_region(prev_frame, region)
-        threshold = parameters.get(
-            "threshold", config.SCREENSPACE_CHANGE_RATIO_THRESHOLD
-        )
-        noise_threshold = parameters.get(
-            "noise_threshold", config.SCREENSPACE_NOISE_THRESHOLD
-        )
-        k = config.SCREENSPACE_BLUR_KERNEL
-        mk = config.SCREENSPACE_MORPH_KERNEL
-        morph_kernel = np.ones((mk, mk), np.uint8)
-        curr_gray = cv2.cvtColor(
-            cv2.GaussianBlur(pixels, (k, k), 0), cv2.COLOR_BGR2GRAY
-        )
-        prev_gray = cv2.cvtColor(
-            cv2.GaussianBlur(prev_pixels, (k, k), 0), cv2.COLOR_BGR2GRAY
-        )
-        diff = cv2.absdiff(prev_gray, curr_gray)
-        _, mask = cv2.threshold(diff, noise_threshold, 255, cv2.THRESH_BINARY)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, morph_kernel)
-        mag = float(np.count_nonzero(mask)) / float(mask.size) if mask.size else 0.0
-        if mag >= threshold:
-            return True, {"magnitude": round(mag, 4)}
-        return False, None
-
-    elif tool_type == "similarity":
-        ref = parameters.get("reference_frame")
-        if ref is None:
-            return False, None
-        pixels = extract_region(frame, region)
-        threshold = parameters.get("threshold", config.SCREENSPACE_SSIM_THRESHOLD)
-        is_sim, score = regions_are_similar(pixels, ref, threshold)
-        if is_sim:
-            return True, {"score": round(score, 4)}
-        return False, None
-
-    elif tool_type == "text":
-        pixels = extract_region(frame, region)
-        search_string = parameters.get("search_string", "")
-        if not search_string:
-            return False, None
-        fuzzy_threshold = parameters.get(
-            "fuzzy_threshold", config.SCREENSPACE_OCR_FUZZY_THRESHOLD
-        )
-        languages = parameters.get("languages") or ["en"]
-        reader = _get_ocr_reader(languages)
-        ocr_results = reader.readtext(pixels, detail=1)
-        search_lower = search_string.lower()
-        for _, text, conf in ocr_results:
-            ratio = difflib.SequenceMatcher(None, search_lower, text.lower()).ratio()
-            if ratio >= fuzzy_threshold:
-                return True, {"text_found": text, "confidence": round(conf, 4)}
-        return False, None
-
-    elif tool_type == "numbers":
-        pixels = extract_region(frame, region)
-        operator = parameters.get("operator", "gt")
-        target_value = parameters.get("target_value", 0)
-        range_min = parameters.get("range_min")
-        range_max = parameters.get("range_max")
-        languages = parameters.get("languages") or ["en"]
-        reader = _get_ocr_reader(languages)
-        ocr_results = reader.readtext(pixels, detail=1)
-        for _, text, _conf in ocr_results:
-            cleaned = text.replace(",", "")
-            for match in _NUMBERS_RE.findall(cleaned):
-                num = float(match)
-                if _number_matches(num, operator, target_value, range_min, range_max):
-                    return True, {"number_found": num}
-        return False, None
-
-    elif tool_type == "template":
-        template_img = parameters.get("template_image")
-        if template_img is None:
-            return False, None
-        threshold = parameters.get(
-            "threshold", config.SCREENSPACE_TEMPLATE_MATCH_THRESHOLD
-        )
-        template_mask = parameters.get("template_mask")
-        # Cache the per-task-constant grayscale/mask on the parameters dict so
-        # multitool scans amortize the prep across frames.
-        prepared = parameters.get("_prepared_template")
-        if prepared is None:
-            prepared = _prepare_template(template_img, template_mask)
-            parameters["_prepared_template"] = prepared
-        matches = match_template(
-            frame,
-            template_img,
-            threshold=threshold,
-            mask=template_mask,
-            prepared=prepared,
-        )
-        if matches:
-            best = max(m["score"] for m in matches)
-            return True, {
-                "best_score": round(best, 4),
-                "match_count": len(matches),
-            }
-        return False, None
-
-    elif tool_type == "flow":
-        if prev_frame is None:
-            return False, None
-        pixels = extract_region(frame, region)
-        prev_pixels = extract_region(prev_frame, region)
-        curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
-        prev_gray_f = cv2.cvtColor(prev_pixels, cv2.COLOR_BGR2GRAY)
-        magnitude_threshold = parameters.get(
-            "magnitude_threshold", config.SCREENSPACE_FLOW_MAGNITUDE_THRESHOLD
-        )
-        flow_result = compute_optical_flow(prev_gray_f, curr_gray)
-        if flow_result["magnitude"] >= magnitude_threshold:
-            return True, {
-                "magnitude": flow_result["magnitude"],
-                "angle": flow_result["angle"],
-            }
-        return False, None
-
-    elif tool_type == "scene":
-        ref_scenes = parameters.get("reference_scenes")
-        if not ref_scenes:
-            return False, None
-        threshold = parameters.get(
-            "threshold", config.SCREENSPACE_SCENE_SIMILARITY_THRESHOLD
-        )
-        pixels = extract_region(frame, region)
-        fp = compute_scene_fingerprint(pixels)
-        best_name = ""
-        best_score = 0.0
-        for ref in ref_scenes:
-            # Cache fingerprint on the reference dict to avoid recomputing per frame
-            ref_fp = ref.get("_cached_fingerprint")
-            if ref_fp is None:
-                ref_fp = compute_scene_fingerprint(ref["frame"])
-                ref["_cached_fingerprint"] = ref_fp
-            score = compare_scene_fingerprints(fp, ref_fp)
-            if score > best_score:
-                best_score = score
-                best_name = ref["name"]
-        if best_score >= threshold:
-            return True, {"scene_name": best_name, "score": round(best_score, 4)}
-        return False, None
-
-    elif tool_type == "inactivity":
-        if prev_frame is None:
-            return False, None
-        pixels = extract_region(frame, region)
-        prev_pixels = extract_region(prev_frame, region)
-        thresh = parameters.get(
-            "threshold", config.SCREENSPACE_INACTIVITY_PHASH_THRESHOLD
-        )
-        curr_h = compute_phash(pixels)
-        prev_h = compute_phash(prev_pixels)
-        dist = int(curr_h - prev_h)
-        if dist <= thresh:
-            return True, {"distance": dist}
-        return False, None
-
-    return False, None
+    return tool.check_frame(frame, prev_frame, region, parameters)
 
 
 def scan_multitool(
@@ -2453,6 +2286,639 @@ def generate_heatmap_gif(
         loop=0,
     )
     return output_path
+
+
+# ---------------------------------------------------------------------------
+# Analysis tools (strategy registry)
+# ---------------------------------------------------------------------------
+#
+# Each tool is a small class wrapping the corresponding module-level ``scan_*``
+# function (preserved for tests that monkeypatch them). The two registry-level
+# dispatch points are:
+#   - :func:`check_frame_for_tool` (single-frame eval used by multitool)
+#   - :meth:`ScreenspaceWorker._dispatch` (full-video scan, called by the worker)
+# Both look up the tool by name in ``TOOLS`` and delegate to its methods.
+
+
+class AnalysisTool:
+    """Base class for screenspace analysis tools.
+
+    Subclasses set ``name`` and override ``check_frame`` (for multitool
+    chaining) and/or ``scan`` (for the full-video sweep). The dispatch
+    layer reads ``fast_scan_region_dim`` / ``supports_fast_scan`` /
+    ``fast_scan_extra_opts`` to build the shared ``fast_opts`` payload.
+    """
+
+    name: ClassVar[str] = ""
+    # Max region dimension when running in "fast" scan mode (passed to the
+    # generic frame extractor as ``max_region_dim``). 0 means no downscale.
+    fast_scan_region_dim: ClassVar[int] = 0
+    # Whether the tool participates in the fast-scan optimization at all.
+    # Timelapse opts out because it has its own ``sample_interval``.
+    supports_fast_scan: ClassVar[bool] = True
+    # Extra keys merged into ``fast_opts`` (e.g. ``{"template_downscale": True}``).
+    fast_scan_extra_opts: ClassVar[dict[str, Any]] = {}
+
+    def check_frame(
+        self,
+        frame: np.ndarray,
+        prev_frame: np.ndarray | None,
+        region: dict[str, int],
+        params: dict[str, Any],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Evaluate a single frame for use in a multitool chain step.
+
+        Default: tool not supported as a multitool step.
+        """
+        return False, None
+
+    def scan(
+        self,
+        video_path: str,
+        region: dict[str, int],
+        params: dict[str, Any],
+        *,
+        task_id: str,
+        scan_mode: str,
+        on_progress: Callable[[float], None],
+        cancel_flag: Callable[[], bool],
+        on_result: Callable[[dict[str, Any]], None] | None,
+        fast_opts: dict[str, Any] | None,
+    ) -> Any:
+        """Run a full-video scan. Subclasses must override."""
+        raise NotImplementedError
+
+
+class ColorTool(AnalysisTool):
+    name = "color"
+    fast_scan_region_dim = 32
+
+    def check_frame(self, frame, prev_frame, region, params):
+        pixels = extract_region(frame, region)
+        target = params.get("target_color", {"h": 0, "s": 0, "v": 0})
+        tol = params.get("tolerance", {"h": 10, "s": 50, "v": 50})
+        matched, conf = color_matches(pixels, target, tol)
+        if matched:
+            return True, {"_confidence": conf}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        return scan_color(
+            video_path,
+            region,
+            target_color=params.get("target_color", {"h": 0, "s": 0, "v": 0}),
+            tolerance=params.get("tolerance", {"h": 10, "s": 50, "v": 50}),
+            interval_seconds=params.get("interval", 0),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class ChangeTool(AnalysisTool):
+    name = "change"
+    fast_scan_region_dim = 128
+
+    def check_frame(self, frame, prev_frame, region, params):
+        if prev_frame is None:
+            return False, None
+        pixels = extract_region(frame, region)
+        prev_pixels = extract_region(prev_frame, region)
+        threshold = params.get("threshold", config.SCREENSPACE_CHANGE_RATIO_THRESHOLD)
+        noise_threshold = params.get(
+            "noise_threshold", config.SCREENSPACE_NOISE_THRESHOLD
+        )
+        k = config.SCREENSPACE_BLUR_KERNEL
+        mk = config.SCREENSPACE_MORPH_KERNEL
+        morph_kernel = np.ones((mk, mk), np.uint8)
+        curr_gray = cv2.cvtColor(
+            cv2.GaussianBlur(pixels, (k, k), 0), cv2.COLOR_BGR2GRAY
+        )
+        prev_gray = cv2.cvtColor(
+            cv2.GaussianBlur(prev_pixels, (k, k), 0), cv2.COLOR_BGR2GRAY
+        )
+        diff = cv2.absdiff(prev_gray, curr_gray)
+        _, mask = cv2.threshold(diff, noise_threshold, 255, cv2.THRESH_BINARY)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, morph_kernel)
+        mag = float(np.count_nonzero(mask)) / float(mask.size) if mask.size else 0.0
+        if mag >= threshold:
+            return True, {"magnitude": round(mag, 4)}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        return scan_changes(
+            video_path,
+            region,
+            threshold=params.get("threshold", 0),
+            interval_seconds=params.get("interval", 0),
+            noise_threshold=params.get("noise_threshold", 0),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class SimilarityTool(AnalysisTool):
+    name = "similarity"
+    fast_scan_region_dim = 128
+
+    def check_frame(self, frame, prev_frame, region, params):
+        ref = params.get("reference_frame")
+        if ref is None:
+            return False, None
+        pixels = extract_region(frame, region)
+        threshold = params.get("threshold", config.SCREENSPACE_SSIM_THRESHOLD)
+        is_sim, score = regions_are_similar(pixels, ref, threshold)
+        if is_sim:
+            return True, {"score": round(score, 4)}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        ref_frame = params.get("reference_frame")
+        if ref_frame is None:
+            raise ValueError("Similarity scan requires a reference_frame parameter")
+        return scan_similarity(
+            video_path,
+            region,
+            reference_frame=ref_frame,
+            threshold=params.get("threshold", 0),
+            interval_seconds=params.get("interval", 0),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class TextTool(AnalysisTool):
+    name = "text"
+
+    def check_frame(self, frame, prev_frame, region, params):
+        pixels = extract_region(frame, region)
+        search_string = params.get("search_string", "")
+        if not search_string:
+            return False, None
+        fuzzy_threshold = params.get(
+            "fuzzy_threshold", config.SCREENSPACE_OCR_FUZZY_THRESHOLD
+        )
+        languages = params.get("languages") or ["en"]
+        reader = _get_ocr_reader(languages)
+        ocr_results = reader.readtext(pixels, detail=1)
+        search_lower = search_string.lower()
+        for _, text, conf in ocr_results:
+            ratio = difflib.SequenceMatcher(None, search_lower, text.lower()).ratio()
+            if ratio >= fuzzy_threshold:
+                return True, {"text_found": text, "confidence": round(conf, 4)}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        return scan_text(
+            video_path,
+            region,
+            search_string=params.get("search_string", ""),
+            interval_seconds=params.get("interval", 2.0),
+            fuzzy_threshold=params.get("fuzzy_threshold", 0),
+            languages=params.get("languages"),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class NumbersTool(AnalysisTool):
+    name = "numbers"
+
+    def check_frame(self, frame, prev_frame, region, params):
+        pixels = extract_region(frame, region)
+        operator = params.get("operator", "gt")
+        target_value = params.get("target_value", 0)
+        range_min = params.get("range_min")
+        range_max = params.get("range_max")
+        languages = params.get("languages") or ["en"]
+        reader = _get_ocr_reader(languages)
+        ocr_results = reader.readtext(pixels, detail=1)
+        for _, text, _conf in ocr_results:
+            cleaned = text.replace(",", "")
+            for match in _NUMBERS_RE.findall(cleaned):
+                num = float(match)
+                if _number_matches(num, operator, target_value, range_min, range_max):
+                    return True, {"number_found": num}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        return scan_numbers(
+            video_path,
+            region,
+            operator=params.get("operator", "gt"),
+            target_value=params.get("target_value", 0),
+            interval_seconds=params.get("interval", 2.0),
+            range_min=params.get("range_min"),
+            range_max=params.get("range_max"),
+            languages=params.get("languages"),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class TemplateTool(AnalysisTool):
+    name = "template"
+    fast_scan_extra_opts: ClassVar[dict[str, Any]] = {"template_downscale": True}
+
+    def check_frame(self, frame, prev_frame, region, params):
+        template_img = params.get("template_image")
+        if template_img is None:
+            return False, None
+        threshold = params.get("threshold", config.SCREENSPACE_TEMPLATE_MATCH_THRESHOLD)
+        template_mask = params.get("template_mask")
+        # Cache the per-task-constant grayscale/mask on the parameters dict so
+        # multitool scans amortize the prep across frames.
+        prepared = params.get("_prepared_template")
+        if prepared is None:
+            prepared = _prepare_template(template_img, template_mask)
+            params["_prepared_template"] = prepared
+        matches = match_template(
+            frame,
+            template_img,
+            threshold=threshold,
+            mask=template_mask,
+            prepared=prepared,
+        )
+        if matches:
+            best = max(m["score"] for m in matches)
+            return True, {"best_score": round(best, 4), "match_count": len(matches)}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        template_img = params.get("template_image")
+        if template_img is None:
+            raise ValueError("Template scan requires a template_image parameter")
+        tmpl_mask = params.get("template_mask")
+        # Fast scan: downscale template + mask by 2x before passing to the
+        # scan function (which separately downscales the frame via the
+        # ``template_downscale`` fast_opts flag).
+        if scan_mode == "fast":
+            th, tw = template_img.shape[:2]
+            ntw, nth = tw // 2, th // 2
+            if ntw > 0 and nth > 0:
+                template_img = cv2.resize(
+                    template_img, (ntw, nth), interpolation=cv2.INTER_AREA
+                )
+                if tmpl_mask is not None:
+                    tmpl_mask = cv2.resize(
+                        tmpl_mask, (ntw, nth), interpolation=cv2.INTER_AREA
+                    )
+        return scan_template(
+            video_path,
+            region,
+            template_image=template_img,
+            threshold=params.get("threshold", 0),
+            interval_seconds=params.get("interval", 0),
+            template_mask=tmpl_mask,
+            template_scale=float(params.get("template_scale", 1.0)),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class FlowTool(AnalysisTool):
+    name = "flow"
+    fast_scan_region_dim = 128
+
+    def check_frame(self, frame, prev_frame, region, params):
+        if prev_frame is None:
+            return False, None
+        pixels = extract_region(frame, region)
+        prev_pixels = extract_region(prev_frame, region)
+        curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        prev_gray_f = cv2.cvtColor(prev_pixels, cv2.COLOR_BGR2GRAY)
+        magnitude_threshold = params.get(
+            "magnitude_threshold", config.SCREENSPACE_FLOW_MAGNITUDE_THRESHOLD
+        )
+        flow_result = compute_optical_flow(prev_gray_f, curr_gray)
+        if flow_result["magnitude"] >= magnitude_threshold:
+            return True, {
+                "magnitude": flow_result["magnitude"],
+                "angle": flow_result["angle"],
+            }
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        return scan_flow(
+            video_path,
+            region,
+            magnitude_threshold=params.get("magnitude_threshold", 0),
+            interval_seconds=params.get("interval", 0),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class SceneTool(AnalysisTool):
+    name = "scene"
+    fast_scan_region_dim = 64
+
+    def check_frame(self, frame, prev_frame, region, params):
+        ref_scenes = params.get("reference_scenes")
+        if not ref_scenes:
+            return False, None
+        threshold = params.get(
+            "threshold", config.SCREENSPACE_SCENE_SIMILARITY_THRESHOLD
+        )
+        pixels = extract_region(frame, region)
+        fp = compute_scene_fingerprint(pixels)
+        best_name = ""
+        best_score = 0.0
+        for ref in ref_scenes:
+            # Cache fingerprint on the reference dict to avoid recomputing per frame
+            ref_fp = ref.get("_cached_fingerprint")
+            if ref_fp is None:
+                ref_fp = compute_scene_fingerprint(ref["frame"])
+                ref["_cached_fingerprint"] = ref_fp
+            score = compare_scene_fingerprints(fp, ref_fp)
+            if score > best_score:
+                best_score = score
+                best_name = ref["name"]
+        if best_score >= threshold:
+            return True, {"scene_name": best_name, "score": round(best_score, 4)}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        ref_scenes = params.get("reference_scenes")
+        if not ref_scenes:
+            raise ValueError("Scene scan requires reference_scenes parameter")
+        return scan_scene(
+            video_path,
+            region,
+            reference_scenes=ref_scenes,
+            threshold=params.get("threshold", 0),
+            interval_seconds=params.get("interval", 0),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class InactivityTool(AnalysisTool):
+    name = "inactivity"
+    fast_scan_region_dim = 64
+
+    def check_frame(self, frame, prev_frame, region, params):
+        if prev_frame is None:
+            return False, None
+        pixels = extract_region(frame, region)
+        prev_pixels = extract_region(prev_frame, region)
+        thresh = params.get("threshold", config.SCREENSPACE_INACTIVITY_PHASH_THRESHOLD)
+        curr_h = compute_phash(pixels)
+        prev_h = compute_phash(prev_pixels)
+        dist = int(curr_h - prev_h)
+        if dist <= thresh:
+            return True, {"distance": dist}
+        return False, None
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        return scan_inactivity(
+            video_path,
+            region,
+            threshold=params.get("threshold", 0),
+            min_duration=params.get("min_duration", 0.0),
+            interval_seconds=params.get("interval", 0),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+class TimelapseTool(AnalysisTool):
+    name = "timelapse"
+    # Has its own ``sample_interval`` and produces a media file rather than
+    # per-frame events, so the generic fast-scan path does not apply.
+    supports_fast_scan = False
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        output_path = params.get("output_path", "")
+        if not output_path:
+            ext = "gif" if params.get("output_format") == "gif" else "mp4"
+            output_path = str(
+                Path(utils.get_effective_output_dir()) / f"timelapse_{task_id}.{ext}"
+            )
+        return generate_timelapse(
+            video_path,
+            region,
+            speedup_factor=params.get("speedup_factor", 10.0),
+            output_path=output_path,
+            output_format=params.get("output_format", "mp4"),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            sample_interval=params.get("sample_interval", 0.0),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+        )
+
+
+class MultitoolTool(AnalysisTool):
+    name = "multitool"
+
+    def scan(
+        self,
+        video_path,
+        region,
+        params,
+        *,
+        task_id,
+        scan_mode,
+        on_progress,
+        cancel_flag,
+        on_result,
+        fast_opts,
+    ):
+        steps = params.get("steps", [])
+        if not steps or len(steps) < 2:
+            raise ValueError("Multitool requires at least 2 steps")
+        # Fast scan: multiply the interval used by scan_multitool
+        # (reads from steps[0]["interval"] with fallback to default).
+        if scan_mode == "fast" and steps:
+            mt_interval = steps[0].get("interval", config.SCREENSPACE_DEFAULT_INTERVAL)
+            steps[0]["interval"] = (
+                mt_interval * config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
+            )
+        return scan_multitool(
+            video_path,
+            region,
+            steps=steps,
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
+
+
+TOOLS: dict[str, AnalysisTool] = {
+    t.name: t
+    for t in (
+        ColorTool(),
+        ChangeTool(),
+        SimilarityTool(),
+        TextTool(),
+        NumbersTool(),
+        TemplateTool(),
+        FlowTool(),
+        SceneTool(),
+        InactivityTool(),
+        TimelapseTool(),
+        MultitoolTool(),
+    )
+}
 
 
 class ScreenspaceWorker:
@@ -2837,234 +3303,41 @@ class ScreenspaceWorker:
         cancel_flag: Callable[[], bool],
         on_result: Callable[[dict[str, Any]], None] | None = None,
     ) -> Any:
-        """Route task to the correct workflow function."""
-        video_path = task["video_path"]
-        region = task["region_coords"]
-        params = task.get("parameters", {})
-        task_type = task["type"]
+        """Route task to the correct tool via the ``TOOLS`` registry.
 
-        # Fast scan: apply interval multiplier and build optimization dict
-        # (timelapse has its own sample_interval and does not use fast scan)
+        Builds the shared fast-scan ``fast_opts`` payload here so individual
+        tool classes only need to declare ``fast_scan_region_dim`` /
+        ``supports_fast_scan`` / ``fast_scan_extra_opts`` as class attributes.
+        """
+        task_type = task["type"]
+        tool = TOOLS.get(task_type)
+        if tool is None:
+            raise ValueError(f"Unknown task type: {task_type}")
+
+        params = task.get("parameters", {})
         scan_mode = params.get("scan_mode", "normal")
         fast_opts: dict[str, Any] | None = None
-        if scan_mode == "fast" and task_type != "timelapse":
+        if scan_mode == "fast" and tool.supports_fast_scan:
             multiplier = config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
             if params.get("interval", 0) > 0:
                 params["interval"] = params["interval"] * multiplier
-            _fast_dims = {
-                "color": 32,
-                "change": 128,
-                "similarity": 128,
-                "flow": 128,
-                "scene": 64,
-                "inactivity": 64,
-            }
             fast_opts = {
                 "phash_skip": True,
-                "max_region_dim": _fast_dims.get(task_type, 0),
+                "max_region_dim": tool.fast_scan_region_dim,
+                **tool.fast_scan_extra_opts,
             }
-            if task_type == "template":
-                fast_opts["template_downscale"] = True
 
-        if task_type == "color":
-            return scan_color(
-                video_path,
-                region,
-                target_color=params.get("target_color", {"h": 0, "s": 0, "v": 0}),
-                tolerance=params.get("tolerance", {"h": 10, "s": 50, "v": 50}),
-                interval_seconds=params.get("interval", 0),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "change":
-            return scan_changes(
-                video_path,
-                region,
-                threshold=params.get("threshold", 0),
-                interval_seconds=params.get("interval", 0),
-                noise_threshold=params.get("noise_threshold", 0),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "similarity":
-            ref_frame = params.get("reference_frame")
-            if ref_frame is None:
-                raise ValueError("Similarity scan requires a reference_frame parameter")
-            return scan_similarity(
-                video_path,
-                region,
-                reference_frame=ref_frame,
-                threshold=params.get("threshold", 0),
-                interval_seconds=params.get("interval", 0),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "text":
-            return scan_text(
-                video_path,
-                region,
-                search_string=params.get("search_string", ""),
-                interval_seconds=params.get("interval", 2.0),
-                fuzzy_threshold=params.get("fuzzy_threshold", 0),
-                languages=params.get("languages"),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "numbers":
-            return scan_numbers(
-                video_path,
-                region,
-                operator=params.get("operator", "gt"),
-                target_value=params.get("target_value", 0),
-                interval_seconds=params.get("interval", 2.0),
-                range_min=params.get("range_min"),
-                range_max=params.get("range_max"),
-                languages=params.get("languages"),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "timelapse":
-            output_path = params.get("output_path", "")
-            if not output_path:
-                ext = "gif" if params.get("output_format") == "gif" else "mp4"
-                output_path = str(
-                    Path(utils.get_effective_output_dir())
-                    / f"timelapse_{task['id']}.{ext}"
-                )
-            return generate_timelapse(
-                video_path,
-                region,
-                speedup_factor=params.get("speedup_factor", 10.0),
-                output_path=output_path,
-                output_format=params.get("output_format", "mp4"),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                sample_interval=params.get("sample_interval", 0.0),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-            )
-        elif task_type == "template":
-            template_img = params.get("template_image")
-            if template_img is None:
-                raise ValueError("Template scan requires a template_image parameter")
-            tmpl_mask = params.get("template_mask")
-            # Fast scan: downscale template + mask by 2x
-            if scan_mode == "fast" and template_img is not None:
-                th, tw = template_img.shape[:2]
-                ntw, nth = tw // 2, th // 2
-                if ntw > 0 and nth > 0:
-                    template_img = cv2.resize(
-                        template_img, (ntw, nth), interpolation=cv2.INTER_AREA
-                    )
-                    if tmpl_mask is not None:
-                        tmpl_mask = cv2.resize(
-                            tmpl_mask, (ntw, nth), interpolation=cv2.INTER_AREA
-                        )
-            return scan_template(
-                video_path,
-                region,
-                template_image=template_img,
-                threshold=params.get("threshold", 0),
-                interval_seconds=params.get("interval", 0),
-                template_mask=tmpl_mask,
-                template_scale=float(params.get("template_scale", 1.0)),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "flow":
-            return scan_flow(
-                video_path,
-                region,
-                magnitude_threshold=params.get("magnitude_threshold", 0),
-                interval_seconds=params.get("interval", 0),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "scene":
-            ref_scenes = params.get("reference_scenes")
-            if not ref_scenes:
-                raise ValueError("Scene scan requires reference_scenes parameter")
-            return scan_scene(
-                video_path,
-                region,
-                reference_scenes=ref_scenes,
-                threshold=params.get("threshold", 0),
-                interval_seconds=params.get("interval", 0),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "multitool":
-            steps = params.get("steps", [])
-            if not steps or len(steps) < 2:
-                raise ValueError("Multitool requires at least 2 steps")
-            # Fast scan: multiply the interval used by scan_multitool
-            # (reads from steps[0]["interval"] with fallback to default)
-            if scan_mode == "fast" and steps:
-                mt_interval = steps[0].get(
-                    "interval", config.SCREENSPACE_DEFAULT_INTERVAL
-                )
-                steps[0]["interval"] = (
-                    mt_interval * config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
-                )
-            return scan_multitool(
-                video_path,
-                region,
-                steps=steps,
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        elif task_type == "inactivity":
-            return scan_inactivity(
-                video_path,
-                region,
-                threshold=params.get("threshold", 0),
-                min_duration=params.get("min_duration", 0.0),
-                interval_seconds=params.get("interval", 0),
-                start_seconds=params.get("start_seconds", 0.0),
-                end_seconds=params.get("end_seconds"),
-                on_progress=on_progress,
-                cancel_flag=cancel_flag,
-                on_result=on_result,
-                fast_opts=fast_opts,
-            )
-        else:
-            raise ValueError(f"Unknown task type: {task_type}")
+        return tool.scan(
+            task["video_path"],
+            task["region_coords"],
+            params,
+            task_id=task["id"],
+            scan_mode=scan_mode,
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -152,10 +152,10 @@ def _agent_state_clean():
     """
 
     def _reset() -> None:
-        for key in transcripts_server._agent_in_flight:
-            transcripts_server._agent_in_flight[key].clear()
-        for key in transcripts_server._agent_cancel_events:
-            transcripts_server._agent_cancel_events[key].clear()
+        for key in transcripts_server._orchestrator._in_flight:
+            transcripts_server._orchestrator._in_flight[key].clear()
+        for key in transcripts_server._orchestrator._cancel_events:
+            transcripts_server._orchestrator._cancel_events[key].clear()
         with transcripts_server._pending_model_unloads_lock:
             for timer in transcripts_server._pending_model_unloads.values():
                 timer.cancel()
@@ -171,8 +171,8 @@ def test_summary_stop_sets_cancel_event(tr_client, _agent_state_clean):
     the participant from the in-flight set so the UI flips to idle."""
     pid = "P01"
     evt = threading.Event()
-    transcripts_server._agent_in_flight["summary"].add(pid)
-    transcripts_server._agent_cancel_events["summary"][pid] = evt
+    transcripts_server._orchestrator._in_flight["summary"].add(pid)
+    transcripts_server._orchestrator._cancel_events["summary"][pid] = evt
 
     resp = tr_client.post(f"/transcripts/api/summary/{pid}/stop")
     assert resp.status_code == 200
@@ -180,7 +180,7 @@ def test_summary_stop_sets_cancel_event(tr_client, _agent_state_clean):
     assert data["ok"] is True
     assert data["running"] is False
     assert evt.is_set()
-    assert pid not in transcripts_server._agent_in_flight["summary"]
+    assert pid not in transcripts_server._orchestrator._in_flight["summary"]
 
 
 def test_citations_stop_sets_cancel_event(tr_client, _agent_state_clean):
@@ -188,8 +188,8 @@ def test_citations_stop_sets_cancel_event(tr_client, _agent_state_clean):
     remove the participant from the in-flight set."""
     pid = "P01"
     evt = threading.Event()
-    transcripts_server._agent_in_flight["citations"].add(pid)
-    transcripts_server._agent_cancel_events["citations"][pid] = evt
+    transcripts_server._orchestrator._in_flight["citations"].add(pid)
+    transcripts_server._orchestrator._cancel_events["citations"][pid] = evt
 
     resp = tr_client.post(f"/transcripts/api/citations/{pid}/stop")
     assert resp.status_code == 200
@@ -197,7 +197,7 @@ def test_citations_stop_sets_cancel_event(tr_client, _agent_state_clean):
     assert data["ok"] is True
     assert data["running"] is False
     assert evt.is_set()
-    assert pid not in transcripts_server._agent_in_flight["citations"]
+    assert pid not in transcripts_server._orchestrator._in_flight["citations"]
 
 
 def test_summary_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
@@ -207,7 +207,7 @@ def test_summary_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
     data = resp.get_json()
     assert data["ok"] is True
     assert data["running"] is False
-    assert "P01" not in transcripts_server._agent_cancel_events["summary"]
+    assert "P01" not in transcripts_server._orchestrator._cancel_events["summary"]
 
 
 def test_citations_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
@@ -217,7 +217,7 @@ def test_citations_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
     data = resp.get_json()
     assert data["ok"] is True
     assert data["running"] is False
-    assert "P01" not in transcripts_server._agent_cancel_events["citations"]
+    assert "P01" not in transcripts_server._orchestrator._cancel_events["citations"]
 
 
 # ---- Model unload scheduling ----
@@ -231,8 +231,8 @@ def test_summary_stop_schedules_model_unload(
     monkeypatch.setattr(config, "OLLAMA_UNLOAD_DELAY_SECONDS", 30.0)
     pid = "P01"
     evt = threading.Event()
-    transcripts_server._agent_in_flight["summary"].add(pid)
-    transcripts_server._agent_cancel_events["summary"][pid] = evt
+    transcripts_server._orchestrator._in_flight["summary"].add(pid)
+    transcripts_server._orchestrator._cancel_events["summary"][pid] = evt
 
     tr_client.post(f"/transcripts/api/summary/{pid}/stop")
 
@@ -247,8 +247,8 @@ def test_citations_stop_schedules_model_unload(
     monkeypatch.setattr(config, "OLLAMA_UNLOAD_DELAY_SECONDS", 30.0)
     pid = "P01"
     evt = threading.Event()
-    transcripts_server._agent_in_flight["citations"].add(pid)
-    transcripts_server._agent_cancel_events["citations"][pid] = evt
+    transcripts_server._orchestrator._in_flight["citations"].add(pid)
+    transcripts_server._orchestrator._cancel_events["citations"][pid] = evt
 
     tr_client.post(f"/transcripts/api/citations/{pid}/stop")
 

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -60,25 +60,11 @@ _participants: list[dict[str, Any]] = []
 _manifest_lock = threading.Lock()
 _transcript_model_warming = False
 _transcript_model_warming_lock = threading.Lock()
-# Tracks in-flight thinking-agent runs, keyed by agent key (e.g. "summary",
-# "citations"). Each value is a set of participant IDs currently being
-# processed by that agent.
-_agent_threads: dict[str, set[threading.Thread]] = {
-    a["key"]: set() for a in thinking_agents.AGENTS
-}
-_agent_in_flight: dict[str, set[str]] = {
-    a["key"]: set() for a in thinking_agents.AGENTS
-}
-# Per-run cancel events. When the orchestrator starts an agent for a
-# participant, it registers a fresh ``threading.Event`` here; the Ollama
-# transport closes its streaming HTTP response on ``event.set()``, which
-# unblocks the read loop and frees the model promptly. The /stop endpoints
-# look up the event and call ``set()``. The discard-on-return check in
-# ``_run_agent`` keeps result-and-chain-advance gated on the same event as a
-# defense-in-depth measure for finish-vs-cancel races.
-_agent_cancel_events: dict[str, dict[str, threading.Event]] = {
-    a["key"]: {} for a in thinking_agents.AGENTS
-}
+# Thinking-agent orchestrator. Owns per-agent in-flight, cancel-event, and
+# thread state. The `AgentOrchestrator` class is defined further down and the
+# instance is bound at module load. Routes call methods on this; nothing else
+# should reach into orchestrator internals.
+_orchestrator: "AgentOrchestrator"
 
 # After a Stop, schedule a delayed Ollama model unload so the model is evicted
 # from memory if no follow-up run starts soon. Keyed by model name → Timer.
@@ -122,11 +108,6 @@ def _cancel_pending_unload(model: str) -> None:
         timer.cancel()
 
 
-def _is_generating(participant: str, agent_key: str) -> bool:
-    """Return True if *agent_key* is currently running for *participant*."""
-    return participant in _agent_in_flight.get(agent_key, set())
-
-
 def _agent_model(agent_key: str) -> str | None:
     """Look up the Ollama model name configured for *agent_key*."""
     agent = thinking_agents.get_agent(agent_key)
@@ -146,7 +127,7 @@ def _step_state_agent(pid: str, entry: dict[str, Any], agent_key: str) -> str:
         (a["manifest_field"] for a in thinking_agents.AGENTS if a["key"] == agent_key),
         agent_key,
     )
-    if _is_generating(pid, agent_key):
+    if _orchestrator.is_generating(pid, agent_key):
         return "running"
     if entry.get(field_name):
         return "done"
@@ -373,7 +354,7 @@ def api_summary(participant: str) -> FlaskResponse:
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry or not entry.get("summary"):
-            if _is_generating(participant, "summary"):
+            if _orchestrator.is_generating(participant, "summary"):
                 return jsonify({"ok": False, "generating": True})
             return jsonify({"ok": False}), 404
         summary = entry["summary"]
@@ -381,7 +362,7 @@ def api_summary(participant: str) -> FlaskResponse:
     resp: dict[str, Any] = {"ok": True, "summary": summary}
     if citations:
         resp["citations"] = citations
-    resp["citations_generating"] = _is_generating(participant, "citations")
+    resp["citations_generating"] = _orchestrator.is_generating(participant, "citations")
     return jsonify(resp)
 
 
@@ -392,7 +373,7 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
     Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False
     so the frontend's per-participant controls can force a run.
     """
-    if _is_generating(participant, "summary"):
+    if _orchestrator.is_generating(participant, "summary"):
         return jsonify({"ok": True, "generating": True})
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
@@ -401,7 +382,7 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
         entry["summary"] = ""
         entry.pop("citations", None)
     _persist_manifest()
-    _run_agent_chain(participant, force=True)
+    _orchestrator.run_chain(participant, force=True)
     return jsonify({"ok": True, "generating": True})
 
 
@@ -414,15 +395,10 @@ def api_summary_stop(participant: str) -> FlaskResponse:
     immediately. After a short delay, the model is unloaded from memory if
     no new run has started in the meantime.
     """
-    if not _is_generating(participant, "summary"):
-        return jsonify({"ok": True, "running": False})
-    event = _agent_cancel_events["summary"].get(participant)
-    if event is not None:
-        event.set()
-    _agent_in_flight["summary"].discard(participant)
-    model = _agent_model("summary")
-    if model:
-        _schedule_model_unload(model)
+    if _orchestrator.stop("summary", participant):
+        model = _agent_model("summary")
+        if model:
+            _schedule_model_unload(model)
     return jsonify({"ok": True, "running": False})
 
 
@@ -455,7 +431,7 @@ def api_citations(participant: str) -> FlaskResponse:
         citations = entry.get("citations")
     if citations:
         return jsonify({"ok": True, "citations": citations})
-    if _is_generating(participant, "citations"):
+    if _orchestrator.is_generating(participant, "citations"):
         return jsonify({"ok": False, "generating": True})
     return jsonify({"ok": False}), 404
 
@@ -466,7 +442,7 @@ def api_citations_regenerate(participant: str) -> FlaskResponse:
 
     Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False.
     """
-    if _is_generating(participant, "citations"):
+    if _orchestrator.is_generating(participant, "citations"):
         return jsonify({"ok": True, "generating": True})
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
@@ -476,7 +452,7 @@ def api_citations_regenerate(participant: str) -> FlaskResponse:
             ), 404
         entry.pop("citations", None)
     _persist_manifest()
-    _run_agent("citations", participant, force=True)
+    _orchestrator.run_agent("citations", participant, force=True)
     return jsonify({"ok": True, "generating": True})
 
 
@@ -489,15 +465,10 @@ def api_citations_stop(participant: str) -> FlaskResponse:
     immediately. After a short delay, the model is unloaded from memory if
     no new run has started in the meantime.
     """
-    if not _is_generating(participant, "citations"):
-        return jsonify({"ok": True, "running": False})
-    event = _agent_cancel_events["citations"].get(participant)
-    if event is not None:
-        event.set()
-    _agent_in_flight["citations"].discard(participant)
-    model = _agent_model("citations")
-    if model:
-        _schedule_model_unload(model)
+    if _orchestrator.stop("citations", participant):
+        model = _agent_model("citations")
+        if model:
+            _schedule_model_unload(model)
     return jsonify({"ok": True, "running": False})
 
 
@@ -1052,7 +1023,7 @@ def _on_task_complete() -> None:
     _persist_manifest()
 
     for pid in newly_completed:
-        _run_agent_chain(pid)
+        _orchestrator.run_chain(pid)
 
 
 def _agent_enabled(agent: thinking_agents.Agent) -> bool:
@@ -1074,127 +1045,182 @@ def _agent_dependencies_met(
     return True
 
 
-def _next_eligible_agent(
-    participant: str, force: bool = False
-) -> thinking_agents.Agent | None:
-    """Find the first agent that should run next for *participant*.
+class AgentOrchestrator:
+    """Owns per-agent in-flight, cancel-event, and thread state.
 
-    An agent is eligible when:
-      - it is enabled (unless *force* is True — manual triggers bypass this),
-      - its result is not already on the entry,
-      - all of its dependencies are satisfied,
-      - it is not already running for this participant.
+    Encapsulates the dicts and orchestration helpers that previously lived as
+    module-level globals. Methods reach into module-level ``_manifest``,
+    ``_persist_manifest``, and ``_cancel_pending_unload`` directly — fine
+    because this class is module-internal and those names resolve at call
+    time.
+
+    The shared ``_manifest_lock`` is passed in at construction so atomicity
+    between manifest reads and in-flight slot claims is preserved verbatim
+    against the pre-refactor behavior.
+
+    Per-run cancel events: when an agent starts for a participant, a fresh
+    ``threading.Event`` is registered; the Ollama transport closes its
+    streaming HTTP response on ``event.set()``, which unblocks the read loop
+    and frees the model promptly. ``stop`` looks up the event and sets it.
+    The ``cancel_event.is_set()`` re-check in ``run_agent`` gates the
+    result-and-chain-advance step as defense-in-depth for finish-vs-cancel
+    races.
     """
-    with _manifest_lock:
-        entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry or not entry.get("segments"):
-            return None
-        for agent in thinking_agents.AGENTS:
-            if not force and not _agent_enabled(agent):
-                continue
-            if entry.get(agent["manifest_field"]):
-                continue
-            if _is_generating(participant, agent["key"]):
-                continue
-            if not _agent_dependencies_met(agent, entry):
-                continue
-            return agent
-    return None
 
+    def __init__(self, lock: threading.Lock) -> None:
+        self._lock = lock
+        self._in_flight: dict[str, set[str]] = {
+            a["key"]: set() for a in thinking_agents.AGENTS
+        }
+        self._cancel_events: dict[str, dict[str, threading.Event]] = {
+            a["key"]: {} for a in thinking_agents.AGENTS
+        }
+        self._threads: dict[str, set[threading.Thread]] = {
+            a["key"]: set() for a in thinking_agents.AGENTS
+        }
 
-def _run_agent(agent_key: str, participant: str, force: bool = False) -> None:
-    """Spawn a daemon thread to run a single agent for *participant*.
+    def is_generating(self, participant: str, agent_key: str) -> bool:
+        """Return True if *agent_key* is currently running for *participant*."""
+        return participant in self._in_flight.get(agent_key, set())
 
-    On success, the agent's result is written to the manifest and the chain
-    advances to the next eligible agent. Guards against double-spawning via
-    ``_agent_in_flight``. Pass *force* to bypass the config enabled check
-    (used by manual triggers from the UI).
-    """
-    agent = thinking_agents.get_agent(agent_key)
-    if agent is None:
-        return
-    if not force and not _agent_enabled(agent):
-        return
+    def stop(self, agent_key: str, participant: str) -> bool:
+        """Abort an in-flight run. Returns True iff a run was actually stopped.
 
-    cancel_event = threading.Event()
-    # Atomically check-and-claim the in-flight slot so two near-simultaneous
-    # chain triggers (e.g. user click + auto-chain from a completed
-    # dependency) can't both spawn a thread for the same participant.
-    with _manifest_lock:
-        if _is_generating(participant, agent_key):
+        Releases the in-flight slot immediately so subsequent ``is_generating``
+        polls (e.g. from the UI) flip to idle without waiting for the daemon
+        thread's ``finally`` block to fire.
+        """
+        with self._lock:
+            if participant not in self._in_flight.get(agent_key, set()):
+                return False
+            event = self._cancel_events.get(agent_key, {}).get(participant)
+            self._in_flight[agent_key].discard(participant)
+        if event is not None:
+            event.set()
+        return True
+
+    def next_eligible(
+        self, participant: str, force: bool = False
+    ) -> thinking_agents.Agent | None:
+        """Find the first agent that should run next for *participant*.
+
+        An agent is eligible when:
+          - it is enabled (unless *force* is True — manual triggers bypass this),
+          - its result is not already on the entry,
+          - all of its dependencies are satisfied,
+          - it is not already running for this participant.
+        """
+        with self._lock:
+            entry = _manifest.get("source_transcripts", {}).get(participant)
+            if not entry or not entry.get("segments"):
+                return None
+            for agent in thinking_agents.AGENTS:
+                if not force and not _agent_enabled(agent):
+                    continue
+                if entry.get(agent["manifest_field"]):
+                    continue
+                if participant in self._in_flight.get(agent["key"], set()):
+                    continue
+                if not _agent_dependencies_met(agent, entry):
+                    continue
+                return agent
+        return None
+
+    def run_agent(self, agent_key: str, participant: str, force: bool = False) -> None:
+        """Spawn a daemon thread to run a single agent for *participant*.
+
+        On success, the agent's result is written to the manifest and the chain
+        advances to the next eligible agent. Guards against double-spawning via
+        the in-flight set. Pass *force* to bypass the config enabled check
+        (used by manual triggers from the UI).
+        """
+        agent = thinking_agents.get_agent(agent_key)
+        if agent is None:
             return
-        _agent_in_flight[agent_key].add(participant)
-        _agent_cancel_events[agent_key][participant] = cancel_event
+        if not force and not _agent_enabled(agent):
+            return
 
-    # If a Stop just scheduled an unload for this model, cancel it — the
-    # next request would only force a reload.
-    model = _agent_model(agent_key)
-    if model:
-        _cancel_pending_unload(model)
-
-    def _run() -> None:
-        try:
-            with _manifest_lock:
-                entry = _manifest.get("source_transcripts", {}).get(participant)
-                if not entry or not entry.get("segments"):
-                    return
-                # Snapshot the entry so the agent does not hold the lock
-                # during the (potentially slow) model call.
-                snapshot = dict(entry)
-            result = agent["run"](snapshot, cancel_event)
-            # Defense in depth: if the model finished in the same tick as a
-            # Stop click, drop the result and skip the chain advance.
-            if cancel_event.is_set():
+        cancel_event = threading.Event()
+        # Atomically check-and-claim the in-flight slot so two near-simultaneous
+        # chain triggers (e.g. user click + auto-chain from a completed
+        # dependency) can't both spawn a thread for the same participant.
+        with self._lock:
+            if participant in self._in_flight[agent_key]:
                 return
-            committed = False
-            if result is not None:
-                with _manifest_lock:
-                    # Re-check the cancel event inside the lock so a Stop that
-                    # arrives between the snapshot read above and this commit
-                    # cannot race past us and leave a stale result behind.
-                    if cancel_event.is_set():
-                        return
+            self._in_flight[agent_key].add(participant)
+            self._cancel_events[agent_key][participant] = cancel_event
+
+        # If a Stop just scheduled an unload for this model, cancel it — the
+        # next request would only force a reload.
+        model = _agent_model(agent_key)
+        if model:
+            _cancel_pending_unload(model)
+
+        def _run() -> None:
+            try:
+                with self._lock:
                     entry = _manifest.get("source_transcripts", {}).get(participant)
-                    if entry is not None:
-                        entry[agent["manifest_field"]] = result
-                        committed = True
-            if committed:
-                _persist_manifest()
-                # Chain into the next eligible agent (e.g. summary → citations).
-                # Propagate *force* so a manual run cascades through disabled
-                # downstream agents too.
-                _run_agent_chain(participant, force=force)
-        except Exception as exc:
-            utils.warning_print(
-                f"{agent_key} generation failed for {participant}: {exc}"
-            )
-        finally:
-            with _manifest_lock:
-                _agent_in_flight[agent_key].discard(participant)
-                _agent_cancel_events[agent_key].pop(participant, None)
-                _agent_threads[agent_key].discard(t)
+                    if not entry or not entry.get("segments"):
+                        return
+                    # Snapshot the entry so the agent does not hold the lock
+                    # during the (potentially slow) model call.
+                    snapshot = dict(entry)
+                result = agent["run"](snapshot, cancel_event)
+                # Defense in depth: if the model finished in the same tick as a
+                # Stop click, drop the result and skip the chain advance.
+                if cancel_event.is_set():
+                    return
+                committed = False
+                if result is not None:
+                    with self._lock:
+                        # Re-check the cancel event inside the lock so a Stop
+                        # that arrives between the snapshot read above and this
+                        # commit cannot race past us and leave a stale result
+                        # behind.
+                        if cancel_event.is_set():
+                            return
+                        entry = _manifest.get("source_transcripts", {}).get(participant)
+                        if entry is not None:
+                            entry[agent["manifest_field"]] = result
+                            committed = True
+                if committed:
+                    _persist_manifest()
+                    # Chain into the next eligible agent (e.g. summary →
+                    # citations). Propagate *force* so a manual run cascades
+                    # through disabled downstream agents too.
+                    self.run_chain(participant, force=force)
+            except Exception as exc:
+                utils.warning_print(
+                    f"{agent_key} generation failed for {participant}: {exc}"
+                )
+            finally:
+                with self._lock:
+                    self._in_flight[agent_key].discard(participant)
+                    self._cancel_events[agent_key].pop(participant, None)
+                    self._threads[agent_key].discard(t)
 
-    # Slot claim happened above under _manifest_lock; just spawn the thread.
-    t = threading.Thread(
-        target=_run,
-        daemon=True,
-        name=f"{agent['thread_name_prefix']}-{participant}",
-    )
-    with _manifest_lock:
-        _agent_threads[agent_key].add(t)
-    t.start()
+        t = threading.Thread(
+            target=_run,
+            daemon=True,
+            name=f"{agent['thread_name_prefix']}-{participant}",
+        )
+        with self._lock:
+            self._threads[agent_key].add(t)
+        t.start()
+
+    def run_chain(self, participant: str, force: bool = False) -> None:
+        """Advance the thinking-agent chain for *participant* by one step.
+
+        Starts the first eligible agent (if any). When that agent completes,
+        ``run_agent`` re-enters this method to start the next step. Pass
+        *force* to bypass config enable checks for manual/UI-triggered runs.
+        """
+        agent = self.next_eligible(participant, force=force)
+        if agent is not None:
+            self.run_agent(agent["key"], participant, force=force)
 
 
-def _run_agent_chain(participant: str, force: bool = False) -> None:
-    """Advance the thinking-agent chain for *participant* by one step.
-
-    Starts the first eligible agent (if any). When that agent completes,
-    ``_run_agent`` re-enters this function to start the next step. Pass
-    *force* to bypass config enable checks for manual/UI-triggered runs.
-    """
-    agent = _next_eligible_agent(participant, force=force)
-    if agent is not None:
-        _run_agent(agent["key"], participant, force=force)
+_orchestrator = AgentOrchestrator(_manifest_lock)
 
 
 # ---- State initialization ----


### PR DESCRIPTION
## Summary

Two contained class-shaped refactors that replace state-juggling module globals and parallel elif chains with small, well-scoped classes.

- **`transcripts_server.py`**: new `AgentOrchestrator` owns the three per-agent dicts (`_in_flight` / `_cancel_events` / `_threads`) and the `next_eligible` / `run_agent` / `run_chain` methods. A new `.stop()` collapses the duplicated 9-line stop idiom in `api_summary_stop` / `api_citations_stop`.
- **`screenspace.py`**: new `AnalysisTool` base + 11 subclasses (registered in `TOOLS`) replace two ~200-line elif chains in `check_frame_for_tool` and `ScreenspaceWorker._dispatch`. Per-tool fast-scan dimensions / opt-outs / extra opts are now class attributes; module-level `scan_*` functions are preserved verbatim so existing tests pass unchanged.

Behavior is preserved — only the test fixture in `tests/test_transcripts_api.py` was updated to reference orchestrator-internal state instead of the removed module dicts.

## Test plan

- [x] `uvx ruff check` + `uvx ruff format --check` clean
- [x] `uvx ty check` clean
- [x] `pytest -c tests/pytest.ini` — 805 passed (unchanged from baseline)
- [ ] Manual: `--transcripts` summary→citations chain, Stop mid-run, Regenerate
- [ ] Manual: `--screenspace` color / change / template / multitool / timelapse, with Fast Scan toggled on at least once