### PR TITLE
fix(screenspace): fast-scan interval, inactivity confidence, stash PUT lock

### DIFF
--- a/screenspace.py
+++ b/screenspace.py
@@ -1894,6 +1894,8 @@ def _extract_confidence(tool_type: str, result: dict[str, Any]) -> float:
     elif tool_type == "multitool":
         return result.get("min_confidence", 0.0)
     elif tool_type == "inactivity":
+        if "_confidence" in result:
+            return float(result["_confidence"])
         return min(result.get("duration", 0.0) / 30.0, 1.0)
     return 1.0
 
@@ -2794,7 +2796,11 @@ class InactivityTool(AnalysisTool):
         prev_h = compute_phash(prev_pixels)
         dist = int(curr_h - prev_h)
         if dist <= thresh:
-            return True, {"distance": dist}
+            if thresh > 0:
+                conf = min((thresh - dist) / float(thresh), 1.0)
+            else:
+                conf = 1.0
+            return True, {"distance": dist, "_confidence": conf}
         return False, None
 
     def scan(
@@ -2880,8 +2886,8 @@ class MultitoolTool(AnalysisTool):
         on_result,
         fast_opts,
     ):
-        steps = params.get("steps", [])
-        if not steps or len(steps) < 2:
+        steps = [dict(s) for s in params.get("steps", [])]
+        if len(steps) < 2:
             raise ValueError("Multitool requires at least 2 steps")
         # Fast scan: multiply the interval used by scan_multitool
         # (reads from steps[0]["interval"] with fallback to default).
@@ -3314,7 +3320,9 @@ class ScreenspaceWorker:
         if tool is None:
             raise ValueError(f"Unknown task type: {task_type}")
 
-        params = task.get("parameters", {})
+        # Shallow copy so fast-scan interval scaling is not persisted on the
+        # task dict (pause/resume re-dispatches the same parameters).
+        params = dict(task.get("parameters", {}))
         scan_mode = params.get("scan_mode", "normal")
         fast_opts: dict[str, Any] | None = None
         if scan_mode == "fast" and tool.supports_fast_scan:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -868,13 +868,12 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
     if not data:
         return jsonify({"ok": False, "error": "JSON body required"}), 400
 
-    stashes = _manifest.get("stashes", [])
-    stash = next((s for s in stashes if s["id"] == stash_id), None)
-    if stash is None:
-        return jsonify({"ok": False, "error": "Stash not found"}), 404
-
     name = data.get("name", "").strip()
     with _manifest_lock:
+        stashes = _manifest.get("stashes", [])
+        stash = next((s for s in stashes if s["id"] == stash_id), None)
+        if stash is None:
+            return jsonify({"ok": False, "error": "Stash not found"}), 404
         if name:
             stash["name"] = name
         _do_persist(drain_events=False)

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1247,6 +1247,8 @@ class TestCheckFrameForTool:
         assert result is not None
         assert "distance" in result
         assert result["distance"] == 0
+        assert result["_confidence"] == 1.0
+        assert screenspace._extract_confidence("inactivity", result) == 1.0
 
     def test_inactivity_different_frames(self):
         frame_a = np.zeros((100, 100, 3), dtype=np.uint8)
@@ -1290,6 +1292,14 @@ class TestExtractConfidence:
 
     def test_inactivity_short(self):
         assert screenspace._extract_confidence("inactivity", {"duration": 3.0}) == 0.1
+
+    def test_inactivity_per_frame_confidence(self):
+        assert (
+            screenspace._extract_confidence(
+                "inactivity", {"distance": 2, "_confidence": 0.8}
+            )
+            == 0.8
+        )
 
     def test_inactivity_capped(self):
         assert screenspace._extract_confidence("inactivity", {"duration": 60.0}) == 1.0
@@ -1371,6 +1381,21 @@ class TestScanMultitool:
         assert len(results) == 1
         assert results[0]["min_confidence"] == 0.5
 
+    def test_inactivity_step_uses_per_frame_confidence(self, monkeypatch):
+        def check(frame, prev, region, ttype, step):
+            if ttype == "inactivity":
+                return True, {"distance": 0, "_confidence": 0.75}
+            return True, {"_confidence": 0.9}
+
+        self._setup_stubs(monkeypatch, check)
+        results = screenspace.scan_multitool(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            steps=[{"type": "color"}, {"type": "inactivity"}],
+        )
+        assert len(results) == 1
+        assert results[0]["min_confidence"] == 0.75
+
 
 # ---------------------------------------------------------------------------
 # Fast Scan mode
@@ -1423,6 +1448,53 @@ class TestFastScanDispatchIntervalMultiplier:
         assert captured["fast_opts"] is not None
         assert captured["fast_opts"]["phash_skip"] is True
         assert captured["fast_opts"]["max_region_dim"] == 32
+
+    def test_fast_scan_interval_not_persisted_on_task(self, monkeypatch):
+        """Pause/resume re-dispatches the same task; interval must not compound."""
+        captured_intervals: list[float] = []
+
+        def fake_scan_color(
+            video_path,
+            region,
+            *,
+            target_color,
+            tolerance,
+            interval_seconds=0,
+            start_seconds=0.0,
+            end_seconds=None,
+            on_progress=None,
+            cancel_flag=None,
+            on_result=None,
+            fast_opts=None,
+        ):
+            captured_intervals.append(interval_seconds)
+            return []
+
+        monkeypatch.setattr(screenspace, "scan_color", fake_scan_color)
+
+        worker = screenspace.ScreenspaceWorker()
+        task = {
+            "id": "ss_resume",
+            "type": "color",
+            "video_path": "/fake.mp4",
+            "region_coords": {"x": 0, "y": 0, "w": 100, "h": 100},
+            "parameters": {
+                "scan_mode": "fast",
+                "interval": 1.0,
+                "target_color": {"h": 0, "s": 0, "v": 0},
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+            },
+        }
+
+        def noop(_progress: float) -> None:
+            return None
+
+        worker._dispatch(task, noop, lambda: False, None)
+        worker._dispatch(task, noop, lambda: False, None)
+
+        expected = 1.0 * config.SCREENSPACE_FAST_SCAN_INTERVAL_MULTIPLIER
+        assert task["parameters"]["interval"] == 1.0
+        assert captured_intervals == [expected, expected]
 
     def test_normal_scan_no_fast_opts(self, monkeypatch):
         captured = {}


### PR DESCRIPTION
## Summary

- **Fast-scan interval**: `_dispatch` and `MultitoolTool.scan` no longer mutate persisted task parameters, so pause/resume does not compound the interval multiplier.
- **Inactivity multitool**: per-frame checks emit `_confidence`; `_extract_confidence` uses it so `min_confidence` is not forced to zero.
- **Stash PUT**: rename lookup runs under `_manifest_lock`, matching DELETE/restore.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace.py::TestFastScanDispatchIntervalMultiplier::test_fast_scan_interval_not_persisted_on_task`
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace.py::TestScanMultitool::test_inactivity_step_uses_per_frame_confidence`
- [x] `uv run ruff check` / `uv run ty check`