### PR TITLE
fix(studio): only queue valid timestamp cells from sheet selection

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -177,11 +177,7 @@
     if (participantId && state.convergenceBaselines) {
       baselineSeconds = state.convergenceBaselines[participantId] || 0;
     }
-    var segments = parseClipSegmentsForCell(raw, baselineSeconds, DEFAULT_DUR);
-    if (segments.length === 0) {
-      segments.push({ startSeconds: 0, duration: DEFAULT_DUR });
-    }
-    return segments;
+    return parseClipSegmentsForCell(raw, baselineSeconds, DEFAULT_DUR);
   }
 
   // Cross-referencing: find overlapping data from other sources for a given
@@ -1415,10 +1411,10 @@
         td.appendChild(chip);
         if (cellData.valid) {
           td.classList.add("valid-ts");
+          td.setAttribute("draggable", "true");
         } else {
           td.classList.add("has-text");
         }
-        td.setAttribute("draggable", "true");
       } else {
         td.classList.add("empty");
       }
@@ -1508,13 +1504,20 @@
     };
   }
 
+  function isSelectableTimestampCell(td) {
+    return !!(td && td.classList.contains("valid-ts"));
+  }
+
   function toggleArtifactCell(info) {
     if (findInQueue(state.artifactQueue, info.participant, info.row) >= 0) {
       removeAllCellEntries(state.artifactQueue, info.participant, info.row);
-    } else {
-      var entries = expandCellToSegments(info);
-      for (var i = 0; i < entries.length; i++) state.artifactQueue.push(entries[i]);
+      renderArtifactQueue();
+      updateSingleCellClass(info.participant, info.row);
+      return;
     }
+    var entries = expandCellToSegments(info);
+    if (entries.length === 0) return;
+    for (var i = 0; i < entries.length; i++) state.artifactQueue.push(entries[i]);
     renderArtifactQueue();
     updateSingleCellClass(info.participant, info.row);
   }
@@ -1522,10 +1525,13 @@
   function toggleReelCell(info) {
     if (findInQueue(state.reelQueue, info.participant, info.row) >= 0) {
       removeAllCellEntries(state.reelQueue, info.participant, info.row);
-    } else {
-      var entries = expandCellToSegments(info);
-      for (var i = 0; i < entries.length; i++) state.reelQueue.push(entries[i]);
+      renderReelQueue();
+      updateSingleCellClass(info.participant, info.row);
+      return;
     }
+    var entries = expandCellToSegments(info);
+    if (entries.length === 0) return;
+    for (var i = 0; i < entries.length; i++) state.reelQueue.push(entries[i]);
     renderReelQueue();
     updateSingleCellClass(info.participant, info.row);
   }
@@ -1539,8 +1545,10 @@
       }
     } else if (findInQueue(targetQueue, info.participant, info.row) < 0) {
       var entries = expandCellToSegments(info);
-      for (var i = 0; i < entries.length; i++) targetQueue.push(entries[i]);
-      added = true;
+      if (entries.length > 0) {
+        for (var i = 0; i < entries.length; i++) targetQueue.push(entries[i]);
+        added = true;
+      }
     }
     if (added) {
       renderFn();
@@ -1548,13 +1556,13 @@
     }
   }
 
-  // Collect all non-empty cell infos matching a filter
+  // Collect selectable timestamp cell infos matching a filter
   function collectCellInfos(filterFn) {
     var infos = [];
     var cells = qsa(".ts-cell");
     for (var i = 0; i < cells.length; i++) {
       var td = cells[i];
-      if (td.classList.contains("empty")) continue;
+      if (!isSelectableTimestampCell(td)) continue;
       var info = getCellInfo(td);
       if (filterFn(info)) infos.push(info);
     }
@@ -1578,6 +1586,7 @@
       for (var k = 0; k < infos.length; k++) {
         if (findInQueue(queue, infos[k].participant, infos[k].row) < 0) {
           var entries = expandCellToSegments(infos[k]);
+          if (entries.length === 0) continue;
           for (var m = 0; m < entries.length; m++) queue.push(entries[m]);
         }
       }
@@ -1642,7 +1651,7 @@
 
       // Single cell select
       var td = ev.target.closest(".ts-cell");
-      if (!td || td.classList.contains("empty")) return;
+      if (!isSelectableTimestampCell(td)) return;
       var info = getCellInfo(td);
 
       if (ev.shiftKey) {
@@ -1654,7 +1663,7 @@
 
     grid.addEventListener("contextmenu", function (ev) {
       var td = ev.target.closest(".ts-cell");
-      if (!td || td.classList.contains("empty")) return;
+      if (!isSelectableTimestampCell(td)) return;
       ev.preventDefault();
       var info = getCellInfo(td);
       toggleReelCell(info);
@@ -1778,7 +1787,7 @@
 
     grid.addEventListener("pointerdown", function (ev) {
       var td = ev.target.closest(".ts-cell");
-      if (!td || td.classList.contains("empty")) {
+      if (!isSelectableTimestampCell(td)) {
         pointerOrigin = null;
         return;
       }
@@ -1791,7 +1800,7 @@
 
     grid.addEventListener("dragstart", function (ev) {
       var td = ev.target.closest(".ts-cell");
-      if (!td || td.classList.contains("empty")) return;
+      if (!isSelectableTimestampCell(td)) return;
 
       var info = getCellInfo(td);
       ev.dataTransfer.setData("application/json", JSON.stringify(info));

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -967,6 +967,55 @@ def test_api_sheet_exposes_keyword_annotations(client, monkeypatch):
     assert rows[1]["cells"]["P02"]["keywords"] == []
 
 
+def test_api_sheet_marks_valid_timestamps_only(client, monkeypatch):
+    """api/sheet distinguishes parseable timestamps from other cell text."""
+    import types
+
+    sheet_data = [
+        ["ID", "P01", "P02", "Observation", "Category"],
+        ["1", "1:23-1:45", "N/A", "obs valid", "catA"],
+        ["2", "see notes", "0:30", "obs invalid", "catB"],
+        ["3", "", "x", "obs empty-ish", "catC"],
+    ]
+    ctx = types.SimpleNamespace(
+        header_row=sheet_data[0],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=2,
+        study_name="study",
+        observation_cell=types.SimpleNamespace(col=4),
+        category_cell=types.SimpleNamespace(col=5),
+        severity_cell=None,
+        baseline_row_idx=None,
+        filename_row_idx=None,
+        first_data_row_idx=1,
+        sheet_data=sheet_data,
+    )
+    monkeypatch.setattr(server, "_sheet_context", ctx)
+
+    resp = client.get("/studio/api/sheet")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+
+    row_valid = data["rows"][0]["cells"]
+    assert row_valid["P01"]["valid"] is True
+    assert row_valid["P01"]["hasText"] is True
+    assert row_valid["P02"]["valid"] is False
+    assert row_valid["P02"]["hasText"] is True
+
+    row_invalid = data["rows"][1]["cells"]
+    assert row_invalid["P01"]["valid"] is False
+    assert row_invalid["P01"]["hasText"] is True
+    assert row_invalid["P02"]["valid"] is True
+    assert row_invalid["P02"]["hasText"] is True
+
+    row_empty = data["rows"][2]["cells"]
+    assert row_empty["P01"]["valid"] is False
+    assert row_empty["P01"]["hasText"] is False
+    assert row_empty["P02"]["valid"] is False
+    assert row_empty["P02"]["hasText"] is True
+
+
 def test_api_generate_titlecard_override(client, monkeypatch):
     """titlecards_enabled and titlecard_duration temporarily override config during generate."""
     import types

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -1,0 +1,26 @@
+"""Static regression checks for Studio sheet selection in assets/web/studio.js."""
+
+from pathlib import Path
+
+STUDIO_JS = Path(__file__).resolve().parent.parent / "assets" / "web" / "studio.js"
+
+
+def _studio_js() -> str:
+    return STUDIO_JS.read_text(encoding="utf-8")
+
+
+def test_studio_selection_requires_valid_timestamp_cells():
+    src = _studio_js()
+    assert "function isSelectableTimestampCell(td)" in src
+    assert 'td.classList.contains("valid-ts")' in src
+    assert "if (!isSelectableTimestampCell(td)) continue;" in src
+    assert "if (!isSelectableTimestampCell(td)) return;" in src
+
+
+def test_studio_parse_clip_timestamps_no_zero_fallback():
+    src = _studio_js()
+    start = src.index("function parseClipTimestamps")
+    end = src.index("  // Cross-referencing:", start)
+    body = src[start:end]
+    assert "segments.push({ startSeconds: 0" not in body
+    assert "return parseClipSegmentsForCell" in body


### PR DESCRIPTION
## Summary
- Studio sheet selection (headers, rows, single cells, drag) now only includes cells marked `valid` by `/api/sheet` (`.valid-ts`), skipping non-timestamp text.
- Removed the client-side fallback that created a synthetic 0s segment for unparseable cells, which produced misleading first-frame thumbnail cards.
- Added API and frontend-source regression tests.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_api.py::test_api_sheet_marks_valid_timestamps_only tests/test_studio_frontend_source.py`
- [ ] Manual: click participant/row/select-all headers on a sheet with both timestamps and plain notes; only valid timestamp cells should queue
- [ ] Manual: click or drag invalid text cells; no cards should appear