### PR TITLE
fix: bug audit sweep — nb_frames crash, stash races, imencode, grid scroll

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1128,10 +1128,9 @@
     tbody.id = "gridTbody";
     table.appendChild(tbody);
     grid.appendChild(table);
+    applyGridFilters();
     grid.scrollTop = prevScrollTop;
     grid.scrollLeft = prevScrollLeft;
-
-    applyGridFilters();
 
     if (!_gridEventsBound) {
       bindGridEvents();

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -346,11 +346,10 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
             ), 400
         import cv2
 
-        _, jpeg = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
+        success, jpeg = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
+        if not success:
+            return jsonify({"ok": False, "error": "Could not extract frame"}), 400
         jpeg_bytes = jpeg.tobytes()
-
-    if jpeg_bytes is None:
-        return jsonify({"ok": False, "error": "Could not extract frame"}), 400
 
     with _frame_cache_lock:
         _frame_cache[cache_key] = jpeg_bytes
@@ -882,12 +881,11 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
 @screenspace_bp.route("/api/stashes/<stash_id>", methods=["DELETE"])
 def api_stashes_delete(stash_id: str) -> FlaskResponse:
     """Dismiss a region stash."""
-    stashes = _manifest.get("stashes", [])
-    idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
-    if idx is None:
-        return jsonify({"ok": False, "error": "Stash not found"}), 404
-
     with _manifest_lock:
+        stashes = _manifest.get("stashes", [])
+        idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
+        if idx is None:
+            return jsonify({"ok": False, "error": "Stash not found"}), 404
         stashes.pop(idx)
         _do_persist(drain_events=False)
     return jsonify({"ok": True})
@@ -896,13 +894,11 @@ def api_stashes_delete(stash_id: str) -> FlaskResponse:
 @screenspace_bp.route("/api/stashes/<stash_id>/restore", methods=["POST"])
 def api_stashes_restore(stash_id: str) -> FlaskResponse:
     """Restore a stash: replace active regions with stashed ones (stash is kept)."""
-    stashes = _manifest.get("stashes", [])
-    idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
-    if idx is None:
-        return jsonify({"ok": False, "error": "Stash not found"}), 404
-
-    stash = stashes[idx]
     with _manifest_lock:
+        stashes = _manifest.get("stashes", [])
+        stash = next((s for s in stashes if s["id"] == stash_id), None)
+        if stash is None:
+            return jsonify({"ok": False, "error": "Stash not found"}), 404
         _manifest["regions"] = copy.deepcopy(stash["regions"])
         _do_persist(drain_events=False)
     return jsonify({"ok": True, "regions": _manifest["regions"]})

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -351,6 +351,9 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
             return jsonify({"ok": False, "error": "Could not extract frame"}), 400
         jpeg_bytes = jpeg.tobytes()
 
+    if jpeg_bytes is None:
+        return jsonify({"ok": False, "error": "Could not extract frame"}), 400
+
     with _frame_cache_lock:
         _frame_cache[cache_key] = jpeg_bytes
         while len(_frame_cache) > _FRAME_CACHE_MAX:

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -238,6 +238,8 @@ def _parse_citation_response(
     result: dict[int, list[dict[str, Any]]] = {}
     for match in _CITATION_LINE_RE.finditer(response):
         claim_num = int(match.group(1))
+        if claim_num < 1:
+            continue
         claim_idx = claim_num - 1
         body = match.group(2).strip()
         if body.upper() == "NONE":

--- a/video.py
+++ b/video.py
@@ -831,7 +831,10 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
                     fps = num / den if den > 0 else 0.0
                 except (ValueError, IndexError):
                     pass
-            nb_frames = int(stream.get("nb_frames", 0) or 0)
+            try:
+                nb_frames = int(stream.get("nb_frames") or 0)
+            except (ValueError, TypeError):
+                nb_frames = 0
         elif codec_type == "audio" and audio_codec is None:
             audio_codec = stream.get("codec_name")
 


### PR DESCRIPTION
Fixes six bugs found during a broad codebase audit.

- **video.py** – `probe_video_properties` crashed with `ValueError` when ffprobe returned `"N/A"` for `nb_frames` (common on H.265/AV1); now caught with `try/except`.
- **screenspace_server.py** – stash delete and restore computed the stash index outside `_manifest_lock`, creating a TOCTOU race under Flask's threaded mode; both lookups now happen inside the lock.
- **screenspace_server.py** – `cv2.imencode` success flag was ignored; the downstream `jpeg_bytes is None` guard could never trigger, silently returning an empty 200 response on encode failure; now checks the flag directly.
- **thinking_agents.py** – citation parser produced `claim_idx = -1` if the model emitted a `0:` claim number, misrouting citations; non-positive claim numbers are now skipped.
- **studio.js** – `applyGridFilters()` was called after `grid.scrollTop` was restored, so the browser clamped scroll to zero against the empty tbody; order is now fill-then-restore.