### PR TITLE
fix: regenerate clips when titlecards toggle on or off

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -871,6 +871,10 @@ def process_clips(
     # Load transcripts manifest once for embedding + transcription
     transcripts_manifest = transcripts.load_transcripts_manifest()
 
+    cards_enabled, card_duration = _resolve_titlecard_options(
+        titlecards_enabled, titlecard_duration_seconds
+    )
+
     for idx, (clip, base_video) in enumerate(prepared):
         generated_count, segment_details = results[idx]
         outputs_generated += generated_count
@@ -878,7 +882,12 @@ def process_clips(
             outputs_skipped += len(clip["times"]) - generated_count
         if segment_details:
             clip_artifacts = viewer.build_artifact_records_for_clip(
-                clip, base_video, segment_details, output_format
+                clip,
+                base_video,
+                segment_details,
+                output_format,
+                titlecards=cards_enabled,
+                titlecard_duration=card_duration,
             )
             _embed_transcript_on_artifacts(
                 clip,
@@ -1373,13 +1382,26 @@ def _regenerate_single_artifact(
     artifact_type = artifact.get("type", "clip")
 
     if artifact_type == "clip":
-        return video.run_ffmpeg(
+        ok = video.run_ffmpeg(
             input_file=source_path,
             output_file=output_path,
             start_pos=start_ts,
             end_pos=end_ts,
             reencode=config.REENCODING,
         )
+        # Reapply titlecards if the manifest entry was generated with them.
+        if ok and artifact.get("titlecards"):
+            clip: ClipRecord = {"desc": artifact.get("description", "")}
+            ok = titlecards.wrap_clip_with_cards(
+                clip,
+                output_path,
+                titlecards_enabled=True,
+                titlecard_duration_seconds=(
+                    artifact.get("titlecardDuration")
+                    or config.TITLECARD_DURATION_SECONDS
+                ),
+            )
+        return ok
     elif artifact_type == "screen":
         return video.extract_screenshot(
             input_file=source_path,

--- a/server.py
+++ b/server.py
@@ -974,6 +974,9 @@ def api_generate() -> FlaskResponse:
         _generate_cancel_event.clear()
         cancel_flag = _generate_cancel_event.is_set
         clip_cells: set[str] = set()
+        req_cards, req_dur = pipeline._resolve_titlecard_options(
+            titlecards_enabled, titlecard_duration_seconds
+        )
 
         # Pass 1: yield already-existing artifacts, collect clips that need generation
         to_generate: list[tuple[Any, str]] = []
@@ -984,20 +987,50 @@ def api_generate() -> FlaskResponse:
             existing = _find_existing_artifacts(
                 clip["cell"].row, clip["cell"].col, output_format
             )
-            if existing:
+            # A cached clip is only reusable when its recorded titlecard state
+            # matches the request; mismatched ones are discarded and regenerated
+            # so toggling Titlecards on/off (or changing the duration) takes
+            # effect on the next Generate.
+            fresh: list[dict[str, Any]] = []
+            stale: list[dict[str, Any]] = []
+            for a in existing:
+                matches = output_format != "clip" or (
+                    bool(a.get("titlecards", False)) == req_cards
+                    and (not req_cards or a.get("titlecardDuration") == req_dur)
+                )
+                (fresh if matches else stale).append(a)
+
+            if fresh:
                 yield (
                     json.dumps(
                         {
                             "cell": cell_str,
                             "ok": True,
-                            "generated": len(existing),
-                            "artifacts": existing,
+                            "generated": len(fresh),
+                            "artifacts": fresh,
                             "skipped": True,
                         }
                     )
                     + "\n"
                 )
             else:
+                # Drop stale records + files so regeneration reuses the same
+                # filename/id and the new record cleanly replaces the old one.
+                if stale:
+                    stale_ids = {a.get("id") for a in stale}
+                    with _generated_output_lock:
+                        _generated_artifacts[:] = [
+                            a
+                            for a in _generated_artifacts
+                            if a.get("id") not in stale_ids
+                        ]
+                    for a in stale:
+                        try:
+                            Path(utils.resolve_output_path(a["file"])).unlink(
+                                missing_ok=True
+                            )
+                        except OSError:
+                            pass
                 to_generate.append((clip, cell_str))
 
         # Pass 2: generate in parallel and yield as each completes

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import clipgen
 import config
 import pipeline
+import viewer
 
 
 def _prepared_clip(raw_clip, times):
@@ -670,3 +671,72 @@ def test_process_reel_dedups_missing_video_across_parallel_clips(
 
     assert result == 0
     assert len(errors) == 1
+
+
+def test_build_artifact_records_for_clip_stamps_titlecard_state(make_clip):
+    """Clip artifacts record their titlecard state; screen/gif artifacts do not."""
+    clip = _prepared_clip(make_clip(), [("00:10", "00:20")])
+    segment_details = [("out.mp4", 0)]
+
+    clip_recs = viewer.build_artifact_records_for_clip(
+        clip,
+        "study_P01.mp4",
+        segment_details,
+        "clip",
+        titlecards=True,
+        titlecard_duration=5,
+    )
+    assert clip_recs[0]["titlecards"] is True
+    assert clip_recs[0]["titlecardDuration"] == 5
+
+    screen_recs = viewer.build_artifact_records_for_clip(
+        clip,
+        "study_P01.mp4",
+        segment_details,
+        "screen",
+        titlecards=True,
+        titlecard_duration=5,
+    )
+    assert "titlecards" not in screen_recs[0]
+    assert "titlecardDuration" not in screen_recs[0]
+
+
+def test_regenerate_single_artifact_applies_titlecards_from_manifest(monkeypatch):
+    """A clip artifact recorded with titlecards is re-wrapped on regeneration;
+    one without titlecards is not."""
+    monkeypatch.setattr(pipeline.utils, "resolve_input_path", lambda p: p)
+    monkeypatch.setattr(pipeline.utils, "resolve_output_path", lambda p: p)
+    monkeypatch.setattr(pipeline.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", lambda **_k: True)
+
+    wrap_calls: list[tuple] = []
+
+    def fake_wrap(clip, out_path, **kwargs):
+        wrap_calls.append((clip, out_path, kwargs))
+        return True
+
+    monkeypatch.setattr(pipeline.titlecards, "wrap_clip_with_cards", fake_wrap)
+
+    with_cards = {
+        "type": "clip",
+        "file": "clip.mp4",
+        "sourceVideo": "study_P01.mp4",
+        "start": 0,
+        "end": 10,
+        "description": "an observation",
+        "titlecards": True,
+        "titlecardDuration": 4,
+    }
+    assert pipeline._regenerate_single_artifact(with_cards, set()) is True
+    assert len(wrap_calls) == 1
+    clip_arg, _out_arg, kwargs = wrap_calls[0]
+    assert clip_arg["desc"] == "an observation"
+    assert kwargs["titlecards_enabled"] is True
+    assert kwargs["titlecard_duration_seconds"] == 4
+
+    # Without the titlecards flag, no wrap happens.
+    wrap_calls.clear()
+    without_cards = dict(with_cards)
+    without_cards["titlecards"] = False
+    assert pipeline._regenerate_single_artifact(without_cards, set()) is True
+    assert wrap_calls == []

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -525,6 +525,116 @@ def test_api_generate_regenerates_when_file_missing(client, monkeypatch, tmp_pat
     assert lines[0]["artifacts"] == [new_artifact]
 
 
+def test_api_generate_regenerates_when_titlecards_toggled(
+    client, monkeypatch, tmp_path
+):
+    """Toggling titlecards on regenerates a cached no-titlecard clip and discards
+    the stale record + file."""
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+
+    # Existing clip generated WITHOUT titlecards; file present on disk.
+    (tmp_path / "clip.mp4").write_bytes(b"video")
+    existing = [
+        {
+            "id": "a5c2s0",
+            "type": "clip",
+            "file": "clip.mp4",
+            "cellRow": 5,
+            "cellCol": 2,
+            "titlecards": False,
+            "titlecardDuration": 0,
+        }
+    ]
+    monkeypatch.setattr(server, "_generated_artifacts", list(existing))
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00")
+    monkeypatch.setattr(
+        "spreadsheet.generate_list",
+        lambda ws, mode, *, ctx=None, cell_specs, skip_prompts: [
+            {"participant": "P01", "cell": cell}
+        ],
+    )
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
+
+    process_called = []
+    new_artifact = {
+        "id": "a5c2s0",
+        "type": "clip",
+        "file": "clip.mp4",
+        "cellRow": 5,
+        "cellCol": 2,
+        "titlecards": True,
+        "titlecardDuration": 2,
+    }
+    monkeypatch.setattr(
+        "pipeline.process_clips",
+        lambda *a, **kw: process_called.append(kw) or (1, [new_artifact]),
+    )
+
+    resp = client.post(
+        "/studio/api/generate",
+        json={"cells": ["P01.5"], "format": "clip", "titlecards_enabled": True},
+    )
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert process_called and process_called[0]["titlecards_enabled"] is True
+    assert "skipped" not in lines[0]
+    assert lines[0]["artifacts"] == [new_artifact]
+    # The stale no-titlecard file was discarded.
+    assert not (tmp_path / "clip.mp4").exists()
+
+
+def test_api_generate_skips_when_titlecards_match(client, monkeypatch, tmp_path):
+    """A cached clip whose titlecard state matches the request is reused."""
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr("config.TITLECARD_DURATION_SECONDS", 2)
+
+    (tmp_path / "clip.mp4").write_bytes(b"video")
+    existing = [
+        {
+            "id": "a5c2s0",
+            "type": "clip",
+            "file": "clip.mp4",
+            "cellRow": 5,
+            "cellCol": 2,
+            "titlecards": True,
+            "titlecardDuration": 2,
+        }
+    ]
+    monkeypatch.setattr(server, "_generated_artifacts", list(existing))
+
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00")
+    monkeypatch.setattr(
+        "spreadsheet.generate_list",
+        lambda ws, mode, *, ctx=None, cell_specs, skip_prompts: [
+            {"participant": "P01", "cell": cell}
+        ],
+    )
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
+
+    process_called = []
+    monkeypatch.setattr(
+        "pipeline.process_clips",
+        lambda *a, **kw: process_called.append(1) or (1, []),
+    )
+
+    resp = client.post(
+        "/studio/api/generate",
+        json={"cells": ["P01.5"], "format": "clip", "titlecards_enabled": True},
+    )
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert lines[0]["skipped"] is True
+    assert lines[0]["artifacts"] == existing
+    assert process_called == []
+    # The matching cached file is left intact.
+    assert (tmp_path / "clip.mp4").exists()
+
+
 def test_api_reel_skips_existing_reel(client, monkeypatch, tmp_path):
     """An identical reel is returned without re-running process_reel."""
     import types

--- a/viewer.py
+++ b/viewer.py
@@ -47,6 +47,9 @@ def build_artifact_records_for_clip(
     base_video: str,
     segment_details: list[tuple[str, int]],
     output_format: str,
+    *,
+    titlecards: bool = False,
+    titlecard_duration: int = 0,
 ) -> list[dict[str, Any]]:
     """Build artifact metadata records from a processed clip's successful outputs.
 
@@ -56,6 +59,10 @@ def build_artifact_records_for_clip(
         segment_details: List of (output_path, time_index) pairs.
             ``time_index`` is the index into ``clip['times']`` for this segment.
         output_format: 'clip', 'screen', or 'gif'
+        titlecards: Whether titlecards were applied (recorded on clip artifacts
+            only; lets the Studio skip logic and manifest regeneration detect a
+            mismatch with the requested titlecard setting).
+        titlecard_duration: Titlecard duration in seconds (clip artifacts only).
 
     Returns:
         List of artifact dicts ready for JSON serialization
@@ -64,7 +71,7 @@ def build_artifact_records_for_clip(
         output_format if output_format in ("clip", "screen", "gif") else "clip"
     )
     times = clip.get("times", [])
-    return [
+    records = [
         utils.build_artifact_record(
             clip,
             base_video,
@@ -76,6 +83,11 @@ def build_artifact_records_for_clip(
         )
         for seg_idx, (out_path, time_idx) in enumerate(segment_details)
     ]
+    if artifact_type == "clip":
+        for record in records:
+            record["titlecards"] = titlecards
+            record["titlecardDuration"] = titlecard_duration
+    return records
 
 
 def finalize_timeline_data(


### PR DESCRIPTION
The Studio /api/generate skip logic matched cached artifacts purely by
cell and type, so toggling Titlecards on/off never regenerated existing
clips. Clip artifact records now record their titlecard state; the skip
logic discards and regenerates clips whose state no longer matches the
request, and regenerate_from_manifest reapplies titlecards stored in the
manifest entry.