### PR TITLE
fix: cancel reel encoder on client disconnect + review follow-ups

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -1400,9 +1400,10 @@
     }
   }
 
-  // Commit the in-flight drag delta without triggering another recalculate.
-  // Called by renderTimeline() before destroying the DOM so a debounce-driven
-  // recalculate during a drag doesn't silently lose the accumulated movement.
+  // Commit the in-flight drag delta when renderTimeline() is about to destroy
+  // the DOM (e.g. a debounce-driven recalculate landed mid-drag). The current
+  // renderTimeline pass already extracted events with the pre-drag offset, so
+  // schedule a deferred recalculate to re-render with the committed value.
   function _cvAbortDrag() {
     var tx = cvState._dragTx;
     if (!tx) return;
@@ -1419,6 +1420,9 @@
         cvState.offsets[tx.pid] = num;
       }
       cvSaveOffsets();
+      // Cannot recalculate() synchronously — this runs inside renderTimeline(),
+      // itself inside recalculate(). Defer so the committed offset renders.
+      setTimeout(recalculate, 0);
     }
   }
 
@@ -1516,7 +1520,9 @@
     document.body.style.userSelect = "";
     cvState._dragTx = null;
     _cvDragLiveInput = null;
-    if (Math.abs(deltaSec) > 0) {
+    // Match _cvAbortDrag's threshold — ignore sub-0.05s jiggles so an
+    // accidental click-drag doesn't trigger a full recalculate.
+    if (Math.abs(deltaSec) >= 0.05) {
       commitOffset(tx.pid, tx.baseOffset + deltaSec);
     }
   }

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3246,7 +3246,11 @@
         concatFraction = typeof data.progress === "number" ? data.progress : 0;
         updateProgress();
       } else if (data.phase === "done") {
-        // Final NDJSON {"ok": ..., "reels": ...} line arrives separately.
+        // Fill the concat segment to 100% — the stream-copy concat path emits
+        // no progress events, so without this the bar would be cleared by
+        // finish() while still showing ~70%. Final {"ok": ...} line follows.
+        concatFraction = 1;
+        updateProgress();
       } else if (data.ok !== undefined || data.error !== undefined) {
         finalPayload = data;
       }

--- a/server.py
+++ b/server.py
@@ -1197,6 +1197,11 @@ def api_reel() -> FlaskResponse:
     def stream_with_busy_release() -> Any:
         try:
             yield from stream()
+        except GeneratorExit:
+            # Client disconnected mid-stream — signal the background encoder to
+            # stop so the freed reel slot isn't held by an orphaned ffmpeg run.
+            _reel_cancel_event.set()
+            raise
         finally:
             _release_busy("reel")
 
@@ -1903,6 +1908,11 @@ def api_reel_direct() -> FlaskResponse:
     def stream_with_busy_release() -> Iterator[str]:
         try:
             yield from stream()
+        except GeneratorExit:
+            # Client disconnected mid-stream — signal the background encoder to
+            # stop so the freed reel slot isn't held by an orphaned ffmpeg run.
+            _reel_cancel_event.set()
+            raise
         finally:
             _release_busy("reel")
 
@@ -1953,7 +1963,10 @@ def _init_studio_state(worksheet: Any) -> None:
             sys.exit(1)
     else:
         _sheet_context = None
-    _generated_artifacts, _generated_reels = viewer._load_manifest_both()
+    # Rebind under the lock so a concurrent generate-worker extend can't land
+    # in the list being swapped out (e.g. spreadsheet switch mid-generation).
+    with _generated_output_lock:
+        _generated_artifacts, _generated_reels = viewer._load_manifest_both()
     _thumbnail_cache = OrderedDict()
 
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1705,3 +1705,87 @@ def test_api_reel_streams_progress_events(client, monkeypatch, tmp_path):
     assert final["ok"] is True
     assert final["generated"] == 1
     assert final["reels"] == [reel_record]
+
+
+def test_api_reel_cancels_worker_on_client_disconnect(client, monkeypatch, tmp_path):
+    """Closing the /api/reel stream early must cancel the background encoder.
+
+    Regression: the streaming reel refactor released the "reel" busy slot in
+    the response generator's finally, but a client disconnect (browser tab
+    closed mid-build) left the worker thread still encoding. The freed slot
+    then let a second reel build start concurrently. The GeneratorExit handler
+    must set _reel_cancel_event so the worker observes the cancellation.
+    """
+    import threading
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00-1:30")
+
+    def fake_generate_list(ws, mode, *, ctx=None, reel_input, skip_prompts):
+        return [
+            {
+                "participant": "P01",
+                "cell": cell,
+                "times": [("1:00", "1:30")],
+                "desc": "test",
+                "category": "cat",
+                "study": "study",
+                "severity": "",
+            }
+        ]
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+    monkeypatch.setattr("files.prepare_clip", lambda clip: clip)
+
+    worker_blocked = threading.Event()
+    allow_worker_finish = threading.Event()
+
+    def fake_process_reel(
+        clips_list, output_file=None, cancel_flag=None, progress_cb=None, **kwargs
+    ):
+        # Emit one event so the stream generator suspends at a yield, then
+        # block to keep the "encode" in flight while the client disconnects.
+        if progress_cb is not None:
+            progress_cb({"phase": "start", "total_clips": 1})
+        worker_blocked.set()
+        allow_worker_finish.wait(timeout=5)
+        return (0, [])
+
+    monkeypatch.setattr("pipeline.process_reel", fake_process_reel)
+    server._reel_cancel_event.clear()
+
+    resp = client.post("/studio/api/reel", json={"cells": ["P01.5"]})
+    try:
+        stream = resp.iter_encoded()
+        first = json.loads(next(stream).decode().strip())
+        assert first["phase"] == "start"
+        assert worker_blocked.wait(timeout=5)
+        # Simulate the browser tab closing mid-build.
+        resp.close()
+        assert server._reel_cancel_event.is_set()
+        assert server._reel_in_progress is False
+    finally:
+        allow_worker_finish.set()
+
+
+def test_api_reel_direct_cancels_on_client_disconnect(client, monkeypatch, tmp_path):
+    """Closing the /api/reel-direct stream early releases the slot and cancels."""
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    server._reel_cancel_event.clear()
+
+    resp = client.post(
+        "/studio/api/reel-direct",
+        json={"segments": [{"participant": "P01", "start": 0, "end": 10}]},
+    )
+    stream = resp.iter_encoded()
+    first = json.loads(next(stream).decode().strip())
+    assert first["phase"] == "start"
+    # Simulate the browser tab closing before the reel finishes.
+    resp.close()
+    assert server._reel_cancel_event.is_set()
+    assert server._reel_in_progress is False


### PR DESCRIPTION
Follow-ups from a review of recent commits (#338-#351):

- server.py: the streaming reel refactor (#347) released the "reel"
  busy slot in the response generator's finally, but a client
  disconnect left the worker thread still encoding -- the freed slot
  let a second reel build start concurrently. /api/reel and
  /api/reel-direct now set _reel_cancel_event on GeneratorExit so the
  background encoder stops.
- server.py: rebind _generated_artifacts/_generated_reels under
  _generated_output_lock in _init_studio_state, matching the locking
  added in #348 for every other mutation of those lists.
- convergence.js: _cvAbortDrag now schedules a deferred recalculate so
  a drag committed mid-render is actually shown; _cvOnDocMouseUp uses
  the same 0.05s commit threshold as _cvAbortDrag.
- studio.js: fill the reel button's concat segment to 100% on the
  "done" event so the bar completes instead of vanishing at ~70%.

Adds regression tests for client-disconnect cancellation on both reel
endpoints.