### PR TITLE
fix(video): probed duration cache; clarify VAD default in transcribe skill

### DIFF
--- a/agents/skills/transcribe/SKILL.md
+++ b/agents/skills/transcribe/SKILL.md
@@ -11,7 +11,7 @@ Omit participant IDs to transcribe all participants. This creates `.md` transcri
 Options:
 - `--whisper-model tiny|base|small|medium|large-v3` (default: `base`)
 - `--transcript-format md|srt|vtt` (default: `md`)
-- `--no-whisper-vad` — disable Silero VAD (default: VAD on via `TRANSCRIBE_VAD_FILTER`)
+- `--no-whisper-vad` — disable Silero VAD when it is enabled (`TRANSCRIBE_VAD_FILTER` is off by default; turn VAD on in Studio or `config.py` when you want speech-only decoding on long silent recordings)
 - `--whisper-hallucination-silence SEC` — enable hallucination silence skip when SEC > 0 (enables word timestamps; slower)
 
 Transcription quality knobs (`TRANSCRIBE_VAD_FILTER`, no-speech / log-probability / compression-ratio thresholds, hallucination silence threshold, condition-on-previous-text) live in `config.py` and are exposed in Studio under **Transcription → Transcription quality**. Set `TRANSCRIBE_HALLUCINATION_SILENCE_THRESHOLD` to `0` to disable silence-based hallucination skip.

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -370,6 +370,32 @@ def test_calculate_target_bitrate_typical_and_min_floor():
     assert zero_duration == 100
 
 
+def test_get_file_duration_returns_rounded_probe_duration(monkeypatch, tmp_path):
+    """After probe_video_properties, duration must not depend on a prior cache hit."""
+    video_f = tmp_path / "video.mp4"
+    video_f.write_bytes(b"x")
+    resolved = str(video_f.resolve())
+    video._file_duration_cache.pop(resolved, None)
+    video._video_properties_cache.pop(resolved, None)
+
+    monkeypatch.setattr(video.os.path, "isfile", lambda _path: True)
+
+    def fake_probe(_path: str) -> dict:
+        return {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": None,
+            "fps": 30.0,
+            "duration": 99.4,
+            "nb_frames": 0,
+        }
+
+    monkeypatch.setattr(video, "probe_video_properties", fake_probe)
+    assert video.get_file_duration(str(video_f)) == 99
+    assert video._file_duration_cache[resolved] == 99
+
+
 def test_get_file_duration_error_paths(monkeypatch):
     # Missing file
     monkeypatch.setattr(video.os.path, "isfile", lambda _path: False)

--- a/video.py
+++ b/video.py
@@ -877,7 +877,9 @@ def get_file_duration(filepath: str) -> int | None:
     if probed is not None:
         dur_f = float(probed.get("duration") or 0)
         if dur_f > 0:
-            return _file_duration_cache.get(resolved)
+            rounded = round(dur_f)
+            _file_duration_cache[resolved] = rounded
+            return rounded
 
     dur = _probe_duration_seconds_ffprobe_format(filepath)
     if dur is not None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small follow-ups from the recent commit review:

1. **`get_file_duration()`** — After `probe_video_properties()` returns a positive duration, round and cache that value instead of reading `_file_duration_cache`, which could still be empty and caused a spurious `None` (and an extra ffprobe fallback).

2. **Transcribe skill** — Document that `TRANSCRIBE_VAD_FILTER` is **off by default** and is a tuning knob for long silent recordings; `--no-whisper-vad` only applies when VAD has been enabled.

## Testing

- `uv run --extra dev pytest -c tests/pytest.ini tests/test_video_commands.py::test_get_file_duration_returns_rounded_probe_duration tests/test_video_commands.py::test_get_file_duration_error_paths`
- `uv run ruff check --fix` / `uv run ty check` on touched Python files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aa8843a-3025-434e-a89f-e8407edabb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aa8843a-3025-434e-a89f-e8407edabb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

