### PR TITLE
perf: Phase 1 quick wins (utils, server, studio, transcripts)

### DIFF
--- a/agents/PERFORMANCE.md
+++ b/agents/PERFORMANCE.md
@@ -18,3 +18,15 @@ Patterns to apply from the start when writing new features, so dedicated optimiz
 
 - **Normalize comparison data once.** If a loop compares against a set of strings (e.g. filename matching), lowercase / normalize the set once before the loop, not inside each iteration. Sorting callbacks (`key=lambda`) are called O(n log n) times — avoid per-call work that can be hoisted.
 - **Use `DocumentFragment` for DOM batching.** When rendering lists of cards/rows, build all elements in a fragment and append once. Never append per-item inside a loop. Viewer and Screenspace already do this; apply the same pattern in any new UI list.
+
+## Tuning knobs
+
+Performance is already adaptive (auto-detected worker counts, lazy thumbnails, mtime caches), but a handful of `config.py` flags exist for users who want to push harder or trade fidelity for speed.
+
+| Knob | Default | When to change it |
+|---|---|---|
+| `CLIP_PARALLEL_WORKERS` | `0` (auto = `min(4, cpu_count)`) | Raise on machines with fast SSDs and many cores when batch clip generation is the bottleneck. Drop to `1` to force sequential ffmpeg if disk contention is the bottleneck instead. Honored by both CLI and Studio. |
+| `SCREENSPACE_PARALLEL_WORKERS` | `2` | Raise to run more concurrent Screenspace analysis tasks. Diminishing returns past CPU core count; OpenCV is already multithreaded inside each task. |
+| `SCREENSPACE_BATCH_EXTRACT` | `True` | Use ffmpeg pipe for frame extraction (faster than cv2 per-frame seek). Falls back to cv2 automatically when ffmpeg is unavailable; flip to `False` only when debugging frame mismatches. |
+| `SCREENSPACE_CV_RESOLUTION_SCALE` | `1.0` | Drop below `1.0` (e.g. `0.5`) to scan large footage faster at the cost of detection fidelity. Raise above `1.0` only when the source is noisy/compressed and detectors miss small artifacts. |
+| `GALLERY_BUNDLE_ENABLED` | `False` | Set to `True` to inline gallery images as base64, producing a single-file HTML viewer. **Do not enable for large galleries** — the HTML balloons to hundreds of MB and browsers choke. |

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1481,18 +1481,23 @@
   // ---- Cell selection ----
 
   function updateCellClasses() {
+    var selected = {};
+    for (var i = 0; i < state.artifactQueue.length; i++) {
+      var a = state.artifactQueue[i];
+      if (a.row) selected[cellKey(a.participant, a.row)] = true;
+    }
+    for (var j = 0; j < state.reelQueue.length; j++) {
+      var r = state.reelQueue[j];
+      if (r.row) selected[cellKey(r.participant, r.row)] = true;
+    }
     var cells = qsa(".ts-cell");
-    for (var i = 0; i < cells.length; i++) {
-      var td = cells[i];
-      var p = td.getAttribute("data-participant");
-      var r = parseInt(td.getAttribute("data-row"), 10);
-      var inArt = findInQueue(state.artifactQueue, p, r) >= 0;
-      var inReel = findInQueue(state.reelQueue, p, r) >= 0;
-      if (inArt || inReel) {
-        td.classList.add("selected");
-      } else {
-        td.classList.remove("selected");
-      }
+    for (var k = 0; k < cells.length; k++) {
+      var td = cells[k];
+      var key = cellKey(
+        td.getAttribute("data-participant"),
+        parseInt(td.getAttribute("data-row"), 10),
+      );
+      td.classList.toggle("selected", !!selected[key]);
     }
   }
 
@@ -1602,7 +1607,9 @@
       }
     }
     renderFn();
-    updateCellClasses();
+    for (var n = 0; n < infos.length; n++) {
+      updateSingleCellClass(infos[n].participant, infos[n].row);
+    }
   }
 
   // ---- Grid events ----
@@ -2171,7 +2178,7 @@
           var removed = state.artifactQueue.splice(idx, 1)[0];
           if (removed.row) delete state.cellResults[cellKey(removed.participant, removed.row)];
           renderArtifactQueue();
-          updateCellClasses();
+          if (removed.row) updateSingleCellClass(removed.participant, removed.row);
         });
       })(i);
       card.appendChild(removeBtn);
@@ -2279,7 +2286,7 @@
           var removed = state.reelQueue.splice(idx, 1)[0];
           if (removed.row) delete state.cellResults[cellKey(removed.participant, removed.row)];
           renderReelQueue();
-          updateCellClasses();
+          if (removed.row) updateSingleCellClass(removed.participant, removed.row);
         });
       })(i);
       card.appendChild(removeBtn);
@@ -2431,7 +2438,9 @@
           state.reelQueue = [];
           renderReelQueue();
           renderStashedReels();
-          updateCellClasses();
+          for (var u = 0; u < items.length; u++) {
+            if (items[u].row) updateSingleCellClass(items[u].participant, items[u].row);
+          }
         }
       })
       .catch(function () {});
@@ -2440,7 +2449,10 @@
   function recallStash(stash) {
     state.reelQueue = stash.items.slice();
     renderReelQueue();
-    updateCellClasses();
+    for (var i = 0; i < state.reelQueue.length; i++) {
+      var it = state.reelQueue[i];
+      if (it.row) updateSingleCellClass(it.participant, it.row);
+    }
   }
 
   function deleteStash(stashId, endpoint, stateArray, renderFn) {
@@ -2549,7 +2561,9 @@
           state.artifactQueue = [];
           renderArtifactQueue();
           renderStashedArtifacts();
-          updateCellClasses();
+          for (var u = 0; u < items.length; u++) {
+            if (items[u].row) updateSingleCellClass(items[u].participant, items[u].row);
+          }
         }
       })
       .catch(function () {});
@@ -2558,7 +2572,10 @@
   function recallArtifactStash(stash) {
     state.artifactQueue = stash.items.slice();
     renderArtifactQueue();
-    updateCellClasses();
+    for (var i = 0; i < state.artifactQueue.length; i++) {
+      var it = state.artifactQueue[i];
+      if (it.row) updateSingleCellClass(it.participant, it.row);
+    }
   }
 
   // ---- Stash drag-reveal ----
@@ -2581,30 +2598,33 @@
 
   function bindButtons() {
     qs("#clearArtifactsBtn").addEventListener("click", function () {
-      for (var i = 0; i < state.artifactQueue.length; i++) {
-        var item = state.artifactQueue[i];
-        delete state.cellResults[cellKey(item.participant, item.row)];
+      var cleared = state.artifactQueue.slice();
+      for (var i = 0; i < cleared.length; i++) {
+        delete state.cellResults[cellKey(cleared[i].participant, cleared[i].row)];
       }
       state.artifactQueue = [];
       renderArtifactQueue();
-      updateCellClasses();
+      for (var u = 0; u < cleared.length; u++) {
+        if (cleared[u].row) updateSingleCellClass(cleared[u].participant, cleared[u].row);
+      }
     });
 
     qs("#addToReelBtn").addEventListener("click", function () {
       for (var i = 0; i < state.artifactQueue.length; i++) {
         addToQueue(state.reelQueue, state.artifactQueue[i], renderReelQueue);
       }
-      updateCellClasses();
     });
 
     qs("#clearReelBtn").addEventListener("click", function () {
-      for (var i = 0; i < state.reelQueue.length; i++) {
-        var item = state.reelQueue[i];
-        delete state.cellResults[cellKey(item.participant, item.row)];
+      var cleared = state.reelQueue.slice();
+      for (var i = 0; i < cleared.length; i++) {
+        delete state.cellResults[cellKey(cleared[i].participant, cleared[i].row)];
       }
       state.reelQueue = [];
       renderReelQueue();
-      updateCellClasses();
+      for (var u = 0; u < cleared.length; u++) {
+        if (cleared[u].row) updateSingleCellClass(cleared[u].participant, cleared[u].row);
+      }
     });
 
     qs("#stashReelBtn").addEventListener("click", stashCurrentReel);
@@ -3218,6 +3238,7 @@
       .then(function (data) {
         state.generating = false;
         if (data.ok && data.clips && data.clips.length > 0) {
+          var prev = state.reelQueue.slice();
           state.reelQueue = [];
           for (var i = 0; i < data.clips.length; i++) {
             var entries = expandCellToSegments(data.clips[i]);
@@ -3226,7 +3247,17 @@
             }
           }
           renderReelQueue();
-          updateCellClasses();
+          var touchedKeys = {};
+          for (var p = 0; p < prev.length; p++) {
+            if (prev[p].row) touchedKeys[cellKey(prev[p].participant, prev[p].row)] = prev[p];
+          }
+          for (var q = 0; q < state.reelQueue.length; q++) {
+            var rq = state.reelQueue[q];
+            if (rq.row) touchedKeys[cellKey(rq.participant, rq.row)] = rq;
+          }
+          for (var key in touchedKeys) {
+            updateSingleCellClass(touchedKeys[key].participant, touchedKeys[key].row);
+          }
           showResult(
             "Added " + clipgenPluralUnit(data.clips.length, "clip", "clips") + " to reel queue",
             null

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -30,7 +30,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
 - **Change:** After the `get`, before returning, `_thumbnail_cache.move_to_end(cache_key)`.
 - **Why:** Mirrors `screenspace_server.py:328-331`. Without it, hot thumbnails are evicted before cold ones under load, causing repeat ffmpeg extractions that *look* like server slowness.
 
-### 1.3 Targeted cell-class updates after queue mutations
+### ✅ 1.3 Targeted cell-class updates after queue mutations
 
 - **File:** `assets/web/studio.js`
 - **Today:** `updateCellClasses()` (lines 1483-1496) is called from 12+ sites including baselines, sidebar filters, and batch ops. It iterates *every* `.ts-cell` and runs `findInQueue` per cell.

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -37,7 +37,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
 - **Change:** Audit the 12 call sites. Where the mutation is known to affect a small set of cells (toggle, single add/remove), call `updateSingleCellClass` per affected cell instead. Where a sweep *is* required (e.g. participant column visibility), keep `updateCellClasses` but cache `findInQueue` lookups by `cellKey` for the duration of the call.
 - **Why:** O(rows × participants × queueLen) per sidebar toggle is the largest source of "Studio feels janky" complaints on large sheets.
 
-### 1.4 Pre-compile correction patterns in `apply_corrections`
+### ✅ 1.4 Pre-compile correction patterns in `apply_corrections`
 
 - **File:** `transcripts.py:346-364`
 - **Today:** `re.compile(re.escape(from_text), re.IGNORECASE)` runs **inside** the per-segment loop. With 1000 segments × 20 corrections that is 20k recompiles per transcript.

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -51,7 +51,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
 - **Change:** Add `@functools.cache` above the `def`. The map is keyed by configured tokens; it never changes during a process lifetime.
 - **Verified:** TRUE — `Grep` confirmed no cache decorator on this function.
 
-### 1.6 Faster `timestamp_to_seconds` dispatch
+### ✅ 1.6 Faster `timestamp_to_seconds` dispatch
 
 - **File:** `utils.py:1050-1065`
 - **Today:** Tries `datetime.strptime(ts, "%M:%S")`, catches `ValueError`, then tries `"%H:%M:%S"`. Every HH:MM:SS timestamp pays the exception cost.

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -12,7 +12,7 @@ Source review: `~/.claude/plans/system-instruction-you-are-working-shimmying-pud
 
 ---
 
-## Phase 1 — Quick wins (single PR)
+## ✅ Phase 1 — Quick wins (single PR)
 
 Seven small, independent diffs. None changes a public contract; all are safe to bundle.
 
@@ -66,7 +66,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
   Same semantics, no exception-driven control flow on the hot path.
 - **Verified:** TRUE — re-reading confirmed the two-format try/except chain.
 
-### 1.7 Tuning documentation
+### ✅ 1.7 Tuning documentation
 
 - **File:** `AGENTS.md` (or a new section in `agents/PERFORMANCE.md`).
 - **Add:** A short table listing the existing knobs and when to turn them: `CLIP_PARALLEL_WORKERS`, `SCREENSPACE_PARALLEL_WORKERS`, `SCREENSPACE_CV_RESOLUTION_SCALE`, `SCREENSPACE_BATCH_EXTRACT`, `GALLERY_BUNDLE_ENABLED`. Note that `GALLERY_BUNDLE_ENABLED` should not be used on large galleries.

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -23,7 +23,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
 - **Change:** `workers = pipeline._resolve_clip_workers()`. Move `_resolve_clip_workers` to `utils.py` if `server.py` should not import from `pipeline.py` (check existing import direction first).
 - **Why:** `config.CLIP_PARALLEL_WORKERS` already exists and is honored by CLI; Studio silently ignores it. Aligns the two paths and unlocks tuning.
 
-### 1.2 LRU refresh on Studio thumbnail cache hit
+### ✅ 1.2 LRU refresh on Studio thumbnail cache hit
 
 - **File:** `server.py:243-249`
 - **Today:** `cached = _thumbnail_cache.get(cache_key)` — no `move_to_end()` on hit.

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -16,7 +16,7 @@ Source review: `~/.claude/plans/system-instruction-you-are-working-shimmying-pud
 
 Seven small, independent diffs. None changes a public contract; all are safe to bundle.
 
-### 1.1 Studio uses `_resolve_clip_workers()`
+### ✅ 1.1 Studio uses `_resolve_clip_workers()`
 
 - **File:** `server.py:757`
 - **Today:** `workers = min(4, os.cpu_count() or 1)` (hardcoded).

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -44,7 +44,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
 - **Change:** Build `pairs = [(re.compile(re.escape(c["from"]), re.IGNORECASE), c["to"]) for c in corrections ...]` once at function entry; iterate that list inside the segment loop.
 - **Verified:** TRUE — re-reading the source confirms the recompile is in the inner loop.
 
-### 1.5 Cache `get_known_annotation_map()`
+### ✅ 1.5 Cache `get_known_annotation_map()`
 
 - **File:** `utils.py:633-639`
 - **Today:** Function rebuilds the dict from `config.ANNOTATION_KEYPHRASES` on every call. No decorator, even though `@functools.cache` is already used in the same file (line 572).

--- a/server.py
+++ b/server.py
@@ -754,7 +754,7 @@ def api_generate() -> FlaskResponse:
 
             # Pass 2: generate in parallel and yield as each completes
             if to_generate:
-                workers = min(4, os.cpu_count() or 1)
+                workers = pipeline._resolve_clip_workers()
                 if workers >= 2 and len(to_generate) >= 2:
                     with concurrent.futures.ThreadPoolExecutor(
                         max_workers=workers

--- a/server.py
+++ b/server.py
@@ -242,6 +242,7 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
     cache_key = (str(video_path), start_sec)
     cached = _thumbnail_cache.get(cache_key)
     if cached is not None:
+        _thumbnail_cache.move_to_end(cache_key)
         return Response(
             cached,
             mimetype="image/jpeg",

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 import pytest
 
@@ -274,7 +275,7 @@ def test_api_thumbnail_returns_jpeg(client, monkeypatch, tmp_path):
         sheet_data=[],
     )
     monkeypatch.setattr(server, "_sheet_context", ctx)
-    monkeypatch.setattr(server, "_thumbnail_cache", {})
+    monkeypatch.setattr(server, "_thumbnail_cache", OrderedDict())
     monkeypatch.setattr("utils.resolve_input_path", lambda name: dummy_video)
     monkeypatch.setattr(video, "extract_thumbnail_bytes", lambda *a, **kw: fake_jpeg)
 
@@ -303,7 +304,7 @@ def test_api_thumbnail_caches(client, monkeypatch, tmp_path):
         sheet_data=[],
     )
     monkeypatch.setattr(server, "_sheet_context", ctx)
-    monkeypatch.setattr(server, "_thumbnail_cache", {})
+    monkeypatch.setattr(server, "_thumbnail_cache", OrderedDict())
     monkeypatch.setattr("utils.resolve_input_path", lambda name: dummy_video)
 
     def counting_extract(*a, **kw):

--- a/transcripts.py
+++ b/transcripts.py
@@ -343,7 +343,11 @@ def apply_corrections(
     if not corrections:
         return list(segments)
 
-    pairs = [(c["from"], c["to"]) for c in corrections if c.get("from") and c.get("to")]
+    pairs = [
+        (re.compile(re.escape(c["from"]), re.IGNORECASE), c["to"])
+        for c in corrections
+        if c.get("from") and c.get("to")
+    ]
     if not pairs:
         return list(segments)
 
@@ -352,8 +356,7 @@ def apply_corrections(
     for seg in segments:
         text = seg["text"]
         seg_applied = 0
-        for from_text, to_text in pairs:
-            pattern = re.compile(re.escape(from_text), re.IGNORECASE)
+        for pattern, to_text in pairs:
             new_text, count = pattern.subn(to_text, text)
             if count > 0:
                 text = new_text

--- a/utils.py
+++ b/utils.py
@@ -1052,18 +1052,16 @@ def timestamp_to_seconds(ts_str: str) -> float | None:
     if not ts:
         return None
 
-    formats = ["%M:%S", "%H:%M:%S"]
-    for fmt in formats:
-        try:
-            parsed = datetime.strptime(ts, fmt)
-            return float(
-                parsed.hour * config.SECONDS_PER_HOUR
-                + parsed.minute * config.SECONDS_PER_MINUTE
-                + parsed.second
-            )
-        except ValueError:
-            continue
-    return None
+    fmt = "%H:%M:%S" if ts.count(":") == 2 else "%M:%S"
+    try:
+        parsed = datetime.strptime(ts, fmt)
+    except ValueError:
+        return None
+    return float(
+        parsed.hour * config.SECONDS_PER_HOUR
+        + parsed.minute * config.SECONDS_PER_MINUTE
+        + parsed.second
+    )
 
 
 def parse_timestamps(

--- a/utils.py
+++ b/utils.py
@@ -630,6 +630,7 @@ def sanitize_filename(text: str) -> str:
 # ---- Annotation and participant helpers ----
 
 
+@functools.cache
 def get_known_annotation_map() -> dict[str, str]:
     """Return configured annotation tokens mapped to normalized annotation IDs."""
     configured_map = getattr(config, "ANNOTATION_KEYPHRASES", {"!key": "key"})


### PR DESCRIPTION
## Summary

Phase 1 of `plans/PERFORMANCE-PLAN-2.md` — seven independent quick wins bundled per the plan's recommended ordering. Studio now honors `CLIP_PARALLEL_WORKERS` and refreshes LRU on thumbnail cache hits, `updateCellClasses` drops from O(cells × queueLen) to O(cells + queueLen) with targeted single-cell updates on known mutations, transcript corrections compile their regexes once per call, `timestamp_to_seconds` and `get_known_annotation_map` shed hot-path overhead, and `agents/PERFORMANCE.md` gains a tuning-knobs reference table.

No public contracts change. Per-item details (and ✅ marks) are in `plans/PERFORMANCE-PLAN-2.md`; each item is its own commit for easy revert.

## Test plan

- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [x] `uv run --extra dev pytest -c tests/pytest.ini` (full suite)
- [ ] Manual Studio smoke: load a real sheet, toggle a participant column, add/remove cells via × buttons, recall a stash, run a generate with ≥4 cells, confirm DevTools scripting time drops on sidebar toggles