### PR TITLE
fix(spreadsheet): restore layout-agnostic participant column detection

### DIFF
--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -153,26 +153,18 @@ def _detect_baseline_row(sheet_data: list[list[str]]) -> int | None:
     return None
 
 
-def _is_participant_header(value: str) -> bool:
-    """Return True if *value* looks like a participant column header (e.g. P01, G02)."""
-    cell = (value or "").strip()
-    if not cell or cell[0] not in config.PARTICIPANT_PREFIXES:
-        return False
-    return len(cell) > 1 and cell[1].isdigit()
+def get_num_participants(header_row: list[str], id_cell: Any, col_count: int) -> int:
+    """Count the number of participant columns in the worksheet.
 
-
-def get_num_participants(
-    header_row: list[str], id_cell: Any, observation_cell: Any
-) -> int:
-    """Count participant columns between the ID and Observation headers.
-
-    Scans only the columns after ID up to (but not including) Observation.
-    Requires P/G prefix followed by a digit so labels like ``Proctor`` are ignored.
+    Scans every column after ID and counts those whose header starts with one
+    of ``config.PARTICIPANT_PREFIXES`` (P / G). Layout-agnostic: makes no
+    assumption about where Observation, Category, or other non-participant
+    columns sit relative to ID.
 
     Args:
         header_row: List of header cell values
-        id_cell: The ID header cell object
-        observation_cell: The Observation header cell object
+        id_cell: The ID header cell object (1-based ``col``)
+        col_count: Total number of columns to consider in ``header_row``
 
     Returns:
         Number of participant columns found
@@ -180,11 +172,12 @@ def get_num_participants(
     start_col = (
         id_cell.col
     )  # id_cell.col is 1-based, so this is the 0-based index of the next column
-    end_col = observation_cell.col - 1  # exclusive 0-based index before Observation
     num_participants = sum(
         1
-        for j in range(start_col, end_col)
-        if j < len(header_row) and _is_participant_header(header_row[j])
+        for j in range(start_col, col_count)
+        if j < len(header_row)
+        and header_row[j]
+        and header_row[j][0] in config.PARTICIPANT_PREFIXES
     )
     utils.standard_print(
         f"Found {num_participants} participants in total, spanning columns {id_cell.col + 1} to {num_participants + id_cell.col}."
@@ -225,7 +218,8 @@ def build_sheet_context(sheet: Any) -> SheetContext | None:
     study_name = utils.normalize_study_name(study_name)
 
     header_row = sheet_data[id_cell.row - 1]
-    num_participants = get_num_participants(header_row, id_cell, observation_cell)
+    col_count = max(len(row) for row in sheet_data)
+    num_participants = get_num_participants(header_row, id_cell, col_count)
 
     filename_cell = _find_in_data(sheet_data, config.FILENAME_HEADER)
     filename_row_idx: int | None = None

--- a/tests/test_spreadsheet_generation.py
+++ b/tests/test_spreadsheet_generation.py
@@ -57,9 +57,7 @@ def test_get_num_participants_and_participant_list():
     sheet_data = _basic_sheet_data()
     header_row = sheet_data[cells.id_cell.row - 1]
 
-    num = spreadsheet.get_num_participants(
-        header_row, cells.id_cell, cells.observation_cell
-    )
+    num = spreadsheet.get_num_participants(header_row, cells.id_cell, len(header_row))
     assert num == 2
 
     participants = spreadsheet.get_participant_list(header_row, cells.id_cell, num)
@@ -67,27 +65,69 @@ def test_get_num_participants_and_participant_list():
 
 
 def test_get_num_participants_ragged_header_row():
+    """col_count may exceed header_row length (build_sheet_context derives it
+    from the longest row in the sheet). The scan must not IndexError."""
     cells = _make_cells()
-    header_row = ["ID", "P01"]  # shorter than Observation column index
+    header_row = ["ID", "P01"]
 
-    num = spreadsheet.get_num_participants(
-        header_row, cells.id_cell, cells.observation_cell
-    )
+    num = spreadsheet.get_num_participants(header_row, cells.id_cell, 5)
     assert num == 1
 
 
-def test_get_num_participants_stops_at_observation_and_ignores_proctor():
-    cells = SimpleNamespace(
-        id_cell=SimpleNamespace(row=2, col=1),
-        observation_cell=SimpleNamespace(row=2, col=4),
-        category_cell=SimpleNamespace(row=2, col=6),
-    )
-    header_row = ["ID", "P01", "P02", "Observation", "Category", "Proctor"]
+def test_get_num_participants_with_observation_before_id():
+    """Reference clipgen-test.xlsx layout: 'Observation' header appears in a
+    row above (and to the left of) the ID/participants header row. Because
+    _find_in_data returns the first match anywhere, observation_cell.col can
+    be smaller than id_cell.col. The participant scan must remain layout-
+    agnostic and still find every P*/G* column after ID."""
+    id_cell = SimpleNamespace(row=2, col=6)
+    header_row = ["", "", "", "", "", "ID", "P01", "P02", "P03", "P04"]
 
-    num = spreadsheet.get_num_participants(
-        header_row, cells.id_cell, cells.observation_cell
-    )
-    assert num == 2
+    num = spreadsheet.get_num_participants(header_row, id_cell, len(header_row))
+    assert num == 4
+
+
+def test_get_num_participants_handles_variable_column_layouts():
+    """Different studies arrange columns differently. The count must reflect
+    only the headers actually starting with P/G — never assume a fixed total
+    or that participants are sandwiched between specific columns."""
+    cases = [
+        (["ID", "P01"], 1, 1),
+        (["ID", "P01", "P02", "P03"], 1, 3),
+        (["ID", "Notes", "P01", "Tags", "G01", "G02"], 1, 3),
+        (["Notes", "ID"], 2, 0),
+    ]
+    for header_row, id_col, expected in cases:
+        id_cell = SimpleNamespace(row=1, col=id_col)
+        num = spreadsheet.get_num_participants(header_row, id_cell, len(header_row))
+        assert num == expected, f"Expected {expected} for {header_row!r}, got {num}"
+
+
+def test_build_sheet_context_with_observation_in_earlier_row():
+    """End-to-end guard for the clipgen-test.xlsx layout that regressed
+    in commit a9f66fb: 'Observation' appears in a header section several
+    rows above (and to the left of) the row that holds 'ID' and the
+    participant columns. build_sheet_context must still detect every P*
+    column rather than aborting with 'No participant columns found'."""
+    sheet_data = [
+        ["Study", "", "", "", "", "", "", "", ""],
+        ["intro", "", "", "", "", "ID", "P01", "P02", "P03"],
+        ["names", "", "", "", "", "Metadata", "Alice", "Bob", "Carol"],
+        ["Count", "Reported", "Severity", "Category", "Observation", "Summary"],
+        ["1", "", "", "CatA", "Obs one", "00:10-00:20"],
+    ]
+
+    class _Sheet:
+        def get_all_values(self):
+            return sheet_data
+
+        spreadsheet = SimpleNamespace(title="study")
+
+    ctx = spreadsheet.build_sheet_context(_Sheet())
+    assert ctx is not None
+    assert ctx.num_participants == 3
+    assert ctx.id_cell.col == 6
+    assert ctx.observation_cell.col == 5
 
 
 def test_collect_categories_skips_ragged_rows():


### PR DESCRIPTION
## Summary

- Commit `a9f66fb` made `get_num_participants` stop the participant scan at `observation_cell.col - 1`, baking in the assumption that Observation always sits to the right of the participant block. Real spreadsheets (e.g. `clipgen-test.xlsx`) put Observation in earlier header sections — `id_cell.col = 6` (row 2), `observation_cell.col = 5` (row 5) — so the range collapsed to `range(6, 4) = []` and every load failed with "No participant columns found".
- Rolled the scan back to its pre-regression form (every column after ID up to `col_count`) and dropped the `_is_participant_header` helper. Verified end-to-end against `clipgen-test.xlsx`: now reports 12 participants where it previously found 0.
- Added regression tests for Observation-before-ID layouts, interleaved non-participant columns, and an end-to-end `build_sheet_context` check so future "stop at column X" attempts fail CI.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 845 passed
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check` — clean
- [ ] `uv run clipgen.py -s "clipgen-test" -o "./output-test" -i "~/Projects/clipgen/" --studio` — Studio loads without "Could not load spreadsheet data for Studio"