### PR TITLE
fix(interactive): restore browse mode broken by get_num_participants change

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,106 +59,19 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies (CPU-only torch)
+        # pytest-cov is installed CI-only, the same pattern as --torch-backend
+        # cpu (see AGENTS.md): kept out of pyproject.toml and uv.lock so
+        # end-user installs and local `uv run` stay unaffected.
         run: |
           uv venv
-          uv pip install ".[dev]" --torch-backend cpu
+          uv pip install ".[dev]" pytest-cov --torch-backend cpu
 
-      - name: Determine changed files
-        id: changes
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
-          CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD)
-          echo "$CHANGED"
-          EOF_DELIM=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "files<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
-          echo "$CHANGED" >> "$GITHUB_OUTPUT"
-          echo "${EOF_DELIM}" >> "$GITHUB_OUTPUT"
-
-      - name: Select test scope
-        id: scope
-        run: |
-          # On push to master or when no change info is available, run all tests
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "tests=" >> "$GITHUB_OUTPUT"
-            echo "Running full test suite (push to master)"
-            exit 0
-          fi
-
-          CHANGED="${{ steps.changes.outputs.files }}"
-          if [[ -z "$CHANGED" ]]; then
-            echo "tests=" >> "$GITHUB_OUTPUT"
-            echo "Running full test suite (no changed files detected)"
-            exit 0
-          fi
-
-          # Broad-impact files: any change triggers the full suite
-          BROAD="utils.py config.py tests/conftest.py tests/pytest.ini pyproject.toml uv.lock .github/workflows/tests.yml"
-          for broad in $BROAD; do
-            if echo "$CHANGED" | grep -Fqx "$broad"; then
-              echo "tests=" >> "$GITHUB_OUTPUT"
-              echo "Broad-impact file changed ($broad) — running full suite"
-              exit 0
-            fi
-          done
-
-          # Map source files to test files
-          TEST_FILES=""
-          add() { for t in "$@"; do TEST_FILES="$TEST_FILES $t"; done; }
-
-          echo "$CHANGED" | grep -qx "cli\.py"                && add tests/test_cli_args.py tests/test_cli_modes.py
-          echo "$CHANGED" | grep -qx "clipgen\.py"            && add tests/test_cli_args.py tests/test_cli_modes.py tests/test_clip_pipeline.py
-          echo "$CHANGED" | grep -qx "files\.py"              && add tests/test_files_and_artifacts.py tests/test_spreadsheet_generation.py
-          echo "$CHANGED" | grep -qx "spreadsheet\.py"        && add tests/test_files_and_artifacts.py tests/test_selectors.py tests/test_spreadsheet_generation.py
-          echo "$CHANGED" | grep -qx "viewer\.py"             && add tests/test_cli_modes.py tests/test_files_and_artifacts.py tests/test_manifest.py tests/test_viewer_data.py tests/test_viewer_inline.py
-          echo "$CHANGED" | grep -qx "screenspace\.py"        && add tests/test_screenspace.py tests/test_screenspace_api.py
-          echo "$CHANGED" | grep -qx "screenspace_server\.py" && add tests/test_screenspace_api.py
-          echo "$CHANGED" | grep -qx "server\.py"             && add tests/test_studio_api.py
-          echo "$CHANGED" | grep -qx "video\.py"              && add tests/test_video_commands.py tests/test_titlecards.py
-          echo "$CHANGED" | grep -qx "titlecards\.py"         && add tests/test_titlecards.py
-          echo "$CHANGED" | grep -qx "transcripts\.py"        && add tests/test_transcripts.py
-          echo "$CHANGED" | grep -qx "google_api\.py"         && add tests/test_google_and_excel_adapters.py
-          echo "$CHANGED" | grep -qx "excel_io\.py"           && add tests/test_google_and_excel_adapters.py
-
-          # If a test file itself changed, include it directly
-          for f in $(echo "$CHANGED" | grep "^tests/test_.*\.py$"); do
-            add "$f"
-          done
-
-          # Unknown source .py files trigger the full suite
-          for f in $(echo "$CHANGED" | grep "\.py$" | grep -v "^tests/"); do
-            case "$f" in
-              cli.py|clipgen.py|config.py|excel_io.py|files.py|google_api.py|\
-              interactive.py|screenspace.py|\
-              screenspace_server.py|server.py|spreadsheet.py|titlecards.py|\
-              transcripts.py|utils.py|video.py|viewer.py) ;;
-              *)
-                echo "Unknown source file: $f — running full suite"
-                echo "tests=" >> "$GITHUB_OUTPUT"
-                exit 0
-                ;;
-            esac
-          done
-
-          # Deduplicate and output
-          TEST_FILES=$(echo "$TEST_FILES" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
-
-          if [[ -z "$TEST_FILES" ]]; then
-            echo "No matching test files — running full suite as safety fallback"
-            echo "tests=" >> "$GITHUB_OUTPUT"
-          else
-            echo "Selected tests: $TEST_FILES"
-            echo "tests=$TEST_FILES" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Run smoke tests
-        run: |
-          if [[ -n "${{ steps.scope.outputs.tests }}" ]]; then
-            echo "Running scoped tests: ${{ steps.scope.outputs.tests }}"
-            uv run --no-sync pytest -c tests/pytest.ini ${{ steps.scope.outputs.tests }}
-          else
-            uv run --no-sync pytest -c tests/pytest.ini
-          fi
+      - name: Run tests with coverage gate
+        # Always run the full suite. It finishes in well under a minute, and a
+        # scoped subset risks false-green PRs when a change breaks an untested
+        # sibling test file. The coverage floor lives in pyproject.toml
+        # ([tool.coverage.report] fail_under) and fails the run if breached.
+        run: uv run --no-sync pytest -c tests/pytest.ini --cov=. --cov-report=term
 
   lint:
     needs: [gate]

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ tests/__pycache__/
 tests/.pytest_cache/
 .pytest_cache/
 .ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
 
 # PyInstaller artifacts
 build/*

--- a/interactive.py
+++ b/interactive.py
@@ -455,9 +455,8 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
 
     # Get participant info
     header_row = sheet_data[id_cell.row - 1]
-    num_participants = spreadsheet.get_num_participants(
-        header_row, id_cell, observation_cell
-    )
+    col_count = max(len(row) for row in sheet_data)
+    num_participants = spreadsheet.get_num_participants(header_row, id_cell, col_count)
 
     if num_participants == 0:
         utils.warning_print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,12 @@ py-modules = [
 
 [tool.uv]
 required-version = ">=0.11.0"
+
+[tool.coverage.run]
+source = ["."]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+# CI coverage ratchet. Raise this as coverage improves; never lower it to make
+# a PR pass. Measured on product modules only (tests/* omitted above).
+fail_under = 60

--- a/tests/test_interactive_prompts.py
+++ b/tests/test_interactive_prompts.py
@@ -1,0 +1,309 @@
+"""Tests for interactive.py prompt helpers.
+
+interactive.py was deliberately split out of spreadsheet.py to keep the
+prompt logic pure and testable: every function takes a SheetContext and
+routes user input through utils.read_user_input(). These tests drive each
+prompt with scripted input sequences and assert on the resolved selection.
+"""
+
+from types import SimpleNamespace
+
+import google_api
+import interactive
+import utils
+from spreadsheet import SheetContext
+
+
+def _scripted(monkeypatch, responses):
+    """Patch utils.read_user_input to return queued responses in order.
+
+    Raises if a prompt is reached after the script is exhausted so an
+    accidental extra prompt surfaces as a test failure, not a hang.
+    """
+    queue = list(responses)
+
+    def _fake(_prompt=""):
+        if not queue:
+            raise AssertionError(
+                f"read_user_input exhausted; unexpected extra prompt: {_prompt!r}"
+            )
+        return queue.pop(0)
+
+    monkeypatch.setattr(utils, "read_user_input", _fake)
+    return queue
+
+
+def _sheet_data():
+    # Row 0: study name. Row 1: header (row 2). Rows 2-4: data rows.
+    return [
+        ["Study", "", "", "", "", ""],
+        ["ID", "P01", "P02", "Observation", "Category", "Severity"],
+        ["1", "00:10-00:20", "", "Obs one", "CatA", "High"],
+        ["2", "", "00:30-00:40 !key", "Obs two", "CatB", "Low"],
+        ["3", "00:50-01:00", "01:10-01:20", "Obs three", "CatA", "Critical"],
+    ]
+
+
+_UNSET = object()
+
+
+def _ctx(sheet_data=None, num_participants=2, severity_cell=_UNSET):
+    """Build a SheetContext mirroring build_sheet_context output for tests."""
+    if sheet_data is None:
+        sheet_data = _sheet_data()
+    sev = SimpleNamespace(row=2, col=6) if severity_cell is _UNSET else severity_cell
+    return SheetContext(
+        sheet_data=sheet_data,
+        id_cell=SimpleNamespace(row=2, col=1),
+        observation_cell=SimpleNamespace(row=2, col=4),
+        category_cell=SimpleNamespace(row=2, col=5),
+        num_participants=num_participants,
+        study_name="study",
+        severity_cell=sev,
+    )
+
+
+# ---- prompt_batch_confirm ----
+
+
+def test_prompt_batch_confirm_yes(monkeypatch):
+    _scripted(monkeypatch, ["y"])
+    assert interactive.prompt_batch_confirm(_ctx()) is True
+
+
+def test_prompt_batch_confirm_no(monkeypatch):
+    _scripted(monkeypatch, ["n"])
+    assert interactive.prompt_batch_confirm(_ctx()) is False
+
+
+# ---- prompt_multi_selection (generic engine) ----
+
+
+def _run_multi(items):
+    """Invoke prompt_multi_selection with fixed display strings."""
+    return interactive.prompt_multi_selection(
+        items,
+        header="Items:",
+        prompt_text="pick",
+        confirm_label="Selected:",
+        no_match_msg="no match",
+    )
+
+
+def test_prompt_multi_selection_by_index(monkeypatch):
+    _scripted(monkeypatch, ["1,3", "y"])
+    assert _run_multi(["alpha", "beta", "gamma"]) == ["alpha", "gamma"]
+
+
+def test_prompt_multi_selection_all_keyword(monkeypatch):
+    _scripted(monkeypatch, ["all"])
+    assert _run_multi(["a", "b"]) == ["a", "b"]
+
+
+def test_prompt_multi_selection_by_text_match(monkeypatch):
+    _scripted(monkeypatch, ["beta", "y"])
+    assert _run_multi(["alpha", "beta"]) == ["beta"]
+
+
+def test_prompt_multi_selection_dedupes_repeated_index(monkeypatch):
+    _scripted(monkeypatch, ["1,1,2", "y"])
+    assert _run_multi(["a", "b"]) == ["a", "b"]
+
+
+def test_prompt_multi_selection_reprompts_after_all_invalid(monkeypatch):
+    # First selection is entirely out of range -> reprompt, then a valid pick.
+    _scripted(monkeypatch, ["9", "2", "y"])
+    assert _run_multi(["a", "b", "c"]) == ["b"]
+
+
+def test_prompt_multi_selection_declined_confirmation_reselects(monkeypatch):
+    # Pick index 1, decline confirmation, then pick index 2 and confirm.
+    _scripted(monkeypatch, ["1", "n", "2", "y"])
+    assert _run_multi(["a", "b"]) == ["b"]
+
+
+# ---- prompt_category_selection ----
+
+
+def test_prompt_category_selection_happy(monkeypatch):
+    _scripted(monkeypatch, ["1", "y"])
+    assert interactive.prompt_category_selection(_ctx()) == ["CatA"]
+
+
+def test_prompt_category_selection_all(monkeypatch):
+    _scripted(monkeypatch, ["all"])
+    assert interactive.prompt_category_selection(_ctx()) == ["CatA", "CatB"]
+
+
+def test_prompt_category_selection_none_when_no_categories(monkeypatch):
+    sheet = [
+        ["Study"],
+        ["ID", "P01", "P02", "Observation", "Category"],
+        ["1", "00:10", "", "Obs one", ""],
+    ]
+    _scripted(monkeypatch, [])  # no prompt should be reached
+    assert interactive.prompt_category_selection(_ctx(sheet_data=sheet)) is None
+
+
+# ---- prompt_severity_selection ----
+
+
+def test_prompt_severity_selection_happy(monkeypatch):
+    monkeypatch.setattr(utils, "_use_rich", lambda: False)
+    _scripted(monkeypatch, ["all"])
+    result = interactive.prompt_severity_selection(_ctx())
+    assert result is not None
+    assert set(result) == {"Critical", "High", "Low"}
+
+
+def test_prompt_severity_selection_by_name(monkeypatch):
+    monkeypatch.setattr(utils, "_use_rich", lambda: False)
+    _scripted(monkeypatch, ["high", "y"])
+    assert interactive.prompt_severity_selection(_ctx()) == ["High"]
+
+
+def test_prompt_severity_selection_none_without_severity_column(monkeypatch):
+    _scripted(monkeypatch, [])
+    assert interactive.prompt_severity_selection(_ctx(severity_cell=None)) is None
+
+
+# ---- prompt_line_selection ----
+
+
+def test_prompt_line_selection_happy(monkeypatch):
+    _scripted(monkeypatch, ["3,4", "y"])
+    assert interactive.prompt_line_selection(_ctx()) == [3, 4]
+
+
+def test_prompt_line_selection_reprompts_on_non_integer(monkeypatch):
+    _scripted(monkeypatch, ["abc", "3", "y"])
+    assert interactive.prompt_line_selection(_ctx()) == [3]
+
+
+def test_prompt_line_selection_filters_out_of_range(monkeypatch):
+    # Row 99 is out of range; row 3 is valid.
+    _scripted(monkeypatch, ["99,3", "y"])
+    assert interactive.prompt_line_selection(_ctx()) == [3]
+
+
+# ---- prompt_range_selection ----
+
+
+def test_prompt_range_selection_happy(monkeypatch):
+    _scripted(monkeypatch, ["3", "4", "y"])
+    assert interactive.prompt_range_selection(_ctx()) == (3, 4)
+
+
+def test_prompt_range_selection_reprompts_on_non_integer(monkeypatch):
+    _scripted(monkeypatch, ["x", "3", "3", "4", "y"])
+    assert interactive.prompt_range_selection(_ctx()) == (3, 4)
+
+
+def test_prompt_range_selection_reprompts_on_inverted_range(monkeypatch):
+    # start > end is rejected by _validate_row_range, then a valid range.
+    _scripted(monkeypatch, ["4", "3", "3", "4", "y"])
+    assert interactive.prompt_range_selection(_ctx()) == (3, 4)
+
+
+# ---- prompt_cell_selection ----
+
+
+def test_prompt_cell_selection_happy(monkeypatch):
+    _scripted(monkeypatch, ["P01.3", "y"])
+    assert interactive.prompt_cell_selection(_ctx()) == [("P01", 3)]
+
+
+def test_prompt_cell_selection_multiple_specs(monkeypatch):
+    _scripted(monkeypatch, ["P01.3 + P02.4", "y"])
+    assert interactive.prompt_cell_selection(_ctx()) == [("P01", 3), ("P02", 4)]
+
+
+def test_prompt_cell_selection_filters_unknown_participant(monkeypatch):
+    # P99 is not a real participant; only the valid spec survives.
+    _scripted(monkeypatch, ["P99.3 + P01.3", "y"])
+    assert interactive.prompt_cell_selection(_ctx()) == [("P01", 3)]
+
+
+def test_prompt_cell_selection_reprompts_on_empty_input(monkeypatch):
+    _scripted(monkeypatch, ["", "P01.3", "y"])
+    assert interactive.prompt_cell_selection(_ctx()) == [("P01", 3)]
+
+
+# ---- prompt_participant_selection ----
+
+
+def test_prompt_participant_selection_by_number(monkeypatch):
+    _scripted(monkeypatch, ["1", "y"])
+    assert interactive.prompt_participant_selection(_ctx()) == ["P01"]
+
+
+def test_prompt_participant_selection_by_id(monkeypatch):
+    _scripted(monkeypatch, ["P02", "y"])
+    assert interactive.prompt_participant_selection(_ctx()) == ["P02"]
+
+
+def test_prompt_participant_selection_dedupes_number_and_id(monkeypatch):
+    # "1" and "P01" refer to the same participant; result must be deduped.
+    _scripted(monkeypatch, ["1, P01", "y"])
+    assert interactive.prompt_participant_selection(_ctx()) == ["P01"]
+
+
+def test_prompt_participant_selection_none_when_no_participants(monkeypatch):
+    _scripted(monkeypatch, [])
+    assert interactive.prompt_participant_selection(_ctx(num_participants=0)) is None
+
+
+# ---- prompt_keyword_selection ----
+
+
+def test_prompt_keyword_selection_single_annotation_confirmed(monkeypatch):
+    _scripted(monkeypatch, ["y"])
+    assert interactive.prompt_keyword_selection(_ctx()) == ["key"]
+
+
+def test_prompt_keyword_selection_single_annotation_declined(monkeypatch):
+    _scripted(monkeypatch, ["n"])
+    assert interactive.prompt_keyword_selection(_ctx()) is None
+
+
+def test_prompt_keyword_selection_none_when_no_annotations(monkeypatch):
+    sheet = _sheet_data()
+    sheet[3][2] = "00:30-00:40"  # remove the only !key annotation
+    _scripted(monkeypatch, [])
+    assert interactive.prompt_keyword_selection(_ctx(sheet_data=sheet)) is None
+
+
+# ---- browse_spreadsheet (smoke) ----
+
+
+def test_browse_spreadsheet_loads_and_quits(monkeypatch):
+    """Browse mode loads the sheet, renders the first page, and exits on quit.
+
+    Non-tty stdin routes _read_browse_key() through utils.read_user_input,
+    so a scripted "quit" drives one full loop iteration.
+    """
+
+    class _FakeSheet:
+        def get_all_values(self):
+            return _sheet_data()
+
+        spreadsheet = SimpleNamespace(title="study", url=None)
+
+    monkeypatch.setattr(google_api, "get_sheet_values", lambda s: s.get_all_values())
+    monkeypatch.setattr(utils, "use_progress", lambda: False)
+    _scripted(monkeypatch, ["quit"])
+    # Returns cleanly without raising.
+    interactive.browse_spreadsheet(_FakeSheet())
+
+
+def test_browse_spreadsheet_returns_early_on_missing_headers(monkeypatch):
+    class _FakeSheet:
+        def get_all_values(self):
+            return [["Study"], ["ID", "P01"]]  # missing Observation/Category
+
+        spreadsheet = SimpleNamespace(title="study", url=None)
+
+    monkeypatch.setattr(google_api, "get_sheet_values", lambda s: s.get_all_values())
+    monkeypatch.setattr(utils, "use_progress", lambda: False)
+    _scripted(monkeypatch, [])  # loop must not be reached
+    interactive.browse_spreadsheet(_FakeSheet())

--- a/tests/test_spreadsheet_generation.py
+++ b/tests/test_spreadsheet_generation.py
@@ -94,7 +94,7 @@ def test_get_num_participants_with_observation_before_id():
     [
         (["ID", "P01"], 1, 1),
         (["ID", "P01", "P02", "P03"], 1, 3),
-        (["ID", "Notes", "P01", "Tags", "G01", "G02"], 1, 3),
+        (["ID", "P01", "P02", "Observation", "Category"], 1, 2),
         (["Notes", "ID"], 2, 0),
         (["ID", "G01", "G02"], 1, 2),
         (["", "", "", "", "", "ID", "P01", "P02", "P03", "P04"], 6, 4),
@@ -102,7 +102,7 @@ def test_get_num_participants_with_observation_before_id():
     ids=[
         "single-participant",
         "three-contiguous",
-        "interleaved-non-participant-columns",
+        "trailing-non-participant-columns",
         "id-is-last-column",
         "group-prefixes",
         "id-deep-in-row",
@@ -111,9 +111,11 @@ def test_get_num_participants_with_observation_before_id():
 def test_get_num_participants_handles_variable_column_layouts(
     header_row, id_col, expected
 ):
-    """Different studies arrange columns differently. The count must reflect
-    only the headers actually starting with P/G — never assume a fixed total
-    or that participants are sandwiched between specific columns.
+    """Participant columns form one contiguous P*/G* block immediately after
+    ID; non-participant columns (Observation, Category, ...) sit outside it.
+    The count reflects only the P/G headers and must not assume a fixed
+    total. Interleaving a non-participant column inside the participant block
+    is not a supported layout, so it is intentionally not exercised here.
 
     Parametrized so a failing layout is named individually instead of
     aborting the loop on the first mismatch."""

--- a/tests/test_spreadsheet_generation.py
+++ b/tests/test_spreadsheet_generation.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 import spreadsheet
 from spreadsheet import SheetContext
 import files
@@ -87,20 +89,72 @@ def test_get_num_participants_with_observation_before_id():
     assert num == 4
 
 
-def test_get_num_participants_handles_variable_column_layouts():
-    """Different studies arrange columns differently. The count must reflect
-    only the headers actually starting with P/G — never assume a fixed total
-    or that participants are sandwiched between specific columns."""
-    cases = [
+@pytest.mark.parametrize(
+    "header_row, id_col, expected",
+    [
         (["ID", "P01"], 1, 1),
         (["ID", "P01", "P02", "P03"], 1, 3),
         (["ID", "Notes", "P01", "Tags", "G01", "G02"], 1, 3),
         (["Notes", "ID"], 2, 0),
-    ]
-    for header_row, id_col, expected in cases:
-        id_cell = SimpleNamespace(row=1, col=id_col)
-        num = spreadsheet.get_num_participants(header_row, id_cell, len(header_row))
-        assert num == expected, f"Expected {expected} for {header_row!r}, got {num}"
+        (["ID", "G01", "G02"], 1, 2),
+        (["", "", "", "", "", "ID", "P01", "P02", "P03", "P04"], 6, 4),
+    ],
+    ids=[
+        "single-participant",
+        "three-contiguous",
+        "interleaved-non-participant-columns",
+        "id-is-last-column",
+        "group-prefixes",
+        "id-deep-in-row",
+    ],
+)
+def test_get_num_participants_handles_variable_column_layouts(
+    header_row, id_col, expected
+):
+    """Different studies arrange columns differently. The count must reflect
+    only the headers actually starting with P/G — never assume a fixed total
+    or that participants are sandwiched between specific columns.
+
+    Parametrized so a failing layout is named individually instead of
+    aborting the loop on the first mismatch."""
+    id_cell = SimpleNamespace(row=1, col=id_col)
+    num = spreadsheet.get_num_participants(header_row, id_cell, len(header_row))
+    assert num == expected
+
+
+@pytest.mark.parametrize(
+    "label_row, label_value",
+    [
+        (0, "Baseline time"),
+        (1, "Baseline time"),
+        (3, "Baseline time"),
+        (1, "BASELINE TIME"),
+        (1, "Baseline time (clock)"),
+        (1, "  baseline time  "),
+    ],
+    ids=[
+        "row-0",
+        "row-1",
+        "row-3",
+        "uppercase",
+        "trailing-descriptive-text",
+        "surrounding-whitespace",
+    ],
+)
+def test_detect_baseline_row_finds_label_at_any_placement(label_row, label_value):
+    """The baseline row is located by a full-sheet scan, so its position is
+    not fixed relative to the header. Detection must be placement-agnostic,
+    case-insensitive, and tolerant of trailing label text."""
+    sheet_data = [["", "", ""] for _ in range(5)]
+    sheet_data[label_row][0] = label_value
+    assert spreadsheet._detect_baseline_row(sheet_data) == label_row
+
+
+def test_detect_baseline_row_absent_or_partial_label():
+    # No baseline row present at all.
+    assert spreadsheet._detect_baseline_row([["ID", "P01"], ["1", "00:10"]]) is None
+    # "Baseline" without "time" must not be mistaken for a baseline row.
+    assert spreadsheet._detect_baseline_row([["Baseline", "P01"]]) is None
 
 
 def test_build_sheet_context_with_observation_in_earlier_row():


### PR DESCRIPTION
Commit d6eefbd (#342) changed get_num_participants's third parameter
from observation_cell to an integer col_count and updated the
build_sheet_context caller, but missed the call site in
browse_spreadsheet(). Browse mode has since crashed with
"TypeError: '_CellLike' object cannot be interpreted as an integer"
on the range() in get_num_participants.

Compute col_count from the widest row, mirroring build_sheet_context.
A regression test lands with the interactive.py prompt coverage in the
following commit.