### PR TITLE
fix(files): atomically reserve output filenames

### DIFF
--- a/files.py
+++ b/files.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """File and filename operations for clipgen."""
 
+import os
 import re
 import unicodedata
 from pathlib import Path
@@ -34,17 +35,24 @@ def _safe_truncate(text: str, max_chars: int) -> str:
 
 
 def get_unique_filename(filename: str, file_format: str | None = None) -> str:
-    """Generate a unique filename by appending an incremented number.
+    """Atomically reserve a unique output path.
+
+    Creates an empty placeholder file at the returned path so that parallel
+    clip / reel / gallery workers each receive a distinct path even when their
+    filename templates collide. The placeholder is overwritten by the ffmpeg
+    process (or file writer) that fills the artifact. Callers that abort before
+    writing real content should remove the placeholder with
+    ``release_reservation()``.
 
     If a file with the given name already exists, appends '-1', '-2', etc.
-    until a unique filename is found. Also truncates if filename exceeds max length.
+    until a free name is found. Also truncates if filename exceeds max length.
 
     Args:
         filename: Original filename
         file_format: File extension to preserve (defaults to config.FILEFORMAT)
 
     Returns:
-        Unique filename path as a string that doesn't exist in the filesystem.
+        Unique filename path as a string, reserved on disk as an empty file.
     """
     file_extension = file_format or config.FILEFORMAT
     resolved = Path(utils.resolve_output_path(filename))
@@ -58,14 +66,47 @@ def get_unique_filename(filename: str, file_format: str | None = None) -> str:
     # Truncate base if needed (reserve space for extension)
     max_base = config.MAX_FILENAME_LENGTH - len(file_extension)
     base = _safe_truncate(base, max_base)
-    candidate = directory / (base + file_extension)
-    counter = 1
-    while candidate.is_file():
+
+    def _candidate(counter: int) -> Path:
+        if counter == 0:
+            return directory / (base + file_extension)
         suffix = f"-{counter}"
         truncated_base = _safe_truncate(base, max_base - len(suffix))
-        candidate = directory / (truncated_base + suffix + file_extension)
-        counter += 1
-    return str(candidate)
+        return directory / (truncated_base + suffix + file_extension)
+
+    counter = 0
+    while True:
+        candidate = _candidate(counter)
+        try:
+            fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            counter += 1
+            continue
+        except OSError:
+            # Reservation not possible (missing/unwritable directory, name too
+            # long, etc.). Fall back to non-atomic uniqueness so callers still
+            # receive a usable path.
+            while candidate.is_file():
+                counter += 1
+                candidate = _candidate(counter)
+            return str(candidate)
+        else:
+            os.close(fd)
+            return str(candidate)
+
+
+def release_reservation(path: str | os.PathLike[str] | None) -> None:
+    """Remove an unused placeholder reserved by ``get_unique_filename()``.
+
+    Safe to call when *path* is missing or ``None``; used by callers that abort
+    before writing real content so empty placeholders are not left on disk.
+    """
+    if not path:
+        return
+    try:
+        Path(path).unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def get_source_video_filename(

--- a/pipeline.py
+++ b/pipeline.py
@@ -610,6 +610,8 @@ def _transcribe_segments(
             artifact["id"] += "_transcript"
             artifact["transcriptFormat"] = config.TRANSCRIBE_FORMAT
             all_artifacts.append(artifact)
+        else:
+            files.release_reservation(t_path)
 
 
 def process_clips(
@@ -1404,6 +1406,8 @@ def _regenerate_reel(reel: dict[str, Any], missing_videos: set[str]) -> bool:
             reencode=config.REENCODING,
         ):
             temp_paths.append(out_name)
+        else:
+            files.release_reservation(out_name)
 
     if not temp_paths:
         return False

--- a/pipeline.py
+++ b/pipeline.py
@@ -78,6 +78,12 @@ def _resolve_clip_workers() -> int:
 # Large .mp4 files in the input dir, keyed by path + mtime_ns (one glob/stat pass per run).
 _fuzzy_input_videos_cache: dict[str, tuple[int | None, list[tuple[int, Path]]]] = {}
 
+# Serializes the missing-video branch of _check_source_video. Reel preparation
+# runs per-clip in worker threads (_run_clip_pipeline parallel=True), so the
+# shared missing_videos / fuzzy_matches structures and any fuzzy-match prompt
+# must not be touched concurrently.
+_fuzzy_match_lock = threading.Lock()
+
 
 def _large_input_videos(input_dir: Path) -> list[tuple[int, Path]]:
     """Return (size_bytes, path) for source-video candidates under *input_dir*."""
@@ -131,51 +137,59 @@ def _check_source_video(
 
     full_path_str = str(full_path)
 
-    # Check fuzzy match cache (value may be None = user rejected or no candidate)
-    if full_path_str in fuzzy_matches:
-        return fuzzy_matches[full_path_str]
+    # The missing-video branch reads and mutates the caller's shared
+    # fuzzy_matches / missing_videos and may prompt the user; serialize it so
+    # parallel reel workers neither race nor interleave prompts.
+    with _fuzzy_match_lock:
+        # Check fuzzy match cache (value may be None = user rejected or no candidate)
+        if full_path_str in fuzzy_matches:
+            return fuzzy_matches[full_path_str]
 
-    input_dir = utils.get_effective_input_dir()
-    candidates: list[tuple[float, int, Path]] = []
-    for size, p in _large_input_videos(input_dir):
-        ratio = difflib.SequenceMatcher(None, base_name.lower(), p.name.lower()).ratio()
-        candidates.append((ratio, size, p))
+        input_dir = utils.get_effective_input_dir()
+        candidates: list[tuple[float, int, Path]] = []
+        for size, p in _large_input_videos(input_dir):
+            ratio = difflib.SequenceMatcher(
+                None, base_name.lower(), p.name.lower()
+            ).ratio()
+            candidates.append((ratio, size, p))
 
-    # Sort by similarity descending, then file size descending as tiebreaker
-    candidates.sort(key=lambda c: (c[0], c[1]), reverse=True)
+        # Sort by similarity descending, then file size descending as tiebreaker
+        candidates.sort(key=lambda c: (c[0], c[1]), reverse=True)
 
-    if candidates and candidates[0][0] >= 0.7 and not utils.NO_INPUT_MODE:
-        best_ratio, best_size, best_path = candidates[0]
-        size_gb = best_size / 1_000_000_000
-        # Pause progress bar so the prompt is visible and input is rendered
-        global _active_progress
-        paused = False
-        if _active_progress is not None:
-            _active_progress.stop()
-            paused = True
-        utils.info_print(f"Source video '{base_name}' not found.")
-        utils.info_print(f"Closest match found: '{best_path.name}' ({size_gb:.1f} GB)")
-        answer = utils.read_user_input("Use this file instead? [y/n]\n>> ")
-        if paused:
-            _active_progress.start()
-        if answer.strip().lower() == "y":
-            resolved = str(best_path)
-            fuzzy_matches[full_path_str] = resolved
-            return resolved
+        if candidates and candidates[0][0] >= 0.7 and not utils.NO_INPUT_MODE:
+            best_ratio, best_size, best_path = candidates[0]
+            size_gb = best_size / 1_000_000_000
+            # Pause progress bar so the prompt is visible and input is rendered
+            global _active_progress
+            paused = False
+            if _active_progress is not None:
+                _active_progress.stop()
+                paused = True
+            utils.info_print(f"Source video '{base_name}' not found.")
+            utils.info_print(
+                f"Closest match found: '{best_path.name}' ({size_gb:.1f} GB)"
+            )
+            answer = utils.read_user_input("Use this file instead? [y/n]\n>> ")
+            if paused:
+                _active_progress.start()
+            if answer.strip().lower() == "y":
+                resolved = str(best_path)
+                fuzzy_matches[full_path_str] = resolved
+                return resolved
 
-    # No match or user rejected — cache and report error
-    fuzzy_matches[full_path_str] = None
-    if full_path_str not in missing_videos:
-        missing_videos.add(full_path_str)
-        utils.error_print(
-            f"Source video file not found: '{base_name}'",
-            [
-                f"Expected location: {full_path_str}",
-                f"Expected format: {{study}}_{{participant}}{config.FILEFORMAT}",
-                skip_detail,
-            ],
-        )
-    return None
+        # No match or user rejected — cache and report error
+        fuzzy_matches[full_path_str] = None
+        if full_path_str not in missing_videos:
+            missing_videos.add(full_path_str)
+            utils.error_print(
+                f"Source video file not found: '{base_name}'",
+                [
+                    f"Expected location: {full_path_str}",
+                    f"Expected format: {{study}}_{{participant}}{config.FILEFORMAT}",
+                    skip_detail,
+                ],
+            )
+        return None
 
 
 def _prepare_and_check_clip(
@@ -622,6 +636,7 @@ def process_clips(
     cancel_flag: Callable[[], bool] | None = None,
     titlecards_enabled: bool | None = None,
     titlecard_duration_seconds: int | None = None,
+    clear_titlecard_cache: bool = True,
 ) -> tuple[int, list[dict[str, Any]]]:
     """Process and generate outputs from the clips list.
 
@@ -634,6 +649,12 @@ def process_clips(
     the next safe boundary. Already-completed segments are kept (each clip is a
     standalone deliverable); in-flight ffmpeg encodes are terminated and their
     partial outputs unlinked.
+
+    *clear_titlecard_cache* controls whether the shared endcard cache is purged
+    when this call finishes. Callers that fan out concurrent ``process_clips``
+    invocations (e.g. Studio per-cell generation) must pass ``False`` so one
+    worker does not delete endcard temp files still in use by another, then
+    clear the cache once themselves after all workers complete.
 
     Returns:
         Tuple of (count of files generated, list of artifact records).
@@ -922,7 +943,7 @@ def process_clips(
     cards_enabled, _card_duration = _resolve_titlecard_options(
         titlecards_enabled, titlecard_duration_seconds
     )
-    if cards_enabled:
+    if cards_enabled and clear_titlecard_cache:
         titlecards.clear_endcard_cache()
 
     if outputs_skipped > 0:
@@ -1067,6 +1088,9 @@ def process_reel(
             missing_videos,
             filename_prefix="_reel_part_",
             collect_paths=True,
+            cancel_flag=cancel_flag,
+            titlecards_enabled=titlecards_enabled,
+            titlecard_duration_seconds=titlecard_duration_seconds,
         )
         times = clip.get("times", [])
         clip_components = [

--- a/plans/STREAMING-FIXES.md
+++ b/plans/STREAMING-FIXES.md
@@ -196,6 +196,10 @@ Tests:
 
 ### P2: Reel Prep Shares Mutable Fuzzy-Match State Across Threads
 
+> **Status:** Done — `_check_source_video()`'s missing-video branch now runs
+> under `_fuzzy_match_lock` (lock alternative), serializing the shared
+> `missing_videos` / `fuzzy_matches` access and the fuzzy-match prompt.
+
 `process_reel()` uses `_run_clip_pipeline(parallel=True)`, and each worker calls `_prepare_and_check_clip()` with shared `missing_videos` and `fuzzy_matches`. Those structures are mutated without synchronization.
 
 Fix:
@@ -224,6 +228,9 @@ Tests:
 
 ### P2: Intake Artifact IDs Collide on Identical Spans
 
+> **Status:** Done — the artifact id hash folds in `source`, `event_ids`,
+> `mark_ids`, and the batch index threaded into `_process_intake_item()`.
+
 `_process_intake_item()` hashes only `{participant}_{start}_{end}` for filename/id. Two intake events covering the same span produce identical artifact ids; manifest dedupe silently replaces one.
 
 Fix:
@@ -236,6 +243,11 @@ Tests:
 - Add an intake stream test with two same-span items and distinct event ids; assert artifact ids differ.
 
 ### P2: Sheet Switch Can Rebind Generated Lists During Active Work
+
+> **Status:** Done — `/api/spreadsheets/open` and `/close` return 409 while any
+> clip, reel, or intake generation is in flight (`_generation_busy()`), and
+> `_init_studio_state()` rebinds the generated lists under
+> `_generated_output_lock`.
 
 `_init_studio_state()` and sheet-open state swaps replace `_generated_artifacts` / `_generated_reels` while generation streams may append under `_generated_output_lock`.
 
@@ -297,8 +309,8 @@ Tests:
 
 ### Task 1: Safe File and Manifest Foundations
 
-- [ ] Add atomic output reservation to `files.py`.
-- [ ] Update ffmpeg call sites that use reserved paths to clean up unused placeholders on early failure.
+- [x] Add atomic output reservation to `files.py`.
+- [x] Update ffmpeg call sites that use reserved paths to clean up unused placeholders on early failure.
 - [x] Add a manifest write lock to `viewer.save_manifest()`.
 - [ ] Run:
 
@@ -308,12 +320,12 @@ uv run --extra dev pytest -c tests/pytest.ini tests/test_manifest.py tests/test_
 
 ### Task 2: Studio Generate and Reel Correctness
 
-- [ ] Fix titlecard cache lifecycle for parallel Studio generation.
-- [ ] Forward reel cancellation/titlecard kwargs into `_process_single_clip_segments()`.
+- [x] Fix titlecard cache lifecycle for parallel Studio generation.
+- [x] Forward reel cancellation/titlecard kwargs into `_process_single_clip_segments()`.
 - [ ] Apply titlecard settings to `/studio/api/reel-direct`.
 - [ ] Pass generate cancellation into running ffmpeg workers and clean up cancelled outputs.
 - [ ] Add intake cancellation support and a busy-slot decision.
-- [ ] Persist streamed successes in generator `finally` blocks.
+- [x] Persist streamed successes in generator `finally` blocks.
 - [ ] Run:
 
 ```bash
@@ -334,10 +346,10 @@ uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_frontend_source.
 
 ### Task 4: Shared Backend Hardening
 
-- [ ] Lock Studio thumbnail cache operations.
-- [ ] Snapshot Screenspace manifest reads under `_manifest_lock`.
-- [ ] Coalesce Screenspace SSE queue overflow into a later full state update.
-- [ ] Improve transcript cancellation checks.
+- [x] Lock Studio thumbnail cache operations.
+- [x] Snapshot Screenspace manifest reads under `_manifest_lock`.
+- [x] Coalesce Screenspace SSE queue overflow into a later full state update.
+- [x] Improve transcript cancellation checks.
 - [ ] Run:
 
 ```bash

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -143,13 +143,27 @@ _manifest_lock = threading.Lock()
 
 
 def _notify_sse_clients(event_type: str = "update") -> None:
-    """Push a notification to all connected SSE clients."""
+    """Push a notification to all connected SSE clients.
+
+    A slow client's bounded queue can fill up. Rather than silently dropping
+    the change — which would leave that client stale until some unrelated
+    notification happened to fit — coalesce on overflow: discard one stale
+    entry and leave a single ``update`` marker, so the client still emits
+    fresh task state once it catches up.
+    """
     with _sse_clients_lock:
         for q in _sse_clients:
             try:
                 q.put_nowait(event_type)
             except queue_mod.Full:
-                pass
+                try:
+                    q.get_nowait()
+                except queue_mod.Empty:
+                    pass
+                try:
+                    q.put_nowait("update")
+                except queue_mod.Full:
+                    pass
 
 
 def _sse_task_payload() -> str:
@@ -198,8 +212,10 @@ def api_participant_notes_get(pid: str) -> FlaskResponse:
     """Return persisted free-form notes for a participant."""
     if not _participant_exists(pid):
         return jsonify({"ok": False, "error": f"Unknown participant {pid}"}), 404
-    entry = _manifest.get("per_participant", {}).get(pid, {})
-    return jsonify({"ok": True, "notes": entry.get("notes", "")})
+    with _manifest_lock:
+        entry = _manifest.get("per_participant", {}).get(pid, {})
+        notes = entry.get("notes", "")
+    return jsonify({"ok": True, "notes": notes})
 
 
 @screenspace_bp.route("/api/participants/<pid>/notes", methods=["PUT"])
@@ -768,7 +784,9 @@ def _is_flask_error_response(value: Any) -> TypeGuard[FlaskResponse]:
 @screenspace_bp.route("/api/regions")
 def api_regions_list() -> FlaskResponse:
     """List all saved region definitions."""
-    return jsonify({"ok": True, "regions": _manifest.get("regions", {})})
+    with _manifest_lock:
+        regions = copy.deepcopy(_manifest.get("regions", {}))
+    return jsonify({"ok": True, "regions": regions})
 
 
 @screenspace_bp.route("/api/regions", methods=["POST"])
@@ -821,11 +839,10 @@ def api_regions_create() -> FlaskResponse:
 @screenspace_bp.route("/api/regions/<name>", methods=["DELETE"])
 def api_regions_delete(name: str) -> FlaskResponse:
     """Delete a region definition."""
-    regions = _manifest.get("regions", {})
-    if name not in regions:
-        return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 404
-
     with _manifest_lock:
+        regions = _manifest.get("regions", {})
+        if name not in regions:
+            return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 404
         del regions[name]
         _do_persist(drain_events=False)
 
@@ -838,7 +855,9 @@ def api_regions_delete(name: str) -> FlaskResponse:
 @screenspace_bp.route("/api/stashes")
 def api_stashes_list() -> FlaskResponse:
     """List all region stashes."""
-    return jsonify({"ok": True, "stashes": _manifest.get("stashes", [])})
+    with _manifest_lock:
+        stashes = copy.deepcopy(_manifest.get("stashes", []))
+    return jsonify({"ok": True, "stashes": stashes})
 
 
 @screenspace_bp.route("/api/stashes", methods=["POST"])
@@ -1493,7 +1512,8 @@ def api_tasks_results(task_id: str) -> FlaskResponse:
 @screenspace_bp.route("/api/events")
 def api_events_list() -> FlaskResponse:
     """List events with optional filtering."""
-    events = _manifest.get("events", [])
+    with _manifest_lock:
+        events = copy.deepcopy(_manifest.get("events", []))
     excluded_filter = request.args.get("excluded")
     if excluded_filter == "false":
         events = [e for e in events if not e.get("excluded")]
@@ -1532,8 +1552,10 @@ def api_export_events() -> FlaskResponse:
     else:
         include_excluded = True
 
+    with _manifest_lock:
+        manifest_snapshot = copy.deepcopy(_manifest)
     records = data_export.build_screenspace_events(
-        _manifest,
+        manifest_snapshot,
         include_excluded=include_excluded,
         participants=[participant] if participant else None,
         detectors=[detector] if detector else None,

--- a/server.py
+++ b/server.py
@@ -63,6 +63,7 @@ import config
 import files
 import spreadsheet
 import pipeline
+import titlecards
 import utils
 import video
 import viewer
@@ -84,6 +85,9 @@ _generated_reels: list[dict[str, Any]] = []
 # (tens of KB each), so a few hundred is plenty.
 _THUMBNAIL_CACHE_MAX = 256
 _thumbnail_cache: "OrderedDict[tuple, bytes]" = OrderedDict()
+# Guards every thumbnail cache access (get / move_to_end / insert / evict);
+# api_thumbnail is served concurrently by Flask's threaded dev server.
+_thumbnail_cache_lock = threading.Lock()
 # A second concurrent /api/generate or /api/reel call would clobber the
 # shared cancel event; reject with 409 instead while one is in flight.
 _reel_cancel_event = threading.Event()
@@ -91,6 +95,10 @@ _generate_cancel_event = threading.Event()
 _busy_lock = threading.Lock()
 _generate_in_progress = False
 _reel_in_progress = False
+# Count of in-flight /api/generate-intake streams. Intake has no single-job
+# slot (it must run alongside /api/generate for mixed queues), but a sheet
+# swap still needs to know whether any intake work is active.
+_intake_active = 0
 # Serializes load → mutate → save for the stash manifests so concurrent
 # stash CRUD requests don't drop each other's writes.
 _stash_lock = threading.Lock()
@@ -147,9 +155,10 @@ def _coerce_mark_categories(value: Any) -> dict[str, dict[str, str]] | None:
 
 def _thumbnail_cache_put(key: tuple, value: bytes) -> None:
     """Insert into the thumbnail cache with simple LRU eviction."""
-    _thumbnail_cache[key] = value
-    while len(_thumbnail_cache) > _THUMBNAIL_CACHE_MAX:
-        _thumbnail_cache.popitem(last=False)
+    with _thumbnail_cache_lock:
+        _thumbnail_cache[key] = value
+        while len(_thumbnail_cache) > _THUMBNAIL_CACHE_MAX:
+            _thumbnail_cache.popitem(last=False)
 
 
 def _try_claim_busy(slot: str) -> bool:
@@ -226,6 +235,23 @@ def _release_busy(slot: str) -> None:
             _reel_in_progress = False
 
 
+def _mark_intake_active(active: bool) -> None:
+    """Increment/decrement the in-flight intake-stream counter."""
+    global _intake_active  # noqa: PLW0603
+    with _busy_lock:
+        _intake_active += 1 if active else -1
+
+
+def _generation_busy() -> bool:
+    """Return True while any clip, reel, or intake generation is in flight.
+
+    Consulted before a sheet swap so generated lists are not rebound under
+    an active stream.
+    """
+    with _busy_lock:
+        return _generate_in_progress or _reel_in_progress or _intake_active > 0
+
+
 @contextmanager
 def _override_config(**overrides: Any) -> Iterator[None]:
     """Temporarily override config attributes, restoring originals on exit."""
@@ -289,9 +315,11 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
         return jsonify({"ok": False, "error": "Source video not found"}), 404
 
     cache_key = (str(video_path), start_sec)
-    cached = _thumbnail_cache.get(cache_key)
+    with _thumbnail_cache_lock:
+        cached = _thumbnail_cache.get(cache_key)
+        if cached is not None:
+            _thumbnail_cache.move_to_end(cache_key)
     if cached is not None:
-        _thumbnail_cache.move_to_end(cache_key)
         return Response(
             cached,
             mimetype="image/jpeg",
@@ -587,8 +615,14 @@ def _process_intake_item(
     item: dict[str, Any],
     output_format: str,
     study: str,
+    index: int = 0,
 ) -> dict[str, Any]:
-    """Process a single intake item; returns one dict with _ok/_error keys."""
+    """Process a single intake item; returns one dict with _ok/_error keys.
+
+    *index* is the item's position in the request batch — folded into the
+    artifact id so two intake events covering the same participant span do not
+    hash to the same id and get collapsed by manifest dedup.
+    """
     participant = item.get("participant", "")
     start = float(item.get("start", 0))
     end = float(item.get("end", 0))
@@ -603,6 +637,22 @@ def _process_intake_item(
         return {"_ok": False, "_error": f"No video for {participant}"}
 
     span_hash = hashlib.md5(f"{participant}_{start}_{end}".encode()).hexdigest()[:8]
+    # Two intake events can cover the same participant span (e.g. distinct
+    # Screenspace events at the same timestamp). Fold source metadata and the
+    # batch index into the artifact id so manifest dedup does not silently
+    # collapse them onto one record.
+    id_basis = "|".join(
+        [
+            participant,
+            str(start),
+            str(end),
+            source,
+            ",".join(str(e) for e in event_ids),
+            ",".join(str(m) for m in mark_ids),
+            str(index),
+        ]
+    )
+    id_hash = hashlib.md5(id_basis.encode()).hexdigest()[:8]
     safe_event_type = utils.sanitize_filename(event_type) if event_type else ""
     desc_part = f"{safe_event_type} " if safe_event_type else ""
     out_name = (
@@ -638,7 +688,7 @@ def _process_intake_item(
         else:
             description = event_type or default_desc
     artifact: dict[str, Any] = {
-        "id": f"intake_{span_hash}_s0",
+        "id": f"intake_{id_hash}_s0",
         "type": output_format,
         "file": Path(out_path).name,
         "start": start,
@@ -697,7 +747,10 @@ def _generate_intake_clips(
     the video was missing or ffmpeg failed) plus an ``"_error"`` string so
     callers can report per-item results without duplicating the loop.
     """
-    return [_process_intake_item(item, output_format, study) for item in items]
+    return [
+        _process_intake_item(item, output_format, study, index=idx)
+        for idx, item in enumerate(items)
+    ]
 
 
 def _load_stashes() -> list[dict[str, Any]]:
@@ -960,6 +1013,7 @@ def api_generate() -> FlaskResponse:
                             cancel_flag=cancel_flag,
                             titlecards_enabled=titlecards_enabled,
                             titlecard_duration_seconds=titlecard_duration_seconds,
+                            clear_titlecard_cache=False,
                         ): (clip, cell_str)
                         for clip, cell_str in to_generate
                     }
@@ -1001,6 +1055,7 @@ def api_generate() -> FlaskResponse:
                             cancel_flag=cancel_flag,
                             titlecards_enabled=titlecards_enabled,
                             titlecard_duration_seconds=titlecard_duration_seconds,
+                            clear_titlecard_cache=False,
                         )
                         _extend_generated_artifacts(artifacts)
                         yield (
@@ -1028,12 +1083,18 @@ def api_generate() -> FlaskResponse:
                 )
         if cancel_flag():
             yield json.dumps({"cancelled": True}) + "\n"
-        _save_manifest_quiet()
 
     def stream_with_busy_release() -> Any:
         try:
             yield from stream()
         finally:
+            # Persist + purge the per-request endcard cache even when the
+            # client disconnects mid-stream, so generated artifacts are not
+            # left on disk without manifest records and endcard temp files
+            # do not leak. Per-cell process_clips() calls run with
+            # clear_titlecard_cache=False, so the cache is purged once here.
+            titlecards.clear_endcard_cache()
+            _save_manifest_quiet()
             _release_busy("generate")
 
     return Response(
@@ -1687,18 +1748,27 @@ def api_generate_intake() -> FlaskResponse:
     study = _sheet_context.study_name if _sheet_context else ""
 
     def stream() -> Iterator[str]:
-        for idx, item in enumerate(items):
-            result = _process_intake_item(item, output_format, study)
-            ok = result.pop("_ok", False)
-            error = result.pop("_error", "")
-            if ok:
-                _append_generated_artifact(result)
-                yield (
-                    json.dumps({"index": idx, "ok": True, "artifact": result}) + "\n"
-                )
-            else:
-                yield json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
-        _save_manifest_quiet()
+        _mark_intake_active(True)
+        try:
+            for idx, item in enumerate(items):
+                result = _process_intake_item(item, output_format, study, index=idx)
+                ok = result.pop("_ok", False)
+                error = result.pop("_error", "")
+                if ok:
+                    _append_generated_artifact(result)
+                    yield (
+                        json.dumps({"index": idx, "ok": True, "artifact": result})
+                        + "\n"
+                    )
+                else:
+                    yield (
+                        json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
+                    )
+        finally:
+            # Persist whatever completed even if the client disconnects or a
+            # later item raises mid-stream.
+            _save_manifest_quiet()
+            _mark_intake_active(False)
 
     return Response(
         stream(),
@@ -1883,7 +1953,6 @@ def api_reel_direct() -> FlaskResponse:
                     "description": f"Intake reel ({len(clip_paths)} segments)",
                 }
                 _append_generated_reel(reel_record)
-                _save_manifest_quiet()
                 yield (
                     json.dumps({"ok": True, "generated": 1, "reels": [reel_record]})
                     + "\n"
@@ -1894,6 +1963,8 @@ def api_reel_direct() -> FlaskResponse:
                     + "\n"
                 )
         finally:
+            # Persist the appended reel even on a mid-stream client disconnect.
+            _save_manifest_quiet()
             for tmp in temp_clips:
                 try:
                     Path(tmp).unlink(missing_ok=True)
@@ -1953,8 +2024,12 @@ def _init_studio_state(worksheet: Any) -> None:
             sys.exit(1)
     else:
         _sheet_context = None
-    _generated_artifacts, _generated_reels = viewer._load_manifest_both()
-    _thumbnail_cache = OrderedDict()
+    # Rebind the shared generated lists under their lock so a streaming
+    # generate/intake append can't run against a half-swapped reference.
+    with _generated_output_lock:
+        _generated_artifacts, _generated_reels = viewer._load_manifest_both()
+    with _thumbnail_cache_lock:
+        _thumbnail_cache = OrderedDict()
 
 
 # ---- Entry point ----
@@ -2043,8 +2118,9 @@ def _swap_worksheet(new_worksheet: Any) -> None:
     except Exception:
         _worksheet = prev_worksheet
         _sheet_context = prev_sheet_context
-        _generated_artifacts = prev_artifacts
-        _generated_reels = prev_reels
+        with _generated_output_lock:
+            _generated_artifacts = prev_artifacts
+            _generated_reels = prev_reels
         # Best-effort: re-pin the two sister blueprints to the restored state.
         # If these themselves throw, swallow — the studio state is already
         # consistent and the original exception is what we want to surface.
@@ -2344,6 +2420,17 @@ def build_combined_app(
                 }
             ), 400
 
+        if _generation_busy():
+            return jsonify(
+                {
+                    "ok": False,
+                    "error": (
+                        "Generation is in progress — wait for it to finish "
+                        "before switching spreadsheets."
+                    ),
+                }
+            ), 409
+
         new_ws: Any = None
         label = ""
         try:
@@ -2413,8 +2500,15 @@ def build_combined_app(
         )
 
     @combined.route("/api/spreadsheets/close", methods=["POST"])
-    def api_spreadsheets_close() -> Response:
+    def api_spreadsheets_close() -> FlaskResponse:
         global _active_sheet_meta
+        if _generation_busy():
+            return jsonify(
+                {
+                    "ok": False,
+                    "error": "Generation is in progress — wait for it to finish.",
+                }
+            ), 409
         _swap_worksheet(None)
         _active_sheet_meta = None
         return jsonify({"ok": True, "sheet_loaded": False})

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -567,3 +567,106 @@ def test_regenerate_from_manifest_parallel(monkeypatch):
     count = pipeline.regenerate_from_manifest(artifacts)
     assert count == 4
     assert sorted(calls) == ["a0", "a1", "a2", "a3"]
+
+
+def test_process_clips_skips_titlecard_cache_clear_when_disabled(
+    monkeypatch, make_clip
+):
+    """clear_titlecard_cache=False keeps a per-cell worker from purging the
+    shared endcard cache mid-flight; the default True clears it once."""
+    raw_clip = make_clip()
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+    monkeypatch.setattr(config, "TITLECARDS_ENABLED", True)
+    monkeypatch.setattr(
+        clipgen.files, "get_unique_filename", lambda *_a, **_k: "out.mp4"
+    )
+    monkeypatch.setattr(clipgen.video, "run_ffmpeg", lambda **_k: True)
+    monkeypatch.setattr(
+        clipgen.video,
+        "probe_video_properties",
+        lambda *_a, **_k: {"width": 1280, "height": 720},
+    )
+    monkeypatch.setattr(
+        pipeline.titlecards, "wrap_clip_with_cards", lambda *_a, **_k: True
+    )
+
+    clear_mock = Mock()
+    monkeypatch.setattr(pipeline.titlecards, "clear_endcard_cache", clear_mock)
+
+    clipgen.process_clips([raw_clip], output_format="clip", clear_titlecard_cache=False)
+    clear_mock.assert_not_called()
+
+    clipgen.process_clips([raw_clip], output_format="clip")
+    clear_mock.assert_called_once()
+
+
+def test_process_reel_forwards_cancel_and_titlecard_options_to_segments(
+    monkeypatch, make_clip
+):
+    """process_reel must pass its cancel_flag and per-request titlecard options
+    into _process_single_clip_segments for each reel part."""
+    raw_clip = make_clip()
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+
+    captured = {}
+
+    def fake_segments(*_args, **kwargs):
+        captured.update(kwargs)
+        return (1, [("_reel_part_1.mp4", 0)])
+
+    monkeypatch.setattr(pipeline, "_process_single_clip_segments", fake_segments)
+    monkeypatch.setattr(clipgen.video, "concatenate_clips", lambda *_a, **_k: True)
+    monkeypatch.setattr(pipeline, "_build_reel_transcript", lambda *_a, **_k: [])
+
+    sentinel = lambda: False  # noqa: E731
+    clipgen.process_reel(
+        [raw_clip],
+        output_file="reel.mp4",
+        cancel_flag=sentinel,
+        titlecards_enabled=True,
+        titlecard_duration_seconds=5,
+    )
+
+    assert captured["cancel_flag"] is sentinel
+    assert captured["titlecards_enabled"] is True
+    assert captured["titlecard_duration_seconds"] == 5
+
+
+def test_process_reel_dedups_missing_video_across_parallel_clips(
+    monkeypatch, make_clip
+):
+    """Parallel reel clips that all reference the same missing source video
+    produce exactly one missing-video error, not one per worker thread."""
+    clips = [make_clip(row=i, col=2) for i in range(3, 7)]
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 4)
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: False)
+    monkeypatch.setattr(pipeline, "_large_input_videos", lambda _d: [])
+
+    errors: list[tuple] = []
+    monkeypatch.setattr(
+        pipeline.utils, "error_print", lambda *a, **_k: errors.append(a)
+    )
+
+    result, _ = clipgen.process_reel(clips, output_file="reel.mp4")
+
+    assert result == 0
+    assert len(errors) == 1

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -514,6 +514,29 @@ def test_build_reel_transcript_uses_request_titlecard_duration(monkeypatch):
     assert merged[0]["end"] == 9.0
 
 
+def test_regenerate_reel_releases_reservation_on_ffmpeg_failure(monkeypatch, tmp_path):
+    """A reel part whose ffmpeg encode fails must not leave a 0-byte placeholder
+    behind from get_unique_filename's atomic reservation."""
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    (input_dir / "study_P01.mp4").write_bytes(b"\x00")
+    monkeypatch.setattr(config, "INPUT_DIR", str(input_dir), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(output_dir), raising=False)
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", lambda **_k: False)
+
+    reel = {
+        "file": "reel.mp4",
+        "components": [{"sourceVideo": "study_P01.mp4", "start": 0, "end": 10}],
+    }
+    ok = pipeline._regenerate_reel(reel, set())
+
+    assert ok is False
+    # The reserved placeholder for the failed part was cleaned up.
+    assert list(output_dir.iterdir()) == []
+
+
 def test_regenerate_from_manifest_parallel(monkeypatch):
     """Independent artifacts regenerate concurrently when workers >= 2."""
     artifacts = [

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -55,6 +56,39 @@ def test_get_unique_filename_truncates_long_names(monkeypatch, tmp_path):
     assert result2.endswith(".mp4")
     assert "-1" in Path(result2).name
     assert result2 != result1
+
+
+def test_get_unique_filename_reserves_distinct_paths_under_threads(
+    monkeypatch, tmp_path
+):
+    """Concurrent callers requesting the same template each receive a distinct
+    path, atomically reserved on disk — no two workers can pick the same name."""
+    monkeypatch.setattr(files.config, "OUTPUT_DIR", str(tmp_path), raising=False)
+
+    def reserve():
+        return files.get_unique_filename("clip.mp4")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = [f.result() for f in [pool.submit(reserve) for _ in range(40)]]
+
+    assert len(set(results)) == len(results)  # every path is unique
+    for path in results:
+        assert Path(path).is_file()  # each path reserved as a placeholder
+
+
+def test_release_reservation_removes_unused_placeholder(monkeypatch, tmp_path):
+    """An unused reservation is removed; release is a no-op on missing/None."""
+    monkeypatch.setattr(files.config, "OUTPUT_DIR", str(tmp_path), raising=False)
+
+    path = files.get_unique_filename("clip.mp4")
+    assert Path(path).is_file()
+
+    files.release_reservation(path)
+    assert not Path(path).exists()
+
+    # Safe to call again, and on None.
+    files.release_reservation(path)
+    files.release_reservation(None)
 
 
 def test_discover_clips_excludes_source_videos(tmp_path, monkeypatch):

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1371,3 +1371,71 @@ def test_export_events_unsupported_format(client):
     assert resp.status_code == 400
     data = resp.get_json()
     assert data["ok"] is False
+
+
+def test_notify_sse_clients_coalesces_on_full_queue():
+    """A saturated client queue keeps a fresh 'update' marker instead of
+    silently dropping the change, so a slow SSE client still converges to
+    current task state once it catches up."""
+    import queue as queue_mod
+
+    q: queue_mod.Queue = queue_mod.Queue(maxsize=4)
+    for _ in range(4):
+        q.put_nowait("stale")
+
+    saved = list(screenspace_server._sse_clients)
+    screenspace_server._sse_clients[:] = [q]
+    try:
+        screenspace_server._notify_sse_clients("task_created")
+    finally:
+        screenspace_server._sse_clients[:] = saved
+
+    drained = []
+    while not q.empty():
+        drained.append(q.get_nowait())
+    assert len(drained) == 4
+    assert "update" in drained
+
+
+def test_events_list_stable_under_concurrent_writes(client):
+    """GET /api/events keeps returning 200 while events are bulk-toggled — the
+    handler snapshots the manifest under _manifest_lock instead of letting
+    jsonify iterate event dicts another request is mutating."""
+    import concurrent.futures
+    import threading
+
+    # Fresh app so each thread can hold its own test client; module state
+    # (_manifest etc.) set up by the fixture is shared across all of them.
+    app = Flask(__name__)
+    app.register_blueprint(screenspace_server.screenspace_bp, url_prefix="/screenspace")
+
+    ids = [f"ev_{i}" for i in range(40)]
+    screenspace_server._manifest["events"] = [_sample_event(i) for i in ids]
+
+    stop = threading.Event()
+    errors: list[object] = []
+
+    def reader() -> None:
+        c = app.test_client()
+        while not stop.is_set():
+            try:
+                resp = c.get("/screenspace/api/events")
+                if resp.status_code != 200:
+                    errors.append(resp.status_code)
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+    def writer() -> None:
+        c = app.test_client()
+        c.put("/screenspace/api/events/bulk-exclude", json={"ids": ids})
+        c.put("/screenspace/api/events/bulk-include", json={"ids": ids})
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
+        readers = [pool.submit(reader) for _ in range(3)]
+        for _ in range(200):
+            pool.submit(writer).result()
+        stop.set()
+        for r in readers:
+            r.result()
+
+    assert errors == []

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -397,3 +397,39 @@ def test_google_auth_records_thread_error(client, monkeypatch):
     assert server._google_auth.client is None
     assert "creds missing" in server._google_auth.error
     assert server._google_auth.in_flight is False
+
+
+# ---------- sheet-switch guard during active generation ---------------------
+
+
+def test_spreadsheets_open_rejected_during_generation(client, monkeypatch):
+    """Switching spreadsheets is rejected with 409 while a clip generation is
+    in progress, so the generated lists are not rebound under an active stream."""
+    monkeypatch.setattr(server, "_generate_in_progress", True)
+    resp = client.post(
+        "/api/spreadsheets/open",
+        json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
+    )
+    assert resp.status_code == 409
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert "in progress" in data["error"]
+
+
+def test_spreadsheets_open_rejected_during_intake(client, monkeypatch):
+    """An in-flight intake stream also blocks a spreadsheet switch."""
+    monkeypatch.setattr(server, "_intake_active", 1)
+    resp = client.post(
+        "/api/spreadsheets/open",
+        json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
+    )
+    assert resp.status_code == 409
+    assert resp.get_json()["ok"] is False
+
+
+def test_spreadsheets_close_rejected_during_reel(client, monkeypatch):
+    """Closing the spreadsheet is rejected with 409 while a reel build runs."""
+    monkeypatch.setattr(server, "_reel_in_progress", True)
+    resp = client.post("/api/spreadsheets/close")
+    assert resp.status_code == 409
+    assert resp.get_json()["ok"] is False

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1121,9 +1121,11 @@ def test_api_generate_passes_titlecard_options_to_pipeline(client, monkeypatch):
         cancel_flag=None,
         titlecards_enabled=None,
         titlecard_duration_seconds=None,
+        clear_titlecard_cache=True,
     ):
         captured["enabled"] = titlecards_enabled
         captured["duration"] = titlecard_duration_seconds
+        captured["clear_titlecard_cache"] = clear_titlecard_cache
         return (1, [{"id": "a1", "type": "clip"}])
 
     monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
@@ -1144,6 +1146,9 @@ def test_api_generate_passes_titlecard_options_to_pipeline(client, monkeypatch):
     resp.data  # consume streamed response so generator finally-block runs
     assert captured["enabled"] is True
     assert captured["duration"] == 5
+    # Per-cell workers must not purge the shared endcard cache; api_generate
+    # clears it once after the stream finishes.
+    assert captured["clear_titlecard_cache"] is False
     assert config.TITLECARDS_ENABLED == original_enabled
     assert config.TITLECARD_DURATION_SECONDS == original_duration
 
@@ -1705,3 +1710,110 @@ def test_api_reel_streams_progress_events(client, monkeypatch, tmp_path):
     assert final["ok"] is True
     assert final["generated"] == 1
     assert final["reels"] == [reel_record]
+
+
+def test_api_generate_intake_distinct_ids_for_same_span(client, monkeypatch):
+    """Two intake items over the same participant span receive distinct artifact
+    ids, so manifest dedup does not silently collapse them onto one record."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr(
+        server.files, "get_unique_filename", lambda name, file_format=None: name
+    )
+
+    same_span = {
+        "participant": "P01",
+        "start": 1.0,
+        "end": 5.0,
+        "event_type": "",
+        "source": "screenspace",
+        "mark_ids": [],
+    }
+    items = [
+        {**same_span, "event_ids": ["e1"]},
+        {**same_span, "event_ids": ["e2"]},
+    ]
+    resp = client.post(
+        "/studio/api/generate-intake", json={"items": items, "format": "clip"}
+    )
+    assert resp.status_code == 200
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    ids = [ln["artifact"]["id"] for ln in lines]
+    assert len(ids) == 2
+    assert len(set(ids)) == 2
+
+
+def test_api_generate_intake_persists_when_later_item_raises(client, monkeypatch):
+    """A later intake item raising still persists the earlier successes via the
+    generator's finally block."""
+    saved: list[bool] = []
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: saved.append(True))
+
+    def flaky(item, output_format, study, index=0):
+        if index == 1:
+            raise RuntimeError("boom")
+        return {
+            "_ok": True,
+            "_error": "",
+            "id": f"art{index}",
+            "participant": item["participant"],
+        }
+
+    monkeypatch.setattr(server, "_process_intake_item", flaky)
+
+    items = [
+        {"participant": "P01", "start": 0, "end": 5},
+        {"participant": "P02", "start": 0, "end": 5},
+    ]
+    resp = client.post(
+        "/studio/api/generate-intake", json={"items": items, "format": "clip"}
+    )
+    try:
+        resp.data  # the generator raises mid-stream; the finally still runs
+    except RuntimeError:
+        pass
+    assert saved == [True]
+
+
+def test_api_generate_intake_persists_on_early_client_close(client, monkeypatch):
+    """Closing the response after one line still persists via the finally."""
+    saved: list[bool] = []
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: saved.append(True))
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        server.files, "get_unique_filename", lambda name, file_format=None: name
+    )
+
+    items = [
+        {"participant": f"P0{i}", "start": 0, "end": 5, "source": "screenspace"}
+        for i in range(1, 5)
+    ]
+    resp = client.post(
+        "/studio/api/generate-intake", json={"items": items, "format": "clip"}
+    )
+    encoded = resp.iter_encoded()
+    next(encoded)  # consume only the first NDJSON line
+    resp.close()  # disconnect mid-stream
+    assert saved == [True]
+
+
+def test_thumbnail_cache_put_is_threadsafe(monkeypatch):
+    """Concurrent _thumbnail_cache_put calls keep the LRU bounded without
+    corrupting the OrderedDict mid-eviction."""
+    import concurrent.futures
+
+    monkeypatch.setattr(server, "_thumbnail_cache", OrderedDict())
+
+    def put(i: int) -> None:
+        server._thumbnail_cache_put((f"v{i}", i), b"jpeg")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(put, range(2000)))
+
+    assert len(server._thumbnail_cache) <= server._THUMBNAIL_CACHE_MAX

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -632,6 +632,76 @@ class TestTranscriptWorker:
         worker = transcripts.TranscriptWorker()
         assert worker.cancel("nonexistent") is False
 
+    def test_execute_task_cancelled_before_model_load(self, monkeypatch):
+        """A task cancelled before model load aborts without loading a model."""
+        from unittest.mock import Mock
+
+        import video as video_mod
+
+        monkeypatch.setattr(config, "DEBUGGING", False)
+        monkeypatch.setattr(video_mod, "probe_video_properties", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            transcripts, "load_transcripts_manifest", lambda: {"corrections": []}
+        )
+        load_model = Mock()
+        monkeypatch.setattr(transcripts, "_load_model", load_model)
+
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", "/v.mp4")
+        task["status"] = "running"
+        task["_cancelled"] = True
+
+        worker._execute_task(task)
+
+        assert task["status"] == "cancelled"
+        assert task["partial_segments"] == []
+        load_model.assert_not_called()
+
+    def test_execute_task_cancelled_between_segments(self, monkeypatch):
+        """Cancelling mid-transcription stops between segments and clears the
+        partial-segment buffer."""
+        from types import SimpleNamespace
+
+        import video as video_mod
+
+        monkeypatch.setattr(config, "DEBUGGING", False)
+        monkeypatch.setattr(
+            video_mod,
+            "probe_video_properties",
+            lambda *_a, **_k: {"duration": 100.0},
+        )
+        monkeypatch.setattr(
+            transcripts, "load_transcripts_manifest", lambda: {"corrections": []}
+        )
+
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", "/v.mp4")
+        task["status"] = "running"
+
+        class FakeSeg:
+            def __init__(self, t):
+                self.start = float(t)
+                self.end = float(t + 1)
+                self.text = f"seg {t}"
+
+        def fake_segments():
+            for i in range(5):
+                if i == 1:
+                    # Trip cancellation once the first segment is consumed.
+                    task["_cancelled"] = True
+                yield FakeSeg(i)
+
+        class FakeModel:
+            def transcribe(self, path, **kwargs):  # noqa: ARG002
+                return fake_segments(), SimpleNamespace(language="en")
+
+        monkeypatch.setattr(transcripts, "_load_model", lambda *_a, **_k: FakeModel())
+
+        worker._execute_task(task)
+
+        assert task["status"] == "cancelled"
+        assert task["partial_segments"] == []
+
     def test_remove_task(self):
         worker = transcripts.TranscriptWorker()
         task = transcripts.create_transcript_task("P01", "/v.mp4")

--- a/transcripts.py
+++ b/transcripts.py
@@ -202,6 +202,7 @@ def transcribe_video(
     initial_prompt: str | None = None,
     context_keywords: list[str] | None = None,
     on_segment: Callable[[float, "TranscriptSegment"], None] | None = None,
+    cancel_flag: Callable[[], bool] | None = None,
 ) -> TranscriptResult | None:
     """Transcribe a video file and return timestamped segments.
 
@@ -215,6 +216,11 @@ def transcribe_video(
         on_segment: Optional callback invoked after each segment with the
             segment's end time (seconds) and the TranscriptSegment.
             Useful for progress tracking and streaming partial results.
+        cancel_flag: Optional callable checked at each safe boundary —
+            before/after the (slow) model load and between segments. When it
+            returns True, transcription aborts with ``_TranscriptionCancelled``
+            instead of waiting for the next ``on_segment`` callback. faster-
+            whisper exposes no hard abort, so cancellation is cooperative.
 
     Returns:
         TranscriptResult with segments, or None on failure.
@@ -228,9 +234,17 @@ def transcribe_video(
             model=resolved_model,
         )
 
+    def _is_cancelled() -> bool:
+        return cancel_flag is not None and cancel_flag()
+
+    if _is_cancelled():
+        raise _TranscriptionCancelled
+
     model = _load_model(resolved_model)
     if model is None:
         return None
+    if _is_cancelled():
+        raise _TranscriptionCancelled
 
     prompt = initial_prompt or config.TRANSCRIBE_INITIAL_PROMPT
     if context_keywords:
@@ -243,8 +257,12 @@ def transcribe_video(
             language=lang, initial_prompt=prompt
         )
         segments_iter, info = model.transcribe(str(video_path), **transcribe_kwargs)
+        if _is_cancelled():
+            raise _TranscriptionCancelled
         segments: list[TranscriptSegment] = []
         for seg in segments_iter:
+            if _is_cancelled():
+                raise _TranscriptionCancelled
             text = seg.text.strip()
             if not text:
                 continue
@@ -851,6 +869,7 @@ class TranscriptWorker:
                 language=task.get("language"),
                 context_keywords=context_kw,
                 on_segment=_on_seg,
+                cancel_flag=lambda: bool(task.get("_cancelled")),
             )
             if result is None:
                 with self._lock:


### PR DESCRIPTION
get_unique_filename() was check-then-use: parallel clip, reel, and gallery
workers could select the same path before either ffmpeg process created it,
silently overwriting one artifact. Reserve the path with an O_CREAT|O_EXCL
placeholder file so each caller receives a distinct name. Callers that abort
before writing real content release the placeholder via release_reservation().