### PR TITLE
perf: cache hot-loop I/O and reallocations (PERFORMANCE-PLAN-2)

### DIFF
--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -95,7 +95,7 @@ Three medium-sized improvements that each unlock a parallel path.
 - **Change:** Wrap the reel loop in a `ThreadPoolExecutor` using the same worker count. Reels are independent encode jobs.
 - **Constraint:** Confirm `_regenerate_reel` is reentrant (no shared mutable state, no progress-bar contention). The existing media-artifact executor at 1138 is a working precedent.
 
-### 2.3 mtime cache for `load_screenspace_events_for_viewer`
+### ✅ 2.3 mtime cache for `load_screenspace_events_for_viewer`
 
 - **Files:** `viewer.py:137-156`, `screenspace.py:load_screenspace_manifest`, `utils.py:515-526`.
 - **Today:** Every call re-reads and re-parses the full `screenspace_manifest.json`.
@@ -163,14 +163,14 @@ Items surfaced by the deep audit that look real but were not exhaustively re-rea
 - **Verify first:** Re-read the call sites and confirm they are all on hot mutation paths (not e.g. user-explicit "save" actions). Confirm that delaying a write by 2–3 seconds is acceptable across power-loss / kill scenarios.
 - **Change:** Introduce a `_manifest_dirty` flag and a `threading.Timer` (or a worker-thread tick) that flushes after a short debounce. Force a flush on shutdown and on explicit user save actions.
 
-### 5.2 Hoist morphology kernel allocations in Screenspace
+### ✅ 5.2 Hoist morphology kernel allocations in Screenspace
 
 - **File:** `screenspace.py` (~lines 197, 996 per the audit — verify).
 - **Today:** `np.ones((mk, mk), np.uint8)` allocated inside per-frame loops in `extract_inactivity()` and `scan_changes()`.
 - **Verify first:** Confirm kernel size (`mk`) is a config constant, not derived from per-frame data. If it is config-static, the kernel is safe to share.
 - **Change:** Hoist to a module-level lazy-initialized `_MORPH_KERNEL` keyed by size if multiple sizes are used; otherwise a single module constant.
 
-### 5.3 Re-read assets from disk on every viewer export
+### ✅ 5.3 Re-read assets from disk on every viewer export
 
 - **File:** `viewer.py` (HTML / CSS / JS template reads in `finalize_*` / export helpers around 176-217 per audit — verify exact functions).
 - **Today:** Each export call re-reads the bundled CSS and JS template files from disk via `Path.read_text()`.
@@ -184,14 +184,14 @@ Items surfaced by the deep audit that look real but were not exhaustively re-rea
 - **Verify first:** Confirm the current transport (`urllib.request` vs `requests`). If `urllib`, decide whether to introduce `requests` as a dependency or switch to `urllib3.PoolManager`.
 - **Change:** Module-level `_session` (or `PoolManager`) reused by all `generate()` / `list_models()` / `is_available()` calls. Set a sane connect/read timeout.
 
-### 5.5 mtime cache for `/api/participants` artifact lookup
+### ✅ 5.5 mtime cache for `/api/participants` artifact lookup
 
 - **File:** `transcripts_server.py:~199` (verify the exact function name and that `viewer.load_manifest_artifacts()` is indeed called per request).
 - **Today:** Each poll of `/api/participants` re-reads and re-parses the artifact manifest, then does a per-participant linear scan over all artifacts.
 - **Verify first:** Confirm the frontend's poll interval and whether the endpoint returns enough state that a per-participant ETag would be useful.
 - **Change:** mtime-cache the artifact list mirroring `viewer._load_manifest_both`. If the linear scan is also hot, index by participant at cache-build time.
 
-### 5.6 Binary-search citation parsing
+### ✅ 5.6 Binary-search citation parsing
 
 - **File:** `thinking_agents.py:~224` (`_find_closest_segment`).
 - **Today:** O(claims × segments) linear scans during citation parsing.

--- a/screenspace.py
+++ b/screenspace.py
@@ -22,7 +22,7 @@ are stored for denormalization to target video resolution.
 
 import copy
 import difflib
-
+import functools
 import math
 import queue
 import re
@@ -54,6 +54,16 @@ import video
 
 _ocr_readers: dict[tuple, Any] = {}
 _ocr_lock = threading.Lock()
+
+
+@functools.cache
+def _morph_kernel(size: int) -> np.ndarray:
+    """Return a shared square uint8 kernel for cv2 morphology ops.
+
+    cv2.morphologyEx treats the kernel as read-only, so callers share one cached
+    array instead of reallocating np.ones() per call/frame.
+    """
+    return np.ones((size, size), np.uint8)
 
 
 ScanCallback = Callable[[float, np.ndarray], bool | None]
@@ -193,8 +203,7 @@ def compute_frame_diff(
     b_gray = cv2.cvtColor(b_blur, cv2.COLOR_BGR2GRAY)
     diff = cv2.absdiff(a_gray, b_gray)
     _, mask = cv2.threshold(diff, noise_threshold, 255, cv2.THRESH_BINARY)
-    mk = config.SCREENSPACE_MORPH_KERNEL
-    kernel = np.ones((mk, mk), np.uint8)
+    kernel = _morph_kernel(config.SCREENSPACE_MORPH_KERNEL)
     mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
     if mask.size == 0:
         return 0.0
@@ -996,8 +1005,7 @@ def scan_changes(
     results: list[dict[str, Any]] = []
     prev_gray: list[np.ndarray | None] = [None]
     k = config.SCREENSPACE_BLUR_KERNEL
-    mk = config.SCREENSPACE_MORPH_KERNEL
-    morph_kernel = np.ones((mk, mk), np.uint8)
+    morph_kernel = _morph_kernel(config.SCREENSPACE_MORPH_KERNEL)
 
     def _cb(ts: float, pixels: np.ndarray) -> bool | None:
         if cancel_flag and cancel_flag():
@@ -2410,8 +2418,7 @@ class ChangeTool(AnalysisTool):
             "noise_threshold", config.SCREENSPACE_NOISE_THRESHOLD
         )
         k = config.SCREENSPACE_BLUR_KERNEL
-        mk = config.SCREENSPACE_MORPH_KERNEL
-        morph_kernel = np.ones((mk, mk), np.uint8)
+        morph_kernel = _morph_kernel(config.SCREENSPACE_MORPH_KERNEL)
         curr_gray = cv2.cvtColor(
             cv2.GaussianBlur(pixels, (k, k), 0), cv2.COLOR_BGR2GRAY
         )

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -2281,3 +2281,15 @@ class TestScanInactivity:
         assert captured["threshold"] == 8
         assert captured["min_duration"] == 5.0
         assert captured["interval_seconds"] == 2.0
+
+
+class TestMorphKernel:
+    def test_shape_and_dtype(self):
+        kernel = screenspace._morph_kernel(3)
+        assert kernel.shape == (3, 3)
+        assert kernel.dtype == np.uint8
+        assert np.all(kernel == 1)
+
+    def test_same_size_returns_cached_array(self):
+        # cv2 morphology treats the kernel read-only, so callers share one array.
+        assert screenspace._morph_kernel(5) is screenspace._morph_kernel(5)

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -236,6 +236,23 @@ class TestParseCitationResponse:
         result = thinking_agents._parse_citation_response(response, segments)
         assert result == {}
 
+    def test_handles_unsorted_segments(self):
+        # Segments supplied out of start order; the binary search must still
+        # resolve to the correct *original* segment index.
+        segments = self._make_segments([120, 45, 62])
+        result = thinking_agents._parse_citation_response("1: 0:45", segments)
+        assert 0 in result
+        assert result[0][0]["segment_index"] == 1  # original index of start=45
+        assert result[0][0]["start"] == 45
+
+    def test_picks_closest_neighbour(self):
+        segments = self._make_segments([10, 20])
+        # 0:12 is nearer the 10s segment; 0:18 is nearer the 20s segment.
+        near_low = thinking_agents._parse_citation_response("1: 0:12", segments)
+        near_high = thinking_agents._parse_citation_response("1: 0:18", segments)
+        assert near_low[0][0]["segment_index"] == 0
+        assert near_high[0][0]["segment_index"] == 1
+
 
 class TestFindCitations:
     def test_returns_none_for_empty_summary(self):

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -56,6 +56,49 @@ def test_prewarm_invalid_config_normalized_in_participants(tr_client, monkeypatc
     assert resp.get_json()["transcribe_prewarm"] == "queue_open"
 
 
+def test_participants_stale_artifact_detection(tr_client, monkeypatch):
+    transcripts_server._participants = [
+        {"id": "P01", "video_path": "study_P01.mp4", "has_video": True},
+        {"id": "P02", "video_path": "study_P02.mp4", "has_video": True},
+    ]
+    transcripts_server._manifest = {
+        "source_transcripts": {
+            "P01": {
+                "segments": [{"start": 0.0, "end": 1.0, "text": "hi"}],
+                "transcribed_at": "2026-05-22T12:00:00Z",
+            },
+            "P02": {
+                "segments": [{"start": 0.0, "end": 1.0, "text": "yo"}],
+                "transcribed_at": "2026-05-22T12:00:00Z",
+            },
+        },
+        "corrections": [],
+        "marks": [],
+    }
+    artifacts = [
+        # P01's artifact was transcribed before the current source transcript.
+        {
+            "participant": "P01",
+            "transcript": "clip_P01.srt",
+            "transcript_version": "2026-05-22T09:00:00Z",
+        },
+        # P02's artifact is current.
+        {
+            "participant": "P02",
+            "transcript": "clip_P02.srt",
+            "transcript_version": "2026-05-22T12:00:00Z",
+        },
+    ]
+    monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: artifacts)
+
+    resp = tr_client.get("/transcripts/api/participants")
+    assert resp.status_code == 200
+    by_id = {p["id"]: p for p in resp.get_json()["participants"]}
+    # The per-participant index must not let P01's stale artifact bleed into P02.
+    assert by_id["P01"]["has_stale_artifacts"] is True
+    assert by_id["P02"]["has_stale_artifacts"] is False
+
+
 def test_warmup_skipped_when_prewarm_off(tr_client, monkeypatch):
     monkeypatch.setattr(config, "TRANSCRIBE_PREWARM", "off")
     resp = tr_client.post("/transcripts/api/transcribe/warmup", json={})

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -192,3 +192,92 @@ def test_generate_gallery_viewer_inlines_css_and_js(tmp_path, monkeypatch):
     assert "<style>" in html
     assert "<script defer>" in html
     assert "window.CLIPGEN_DATA" in html
+
+
+# ---- bundled asset cache ----
+
+
+def test_read_bundled_asset_caches_first_read(tmp_path):
+    asset = tmp_path / "asset.txt"
+    asset.write_text("original", encoding="utf-8")
+    first = viewer._read_bundled_asset(str(asset))
+    # Bundled assets never change at runtime; a later mutation must not be seen.
+    asset.write_text("changed", encoding="utf-8")
+    second = viewer._read_bundled_asset(str(asset))
+    assert first == "original"
+    assert second == "original"
+
+
+# ---- screenspace events for viewer ----
+
+
+def test_load_screenspace_events_for_viewer_caches_by_mtime(tmp_path, monkeypatch):
+    import os
+
+    import config
+    import screenspace
+
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    viewer._reset_screenspace_events_cache()
+
+    screenspace.save_screenspace_manifest(
+        {},
+        [],
+        [
+            {
+                "id": "ev_keep",
+                "detector": "change",
+                "participant": "P01",
+                "time_in": 1.0,
+                "time_out": 2.0,
+                "excluded": False,
+            },
+            {
+                "id": "ev_drop",
+                "detector": "color",
+                "participant": "P02",
+                "time_in": 3.0,
+                "time_out": 4.0,
+                "excluded": True,
+            },
+        ],
+    )
+
+    load_calls = []
+    real_load = screenspace.load_screenspace_manifest
+
+    def counting_load():
+        load_calls.append(1)
+        return real_load()
+
+    monkeypatch.setattr(screenspace, "load_screenspace_manifest", counting_load)
+
+    first = viewer.load_screenspace_events_for_viewer()
+    second = viewer.load_screenspace_events_for_viewer()
+    # Excluded events are filtered out; the second call is served from cache.
+    assert [e["id"] for e in first] == ["ev_keep"]
+    assert [e["id"] for e in second] == ["ev_keep"]
+    assert len(load_calls) == 1
+
+    # Rewriting the manifest bumps its mtime and invalidates the cache.
+    screenspace.save_screenspace_manifest(
+        {},
+        [],
+        [
+            {
+                "id": "ev_new",
+                "detector": "scene",
+                "participant": "P03",
+                "time_in": 5.0,
+                "time_out": 6.0,
+                "excluded": False,
+            }
+        ],
+    )
+    manifest_path = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
+    st = manifest_path.stat()
+    os.utime(manifest_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+    third = viewer.load_screenspace_events_for_viewer()
+    assert [e["id"] for e in third] == ["ev_new"]
+    assert len(load_calls) == 2

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -21,6 +21,7 @@ Adding a new agent is a matter of writing a ``run`` callable, defining an
 
 from __future__ import annotations
 
+import bisect
 import re
 import threading
 from typing import Any, Callable, TypedDict
@@ -213,20 +214,33 @@ def _timestamp_to_seconds(ts: str) -> float | None:
 
 
 def _find_closest_segment(
-    target_seconds: float, seg_starts: list[float], tolerance: float = 5.0
+    target_seconds: float,
+    sorted_starts: list[float],
+    sorted_indices: list[int],
+    tolerance: float = 5.0,
 ) -> int | None:
-    """Find the segment index whose start time is closest to *target_seconds*.
+    """Find the original segment index whose start time is closest to *target_seconds*.
 
-    Returns None if the closest segment is more than *tolerance* seconds away.
+    *sorted_starts* must be ascending; *sorted_indices* maps each sorted position
+    back to the segment's original index. The closest element in a sorted array
+    is always a neighbour of the bisect insertion point, so only two candidates
+    are checked. Returns None if the closest segment is more than *tolerance*
+    seconds away.
     """
-    best_idx: int | None = None
+    if not sorted_starts:
+        return None
+    pos = bisect.bisect_left(sorted_starts, target_seconds)
+    best_pos: int | None = None
     best_dist = tolerance + 1
-    for i, start in enumerate(seg_starts):
-        dist = abs(start - target_seconds)
-        if dist < best_dist:
-            best_dist = dist
-            best_idx = i
-    return best_idx
+    for candidate in (pos - 1, pos):
+        if 0 <= candidate < len(sorted_starts):
+            dist = abs(sorted_starts[candidate] - target_seconds)
+            if dist < best_dist:
+                best_dist = dist
+                best_pos = candidate
+    if best_pos is None:
+        return None
+    return sorted_indices[best_pos]
 
 
 def _parse_citation_response(
@@ -234,7 +248,11 @@ def _parse_citation_response(
     segments: list[dict[str, Any]],
 ) -> dict[int, list[dict[str, Any]]]:
     """Parse model output into ``{claim_index: [ref_dicts]}``."""
-    seg_starts = [seg.get("start", 0.0) for seg in segments]
+    sorted_pairs = sorted(
+        (seg.get("start", 0.0), idx) for idx, seg in enumerate(segments)
+    )
+    sorted_starts = [start for start, _ in sorted_pairs]
+    sorted_indices = [idx for _, idx in sorted_pairs]
     result: dict[int, list[dict[str, Any]]] = {}
     for match in _CITATION_LINE_RE.finditer(response):
         claim_num = int(match.group(1))
@@ -249,7 +267,7 @@ def _parse_citation_response(
             ts_seconds = _timestamp_to_seconds(ts_match.group(1))
             if ts_seconds is None:
                 continue
-            best_idx = _find_closest_segment(ts_seconds, seg_starts)
+            best_idx = _find_closest_segment(ts_seconds, sorted_starts, sorted_indices)
             if best_idx is not None:
                 seg = segments[best_idx]
                 refs.append(

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -40,6 +40,7 @@ import os
 import tempfile
 import threading
 import uuid
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -197,6 +198,9 @@ def api_participants() -> FlaskResponse:
 
     # Check for stale artifacts (transcript outdated relative to source)
     artifacts = viewer.load_manifest_artifacts()
+    artifacts_by_participant: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for art in artifacts:
+        artifacts_by_participant[art.get("participant", "")].append(art)
     for info in result:
         if not info.get("has_transcript"):
             info["has_stale_artifacts"] = False
@@ -207,9 +211,7 @@ def api_participants() -> FlaskResponse:
             info["has_stale_artifacts"] = False
             continue
         has_stale = False
-        for art in artifacts:
-            if art.get("participant") != pid:
-                continue
+        for art in artifacts_by_participant.get(pid, []):
             if not art.get("transcript"):
                 continue
             art_tv = art.get("transcript_version", "")

--- a/viewer.py
+++ b/viewer.py
@@ -23,6 +23,7 @@ Artifact manifest (save_manifest / load_manifest_*):
 """
 
 import base64
+import functools
 import json
 import math
 import re
@@ -134,12 +135,52 @@ def _sanitize_event_metadata(obj: Any) -> Any:
     return obj
 
 
+# Module-level mtime cache for the screenspace-events-for-viewer transform.
+# Viewer exports call load_screenspace_events_for_viewer() repeatedly; re-reading
+# and re-parsing screenspace_manifest.json each time is pure overhead. Keyed on
+# the manifest's (path, mtime_ns), so it invalidates automatically when the file
+# is rewritten. Bounded at one entry — this is a single-process export path.
+_SS_EVENTS_CACHE_LOCK = threading.Lock()
+_ss_events_cache: dict[str, Any] = {
+    "path": None,
+    "mtime_ns": None,
+    "events": [],
+}
+
+
+def _reset_screenspace_events_cache() -> None:
+    """Drop the in-memory screenspace-events cache. Intended for test fixtures."""
+    with _SS_EVENTS_CACHE_LOCK:
+        _ss_events_cache["path"] = None
+        _ss_events_cache["mtime_ns"] = None
+        _ss_events_cache["events"] = []
+
+
 def load_screenspace_events_for_viewer() -> list[dict[str, Any]]:
-    """Load non-excluded events from screenspace manifest for viewer export."""
+    """Load non-excluded events from screenspace manifest for viewer export.
+
+    Memoizes the transformed event list keyed on the manifest's path + mtime_ns
+    so repeated viewer exports share a single read/parse until the file changes.
+    """
     import screenspace
 
+    path = Path(utils.get_effective_output_dir()) / config.SCREENSPACE_MANIFEST_FILENAME
+    path_str = str(path)
+    try:
+        mtime_ns: int | None = path.stat().st_mtime_ns if path.is_file() else None
+    except OSError:
+        mtime_ns = None
+
+    with _SS_EVENTS_CACHE_LOCK:
+        if (
+            mtime_ns is not None
+            and _ss_events_cache["path"] == path_str
+            and _ss_events_cache["mtime_ns"] == mtime_ns
+        ):
+            return list(_ss_events_cache["events"])
+
     manifest = screenspace.load_screenspace_manifest()
-    return [
+    events = [
         {
             "id": e.get("id", ""),
             "type": e.get("detector", ""),
@@ -155,8 +196,25 @@ def load_screenspace_events_for_viewer() -> list[dict[str, Any]]:
         if not e.get("excluded")
     ]
 
+    with _SS_EVENTS_CACHE_LOCK:
+        _ss_events_cache["path"] = path_str
+        _ss_events_cache["mtime_ns"] = mtime_ns
+        _ss_events_cache["events"] = events
+
+    return list(events)
+
 
 _CLIPGEN_DATA_PLACEHOLDER = "<!-- CLIPGEN_DATA_HERE -->"
+
+
+@functools.cache
+def _read_bundled_asset(path_str: str) -> str:
+    """Read a bundled asset file as text, cached for the process lifetime.
+
+    Bundled CSS/JS/HTML templates never change at runtime, so repeated viewer
+    exports share a single read instead of re-hitting disk each time.
+    """
+    return Path(path_str).read_text(encoding="utf-8")
 
 
 def _generate_viewer_html(
@@ -188,14 +246,14 @@ def _generate_viewer_html(
             return None
 
     try:
-        template_html = template_path.read_text(encoding="utf-8")
+        template_html = _read_bundled_asset(str(template_path))
     except OSError as e:
         utils.warning_print(f"Could not read {viewer_label.lower()} template: {e}")
         return None
 
     try:
-        css_text = css_path.read_text(encoding="utf-8")
-        js_text = js_path.read_text(encoding="utf-8")
+        css_text = _read_bundled_asset(str(css_path))
+        js_text = _read_bundled_asset(str(js_path))
     except OSError as e:
         utils.warning_print(f"Could not read {viewer_label.lower()} assets: {e}")
         return None
@@ -204,7 +262,7 @@ def _generate_viewer_html(
     tokens_path = assets_dir / "tokens.css"
     if tokens_path.is_file():
         try:
-            css_text = tokens_path.read_text(encoding="utf-8") + "\n" + css_text
+            css_text = _read_bundled_asset(str(tokens_path)) + "\n" + css_text
         except OSError:
             pass
 
@@ -212,7 +270,7 @@ def _generate_viewer_html(
     utils_js_path = assets_dir / "utils.js"
     if utils_js_path.is_file():
         try:
-            js_text = utils_js_path.read_text(encoding="utf-8") + "\n" + js_text
+            js_text = _read_bundled_asset(str(utils_js_path)) + "\n" + js_text
         except OSError:
             pass
 


### PR DESCRIPTION
Implements the no-risk caching batch from plans/PERFORMANCE-PLAN-2.md
(phases 2.3, 5.2, 5.3, 5.5, 5.6):

- viewer: mtime-cache load_screenspace_events_for_viewer so repeated
  viewer exports skip re-reading and re-parsing screenspace_manifest.json
- viewer: cache bundled CSS/JS/HTML template reads for the process
  lifetime instead of hitting disk on every export
- screenspace: hoist morphology-kernel allocation behind a cached
  _morph_kernel() helper instead of np.ones() per call/frame
- transcripts_server: index /api/participants artifacts by participant
  to drop the O(participants x artifacts) stale-artifact scan
- thinking_agents: binary-search citation segment lookup instead of a
  per-timestamp linear scan

No behavior change; covered by new and existing pytest cases.