### PR TITLE
perf: NDJSON streaming for /api/generate-intake (Phase 4.2)

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2963,26 +2963,55 @@
         };
       });
 
-      apiPost("api/generate-intake", { items: intakePayload, format: format })
-        .then(function (data) {
-          if (data.ok && data.results) {
-            for (var ri = 0; ri < data.results.length; ri++) {
-              var res = data.results[ri];
-              var card = intakeCardEls[ri];
-              if (res.ok) {
-                totalSuccess++;
-                if (res.artifact) {
-                  allArtifacts.push(res.artifact);
-                  state.generatedArtifacts.push(res.artifact);
-                }
-                if (card) setCardResult(card, true);
-              } else {
-                totalFail++;
-                if (card) setCardResult(card, false);
-              }
-            }
+      function handleIntakeLine(line) {
+        var data;
+        try { data = JSON.parse(line); } catch (_) { return; }
+        if (!data || typeof data.index !== "number") return;
+        var card = intakeCardEls[data.index];
+        if (data.ok) {
+          totalSuccess++;
+          if (data.artifact) {
+            allArtifacts.push(data.artifact);
+            state.generatedArtifacts.push(data.artifact);
           }
-          finishBranch();
+          if (card) setCardResult(card, true);
+        } else {
+          totalFail++;
+          if (card) setCardResult(card, false);
+        }
+      }
+
+      // Streaming NDJSON response — manual fetch is required to get a reader
+      // and parse line-delimited per-item events as ffmpeg finishes each cut.
+      fetch("api/generate-intake", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items: intakePayload, format: format }),
+      })
+        .then(function (response) {
+          if (!response.ok) throw new Error("Server error " + response.status);
+          var reader = response.body.getReader();
+          var decoder = new TextDecoder();
+          var buffer = "";
+
+          function read() {
+            return reader.read().then(function (result) {
+              if (result.done) {
+                if (buffer.trim()) handleIntakeLine(buffer.trim());
+                finishBranch();
+                return;
+              }
+              buffer += decoder.decode(result.value, { stream: true });
+              var lines = buffer.split("\n");
+              buffer = lines.pop();
+              for (var li = 0; li < lines.length; li++) {
+                if (lines[li].trim()) handleIntakeLine(lines[li].trim());
+              }
+              return read();
+            });
+          }
+
+          return read();
         })
         .catch(function () {
           for (var j = 0; j < intakeCardEls.length; j++) {

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -138,7 +138,7 @@ Two larger frontend changes. Each is its own session.
   3. **If sheet load / baseline arrival dominates:** Render in chunks via `requestAnimationFrame`, yielding to paint between row batches.
   4. **Only if both still feel slow:** Virtualize rows (windowed render + spacer divs). This is the largest invasive change in the plan — keep it last.
 
-### 4.2 NDJSON streaming for `/api/generate-intake`
+### ✅ 4.2 NDJSON streaming for `/api/generate-intake`
 
 - **Files:** `server.py:1474-1497` (endpoint), `assets/web/studio.js:2946` (client).
 - **Today:** Blocking POST, single `jsonify()` response after the full batch.

--- a/server.py
+++ b/server.py
@@ -460,6 +460,109 @@ def _resolve_intake_video_path(participant: str, source: str = "") -> str | None
     return None
 
 
+def _process_intake_item(
+    item: dict[str, Any],
+    output_format: str,
+    study: str,
+) -> dict[str, Any]:
+    """Process a single intake item; returns one dict with _ok/_error keys."""
+    participant = item.get("participant", "")
+    start = float(item.get("start", 0))
+    end = float(item.get("end", 0))
+    event_type = item.get("event_type", "")
+    event_ids = item.get("event_ids", [])
+    source = item.get("source", "screenspace")
+    mark_ids = item.get("mark_ids", [])
+
+    video_path = _resolve_intake_video_path(participant, source)
+
+    if not video_path:
+        return {"_ok": False, "_error": f"No video for {participant}"}
+
+    span_hash = hashlib.md5(f"{participant}_{start}_{end}".encode()).hexdigest()[:8]
+    safe_event_type = utils.sanitize_filename(event_type) if event_type else ""
+    desc_part = f"{safe_event_type} " if safe_event_type else ""
+    out_name = (
+        f"{study} {participant} {desc_part}intake {span_hash}{config.FILEFORMAT}"
+        if study
+        else f"intake_{span_hash}{config.FILEFORMAT}"
+    )
+    out_path = files.get_unique_filename(out_name)
+
+    start_str = utils.seconds_to_timestamp(int(round(start)))
+    end_str = utils.seconds_to_timestamp(int(round(end)))
+
+    success = video.run_ffmpeg(
+        video_path, out_path, start_str, end_str, config.REENCODING
+    )
+
+    if not success:
+        return {"_ok": False, "_error": "ffmpeg failed"}
+
+    default_desc = (
+        "Transcript intake" if source == "transcript" else "Screenspace intake"
+    )
+    item_text = str(item.get("text") or "").strip()
+    item_label = str(item.get("label") or "").strip()
+    description = event_type or default_desc
+    if source == "transcript":
+        # Prefer the user's label, then a truncated transcript excerpt,
+        # then the category — so cards aren't all titled "Transcript intake".
+        if item_label:
+            description = item_label
+        elif item_text:
+            description = item_text if len(item_text) <= 80 else item_text[:77] + "…"
+        else:
+            description = event_type or default_desc
+    artifact: dict[str, Any] = {
+        "id": f"intake_{span_hash}_s0",
+        "type": output_format,
+        "file": Path(out_path).name,
+        "start": start,
+        "end": end,
+        "thumbnail": "",
+        "study": study,
+        "participant": participant,
+        "category": "",
+        "severity": "",
+        "description": description,
+        "cellRow": None,
+        "cellCol": None,
+        "cellA1": "",
+        "annotations": [],
+        "source": source,
+        "event_ids": event_ids,
+        "mark_ids": mark_ids,
+        "intake_label": event_type,
+        "sourceVideo": Path(video_path).name,
+        "_ok": True,
+        "_error": "",
+    }
+    if source == "transcript":
+        import transcripts_server
+
+        with transcripts_server._manifest_lock:
+            src_entry = transcripts_server._manifest.get("source_transcripts", {}).get(
+                participant, {}
+            )
+            transcript_text = item_text
+            if not transcript_text and mark_ids:
+                # Fallback: look up segment text by id from the manifest.
+                wanted = set(mark_ids)
+                parts: list[str] = []
+                for seg in src_entry.get("segments", []) or []:
+                    if seg.get("id") in wanted:
+                        t = (seg.get("text") or "").strip()
+                        if t:
+                            parts.append(t)
+                transcript_text = " ".join(parts)
+        artifact["transcript_version"] = src_entry.get("transcribed_at", "")
+        artifact["transcriptText"] = transcript_text
+        if item_label:
+            artifact["transcriptLabel"] = item_label
+    return artifact
+
+
 def _generate_intake_clips(
     items: list[dict[str, Any]],
     output_format: str = "clip",
@@ -471,109 +574,7 @@ def _generate_intake_clips(
     the video was missing or ffmpeg failed) plus an ``"_error"`` string so
     callers can report per-item results without duplicating the loop.
     """
-    results: list[dict[str, Any]] = []
-
-    for item in items:
-        participant = item.get("participant", "")
-        start = float(item.get("start", 0))
-        end = float(item.get("end", 0))
-        event_type = item.get("event_type", "")
-        event_ids = item.get("event_ids", [])
-        source = item.get("source", "screenspace")
-        mark_ids = item.get("mark_ids", [])
-
-        video_path = _resolve_intake_video_path(participant, source)
-
-        if not video_path:
-            results.append({"_ok": False, "_error": f"No video for {participant}"})
-            continue
-
-        span_hash = hashlib.md5(f"{participant}_{start}_{end}".encode()).hexdigest()[:8]
-        safe_event_type = utils.sanitize_filename(event_type) if event_type else ""
-        desc_part = f"{safe_event_type} " if safe_event_type else ""
-        out_name = (
-            f"{study} {participant} {desc_part}intake {span_hash}{config.FILEFORMAT}"
-            if study
-            else f"intake_{span_hash}{config.FILEFORMAT}"
-        )
-        out_path = files.get_unique_filename(out_name)
-
-        start_str = utils.seconds_to_timestamp(int(round(start)))
-        end_str = utils.seconds_to_timestamp(int(round(end)))
-
-        success = video.run_ffmpeg(
-            video_path, out_path, start_str, end_str, config.REENCODING
-        )
-
-        if success:
-            default_desc = (
-                "Transcript intake" if source == "transcript" else "Screenspace intake"
-            )
-            item_text = str(item.get("text") or "").strip()
-            item_label = str(item.get("label") or "").strip()
-            description = event_type or default_desc
-            if source == "transcript":
-                # Prefer the user's label, then a truncated transcript excerpt,
-                # then the category — so cards aren't all titled "Transcript intake".
-                if item_label:
-                    description = item_label
-                elif item_text:
-                    description = (
-                        item_text if len(item_text) <= 80 else item_text[:77] + "…"
-                    )
-                else:
-                    description = event_type or default_desc
-            artifact: dict[str, Any] = {
-                "id": f"intake_{span_hash}_s0",
-                "type": output_format,
-                "file": Path(out_path).name,
-                "start": start,
-                "end": end,
-                "thumbnail": "",
-                "study": study,
-                "participant": participant,
-                "category": "",
-                "severity": "",
-                "description": description,
-                "cellRow": None,
-                "cellCol": None,
-                "cellA1": "",
-                "annotations": [],
-                "source": source,
-                "event_ids": event_ids,
-                "mark_ids": mark_ids,
-                "intake_label": event_type,
-                "sourceVideo": Path(video_path).name,
-                "_ok": True,
-                "_error": "",
-            }
-            if source == "transcript":
-                import transcripts_server
-
-                with transcripts_server._manifest_lock:
-                    src_entry = transcripts_server._manifest.get(
-                        "source_transcripts", {}
-                    ).get(participant, {})
-                    transcript_text = item_text
-                    if not transcript_text and mark_ids:
-                        # Fallback: look up segment text by id from the manifest.
-                        wanted = set(mark_ids)
-                        parts: list[str] = []
-                        for seg in src_entry.get("segments", []) or []:
-                            if seg.get("id") in wanted:
-                                t = (seg.get("text") or "").strip()
-                                if t:
-                                    parts.append(t)
-                        transcript_text = " ".join(parts)
-                artifact["transcript_version"] = src_entry.get("transcribed_at", "")
-                artifact["transcriptText"] = transcript_text
-                if item_label:
-                    artifact["transcriptLabel"] = item_label
-            results.append(artifact)
-        else:
-            results.append({"_ok": False, "_error": "ffmpeg failed"})
-
-    return results
+    return [_process_intake_item(item, output_format, study) for item in items]
 
 
 def _load_stashes() -> list[dict[str, Any]]:
@@ -1474,7 +1475,12 @@ def api_settings_put() -> FlaskResponse:
 
 @studio_bp.route("/api/generate-intake", methods=["POST"])
 def api_generate_intake() -> FlaskResponse:
-    """Generate clips from intake spans (Screenspace or Transcript)."""
+    """Generate clips from intake spans (Screenspace or Transcript).
+
+    Streams NDJSON: one ``{"index", "ok", "artifact"|"error"}`` line per item
+    so the client can paint each queue card as soon as its ffmpeg call
+    finishes, rather than waiting for the whole batch.
+    """
     data = request.get_json(silent=True) or {}
     items = data.get("items", [])
     if not items:
@@ -1483,19 +1489,25 @@ def api_generate_intake() -> FlaskResponse:
     output_format = data.get("format", "clip")
     study = _sheet_context.study_name if _sheet_context else ""
 
-    raw = _generate_intake_clips(items, output_format=output_format, study=study)
-    results: list[dict[str, Any]] = []
-    for r in raw:
-        ok = r.pop("_ok", False)
-        error = r.pop("_error", "")
-        if ok:
-            _generated_artifacts.append(r)
-            results.append({"ok": True, "artifact": r})
-        else:
-            results.append({"ok": False, "error": error})
+    def stream() -> Iterator[str]:
+        for idx, item in enumerate(items):
+            result = _process_intake_item(item, output_format, study)
+            ok = result.pop("_ok", False)
+            error = result.pop("_error", "")
+            if ok:
+                _generated_artifacts.append(result)
+                yield (
+                    json.dumps({"index": idx, "ok": True, "artifact": result}) + "\n"
+                )
+            else:
+                yield json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
+        _save_manifest_quiet()
 
-    _save_manifest_quiet()
-    return jsonify({"ok": True, "results": results})
+    return Response(
+        stream(),
+        mimetype="application/x-ndjson",
+        headers={"X-Accel-Buffering": "no"},
+    )
 
 
 @studio_bp.route("/api/reel-direct", methods=["POST"])

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1445,3 +1445,81 @@ def test_api_generate_cancel_endpoint(client):
     assert resp.status_code == 200
     assert data["ok"] is True
     assert server._generate_cancel_event.is_set()
+
+
+def test_api_generate_intake_streams_per_item(client, monkeypatch):
+    """POST /api/generate-intake yields one NDJSON line per item with index/ok."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+
+    items = [
+        {
+            "participant": "P01",
+            "start": 0.0,
+            "end": 5.0,
+            "event_type": "x",
+            "event_ids": [],
+            "source": "screenspace",
+            "mark_ids": [],
+        },
+        {
+            "participant": "P02",
+            "start": 0.0,
+            "end": 5.0,
+            "event_type": "y",
+            "event_ids": [],
+            "source": "screenspace",
+            "mark_ids": [],
+        },
+    ]
+    resp = client.post(
+        "/studio/api/generate-intake",
+        json={"items": items, "format": "clip"},
+    )
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/x-ndjson"
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert len(lines) == 2
+    assert {ln["index"] for ln in lines} == {0, 1}
+    for ln in lines:
+        assert ln["ok"] is True
+        assert ln["artifact"]["participant"] in {"P01", "P02"}
+
+
+def test_api_generate_intake_streams_failure(client, monkeypatch):
+    """Items with no resolvable video stream an ok=false line with error."""
+    monkeypatch.setattr(server, "_resolve_intake_video_path", lambda p, s="": None)
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+
+    items = [
+        {
+            "participant": "Pxx",
+            "start": 0.0,
+            "end": 5.0,
+            "event_type": "",
+            "event_ids": [],
+            "source": "screenspace",
+            "mark_ids": [],
+        },
+    ]
+    resp = client.post(
+        "/studio/api/generate-intake",
+        json={"items": items, "format": "clip"},
+    )
+    assert resp.status_code == 200
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert len(lines) == 1
+    assert lines[0]["ok"] is False
+    assert lines[0]["index"] == 0
+    assert "No video" in lines[0]["error"]
+
+
+def test_api_generate_intake_rejects_empty(client):
+    """POST /api/generate-intake without items returns a 400."""
+    resp = client.post("/studio/api/generate-intake", json={"items": []})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["ok"] is False


### PR DESCRIPTION
## Summary

- Converts `POST /api/generate-intake` from a blocking JSON response to an NDJSON stream, mirroring `/api/generate`. Intake queue cards now flip to success/fail individually as each ffmpeg cut finishes instead of waiting on the whole batch.
- Splits `_generate_intake_clips` into a per-item `_process_intake_item` helper; the batch caller in `api_timeline_viewer` is unchanged.
- Client (`studio.js`) replaces the `apiPost` call with a `fetch` + NDJSON reader; line shape is `{"index", "ok", "artifact"|"error"}` so card matching survives the planned parallel intake (Phase 2.1).
- Adds three endpoint tests (success stream, missing-video failure, empty payload) — it had no direct coverage before. Marks 4.2 ✅ in `plans/PERFORMANCE-PLAN-2.md`.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini`
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [ ] Manual: queue ≥4 intake items in Studio, click Generate, confirm cards transition one-by-one rather than all at once