### PR TITLE
feat: guard optional ffmpeg features (drawtext, libvpx-vp9)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3287,6 +3287,27 @@ def main() -> None:
         )
         sys.exit(1)
 
+    if config.GIF_FORMAT.lower() == ".webm" and not video.check_vp9_support():
+        utils.error_print(
+            "WebM output is configured but ffmpeg lacks libvpx-vp9 support.",
+            [
+                "Affected config: GIF_FORMAT",
+                "Install an ffmpeg build with libvpx, or change GIF_FORMAT back to .gif/.webp in config.py.",
+            ],
+        )
+        sys.exit(1)
+
+    if config.TITLECARDS_ENABLED and not video.check_drawtext_support():
+        utils.error_print(
+            "Titlecards are enabled but ffmpeg lacks the drawtext filter.",
+            [
+                "drawtext requires libfreetype (often missing from Homebrew's default ffmpeg 8.x build).",
+                "Install an ffmpeg build with libfreetype to restore titlecards.",
+                "Disabling titlecards for this run.",
+            ],
+        )
+        config.TITLECARDS_ENABLED = False
+
     if _dispatch_standalone_mode(args, cli_mode, gallery_arg):
         sys.exit(0)
 

--- a/server.py
+++ b/server.py
@@ -1698,22 +1698,41 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
     if not isinstance(settings_data, dict):
         return {}, "Invalid settings payload"
 
-    for webp_name in ("SCREENSHOT_FORMAT", "GIF_FORMAT"):
-        if webp_name not in settings_data:
+    for format_name in ("SCREENSHOT_FORMAT", "GIF_FORMAT"):
+        if format_name not in settings_data:
             continue
-        new_value = str(settings_data[webp_name]).lower()
-        current_value = str(getattr(config, webp_name, "")).lower()
-        # Only validate when the user is *changing* the value to .webp; an
-        # unchanged .webp value already on disk shouldn't block edits to other
-        # fields.
-        if (
-            new_value == ".webp"
-            and current_value != ".webp"
-            and not video.check_webp_support()
-        ):
+        new_value = str(settings_data[format_name]).lower()
+        current_value = str(getattr(config, format_name, "")).lower()
+        # Only validate when the user is *changing* the value; an unchanged
+        # value already on disk shouldn't block edits to other fields.
+        if new_value == current_value:
+            continue
+        if new_value == ".webp" and not video.check_webp_support():
             return {}, (
                 f"WebP not available: ffmpeg has no libwebp encoder. "
-                f"Install an ffmpeg build with libwebp to set {webp_name} to .webp."
+                f"Install an ffmpeg build with libwebp to set {format_name} to .webp."
+            )
+        if new_value == ".webm" and not video.check_vp9_support():
+            return {}, (
+                f"WebM not available: ffmpeg has no libvpx-vp9 encoder. "
+                f"Install an ffmpeg build with libvpx to set {format_name} to .webm."
+            )
+
+    if "TITLECARDS_ENABLED" in settings_data:
+        raw_value = settings_data["TITLECARDS_ENABLED"]
+        new_enabled = (
+            raw_value
+            if isinstance(raw_value, bool)
+            else str(raw_value).lower() in ("true", "1", "yes", "on")
+        )
+        if (
+            new_enabled
+            and not getattr(config, "TITLECARDS_ENABLED", False)
+            and not video.check_drawtext_support()
+        ):
+            return {}, (
+                "Titlecards not available: ffmpeg lacks the drawtext filter "
+                "(requires libfreetype). Install an ffmpeg build with libfreetype to enable titlecards."
             )
 
     applied = {}

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -479,6 +479,92 @@ def test_check_webp_support_ignores_codecs_listing(monkeypatch):
     assert video.check_webp_support() is False
 
 
+_FFMPEG_FILTERS_WITH_DRAWTEXT = (
+    "Filters:\n"
+    "  T.. = Timeline support\n"
+    " ... drawbox           V->V       Draw a colored box.\n"
+    " T.. drawtext          V->V       Draw text on top of video.\n"
+)
+
+_FFMPEG_FILTERS_NO_DRAWTEXT = (
+    "Filters:\n"
+    "  T.. = Timeline support\n"
+    " ... drawbox           V->V       Draw a colored box.\n"
+)
+
+_FFMPEG_ENCODERS_WITH_VP9 = (
+    "Encoders:\n"
+    " V..... = Video\n"
+    " ------\n"
+    " V..... libvpx-vp9      libvpx VP9 (codec vp9)\n"
+)
+
+_FFMPEG_ENCODERS_NO_VP9 = (
+    "Encoders:\n V..... = Video\n ------\n V..... libx264         H.264 (codec h264)\n"
+)
+
+
+def test_check_drawtext_support_detects_filter(monkeypatch):
+    monkeypatch.setattr(video, "_drawtext_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_FILTERS_WITH_DRAWTEXT, stderr=""
+        ),
+    )
+    assert video.check_drawtext_support() is True
+
+    monkeypatch.setattr(video, "_drawtext_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_FILTERS_NO_DRAWTEXT, stderr=""
+        ),
+    )
+    assert video.check_drawtext_support() is False
+
+
+def test_check_vp9_support_detects_encoder(monkeypatch):
+    monkeypatch.setattr(video, "_vp9_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_ENCODERS_WITH_VP9, stderr=""
+        ),
+    )
+    assert video.check_vp9_support() is True
+
+    monkeypatch.setattr(video, "_vp9_support_cache", None)
+    monkeypatch.setattr(
+        video.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            [], 0, stdout=_FFMPEG_ENCODERS_NO_VP9, stderr=""
+        ),
+    )
+    assert video.check_vp9_support() is False
+
+
+def test_extract_gif_rejects_webm_when_vp9_unsupported(monkeypatch):
+    monkeypatch.setattr(video, "check_vp9_support", lambda: False)
+    monkeypatch.setattr(video, "_vp9_missing_warned", False)
+
+    called = {"run": False}
+
+    def fake_run(*_a, **_kw):
+        called["run"] = True
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    ok = video.extract_gif("/in.mp4", "/out.webm", "0:10", 3)
+    assert ok is False
+    assert called["run"] is False
+
+
 def test_extract_gif_includes_webp_quality_for_webp_output(monkeypatch):
     import config as cfg
 
@@ -520,6 +606,7 @@ def test_extract_gif_uses_vp9_for_webm_output(monkeypatch):
     monkeypatch.setattr(
         video.Path, "stat", lambda self: type("S", (), {"st_size": 1})()
     )
+    monkeypatch.setattr(video, "check_vp9_support", lambda: True)
 
     captured: dict = {}
 

--- a/video.py
+++ b/video.py
@@ -95,8 +95,35 @@ def check_ffmpeg_tools_available() -> bool:
     return False
 
 
+def _probe_ffmpeg_listing(listing_arg: str, target_tokens: set[str]) -> bool:
+    """Run `ffmpeg -hide_banner <listing_arg>` and report whether any line's
+    second whitespace-separated token is in *target_tokens*.
+
+    Used to detect optional ffmpeg features (encoders, filters). Only the
+    listing arg matters — `-encoders`, `-filters`, etc. each emit a tabular
+    listing whose second column is the encoder/filter name.
+    """
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", listing_arg],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    for line in (result.stdout or "").splitlines():
+        tokens = line.strip().split()
+        if len(tokens) >= 2 and tokens[1] in target_tokens:
+            return True
+    return False
+
+
 _webp_support_cache: bool | None = None
 _webp_missing_warned: bool = False
+_drawtext_support_cache: bool | None = None
+_vp9_support_cache: bool | None = None
+_vp9_missing_warned: bool = False
 
 
 def check_webp_support() -> bool:
@@ -108,25 +135,35 @@ def check_webp_support() -> bool:
     a line starting with `libwebp` or `libwebp_anim`. Result is cached.
     """
     global _webp_support_cache
-    if _webp_support_cache is not None:
-        return _webp_support_cache
-    try:
-        result = subprocess.run(
-            ["ffmpeg", "-hide_banner", "-encoders"],
-            capture_output=True,
-            text=True,
-            timeout=10,
+    if _webp_support_cache is None:
+        _webp_support_cache = _probe_ffmpeg_listing(
+            "-encoders", {"libwebp", "libwebp_anim"}
         )
-        stdout = result.stdout or ""
-        _webp_support_cache = False
-        for line in stdout.splitlines():
-            tokens = line.strip().split()
-            if len(tokens) >= 2 and tokens[1] in ("libwebp", "libwebp_anim"):
-                _webp_support_cache = True
-                break
-    except (OSError, subprocess.SubprocessError):
-        _webp_support_cache = False
     return _webp_support_cache
+
+
+def check_drawtext_support() -> bool:
+    """Return True when ffmpeg has the `drawtext` filter available.
+
+    `drawtext` requires libfreetype, which is omitted from Homebrew's default
+    ffmpeg 8.x build. Without it, titlecard encoding fails. Result is cached.
+    """
+    global _drawtext_support_cache
+    if _drawtext_support_cache is None:
+        _drawtext_support_cache = _probe_ffmpeg_listing("-filters", {"drawtext"})
+    return _drawtext_support_cache
+
+
+def check_vp9_support() -> bool:
+    """Return True when ffmpeg has a libvpx-vp9 encoder available.
+
+    Needed when GIF_FORMAT is ".webm". Same caveat as libwebp — only the
+    `-encoders` listing is authoritative. Result is cached.
+    """
+    global _vp9_support_cache
+    if _vp9_support_cache is None:
+        _vp9_support_cache = _probe_ffmpeg_listing("-encoders", {"libvpx-vp9"})
+    return _vp9_support_cache
 
 
 def _warn_webp_unavailable_once(output_file: str) -> None:
@@ -141,6 +178,22 @@ def _warn_webp_unavailable_once(output_file: str) -> None:
             f"Tried to write: '{output_file}'",
             "Install an ffmpeg build with libwebp, or change SCREENSHOT_FORMAT/GIF_FORMAT back to .png/.jpg/.gif.",
             "Skipping all WebP outputs for this run.",
+        ],
+    )
+
+
+def _warn_vp9_unavailable_once(output_file: str) -> None:
+    """Print a single clear error per session when WebM/VP9 is requested but unsupported."""
+    global _vp9_missing_warned
+    if _vp9_missing_warned:
+        return
+    _vp9_missing_warned = True
+    utils.error_print(
+        "WebM output requested but ffmpeg has no libvpx-vp9 encoder.",
+        [
+            f"Tried to write: '{output_file}'",
+            "Install an ffmpeg build with libvpx, or change GIF_FORMAT back to .gif/.webp.",
+            "Skipping all WebM outputs for this run.",
         ],
     )
 
@@ -807,6 +860,9 @@ def extract_gif(
         ic(input_file, output_file, timestamp, duration_seconds)
     if output_file.lower().endswith(".webp") and not check_webp_support():
         _warn_webp_unavailable_once(output_file)
+        return False
+    if output_file.lower().endswith(".webm") and not check_vp9_support():
+        _warn_vp9_unavailable_once(output_file)
         return False
     if not Path(input_file).is_file():
         utils.error_print(


### PR DESCRIPTION
## Summary

Adds the same kind of upfront guard we already have for libwebp to two other optional ffmpeg features that clipgen relies on: the `drawtext` filter (titlecards) and `libvpx-vp9` (`.webm` GIF output). Without these, titlecards silently fail per-clip and `.webm` runs hit a hard ffmpeg error mid-run — both now surface at startup (or at Studio toggle time) with a single clear message, with titlecards soft-degrading so clip generation still proceeds.

Refactors the existing `check_webp_support` to share a small `_probe_ffmpeg_listing` helper with the two new probes, and tightens the Studio settings handler so it rejects toggling `TITLECARDS_ENABLED` on or `GIF_FORMAT` to `.webm` when the corresponding ffmpeg feature is missing.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 940 passed
- [x] `uv run ruff format --check && uv run ruff check` — clean
- [x] `uv run ty check` — no new diagnostics (pre-existing pytest-import warnings only)
- [ ] Manual: with `check_drawtext_support` mocked False, confirm `clipgen.py --titlecards` prints one clear error at startup and proceeds without per-clip warnings
- [ ] Manual: in Studio, toggle titlecards on with drawtext mocked False → settings save returns rejection message