### PR TITLE
perf: parallel regenerate, source cache, and UI churn reductions

### DIFF
--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -5,6 +5,38 @@
   var data = window.CLIPGEN_DATA || null;
   if (data) clipgenApplyConfig(data.config);
   var state = { artifacts: [], lightboxIndex: -1 };
+  var _galleryVideoObserver = null;
+  var _galleryVideoObserverBound = false;
+
+  function _ensureGalleryVideoObserver() {
+    if (_galleryVideoObserver || typeof IntersectionObserver === "undefined") return;
+    _galleryVideoObserver = new IntersectionObserver(function (entries) {
+      for (var i = 0; i < entries.length; i++) {
+        var ent = entries[i];
+        var video = ent.target;
+        if (ent.isIntersecting) {
+          video.play().catch(function () {});
+        } else {
+          video.pause();
+        }
+      }
+    }, { rootMargin: "80px" });
+  }
+
+  function createGalleryLoopVideo(src, alt) {
+    var video = createLoopVideo(src, alt);
+    video.autoplay = false;
+    video.removeAttribute("autoplay");
+    video.preload = "metadata";
+    _ensureGalleryVideoObserver();
+    if (_galleryVideoObserver) {
+      _galleryVideoObserver.observe(video);
+    } else {
+      video.autoplay = true;
+    }
+    return video;
+  }
+
   // ---- Init ----
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -73,7 +105,7 @@
       var src = a.data || a.file;
       var altText = a.timestamp_formatted || formatTime(a.timestamp);
       if (isVideoLoop(a.file)) {
-        card.appendChild(createLoopVideo(src, altText));
+        card.appendChild(createGalleryLoopVideo(src, altText));
       } else {
         var img = document.createElement("img");
         img.src = src;
@@ -90,6 +122,17 @@
       frag.appendChild(card);
     }
     grid.appendChild(frag);
+
+    if (!_galleryVideoObserverBound) {
+      _galleryVideoObserverBound = true;
+      document.addEventListener("visibilitychange", function () {
+        if (!_galleryVideoObserver) return;
+        var videos = grid.querySelectorAll("video");
+        for (var vi = 0; vi < videos.length; vi++) {
+          if (document.hidden) videos[vi].pause();
+        }
+      });
+    }
 
     grid.addEventListener("click", function (e) {
       var card = e.target.closest(".gallery-card");

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2104,6 +2104,16 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   pointer-events: none;
 }
 
+.generate-progress {
+  font-size: var(--text-sm);
+  color: var(--color-text-dim);
+  white-space: nowrap;
+}
+
+.generate-progress.hidden {
+  display: none;
+}
+
 /* Status overlay */
 
 #statusOverlay {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -134,6 +134,7 @@
         <span id="artifactsCount" class="bs-count cg-mono">(0)</span>
         <span id="viewerArtifactCount" class="bs-count cg-mono"></span>
         <svg id="artifactsSpinner" class="title-spinner bs-spinner" width="12" height="12" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>
+        <span id="generateProgress" class="generate-progress hidden cg-mono" aria-live="polite"></span>
         <select id="artifactFormat" class="bs-select">
           <option value="clip">Clip (.mp4)</option>
           <option value="screen">Screenshot (.png)</option>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2726,6 +2726,33 @@
 
   // ---- API calls ----
 
+  function buildGenerateCardIndex(listEl) {
+    var map = {};
+    var cards = listEl.querySelectorAll(".queue-card");
+    for (var i = 0; i < cards.length; i++) {
+      var card = cards[i];
+      var participant = card.getAttribute("data-participant");
+      var row = card.getAttribute("data-row");
+      if (!participant || row == null) continue;
+      var key = participant + "." + row;
+      if (!map[key]) map[key] = [];
+      map[key].push(card);
+    }
+    return map;
+  }
+
+  function updateGenerateProgress(done, total) {
+    var el = qs("#generateProgress");
+    if (!el) return;
+    if (!total || total <= 0) {
+      el.classList.add("hidden");
+      el.textContent = "";
+      return;
+    }
+    el.classList.remove("hidden");
+    el.textContent = done + " / " + total + " cells";
+  }
+
   function onGenerate() {
     if (state.generating || state.artifactQueue.length === 0) return;
     state.generating = true;
@@ -2765,9 +2792,13 @@
     var allArtifacts = [];
     var cancelled = false;
     var pending = (sheetItems.length > 0 ? 1 : 0) + (intakeItems.length > 0 ? 1 : 0);
+    var sheetCellTotal = 0;
+    var sheetCellsDone = 0;
+    var generateCardIndex = null;
 
     function finishBranch() {
       if (--pending > 0) return;
+      updateGenerateProgress(0, 0);
       setTitleSpinner("artifactsSpinner", false);
       state.generating = false;
       setGeneratingLock(false);
@@ -2800,6 +2831,9 @@
         var ck = sheetItems[si].participant + "." + sheetItems[si].row;
         if (!cellsSeen[ck]) { cellsSeen[ck] = true; cells.push(ck); }
       }
+      sheetCellTotal = cells.length;
+      generateCardIndex = buildGenerateCardIndex(list);
+      updateGenerateProgress(0, sheetCellTotal);
 
       function handleLine(line) {
         var data;
@@ -2814,13 +2848,9 @@
           return;
         }
         if (!data.cell) return;
-        var dot = data.cell.lastIndexOf(".");
-        var participant = data.cell.substring(0, dot);
-        var row = data.cell.substring(dot + 1);
-        var cards = list.querySelectorAll(
-          '[data-participant="' + CSS.escape(participant) +
-          '"][data-row="' + CSS.escape(row) + '"]'
-        );
+        sheetCellsDone++;
+        updateGenerateProgress(sheetCellsDone, sheetCellTotal);
+        var cards = generateCardIndex[data.cell] || [];
         if (data.ok) {
           for (var ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], true);
           totalSuccess += (data.generated || 1);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1140,6 +1140,26 @@
       '</div>';
   }
 
+  var _streamIndicatorRaf = null;
+  var _streamIndicatorPending = null;
+
+  function _updateStreamingIndicator(container, progress) {
+    _streamIndicatorPending = { container: container, progress: progress };
+    if (_streamIndicatorRaf) return;
+    _streamIndicatorRaf = requestAnimationFrame(function () {
+      _streamIndicatorRaf = null;
+      var pending = _streamIndicatorPending;
+      _streamIndicatorPending = null;
+      if (!pending || !pending.container || !pending.container.isConnected) return;
+      var ind = pending.container.querySelector(".streaming-indicator");
+      if (ind) ind.parentNode.removeChild(ind);
+      pending.container.insertAdjacentHTML(
+        "beforeend",
+        _streamingIndicatorHtml(pending.progress)
+      );
+    });
+  }
+
   function renderPartialSegments(segments, progress) {
     var container = qs("#segmentList");
     var empty = qs("#transcriptEmpty");
@@ -1164,6 +1184,8 @@
       _partialRender.marksVersion === _streamingMarksVersion &&
       segments.length >= _partialRender.count &&
       container.querySelector(".segment-streaming") !== null;
+    var indicatorOnly =
+      canAppend && segments.length === _partialRender.count;
 
     if (canAppend && segments.length > _partialRender.count) {
       // Append only the new trailing rows, then move/refresh the indicator.
@@ -1180,10 +1202,8 @@
       container.appendChild(frag);
       container.insertAdjacentHTML("beforeend", _streamingIndicatorHtml(progress));
     } else if (canAppend && segments.length === _partialRender.count) {
-      // Same segment count - only refresh the progress indicator.
-      var ind = container.querySelector(".streaming-indicator");
-      if (ind) ind.parentNode.removeChild(ind);
-      container.insertAdjacentHTML("beforeend", _streamingIndicatorHtml(progress));
+      // Same segment count - only refresh the progress indicator (coalesced).
+      _updateStreamingIndicator(container, progress);
     } else {
       // Full rebuild: pid change, restart, or marks cache changed.
       var html = "";
@@ -1220,7 +1240,9 @@
       });
     }
     state.segments = mirrored;
-    renderTimeline();
+    if (!indicatorOnly) {
+      renderTimeline();
+    }
   }
 
   // ---- Segment list event delegation ----

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -26,7 +26,8 @@
   };
 
   var _thumbQueue = [];
-  var _thumbProcessing = false;
+  var _thumbActive = 0;
+  var THUMB_CONCURRENCY = 3;
   var _thumbObserver = null;
   var _thumbCache = {};
 
@@ -182,13 +183,14 @@
   }
 
   function processThumbQueue() {
-    if (_thumbProcessing || !_thumbQueue.length) return;
-    _thumbProcessing = true;
-    var item = _thumbQueue.shift();
-    generateClipThumbnail(item.mediaEl, item.artifact, function () {
-      _thumbProcessing = false;
-      processThumbQueue();
-    });
+    while (_thumbActive < THUMB_CONCURRENCY && _thumbQueue.length) {
+      _thumbActive++;
+      var item = _thumbQueue.shift();
+      generateClipThumbnail(item.mediaEl, item.artifact, function () {
+        _thumbActive--;
+        processThumbQueue();
+      });
+    }
   }
 
   // ---- Sidebar video scrub ----
@@ -285,7 +287,7 @@
   function initClipThumbnails() {
     if (_thumbObserver) { _thumbObserver.disconnect(); _thumbObserver = null; }
     _thumbQueue = [];
-    _thumbProcessing = false;
+    _thumbActive = 0;
 
     var cards = qsa("#artifactList .artifact-card");
     if (!cards.length) return;

--- a/pipeline.py
+++ b/pipeline.py
@@ -18,6 +18,7 @@ import concurrent.futures
 import difflib
 import hashlib
 import os
+import threading
 from pathlib import Path
 from typing import Any, Callable
 
@@ -55,6 +56,38 @@ def _resolve_clip_workers() -> int:
     return workers
 
 
+# Large .mp4 files in the input dir, keyed by path + mtime_ns (one glob/stat pass per run).
+_fuzzy_input_videos_cache: dict[str, tuple[int | None, list[tuple[int, Path]]]] = {}
+
+
+def _large_input_videos(input_dir: Path) -> list[tuple[int, Path]]:
+    """Return (size_bytes, path) for source-video candidates under *input_dir*."""
+    dir_str = str(input_dir)
+    try:
+        mtime_ns: int | None = (
+            input_dir.stat().st_mtime_ns if input_dir.is_dir() else None
+        )
+    except OSError:
+        mtime_ns = None
+
+    cached = _fuzzy_input_videos_cache.get(dir_str)
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1]
+
+    size_threshold = config.MIN_SOURCE_VIDEO_SIZE_MB * 1_000_000
+    entries: list[tuple[int, Path]] = []
+    for p in input_dir.glob(f"*{config.FILEFORMAT}"):
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        if size >= size_threshold:
+            entries.append((size, p))
+
+    _fuzzy_input_videos_cache[dir_str] = (mtime_ns, entries)
+    return entries
+
+
 def _check_source_video(
     clip: ClipRecord,
     missing_videos: set[str],
@@ -83,20 +116,11 @@ def _check_source_video(
     if full_path_str in fuzzy_matches:
         return fuzzy_matches[full_path_str]
 
-    # Scan input directory for large .mp4 files as fuzzy candidates
     input_dir = utils.get_effective_input_dir()
-    size_threshold = config.MIN_SOURCE_VIDEO_SIZE_MB * 1_000_000
-    candidates = []
-    for p in input_dir.glob(f"*{config.FILEFORMAT}"):
-        try:
-            size = p.stat().st_size
-        except OSError:
-            continue
-        if size >= size_threshold:
-            ratio = difflib.SequenceMatcher(
-                None, base_name.lower(), p.name.lower()
-            ).ratio()
-            candidates.append((ratio, size, p))
+    candidates: list[tuple[float, int, Path]] = []
+    for size, p in _large_input_videos(input_dir):
+        ratio = difflib.SequenceMatcher(None, base_name.lower(), p.name.lower()).ratio()
+        candidates.append((ratio, size, p))
 
     # Sort by similarity descending, then file size descending as tiebreaker
     candidates.sort(key=lambda c: (c[0], c[1]), reverse=True)
@@ -1091,24 +1115,62 @@ def regenerate_from_manifest(
 
     utils.print_mode_heading("Regenerating artifacts", "mode.regenerate")
     missing_videos: set[str] = set()
+    missing_lock = threading.Lock()
     generated = 0
+    reel_list = reels or []
+    workers = _resolve_clip_workers()
+    parallel_media = workers >= 2 and len(media) >= 2
+
+    def _regenerate_artifact_threadsafe(artifact: dict[str, Any]) -> bool:
+        local_missing: set[str] = set()
+        ok = _regenerate_single_artifact(artifact, local_missing)
+        if local_missing:
+            with missing_lock:
+                missing_videos.update(local_missing)
+        return ok
 
     progress = utils.create_progress_bar()
     if progress:
         with progress:
             task = progress.add_task("Regenerating", total=total)
-            for artifact in media:
-                desc_preview = (artifact.get("description") or "")[
-                    : config.PROGRESS_DESCRIPTION_LENGTH
-                ]
-                progress.update(
-                    task,
-                    description=f"[{artifact.get('participant', '')}] {desc_preview}...",
-                )
-                if _regenerate_single_artifact(artifact, missing_videos):
-                    generated += 1
-                progress.update(task, advance=1)
-            for reel in reels or []:
+            if parallel_media:
+                results: list[bool] = [False] * len(media)
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=workers,
+                ) as pool:
+                    future_to_idx = {
+                        pool.submit(_regenerate_artifact_threadsafe, art): idx
+                        for idx, art in enumerate(media)
+                    }
+                    for future in concurrent.futures.as_completed(future_to_idx):
+                        idx = future_to_idx[future]
+                        try:
+                            results[idx] = future.result()
+                        except Exception as exc:
+                            art = media[idx]
+                            desc_preview = (art.get("description") or "")[
+                                : config.PROGRESS_DESCRIPTION_LENGTH
+                            ]
+                            utils.error_print(
+                                f"Regenerate failed: [{art.get('participant', '')}] {desc_preview}",
+                                [str(exc)],
+                            )
+                            results[idx] = False
+                        progress.update(task, advance=1)
+                generated += sum(1 for ok in results if ok)
+            else:
+                for artifact in media:
+                    desc_preview = (artifact.get("description") or "")[
+                        : config.PROGRESS_DESCRIPTION_LENGTH
+                    ]
+                    progress.update(
+                        task,
+                        description=f"[{artifact.get('participant', '')}] {desc_preview}...",
+                    )
+                    if _regenerate_single_artifact(artifact, missing_videos):
+                        generated += 1
+                    progress.update(task, advance=1)
+            for reel in reel_list:
                 progress.update(
                     task,
                     description=reel.get("description", "Reel")[
@@ -1118,11 +1180,33 @@ def regenerate_from_manifest(
                 if _regenerate_reel(reel, missing_videos):
                     generated += 1
                 progress.update(task, advance=1)
+    elif parallel_media:
+        results = [False] * len(media)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            future_to_idx = {
+                pool.submit(_regenerate_artifact_threadsafe, art): idx
+                for idx, art in enumerate(media)
+            }
+            for future in concurrent.futures.as_completed(future_to_idx):
+                idx = future_to_idx[future]
+                try:
+                    results[idx] = future.result()
+                except Exception as exc:
+                    art = media[idx]
+                    utils.error_print(
+                        f"Regenerate failed: [{art.get('participant', '')}]",
+                        [str(exc)],
+                    )
+                    results[idx] = False
+        generated += sum(1 for ok in results if ok)
+        for reel in reel_list:
+            if _regenerate_reel(reel, missing_videos):
+                generated += 1
     else:
         for artifact in media:
             if _regenerate_single_artifact(artifact, missing_videos):
                 generated += 1
-        for reel in reels or []:
+        for reel in reel_list:
             if _regenerate_reel(reel, missing_videos):
                 generated += 1
 

--- a/server.py
+++ b/server.py
@@ -1171,8 +1171,7 @@ def api_open_viewer() -> FlaskResponse:
 @studio_bp.route("/api/manifest", methods=["GET", "POST"])
 def api_manifest() -> FlaskResponse:
     if request.method == "GET":
-        artifacts = viewer.load_manifest_artifacts()
-        reels = viewer.load_manifest_reels()
+        artifacts, reels = viewer._load_manifest_both()
         return jsonify({"ok": True, "artifacts": artifacts, "reels": reels})
 
     # Snapshot the shared lists so a worker thread extending mid-export

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -410,3 +410,47 @@ def test_process_single_clip_segments_unlinks_partial_on_cancel(
     assert generated == 0
     assert paths == []
     assert not out_path.exists()
+
+
+def test_large_input_videos_cached(tmp_path, monkeypatch):
+    """_large_input_videos should glob/stat the input dir once per mtime."""
+    pipeline._fuzzy_input_videos_cache.clear()
+    monkeypatch.setattr(config, "MIN_SOURCE_VIDEO_SIZE_MB", 1)
+    (tmp_path / "study_P01.mp4").write_bytes(b"x" * 2_000_000)
+    first = pipeline._large_input_videos(tmp_path)
+    second = pipeline._large_input_videos(tmp_path)
+    assert first == second
+    assert len(first) == 1
+    assert first[0][1].name == "study_P01.mp4"
+
+
+def test_regenerate_from_manifest_parallel(monkeypatch):
+    """Independent artifacts regenerate concurrently when workers >= 2."""
+    artifacts = [
+        {
+            "id": f"a{i}",
+            "type": "clip",
+            "file": f"clip{i}.mp4",
+            "sourceVideo": "study_P01.mp4",
+            "start": 0,
+            "end": 10,
+            "description": f"clip {i}",
+            "participant": "P01",
+        }
+        for i in range(4)
+    ]
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 4)
+    monkeypatch.setattr(pipeline.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(pipeline.utils, "print_mode_heading", lambda *a, **k: None)
+
+    calls: list[str] = []
+
+    def fake_regenerate(artifact, missing_videos):
+        calls.append(artifact["id"])
+        return True
+
+    monkeypatch.setattr(pipeline, "_regenerate_single_artifact", fake_regenerate)
+
+    count = pipeline.regenerate_from_manifest(artifacts)
+    assert count == 4
+    assert sorted(calls) == ["a0", "a1", "a2", "a3"]

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -325,8 +325,7 @@ def test_api_manifest_get_returns_artifacts(client, monkeypatch):
     fake_artifacts = [
         {"id": "a5c2s0", "type": "clip", "participant": "P01", "cellRow": 5}
     ]
-    monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: fake_artifacts)
-    monkeypatch.setattr(viewer, "load_manifest_reels", lambda: [])
+    monkeypatch.setattr(viewer, "_load_manifest_both", lambda: (fake_artifacts, []))
     resp = client.get("/studio/api/manifest")
     assert resp.status_code == 200
     data = resp.get_json()
@@ -339,8 +338,7 @@ def test_api_manifest_get_returns_artifacts(client, monkeypatch):
 def test_api_manifest_get_empty(client, monkeypatch):
     import viewer
 
-    monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: [])
-    monkeypatch.setattr(viewer, "load_manifest_reels", lambda: [])
+    monkeypatch.setattr(viewer, "_load_manifest_both", lambda: ([], []))
     resp = client.get("/studio/api/manifest")
     assert resp.status_code == 200
     data = resp.get_json()


### PR DESCRIPTION
## Summary

- Backend: single manifest read in Studio GET, cached fuzzy source-video directory scan, parallel artifact regeneration.
- Studio: NDJSON generation uses a card index and shows `N / total cells` progress.
- Viewer/Gallery/Transcripts: bounded clip thumbnail concurrency, lazy gallery loop videos, coalesced streaming indicator updates without redundant timeline redraws.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini`
- [x] `uv run ruff check --fix && uv run ruff format`
- [x] `uv run ty check pipeline.py server.py`
- [ ] Manual: Studio multi-cell generate (progress counter + card updates)
- [ ] Manual: large Gallery scroll (loop videos start only when visible)
- [ ] Manual: Transcripts streaming (smooth indicator, timeline not thrashing)