### PR TITLE
fix(studio): refresh Metadata tab when sheet and intake data load

### DIFF
--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -1683,6 +1683,11 @@
     }
   }
 
+  function refreshIfActive() {
+    if (!mdState.active) return;
+    refresh();
+  }
+
   function deactivate() {
     mdState.active = false;
   }
@@ -1704,5 +1709,6 @@
   // --- Window exports ---
   window.metadataActivate = activate;
   window.metadataDeactivate = deactivate;
+  window.metadataRefreshIfActive = refreshIfActive;
   window.metadataResize = debounce(resize, 200);
 })();

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -800,6 +800,11 @@
     }
   }
 
+  function refreshMetadataIfActive() {
+    if (state.activePreviewTab !== "metadata") return;
+    if (window.metadataRefreshIfActive) window.metadataRefreshIfActive();
+  }
+
   // ---- Queue persistence (sessionStorage) ----
 
   function saveQueues() {
@@ -853,6 +858,7 @@
           }
           clipgenApplyConfig(data.config);
           state.sheetData = data;
+          refreshMetadataIfActive();
           return;
         }
         state.sheetData = data;
@@ -868,8 +874,12 @@
           .then(function (bdata) {
             state.convergenceBaselines = (bdata.ok && bdata.baselines) ? bdata.baselines : {};
             if (Object.keys(state.convergenceBaselines).length > 0) renderGrid();
+            refreshMetadataIfActive();
           })
-          .catch(function () { state.convergenceBaselines = {}; });
+          .catch(function () {
+            state.convergenceBaselines = {};
+            refreshMetadataIfActive();
+          });
         populateGalleryParticipants(data.participants || []);
         var durInput = qs("#highlightsDuration");
         if (durInput && data.highlightsDuration) {
@@ -898,6 +908,7 @@
         }
         loadManifestState();
         checkConvergenceTabVisibility();
+        refreshMetadataIfActive();
       })
       .catch(function (err) {
         qs("#sheetLoading").textContent = "Failed to load sheet: " + err;
@@ -3756,6 +3767,7 @@
         state.intakeClusters = clusterIntakeEvents(events, threshold);
         renderIntake(hasNew);
         checkConvergenceTabVisibility();
+        refreshMetadataIfActive();
       })
       .catch(function (err) {
         console.warn("[Intake] poll failed:", err);
@@ -4251,12 +4263,14 @@
                 state.trIntakeClusters = clusterTranscriptMarks(allItems, threshold);
                 renderTranscriptIntake();
                 checkConvergenceTabVisibility();
+                refreshMetadataIfActive();
               });
             })
             .catch(function () {});
         } else {
           renderTranscriptIntake();
           checkConvergenceTabVisibility();
+          refreshMetadataIfActive();
         }
       })
       .catch(function () {});


### PR DESCRIPTION
## Summary

- Export `window.metadataRefreshIfActive` from `metadata.js` so Studio can re-render Metadata when upstream data arrives.
- Call it from `loadSheetData()` (including baseline fetch) and intake poll handlers when the Metadata tab is active.

Fixes stale "No data loaded" on return to Studio when Metadata was the restored tab — data loaded asynchronously after the first `metadataActivate()` render.

## Test plan

- [ ] Open Studio with a loaded spreadsheet; switch to **Metadata**; navigate to Screenspace (or Transcripts); return to Studio — statistics appear without switching Studio tabs.
- [ ] Repeat with intake-only data (no sheet rows) if applicable — Metadata populates after polls without a tab toggle.