### PR TITLE
perf: ffprobe cache, Screenspace drag RAF, Studio poll skips

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3102,6 +3102,8 @@
   };
 
   var _multitoolDragMidpoints = null;
+  var _multitoolDragOverRaf = null;
+  var _multitoolPendingDragOver = null;
 
   function _cacheMultitoolDragMidpoints(container) {
     var cards = container.querySelectorAll(".multitool-step:not(.dragging)");
@@ -3277,6 +3279,11 @@
         card.classList.remove("dragging");
         card.removeAttribute("draggable");
       }
+      if (_multitoolDragOverRaf != null) {
+        cancelAnimationFrame(_multitoolDragOverRaf);
+        _multitoolDragOverRaf = null;
+      }
+      _multitoolPendingDragOver = null;
       clearMultitoolDragIndicators(stepsDiv);
       _multitoolDragMidpoints = null;
     });
@@ -3284,19 +3291,28 @@
       if (e.dataTransfer.types.indexOf("text/plain") < 0) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
-      clearMultitoolDragIndicators(stepsDiv);
-      var isTaskDrop = e.dataTransfer.types.indexOf("application/x-task-id") >= 0;
-      if (isTaskDrop) {
-        stepsDiv.classList.add("drag-over-append");
-      } else {
-        var cards = stepsDiv.querySelectorAll(".multitool-step:not(.dragging)");
-        var insertIdx = getMultitoolDropIndex(stepsDiv, e.clientY);
-        if (insertIdx < cards.length) {
-          cards[insertIdx].classList.add("drag-over");
-        } else {
+      _multitoolPendingDragOver = {
+        clientY: e.clientY,
+        isTaskDrop: e.dataTransfer.types.indexOf("application/x-task-id") >= 0,
+      };
+      if (_multitoolDragOverRaf != null) return;
+      _multitoolDragOverRaf = requestAnimationFrame(function () {
+        _multitoolDragOverRaf = null;
+        var pending = _multitoolPendingDragOver;
+        if (!pending) return;
+        clearMultitoolDragIndicators(stepsDiv);
+        if (pending.isTaskDrop) {
           stepsDiv.classList.add("drag-over-append");
+        } else {
+          var cards = stepsDiv.querySelectorAll(".multitool-step:not(.dragging)");
+          var insertIdx = getMultitoolDropIndex(stepsDiv, pending.clientY);
+          if (insertIdx < cards.length) {
+            cards[insertIdx].classList.add("drag-over");
+          } else {
+            stepsDiv.classList.add("drag-over-append");
+          }
         }
-      }
+      });
     });
     stepsDiv.addEventListener("dragleave", function (e) {
       var card = e.target.closest(".multitool-step");
@@ -5085,6 +5101,11 @@
         card.classList.remove("dragging");
         card.removeAttribute("draggable");
       }
+      if (_taskListDragOverRaf != null) {
+        cancelAnimationFrame(_taskListDragOverRaf);
+        _taskListDragOverRaf = null;
+      }
+      _taskListPendingDragOver = null;
       clearDragIndicators(taskListEl);
       _taskDragCache = null;
     });
@@ -5117,12 +5138,22 @@
 
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
-      clearDragIndicators(taskListEl);
-      if (insertIdx < cards.length) {
-        cards[insertIdx].classList.add("drag-over");
-      } else {
-        taskListEl.classList.add("drag-over-append");
-      }
+
+      _taskListPendingDragOver = { insertIdx: insertIdx };
+      if (_taskListDragOverRaf != null) return;
+      _taskListDragOverRaf = requestAnimationFrame(function () {
+        _taskListDragOverRaf = null;
+        var pending = _taskListPendingDragOver;
+        if (!pending) return;
+        var idx = pending.insertIdx;
+        var cardsNow = taskListEl.querySelectorAll(".task-card:not(.dragging)");
+        clearDragIndicators(taskListEl);
+        if (idx < cardsNow.length) {
+          cardsNow[idx].classList.add("drag-over");
+        } else {
+          taskListEl.classList.add("drag-over-append");
+        }
+      });
     });
 
     taskListEl.addEventListener("dragleave", function (e) {
@@ -5191,6 +5222,8 @@
 
   // Cached at dragstart: { all: number[], statusGrouped: { queued: number[], finished: number[] } }
   var _taskDragCache = null;
+  var _taskListDragOverRaf = null;
+  var _taskListPendingDragOver = null;
 
   function _cacheTaskDragMidpoints(container) {
     var cards = container.querySelectorAll(".task-card:not(.dragging)");
@@ -5694,6 +5727,16 @@
   }
 
   document.addEventListener("dragend", function () {
+    if (_multitoolDragOverRaf != null) {
+      cancelAnimationFrame(_multitoolDragOverRaf);
+      _multitoolDragOverRaf = null;
+    }
+    _multitoolPendingDragOver = null;
+    if (_taskListDragOverRaf != null) {
+      cancelAnimationFrame(_taskListDragOverRaf);
+      _taskListDragOverRaf = null;
+    }
+    _taskListPendingDragOver = null;
     var stepsDiv = document.querySelector(".multitool-steps");
     if (stepsDiv) clearMultitoolDragIndicators(stepsDiv);
     var taskListEl = qs("#taskList");

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3639,6 +3639,7 @@
     apiGet("../screenspace/api/tasks")
       .then(function (data) {
         if (!data || !data.ok) {
+          state._intakeTabDotOn = false;
           setTabDot("intakeTabDot", false);
           return;
         }
@@ -3649,9 +3650,13 @@
           if (tasks[i].status === "running") { running = true; break; }
           if (tasks[i].status === "queued") hasQueued = true;
         }
-        setTabDot("intakeTabDot", running || (data.worker_alive && hasQueued));
+        var dotOn = running || (data.worker_alive && hasQueued);
+        if (state._intakeTabDotOn === dotOn) return;
+        state._intakeTabDotOn = dotOn;
+        setTabDot("intakeTabDot", dotOn);
       })
       .catch(function () {
+        state._intakeTabDotOn = false;
         setTabDot("intakeTabDot", false);
       });
   }
@@ -3680,6 +3685,8 @@
           }
         }
       }
+      if (state._trIntakeTabDotOn === running) return;
+      state._trIntakeTabDotOn = running;
       setTabDot("trIntakeTabDot", running);
     });
   }
@@ -3689,6 +3696,9 @@
       .then(function (data) {
         if (!data.ok) return;
         var events = data.events || [];
+        var raw = JSON.stringify(events);
+        if (raw === state._intakeEventsPollRaw) return;
+        state._intakeEventsPollRaw = raw;
         var hasNew = false;
         events.forEach(function (ev) {
           if (!state.intakeSeenIds[ev.id]) {
@@ -4143,9 +4153,19 @@
     apiGet("../transcripts/api/marks")
       .then(function (data) {
         if (!data.ok) return;
+        var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value) || 10;
+        if (!state.trIntakeShowAll) {
+          var fp =
+            String(threshold) +
+            "\0" +
+            (data.categories ? JSON.stringify(data.categories) : "") +
+            "\0" +
+            JSON.stringify(data.marks || []);
+          if (fp === state._trIntakeMarksPollFp) return;
+          state._trIntakeMarksPollFp = fp;
+        }
         if (data.categories) setMarkCategories(data.categories);
         state.trIntakeMarks = data.marks.filter(function (m) { return m.valid; });
-        var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value) || 10;
         state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, threshold);
 
         // If "Show all" is enabled, also fetch all segments as unmark items
@@ -4534,6 +4554,7 @@
     if (showAllToggle) {
       showAllToggle.addEventListener("change", function () {
         state.trIntakeShowAll = this.checked;
+        state._trIntakeMarksPollFp = null;
         pollTranscriptIntakeMarks();
       });
     }

--- a/video.py
+++ b/video.py
@@ -692,29 +692,8 @@ def extract_gif(
     return True
 
 
-def get_file_duration(filepath: str) -> int | None:
-    """Calls ffprobe to get duration of video container.
-
-    Args:
-        filepath: Path to video file
-
-    Returns:
-        The duration in seconds, or None if the file cannot be probed.
-    """
-    resolved = str(Path(filepath).resolve())
-    if resolved in _file_duration_cache:
-        return _file_duration_cache[resolved]
-
-    if not Path(filepath).is_file():
-        utils.error_print(
-            f"Video file not found: '{filepath}'",
-            [
-                f"Expected location: {Path(filepath).resolve()}",
-                "Please ensure the video file exists in the configured input directory or working directory.",
-            ],
-        )
-        return None
-
+def _probe_duration_seconds_ffprobe_format(filepath: str) -> int | None:
+    """Duration-only ffprobe read for fallback paths; emits detailed errors."""
     probe_command = [
         "ffprobe",
         "-v",
@@ -731,9 +710,7 @@ def get_file_duration(filepath: str) -> int | None:
         duration_seconds = float(
             subprocess.check_output(probe_command, encoding="utf-8")
         )
-        result = round(duration_seconds)
-        _file_duration_cache[resolved] = result
-        return result
+        return round(duration_seconds)
     except FileNotFoundError:
         utils.error_print(
             "ffprobe is not installed or not found in system PATH.",
@@ -760,6 +737,52 @@ def get_file_duration(filepath: str) -> int | None:
         return None
 
 
+def get_file_duration(filepath: str) -> int | None:
+    """Calls ffprobe to get duration of video container.
+
+    Reuses ``probe_video_properties`` when possible so one file is not probed
+    twice for duration vs stream metadata.
+
+    Args:
+        filepath: Path to video file
+
+    Returns:
+        The duration in seconds, or None if the file cannot be probed.
+    """
+    resolved = str(Path(filepath).resolve())
+    if resolved in _file_duration_cache:
+        return _file_duration_cache[resolved]
+
+    if not Path(filepath).is_file():
+        utils.error_print(
+            f"Video file not found: '{filepath}'",
+            [
+                f"Expected location: {Path(filepath).resolve()}",
+                "Please ensure the video file exists in the configured input directory or working directory.",
+            ],
+        )
+        return None
+
+    cached_props = _video_properties_cache.get(resolved)
+    if cached_props is not None:
+        dur_f = float(cached_props.get("duration") or 0)
+        if dur_f > 0:
+            rounded = round(dur_f)
+            _file_duration_cache[resolved] = rounded
+            return rounded
+
+    probed = probe_video_properties(filepath)
+    if probed is not None:
+        dur_f = float(probed.get("duration") or 0)
+        if dur_f > 0:
+            return _file_duration_cache.get(resolved)
+
+    dur = _probe_duration_seconds_ffprobe_format(filepath)
+    if dur is not None:
+        _file_duration_cache[resolved] = dur
+    return dur
+
+
 def probe_video_properties(filepath: str) -> dict[str, Any] | None:
     """Probe video file for stream properties (resolution, codecs, timing).
 
@@ -770,8 +793,10 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         'nb_frames' (int, 0 if unknown),
         or None if probe fails.
     """
+    resolved = str(Path(filepath).resolve())
+
     if config.DEBUGGING:
-        return {
+        result = {
             "width": 1920,
             "height": 1080,
             "video_codec": "h264",
@@ -780,8 +805,10 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
             "duration": 300.0,
             "nb_frames": 9000,
         }
+        _video_properties_cache[resolved] = result
+        _file_duration_cache[resolved] = round(result["duration"])
+        return result
 
-    resolved = str(Path(filepath).resolve())
     if resolved in _video_properties_cache:
         return _video_properties_cache[resolved]
 
@@ -862,6 +889,8 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         "nb_frames": nb_frames,
     }
     _video_properties_cache[resolved] = result
+    if fmt_duration > 0:
+        _file_duration_cache[resolved] = round(fmt_duration)
     return result
 
 


### PR DESCRIPTION
## Summary
- **video**: Reuse `probe_video_properties` JSON output to populate `_file_duration_cache`, with duration-only ffprobe as fallback when full probe fails.
- **Screenspace**: Coalesce multitool and task-queue `dragover` indicator updates with `requestAnimationFrame`; cancel pending frames on drag end.
- **Studio**: Skip redundant intake event processing when the events payload is unchanged; avoid repeated tab-dot toggles; fingerprint transcript intake marks (including cluster threshold) when not in “Show all” mode.

## Test plan
- [ ] `uv run --extra dev pytest -c tests/pytest.ini` (pass locally)
- [ ] Manual: Screenspace multitool + task reorder drag indicators feel smooth
- [ ] Manual: Studio intake / transcript intake tabs — dots and lists update when data changes