### PR TITLE
fix(studio): responsive artifacts toolbar and proper plurals

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5920,7 +5920,7 @@
         });
         renderResults();
         renderTimeline();
-        showToast("Excluded " + idsToExclude.length + " events");
+        showToast("Excluded " + clipgenPluralUnit(idsToExclude.length, "event", "events"));
       });
     });
   }
@@ -6532,7 +6532,7 @@
       .then(function (res) {
         if (res.ok && res.j && res.j.ok) {
           var n = (res.j.written || []).length;
-          showToast("Exported " + n + " file(s) to " + res.j.output_dir);
+          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
         } else {
           showToast((res.j && res.j.error) || "Export failed");
         }

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -645,12 +645,6 @@ body[data-active-tab]:not([data-active-tab="sheet"]) #studioSidebar {
   opacity: 0.9;
 }
 
-#viewerArtifactCount {
-  font-weight: 400;
-  font-size: var(--text-sm);
-  color: var(--color-text-dim);
-}
-
 #sheetGrid {
   overflow: auto;
   user-select: none;
@@ -1161,6 +1155,20 @@ body.dragging .ts-cell:hover {
   padding: 0 20px;
   border-bottom: 1px solid var(--hairline);
   flex: 0 0 auto;
+}
+
+/* Collapse format/titlecard controls when the artifacts column is narrow so
+ * Generate / Stash / Clear stay on-screen. */
+#artifactsToolbar {
+  container-type: inline-size;
+  container-name: artifacts-toolbar;
+}
+
+@container artifacts-toolbar (max-width: 720px) {
+  #artifactFormat,
+  #titlecardGroup {
+    display: none;
+  }
 }
 
 .bs-label {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -137,7 +137,6 @@
       <div class="bs-toolbar" id="artifactsToolbar">
         <span class="bs-label">Artifacts</span>
         <span id="artifactsCount" class="bs-count cg-mono">(0)</span>
-        <span id="viewerArtifactCount" class="bs-count cg-mono"></span>
         <svg id="artifactsSpinner" class="title-spinner bs-spinner" width="12" height="12" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>
         <span id="generateProgress" class="generate-progress hidden cg-mono" aria-live="polite"></span>
         <select id="artifactFormat" class="bs-select">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -979,7 +979,6 @@
         );
         renderArtifactQueue();
         updateCellClasses();
-        updateViewerButton();
       })
       .catch(function () {});
   }
@@ -2814,16 +2813,15 @@
       state.generating = false;
       setGeneratingLock(false);
       qs("#cancelGenerateBtn").classList.add("hidden");
-      updateViewerButton();
       var msg;
       var err = null;
       if (cancelled) {
         msg = totalSuccess > 0
-          ? "Cancelled after " + totalSuccess + " artifact(s)"
+          ? "Cancelled after " + clipgenPluralUnit(totalSuccess, "artifact", "artifacts")
           : null;
         err = totalSuccess > 0 ? null : "Generation cancelled";
       } else {
-        msg = "Generated " + totalSuccess + " artifact(s)";
+        msg = "Generated " + clipgenPluralUnit(totalSuccess, "artifact", "artifacts");
         if (totalFail > 0) msg += ", " + totalFail + " failed";
         if (totalSuccess === 0 && totalFail > 0) {
           msg = null;
@@ -2868,7 +2866,6 @@
           if (data.artifacts) {
             allArtifacts = allArtifacts.concat(data.artifacts);
             state.generatedArtifacts = state.generatedArtifacts.concat(data.artifacts);
-            updateViewerButton();
           }
         } else {
           for (ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], false);
@@ -2946,7 +2943,6 @@
                 if (res.artifact) {
                   allArtifacts.push(res.artifact);
                   state.generatedArtifacts.push(res.artifact);
-                  updateViewerButton();
                 }
                 if (card) setCardResult(card, true);
               } else {
@@ -3135,8 +3131,9 @@
         state.generating = false;
         if (data.ok) {
           var msg = "Timeline viewer created: " + (data.file || "");
-          if (data.generated) msg = "Generated " + data.generated + " clip(s). " + msg;
-          updateViewerButton();
+          if (data.generated) {
+            msg = "Generated " + clipgenPluralUnit(data.generated, "clip", "clips") + ". " + msg;
+          }
           showResult(msg, null, data.file);
         } else {
           showResult(null, data.error || "Timeline viewer build failed");
@@ -3192,7 +3189,7 @@
           renderReelQueue();
           updateCellClasses();
           showResult(
-            "Added " + data.clips.length + " clip(s) to reel queue",
+            "Added " + clipgenPluralUnit(data.clips.length, "clip", "clips") + " to reel queue",
             null
           );
         } else {
@@ -3283,12 +3280,6 @@
         closeGalleryDialog();
       }
     });
-  }
-
-  function updateViewerButton() {
-    var count = qs("#viewerArtifactCount");
-    var n = state.generatedArtifacts.length;
-    count.textContent = n > 0 ? n + " artifact(s) ready" : "";
   }
 
   // ---- Status overlay ----
@@ -4712,7 +4703,7 @@
       .then(function (res) {
         if (res.ok && res.j && res.j.ok) {
           var n = (res.j.written || []).length;
-          showToast("Exported " + n + " file(s) to " + res.j.output_dir);
+          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
         } else {
           showToast((res.j && res.j.error) || "Export failed");
         }
@@ -4750,7 +4741,6 @@
     loadSheetData();
     loadStashes();
     loadArtifactStashes();
-    updateViewerButton();
     checkNavLinks();
     initFrontendSwitcher();
     initTopNavActions();

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2369,7 +2369,7 @@
       category: state.lastMarkCategory,
     }).then(function (data) {
       if (data.ok) {
-        showToast("Marked " + data.marks.length + " segment" + (data.marks.length === 1 ? "" : "s"));
+        showToast("Marked " + clipgenPluralUnit(data.marks.length, "segment", "segments"));
         if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
       }
     });
@@ -3180,7 +3180,7 @@
         showToast("Failed to enqueue transcription");
         return;
       }
-      showToast("Enqueued " + data.tasks.length + " transcription(s)");
+      showToast("Enqueued " + clipgenPluralUnit(data.tasks.length, "transcription", "transcriptions"));
       startPolling();
       pollTaskStatus();
     });
@@ -3491,7 +3491,7 @@
       .then(function (res) {
         if (res.ok && res.j && res.j.ok) {
           var n = (res.j.written || []).length;
-          showToast("Exported " + n + " file(s) to " + res.j.output_dir);
+          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
         } else {
           showToast((res.j && res.j.error) || "Export failed");
         }
@@ -3522,7 +3522,7 @@
         var results = data.results || [];
         var okCount = 0;
         for (var i = 0; i < results.length; i++) if (results[i].ok) okCount++;
-        showToast("Embedded " + okCount + "/" + results.length + " video(s) to " + data.output_dir);
+        showToast("Embedded " + okCount + "/" + clipgenPluralUnit(results.length, "video", "videos") + " to " + data.output_dir);
       })
       .catch(function (err) { showToast("Embed failed: " + err.message); });
   }

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -75,6 +75,11 @@ var el = function (tag, cls, text) {
   return e;
 };
 
+// English-only count + noun phrase (1 → singular, else plural).
+var clipgenPluralUnit = function (n, singular, plural) {
+  return n + " " + (n === 1 ? singular : plural);
+};
+
 // Populate a container with a skeleton table: `cols` header cells plus
 // `rows × cols` body cells. Pairs with the `.skeleton-grid` / `.skeleton-cell`
 // CSS in primitives.css (and the shimmer in tokens.css). Target should


### PR DESCRIPTION
## Summary
- Hide artifact format dropdown and titlecard controls via a container query when the artifacts column is narrow, so Generate/Stash/Clear stay on-screen.
- Remove the "N artifact(s) ready" counter from the artifacts toolbar.
- Add `clipgenPluralUnit` in `utils.js` and use it for count messages in Studio, Screenspace, and Transcripts (replacing `(s)` suffix hacks).

## Test plan
- [ ] Resize Studio with a split bottom panel: format/titlecards hide under ~720px column width; action buttons remain visible.
- [ ] Confirm the generated-artifact ready counter is gone; queue count `(N)` still shows.
- [ ] Spot-check toasts/messages with count 1 vs 2+ (export, exclude events, enqueue transcriptions, embed videos).