### PR TITLE
perf: parallelize intake clips and reel regeneration (PERFORMANCE-PLAN-2 phase 2)

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1261,10 +1261,19 @@ def regenerate_from_manifest(
     reel_list = reels or []
     workers = _resolve_clip_workers()
     parallel_media = workers >= 2 and len(media) >= 2
+    parallel_reels = workers >= 2 and len(reel_list) >= 2
 
     def _regenerate_artifact_threadsafe(artifact: dict[str, Any]) -> bool:
         local_missing: set[str] = set()
         ok = _regenerate_single_artifact(artifact, local_missing)
+        if local_missing:
+            with missing_lock:
+                missing_videos.update(local_missing)
+        return ok
+
+    def _regenerate_reel_threadsafe(reel: dict[str, Any]) -> bool:
+        local_missing: set[str] = set()
+        ok = _regenerate_reel(reel, local_missing)
         if local_missing:
             with missing_lock:
                 missing_videos.update(local_missing)
@@ -1311,16 +1320,39 @@ def regenerate_from_manifest(
                     if _regenerate_single_artifact(artifact, missing_videos):
                         generated += 1
                     progress.update(task, advance=1)
-            for reel in reel_list:
-                progress.update(
-                    task,
-                    description=reel.get("description", "Reel")[
-                        : config.PROGRESS_DESCRIPTION_LENGTH
-                    ],
-                )
-                if _regenerate_reel(reel, missing_videos):
-                    generated += 1
-                progress.update(task, advance=1)
+            if parallel_reels:
+                reel_results: list[bool] = [False] * len(reel_list)
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=workers,
+                ) as pool:
+                    reel_future_to_idx = {
+                        pool.submit(_regenerate_reel_threadsafe, reel): idx
+                        for idx, reel in enumerate(reel_list)
+                    }
+                    for future in concurrent.futures.as_completed(reel_future_to_idx):
+                        idx = reel_future_to_idx[future]
+                        try:
+                            reel_results[idx] = future.result()
+                        except Exception as exc:
+                            reel = reel_list[idx]
+                            utils.error_print(
+                                f"Reel regen failed: {reel.get('description', 'reel')[: config.PROGRESS_DESCRIPTION_LENGTH]}",
+                                [str(exc)],
+                            )
+                            reel_results[idx] = False
+                        progress.update(task, advance=1)
+                generated += sum(1 for ok in reel_results if ok)
+            else:
+                for reel in reel_list:
+                    progress.update(
+                        task,
+                        description=reel.get("description", "Reel")[
+                            : config.PROGRESS_DESCRIPTION_LENGTH
+                        ],
+                    )
+                    if _regenerate_reel(reel, missing_videos):
+                        generated += 1
+                    progress.update(task, advance=1)
     elif parallel_media:
         results = [False] * len(media)
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
@@ -1340,16 +1372,56 @@ def regenerate_from_manifest(
                     )
                     results[idx] = False
         generated += sum(1 for ok in results if ok)
-        for reel in reel_list:
-            if _regenerate_reel(reel, missing_videos):
-                generated += 1
+        if parallel_reels:
+            reel_results = [False] * len(reel_list)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+                reel_future_to_idx = {
+                    pool.submit(_regenerate_reel_threadsafe, reel): idx
+                    for idx, reel in enumerate(reel_list)
+                }
+                for future in concurrent.futures.as_completed(reel_future_to_idx):
+                    idx = reel_future_to_idx[future]
+                    try:
+                        reel_results[idx] = future.result()
+                    except Exception as exc:
+                        reel = reel_list[idx]
+                        utils.error_print(
+                            f"Reel regen failed: {reel.get('description', 'reel')[: config.PROGRESS_DESCRIPTION_LENGTH]}",
+                            [str(exc)],
+                        )
+                        reel_results[idx] = False
+            generated += sum(1 for ok in reel_results if ok)
+        else:
+            for reel in reel_list:
+                if _regenerate_reel(reel, missing_videos):
+                    generated += 1
     else:
         for artifact in media:
             if _regenerate_single_artifact(artifact, missing_videos):
                 generated += 1
-        for reel in reel_list:
-            if _regenerate_reel(reel, missing_videos):
-                generated += 1
+        if parallel_reels:
+            reel_results = [False] * len(reel_list)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+                reel_future_to_idx = {
+                    pool.submit(_regenerate_reel_threadsafe, reel): idx
+                    for idx, reel in enumerate(reel_list)
+                }
+                for future in concurrent.futures.as_completed(reel_future_to_idx):
+                    idx = reel_future_to_idx[future]
+                    try:
+                        reel_results[idx] = future.result()
+                    except Exception as exc:
+                        reel = reel_list[idx]
+                        utils.error_print(
+                            f"Reel regen failed: {reel.get('description', 'reel')[: config.PROGRESS_DESCRIPTION_LENGTH]}",
+                            [str(exc)],
+                        )
+                        reel_results[idx] = False
+            generated += sum(1 for ok in reel_results if ok)
+        else:
+            for reel in reel_list:
+                if _regenerate_reel(reel, missing_videos):
+                    generated += 1
 
     if missing_videos:
         utils.standard_print(f"* Missing source video files: {len(missing_videos)}")

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -81,7 +81,7 @@ Seven small, independent diffs. None changes a public contract; all are safe to 
 
 Three medium-sized improvements that each unlock a parallel path.
 
-### 2.1 Parallelize `_generate_intake_clips`
+### ✅ 2.1 Parallelize `_generate_intake_clips`
 
 - **File:** `server.py:475-505`
 - **Today:** Bare `for item in items:` calling `video.run_ffmpeg()`. No executor.

--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -88,7 +88,7 @@ Three medium-sized improvements that each unlock a parallel path.
 - **Change:** Mirror the gallery pattern — collect work, dispatch to `ThreadPoolExecutor(max_workers=pipeline._resolve_clip_workers())`, return ordered results via index. Each task returns the existing `_ok` / `_error` shape.
 - **Constraint:** Output filename collisions — verify each item already gets a unique output path before parallelizing (or serialize the naming step).
 
-### 2.2 Parallel reel regeneration
+### ✅ 2.2 Parallel reel regeneration
 
 - **File:** `pipeline.py:1173-1182` (and the follow-up loops at 1202-1204, 1209-1211).
 - **Today:** `for reel in reel_list: _regenerate_reel(reel)` — sequential despite the surrounding code parallelizing media artifacts.

--- a/server.py
+++ b/server.py
@@ -747,10 +747,28 @@ def _generate_intake_clips(
     the video was missing or ffmpeg failed) plus an ``"_error"`` string so
     callers can report per-item results without duplicating the loop.
     """
-    return [
-        _process_intake_item(item, output_format, study, index=idx)
-        for idx, item in enumerate(items)
-    ]
+    workers = pipeline._resolve_clip_workers()
+    if workers < 2 or len(items) < 2:
+        return [
+            _process_intake_item(item, output_format, study, index=idx)
+            for idx, item in enumerate(items)
+        ]
+
+    results: list[dict[str, Any]] = [{} for _ in items]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        future_to_idx = {
+            pool.submit(
+                _process_intake_item, item, output_format, study, index=idx
+            ): idx
+            for idx, item in enumerate(items)
+        }
+        for future in concurrent.futures.as_completed(future_to_idx):
+            idx = future_to_idx[future]
+            try:
+                results[idx] = future.result()
+            except Exception as exc:
+                results[idx] = {"_ok": False, "_error": str(exc)}
+    return results
 
 
 def _load_stashes() -> list[dict[str, Any]]:
@@ -1804,23 +1822,47 @@ def api_generate_intake() -> FlaskResponse:
     output_format = data.get("format", "clip")
     study = _sheet_context.study_name if _sheet_context else ""
 
+    def _emit(idx: int, result: dict[str, Any]) -> str:
+        ok = result.pop("_ok", False)
+        error = result.pop("_error", "")
+        if ok:
+            _append_generated_artifact(result)
+            return json.dumps({"index": idx, "ok": True, "artifact": result}) + "\n"
+        return json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
+
     def stream() -> Iterator[str]:
         _mark_intake_active(True)
         try:
-            for idx, item in enumerate(items):
-                result = _process_intake_item(item, output_format, study, index=idx)
-                ok = result.pop("_ok", False)
-                error = result.pop("_error", "")
-                if ok:
-                    _append_generated_artifact(result)
-                    yield (
-                        json.dumps({"index": idx, "ok": True, "artifact": result})
-                        + "\n"
-                    )
-                else:
-                    yield (
-                        json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
-                    )
+            workers = pipeline._resolve_clip_workers()
+            if workers >= 2 and len(items) >= 2:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+                    future_to_idx = {
+                        pool.submit(
+                            _process_intake_item,
+                            item,
+                            output_format,
+                            study,
+                            index=idx,
+                        ): idx
+                        for idx, item in enumerate(items)
+                    }
+                    for future in concurrent.futures.as_completed(future_to_idx):
+                        idx = future_to_idx[future]
+                        try:
+                            result = future.result()
+                        except Exception as exc:
+                            yield (
+                                json.dumps(
+                                    {"index": idx, "ok": False, "error": str(exc)}
+                                )
+                                + "\n"
+                            )
+                            continue
+                        yield _emit(idx, result)
+            else:
+                for idx, item in enumerate(items):
+                    result = _process_intake_item(item, output_format, study, index=idx)
+                    yield _emit(idx, result)
         finally:
             # Persist whatever completed even if the client disconnects or a
             # later item raises mid-stream.


### PR DESCRIPTION
## Summary
- Phase 2.1: `_generate_intake_clips` and the `/api/generate-intake` NDJSON stream fan out across `pipeline._resolve_clip_workers()` workers via `as_completed`. The client already keys cards by `index`, so out-of-order completion just means cards now light up as each ffmpeg finishes instead of one-by-one after the whole batch.
- Phase 2.2: the three `for reel in reel_list` loops in `regenerate_from_manifest()` now run concurrently when `parallel_reels = workers >= 2 and len(reel_list) >= 2`, mirroring the existing media-artifact parallel path. `_regenerate_reel_threadsafe` wraps `_regenerate_reel` with a local `missing_videos` set merged under `missing_lock`. Per-reel description updates are dropped on the parallel branch; the progress bar still advances per completion.
- Safety: `files.get_unique_filename()` reserves output paths atomically via `O_EXCL`, and all shared state (`_generated_artifacts`, `missing_videos`, `_busy_lock`) is already lock-guarded.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 940 passed
- [x] `uv run ruff format && uv run ruff check && uv run ty check` — clean
- [ ] Manual: Studio intake with ≥4 queued items, confirm cards finish out-of-order and wall-clock drops
- [ ] Manual: `uv run clipgen.py --regenerate` on a manifest with ≥2 reels, confirm reel encodes overlap and the reel files play correctly