### PR TITLE
fix(viewer): serialize manifest save to prevent lost merges

### DIFF
--- a/plans/STREAMING-FIXES.md
+++ b/plans/STREAMING-FIXES.md
@@ -56,6 +56,10 @@ Tests:
 
 ### P0: Manifest Save Race
 
+> **Status:** Done — branch `claude/streaming-fixes-plan-6ConI`. Added
+> `_MANIFEST_WRITE_LOCK` in `viewer.py` wrapping the full load-merge-write
+> cycle of `save_manifest()`; regression test in `tests/test_manifest.py`.
+
 `server._save_manifest_quiet()` snapshots `_generated_artifacts` / `_generated_reels` under `_generated_output_lock`, then releases it before `viewer.save_manifest()` performs load-merge-save. Concurrent Studio artifact/reel/intake completions can each read the same old manifest and last-writer-wins a partial merge.
 
 Fix:
@@ -295,7 +299,7 @@ Tests:
 
 - [ ] Add atomic output reservation to `files.py`.
 - [ ] Update ffmpeg call sites that use reserved paths to clean up unused placeholders on early failure.
-- [ ] Add a manifest write lock to `viewer.save_manifest()`.
+- [x] Add a manifest write lock to `viewer.save_manifest()`.
 - [ ] Run:
 
 ```bash

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,4 +1,6 @@
 import json
+import threading
+import time
 
 import config
 import viewer
@@ -199,3 +201,71 @@ def test_cli_manifest_flag_defaults_false(monkeypatch):
     monkeypatch.setattr("sys.argv", ["clipgen.py"])
     args = cli.parse_arguments()
     assert args.manifest is False
+
+
+def _make_reel(reel_id):
+    return {
+        "id": reel_id,
+        "file": f"{reel_id}.mp4",
+        "study": "study",
+        "description": "Reel: 1 segment",
+        "components": [
+            {
+                "cellRow": 3,
+                "cellCol": 2,
+                "participant": "P01",
+                "sourceVideo": "study_P01.mp4",
+                "start": 10.0,
+                "end": 20.0,
+                "category": "cat",
+                "description": "desc",
+                "severity": "",
+            }
+        ],
+    }
+
+
+def test_save_manifest_concurrent_writes_keep_every_id(tmp_path, monkeypatch):
+    """Concurrent save_manifest() calls must not last-writer-wins a partial merge.
+
+    Each thread saves a distinct artifact and reel. The real finalize step is
+    wrapped with a small sleep to widen the load->write window: without the
+    write lock every thread would load the same empty manifest during that
+    window and only one record of each kind would survive.
+    """
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+
+    real_finalize = viewer.finalize_timeline_data
+
+    def slow_finalize(*args, **kwargs):
+        time.sleep(0.05)
+        return real_finalize(*args, **kwargs)
+
+    monkeypatch.setattr(viewer, "finalize_timeline_data", slow_finalize)
+
+    n = 8
+    barrier = threading.Barrier(n)
+    errors = []
+
+    def worker(i):
+        try:
+            barrier.wait(timeout=5)
+            viewer.save_manifest(
+                [_make_artifact(f"a{i}")], new_reels=[_make_reel(f"reel{i}")]
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"worker threads raised: {errors}"
+    assert not any(t.is_alive() for t in threads)
+
+    artifact_ids = {a["id"] for a in viewer.load_manifest_artifacts()}
+    reel_ids = {r["id"] for r in viewer.load_manifest_reels()}
+    assert artifact_ids == {f"a{i}" for i in range(n)}
+    assert reel_ids == {f"reel{i}" for i in range(n)}

--- a/viewer.py
+++ b/viewer.py
@@ -361,6 +361,10 @@ def generate_gallery_viewer(
 # normal happy path — _reset_manifest_cache() exists only for tests that reuse
 # the same output directory across mutations without touching mtime.
 _MANIFEST_CACHE_LOCK = threading.Lock()
+# Serializes the full load-merge-write cycle in save_manifest() so concurrent
+# Studio completions cannot last-writer-wins a partial merge. Always acquired
+# before _MANIFEST_CACHE_LOCK, never the reverse, so the two cannot deadlock.
+_MANIFEST_WRITE_LOCK = threading.Lock()
 _manifest_cache: dict[str, Any] = {
     "path": None,
     "mtime_ns": None,
@@ -449,33 +453,38 @@ def save_manifest(
     Deduplicates by ``id``; newer entries win.
     Returns the manifest path on success, or None on failure.
     """
-    existing, existing_reels = _load_manifest_both()
-    merged = {a["id"]: a for a in existing}
-    for a in new_artifacts:
-        merged[a["id"]] = a
-    all_artifacts = list(merged.values())
+    # Hold the write lock across the whole load-merge-write cycle: a concurrent
+    # writer must see this writer's persisted result before computing its merge,
+    # otherwise both read the same old manifest and the second write drops the
+    # first writer's records.
+    with _MANIFEST_WRITE_LOCK:
+        existing, existing_reels = _load_manifest_both()
+        merged = {a["id"]: a for a in existing}
+        for a in new_artifacts:
+            merged[a["id"]] = a
+        all_artifacts = list(merged.values())
 
-    reel_merged = {r["id"]: r for r in existing_reels}
-    for r in new_reels or []:
-        reel_merged[r["id"]] = r
-    all_reels = list(reel_merged.values())
+        reel_merged = {r["id"]: r for r in existing_reels}
+        for r in new_reels or []:
+            reel_merged[r["id"]] = r
+        all_reels = list(reel_merged.values())
 
-    data = finalize_timeline_data(
-        all_artifacts,
-        reels=all_reels or None,
-        study=study,
-        participant=participant,
-        worksheet_title=worksheet_title,
-        is_excel=is_excel,
-        mode=mode,
-        output_format=output_format,
-    )
+        data = finalize_timeline_data(
+            all_artifacts,
+            reels=all_reels or None,
+            study=study,
+            participant=participant,
+            worksheet_title=worksheet_title,
+            is_excel=is_excel,
+            mode=mode,
+            output_format=output_format,
+        )
 
-    result = utils.save_json_manifest(
-        config.MANIFEST_FILENAME, data, warn_label="manifest"
-    )
-    # Invalidate the cache so the next load picks up what we just wrote,
-    # even if the filesystem's mtime resolution elides the change.
-    if result is not None:
-        _reset_manifest_cache()
+        result = utils.save_json_manifest(
+            config.MANIFEST_FILENAME, data, warn_label="manifest"
+        )
+        # Invalidate the cache so the next load picks up what we just wrote,
+        # even if the filesystem's mtime resolution elides the change.
+        if result is not None:
+            _reset_manifest_cache()
     return result


### PR DESCRIPTION
save_manifest() ran load -> merge -> write with no lock, so concurrent
Studio completions could each read the same old manifest and last-writer
-wins a partial merge, silently dropping artifacts/reels from disk. Wrap
the full cycle in a new _MANIFEST_WRITE_LOCK so each writer merges on top
of the previous writer's persisted result.