### PR TITLE
docs(plans): align friction and CV plans with codebase

### DIFF
--- a/plans/CV-PLAN.md
+++ b/plans/CV-PLAN.md
@@ -30,10 +30,36 @@ Together, these give researchers a skeleton of the video—entry points into lon
 ## Constraints to Preserve
 
 - **CPU/GPU flexibility**: Solo researchers on laptops + studio servers running as service. Detectors must degrade gracefully.
-- **Real-time iteration**: No pre-caching. Researchers adjust parameters and re-process on demand. Keep latency manageable.
+- **On-demand recomputation**: Researchers adjust parameters and re-process when they ask — avoid shipping huge precomputed frame caches or blocking the UI on full-video pre-analysis. **This does not mean “never cache”:** reuse existing decode paths, manifest reads, and detector outputs where clipgen already does (see **Relationship to Screenspace detectors**).
 - **Researcher agency**: Tool helps orient exploration, doesn't impose interpretation.
+
+## Integration map
+
+| Area | Role | Likely touchpoints |
+| --- | --- | --- |
+| **Studio** | Batch study view; spreadsheet-linked timeline and markers | [`server.py`](server.py) routes, [`assets/web/studio.js`](assets/web/studio.js) timeline / Screenspace intake density UI |
+| **Screenspace** | Single-video deep analysis; per-task detectors and timeline | [`screenspace.py`](screenspace.py), [`screenspace_server.py`](screenspace_server.py), [`assets/web/screenspace.js`](assets/web/screenspace.js) (`amplitudeGraphEnabled` band on timeline — reference for Transcripts friction heatmap) |
+| **Viewer** | Exported HTML timeline | [`viewer.py`](viewer.py), viewer timeline assets |
+| **Manifest** | Persisted events remain source of truth for detectors | Screenspace manifest events; navigation curves are **additive** overlays, not replacements |
+
+**Studio-first vs Screenspace-first (open):** Optical flow / keyframes could land in Studio first (orient across many participant videos) or Screenspace first (one long session, parameter iteration). Pick one primary surface per primitive before implementation; the other can follow.
+
+## Relationship to Screenspace detectors
+
+[`screenspace.py`](screenspace.py) already computes motion, template match, scene change, and related signals for task detectors. Navigation primitives should **prefer reusing or deriving from those outputs** (e.g. aggregate existing event timestamps into an activity curve) rather than always spawning a second full-video OpenCV pass. Where no detector covers the need (e.g. session-wide optical-flow magnitude without a task), add a focused pipeline — document cost and whether results are stored on the manifest or computed ephemerally per request.
+
+## Primitive roadmap
+
+| Primitive | Phase | UI surface (initial) | Dependencies | Effort (rough) |
+| --- | --- | --- | --- | --- |
+| Optical flow magnitude over time | Near-term | Studio or Screenspace timeline density band | OpenCV / ffmpeg (existing stack) | Small–medium |
+| Keyframe / scene boundaries | Near-term | Timeline markers (Studio + Screenspace) | Frame diff or perceptual hash; no training | Small |
+| Motion summary maps | Medium | Screenspace timeline or side panel | Aggregated flow or detector events | Medium |
+| Perceptual clustering | Medium | Screenspace gallery or Studio batch | Embeddings or hash buckets; may add dep | Medium–large |
+| Attention-guided scrubbing | Medium | Timeline flags | Saliency or change-detection; GPU optional | Medium |
+| Contrastive deviation | Long | TBD (likely Screenspace task) | Example-driven model; research | Large |
 
 ## Integration Points
 
-- Optical flow and keyframes feed into existing timeline markers in Studio.
-- Screenspace manifest remains ground truth; navigation layer is additive, not prescriptive.
+- Optical flow and keyframes feed into **existing timeline markers** in Studio and/or Screenspace (same marker hit-test and seek behavior as today).
+- Screenspace manifest remains ground truth for detector-produced events; navigation layers read manifest + video metadata, write optional derived series (e.g. `navigation.flow_curve`) only if persistence is justified.

--- a/plans/FRICTION-PLAN.md
+++ b/plans/FRICTION-PLAN.md
@@ -24,7 +24,7 @@ The researcher still drives interpretation. The system *suggests* areas of inter
 - New Friction tab in summary panel containing stats, top-5 moments, and a filter section
 - Filter (score-threshold slider + category checkboxes) with a "Mark all matching" action that creates user Marks via the existing API
 - Manual Run / Re-run via the participant pill dropdown (always available)
-- Global config flag `OLLAMA_FRICTION_ENABLED`, off by default; when on, agent auto-runs after `summary` for any participant lacking friction data
+- Global config flag `OLLAMA_FRICTION_ENABLED`, off by default; when on, agent auto-runs after `summary` exists for any participant lacking a `friction` manifest field (see **Agent chain order** — not always a literal “third pass”)
 
 ## Non-goals (deferred to future)
 
@@ -35,6 +35,7 @@ The researcher still drives interpretation. The system *suggests* areas of inter
 - **Per-participant normalization or sensitivity sliders.** Researchers mentally adjust for v1; the score-threshold filter doubles as the implicit calibration.
 - **Pause-length scoring.** Whisper currently drops short fillers and hallucinates on silence; pause signal is unreliable until those issues are addressed separately.
 - **Auto-update on segment edit.** Segment edits and corrections mark friction stale (UI indicator), but do not re-trigger the LLM pass. User explicitly re-runs.
+- **Non-English transcripts.** Phrase patterns are English-centric in v1; multilingual pattern sets are future work.
 
 ---
 
@@ -70,24 +71,44 @@ Whisper segments  (existing — transcripts.py)
         │
         ▼
 [2] Friction agent  (thinking_agents.py — new entry in AGENTS)
-        │   - depends_on: ["summary"]
+        │   - depends_on: ["summary"] only (does not wait for citations)
+        │   - Reads entry["segments"] + entry["summary"]; runs scorer in-thread
         │   - Inputs: session summary + top-15 candidates with ±1 segment of context
         │   - System prompt asks for EXACTLY 5 moments
-        │   - Output: JSON [{segment_ids, category, rationale, score}]
-        │   - <think> blocks already stripped by ollama_client.generate()
+        │   - Returns complete friction dict (programmatic + LLM fields)
+        │   - ollama_client.generate(..., think=False) — same as citations
         │
         ▼
-Manifest:  source_transcripts[participant].friction
+Manifest:  source_transcripts[participant].friction  (single commit when agent finishes)
 ```
+
+### Agent chain order
+
+`AgentOrchestrator` walks [`thinking_agents.AGENTS`](thinking_agents.py) **in list order**. Friction is appended **after** `citations`:
+
+- If **`OLLAMA_CITATIONS_ENABLED` is True** and citations run: **summary → citations → friction** (third enabled pass).
+- If citations are disabled or skipped: friction runs **immediately after summary** (second pass for that participant).
+
+Friction **`depends_on: ["summary"]` only** — it does not require citations. The prompt uses the session summary text, not citation refs.
+
+### Orchestrator invariants
+
+These match existing summary/citations behavior in [`transcripts_server.py`](transcripts_server.py); friction must follow them:
+
+1. **`next_eligible` skips when `entry[manifest_field]` is truthy.** Do not persist a partial `friction` object to the manifest before the agent thread completes, or auto-chain will never pick up friction for that participant.
+2. **`run_agent` assigns `entry[field] = result` — no deep merge.** `_run_friction` must **return the full friction dict** (segments, stats, moments, computed_at, model, stale, …), not `{"moments": [...]}` alone.
+3. **In-flight UX** uses `_orchestrator.is_generating(participant, "friction")` (and optional GET fields), not a truthy on-disk `friction` key.
+4. **Manual regenerate** clears `entry.pop("friction", None)` then calls `run_agent("friction", participant, force=True)` — same pattern as summary regenerate clearing `summary` / `citations`.
+5. **`model_config_key`** on the agent entry drives `_agent_model()` and delayed unload after Stop; required on the TypedDict.
 
 ### Programmatic scorer (`friction.py`, new module)
 
-Functions (no class — single-purpose utilities, follows project preference):
+Functions (no class — single-purpose utilities, follows project preference). Segment types are **`list[dict[str, Any]]`** (same as transcript segments elsewhere); scored rows are plain dicts with `id`, `score`, `categories`, `markers`.
 
-- `score_segments(segments: list[TranscriptSegment]) -> list[FrictionSegment]` — runs phrase patterns, returns per-segment scores, matched markers, categories.
-- `select_candidates(scored: list[FrictionSegment], n: int = 15) -> list[FrictionSegment]` — top-N for LLM input.
-- `compute_stats(scored: list[FrictionSegment], duration_seconds: float) -> dict` — `by_category` counts, `markers_per_minute`, total markers.
-- `smooth_scores(scored: list[FrictionSegment], window: int = 5) -> list[float]` — rolling-window mean for the heatmap render path. The raw per-segment score still drives the segment background tint.
+- `score_segments(segments: list[dict[str, Any]]) -> list[dict[str, Any]]` — runs phrase patterns, returns per-segment scores, matched markers, categories.
+- `select_candidates(scored: list[dict[str, Any]], n: int = 15) -> list[dict[str, Any]]` — top-N for LLM input.
+- `compute_stats(scored: list[dict[str, Any]], duration_seconds: float) -> dict` — `by_category` counts, `markers_per_minute`, total markers.
+- `smooth_scores(scored: list[dict[str, Any]], window: int = 5) -> list[float]` — rolling-window mean for the heatmap render path. The raw per-segment score still drives the segment background tint.
 
 Phrase patterns, not bare words. Examples (final list refined during implementation):
 
@@ -132,25 +153,41 @@ Patterns are compiled once at module load. Matching is case-insensitive. Word bo
 
 ### Friction agent (append to `AGENTS` in `thinking_agents.py`)
 
+`Agent` is a **TypedDict** — append a dict literal (not a constructor call):
+
 ```python
 Agent(
     key="friction",
     enabled_config_key="OLLAMA_FRICTION_ENABLED",
+    model_config_key="OLLAMA_FRICTION_MODEL",
     manifest_field="friction",
     depends_on=["summary"],
-    thread_name_prefix="friction-agent",
+    thread_name_prefix="friction",
     run=_run_friction,
-)
+),
 ```
 
-`_run_friction(transcript_entry, cancel_event)`:
+`_run_friction(entry, cancel_event)`:
 
-1. Build candidate list via `friction.select_candidates(transcript_entry["friction"]["segments"], n=15)`.
-2. Resolve each candidate to its segment text plus ±1 context segment for readability.
-3. Compose prompt with three sections: session summary, candidate segments (with IDs), task instructions.
-4. Call `ollama_client.generate(model=config.OLLAMA_FRICTION_MODEL, prompt=...)` (defaults to `qwen3.5:9b`, same as summary/citations).
-5. Parse JSON response (defensive: fall back to empty `moments` on parse failure, log warning).
-6. Return `{"moments": [...]}` for merging into the manifest entry's `friction` field.
+1. Read `segments = entry.get("segments") or []` and `summary = entry.get("summary") or ""`. Segment IDs are already `{participant}:{idx}` (assigned in [`transcripts.py`](transcripts.py)).
+2. Run `score_segments(segments)` → scored list; `compute_stats(...)`; `select_candidates(scored, n=config.FRICTION_CANDIDATE_LIMIT)`.
+3. Resolve each candidate to its segment text plus ±1 context segment for readability.
+4. Compose prompt: session summary, candidate segments (with IDs), task instructions.
+5. Call `ollama_client.generate(..., model=config.OLLAMA_FRICTION_MODEL, think=False, cancel_event=cancel_event)`.
+6. Parse JSON response (defensive: empty `moments` on failure, log warning). Extract first valid JSON array if wrapped in prose.
+7. If `cancel_event` is set, return `None` (orchestrator skips persist).
+8. **Return the complete friction dict** for orchestrator to assign to `entry["friction"]`:
+
+```python
+{
+    "segments": [...],       # per-segment scores from step 2
+    "stats": {...},
+    "moments": [...],        # from LLM
+    "computed_at": "...",
+    "model": config.OLLAMA_FRICTION_MODEL,
+    "stale": False,
+}
+```
 
 System prompt sketch (refined during implementation):
 
@@ -206,17 +243,18 @@ Output JSON only, no prose, no <think> blocks:
 }
 ```
 
-`segments`, `stats`, and `computed_at` are written by the programmatic scorer. `moments` and `model` are written by the LLM agent. The `stale` flag is set to `true` when a user edit, correction, or transcript regeneration invalidates the LLM moments; the UI shows a "Re-run friction" prompt. (No auto-rerun, per earlier decision.)
+The entire object is **persisted once** when `_run_friction` returns (orchestrator `entry["friction"] = result`). Nothing is written under `friction` while the agent thread is still running.
+
+The `stale` flag is set to `true` when segment text, corrections, or transcript regeneration invalidate scores/moments; the UI shows a "Re-run friction" prompt. **Summary edits** also set `stale: true` (or `pop("friction")`) because the LLM prompt uses summary context — mirror summary-save invalidating citations. No auto-rerun.
 
 ### Trigger model
 
 - `OLLAMA_FRICTION_ENABLED = False` in `config.py`. Mirrors existing `OLLAMA_SUMMARY_ENABLED` / `OLLAMA_CITATIONS_ENABLED`.
-- When `True`: orchestrator's `_next_eligible_agent()` picks up `friction` whenever `summary` exists and `friction` is missing. Auto-chains as a third pass.
-- The pill-dropdown "Run friction" / "Re-run friction" action **bypasses the global flag** — it is always available. It calls a new endpoint that:
-  - Clears the existing `friction.moments` and `friction.model` for that participant
-  - Recomputes `friction.segments`/`stats` synchronously (cheap)
-  - Triggers the LLM agent for that participant in a daemon thread
-- Cancellation: standard `_agent_in_flight[("friction", participant)]` plus `Event` plumbing already used by summary and citations.
+- When `True`: after transcription completes, `_on_task_complete` → `run_chain` eventually reaches friction when `summary` exists and `entry.get("friction")` is falsy (see **Agent chain order**).
+- The pill-dropdown "Run friction" / "Re-run friction" action **bypasses the global flag** (`force=True`). It calls **`POST /api/friction/<participant>/regenerate`**, which:
+  - Returns `200 {"ok": true, "generating": true}` if already in-flight (same as summary/citations — not 409)
+  - Otherwise `entry.pop("friction", None)`, persist, then `_orchestrator.run_agent("friction", participant, force=True)`
+- Cancellation: **`POST /api/friction/<participant>/stop`** → `_orchestrator.stop("friction", participant)` plus optional model unload (same as summary/citations).
 
 ---
 
@@ -230,12 +268,13 @@ Output JSON only, no prose, no <think> blocks:
 - `FRICTION_MOMENT_LIMIT: int = 5`
 - `FRICTION_HEATMAP_WINDOW: int = 5`
 - Friction category labels for frontend mirroring (see Frontend config below)
+- Add **`friction`** to `MARK_CATEGORIES` (single bucket for all friction-created marks): `{label: "Friction", color: ...}` — specificity lives in the mark **label**, not separate category keys per friction type
 
 ### `friction.py` (new module)
 
 - Module-level `FRICTION_PATTERNS`, `CATEGORY_WEIGHTS`, compiled regex tables
 - Functions: `score_segments`, `select_candidates`, `compute_stats`, `smooth_scores`
-- `compute_friction(transcript_entry) -> dict` — orchestrating helper that runs programmatic scoring end-to-end and returns the partial friction dict (segments, stats, computed_at; moments empty until LLM agent fills them)
+- `build_friction_result(segments, summary, *, cancel_event, model) -> dict | None` — internal helper used by `_run_friction`: programmatic scoring + LLM + assembled dict (not persisted here)
 
 ### `thinking_agents.py`
 
@@ -245,16 +284,17 @@ Output JSON only, no prose, no <think> blocks:
 
 ### `transcripts_server.py`
 
-New endpoints, mirroring summary/citations conventions:
+New endpoints, mirroring **summary/citations** conventions (not a separate DELETE cancel route):
 
-- `GET /api/friction/<participant>` — return cached friction data; 404 if absent
-- `POST /api/friction/<participant>` — manual trigger; runs programmatic scorer synchronously, then dispatches LLM agent in background thread; returns 202 with in-flight status
-- `DELETE /api/friction/<participant>/run` — cancel in-flight LLM run via the agent's `Event`
-- `GET /api/friction/<participant>/status` — return `{in_flight: bool, computed_at, stale}` for UI polling
+- `GET /api/friction/<participant>` — return cached friction; if in-flight and absent, `{"ok": false, "generating": true}` (like summary); 404 when idle and absent
+- `POST /api/friction/<participant>/regenerate` — manual trigger; `pop("friction")`, persist, `run_agent("friction", participant, force=True)`; `200 {"generating": true}` (or `generating: true` if already running)
+- `POST /api/friction/<participant>/stop` — cancel in-flight run; schedule model unload via `_agent_model("friction")`
 
-Modify `_run_agent_chain()`: friction slots in naturally as a third agent — no orchestrator edits needed beyond appending to `AGENTS`. Verify after implementation.
+No orchestrator class edits beyond appending to `AGENTS` — `run_chain` / `run_agent` already chain dependents.
 
-Wire programmatic scoring into the segment-edit and correction-add code paths: invalidate (`stale = true`) but do not recompute. The frontend prompts the user to re-run.
+**Participant API:** extend responses that expose agent step state (e.g. `citations_generating` on summary GET, participant list payloads using `_step_state_agent`) with **`friction_generating`** / friction `done|idle|running` so the pill dropdown and Friction tab can poll without guessing.
+
+Wire **invalidation** (not recompute) on segment edit, correction add, summary PUT, and transcript regeneration: set `friction["stale"] = true` or `pop("friction")` per the same rules as citations on summary edit.
 
 ### `data_export.py`
 
@@ -308,9 +348,9 @@ Three stacked sections inside the tab:
    - Score threshold slider, range 0.0–1.0, default 0.5
    - Six category checkboxes (all checked by default)
    - `Mark all matching` button — creates Marks for every segment whose score ≥ threshold AND has at least one matching category
-     - Mark category = the segment's primary friction category
-     - Mark label = `Friction: <category>`
-     - Uses existing marks API (`POST /api/marks`)
+     - Mark **category** = `friction` (single `MARK_CATEGORIES` bucket for all friction marks)
+     - Mark **label** = `Friction · <primary_category>` (e.g. `Friction · frustration`) — specificity in label only
+     - Uses existing marks API (`POST /api/marks` with `segment_ids`, `category`, `label`)
    - Top-5 moments list (filtered by the same controls)
      - Each row: category badge, score, rationale text, timestamp range
      - Click → seek video to first segment's start AND scroll segment list to first segment_id
@@ -322,7 +362,7 @@ Add `Run friction` / `Re-run friction` entry to the participant pill dropdown:
 - Disabled with tooltip if `summary` doesn't exist (`depends_on`)
 - In-flight indicator (spinner) on the entry while running
 - Cancel option appears while in-flight
-- Calls `POST /api/friction/<participant>`
+- Calls `POST /api/friction/<participant>/regenerate`
 
 ### Frontend config
 
@@ -332,7 +372,7 @@ Add to `utils.get_frontend_config()` so JS doesn't hardcode:
 - `friction_color_token`: name of the CSS variable (`--color-friction`)
 - `friction_moment_limit`: 5
 
-Per the constants-mirroring rule, add a corresponding test in `tests/test_shared_constants.py` that asserts the JS defaults match Python.
+Per the constants-mirroring rule, add a corresponding test in `tests/test_shared_constants.py` that asserts **`CLIPGEN_CONFIG` defaults in [`assets/web/utils.js`](assets/web/utils.js)** match Python after `clipgenApplyConfig()` overlays server config.
 
 ---
 
@@ -349,20 +389,21 @@ Per the constants-mirroring rule, add a corresponding test in `tests/test_shared
   - `compute_stats` aggregates category counts and markers/min correctly
 
 - `tests/test_friction_agent.py`
-  - Prompt is built from summary + candidates
+  - Prompt is built from `entry["segments"]` + summary + candidates (not from pre-existing `friction` on entry)
   - JSON output parsing is defensive (handles wrapping prose, extra fields)
-  - Cancellation event short-circuits
+  - Cancellation event returns `None`; successful run returns full friction dict shape
 
 ### Integration
 
 - `tests/test_transcripts_server.py`
-  - `GET /api/friction/<p>` returns 404 then cached after run
-  - `POST /api/friction/<p>` triggers run; second call while in-flight returns 409 (or matches existing summary endpoint convention)
-  - `DELETE /api/friction/<p>/run` cancels
+  - `GET /api/friction/<p>` returns 404 then cached after run; `generating: true` while in-flight
+  - `POST /api/friction/<p>/regenerate` triggers run; second call while in-flight returns `200 {"generating": true}` (summary convention)
+  - `POST /api/friction/<p>/stop` cancels
   - Auto-chain skipped when `OLLAMA_FRICTION_ENABLED = False`
-  - Auto-chain runs when flag is `True` and summary completes
-  - Manual override works regardless of flag
-  - Segment edit flips `stale = true` without rerunning LLM
+  - Auto-chain runs when flag is `True` and summary exists (with or without citations depending on `OLLAMA_CITATIONS_ENABLED`)
+  - Manual `force=True` works regardless of flag
+  - Segment edit sets `stale` or clears friction without rerunning LLM
+  - Summary PUT invalidates friction like citations
 
 ### Smoke
 
@@ -376,7 +417,7 @@ Per the constants-mirroring rule, add a corresponding test in `tests/test_shared
 1. **Prereq**: Rework summary panel into always-visible tabbed shell; existing Summary tab content moves into the first tab; second tab is a placeholder until step 6.
 2. `friction.py` module (patterns, weights, scorer, smoothing, stats).
 3. Friction agent entry in `thinking_agents.py` + Ollama prompt.
-4. Endpoints in `transcripts_server.py` (GET/POST/DELETE/status).
+4. Endpoints in `transcripts_server.py` (GET, POST regenerate, POST stop) + participant `friction_generating` fields.
 5. `config.py` flags + `utils.get_frontend_config()` mirroring + design token in `tokens.css`.
 6. Friction tab content (stats, filter, top-5 moments) in `transcripts.{html,js,css}`.
 7. Timeline toggle + heatmap render + segment tint (mirror PR #266 amplitude graph pattern).
@@ -395,6 +436,8 @@ Per the constants-mirroring rule, add a corresponding test in `tests/test_shared
 - **JSON parse robustness.** Qwen sometimes wraps JSON in prose despite "JSON only" instructions. The parser should locate and extract the first valid JSON array, not require a clean response.
 - **Smoothing window size.** Default 5 is a starting point. May need tuning once we see real heatmaps against real transcripts.
 - **Stale detection granularity.** A single `stale` flag is coarse; future refinement might track which moments became stale, but v1 keeps it simple.
+- **Group sessions (`G##`).** v1 runs friction with the same pipeline; UI may show a short “mixed voices — noisier signal” note. A config gate is optional if feedback warrants it.
+- **Auto-run prerequisite.** Friction auto-chains when `summary` is non-empty on the entry; it does not require citations to succeed.
 
 ## Future work (revisit)
 


### PR DESCRIPTION
## Summary

- **FRICTION-PLAN.md**: Aligns with `thinking_agents` / `transcripts_server` orchestration — TypedDict agent entry with `model_config_key`, single-commit `friction` manifest, correct regenerate/stop endpoints, agent chain order vs citations, marks single-bucket strategy, and related test/API notes.
- **CV-PLAN.md**: Adds integration map, clarifies on-demand vs caching, Screenspace detector reuse, and a primitive roadmap table.

## Test plan

- [x] Documentation-only change; no code or tests to run