### PR TITLE
perf: artifact index + debounced screenspace manifest writes

### DIFF
--- a/plans/PERFORMANCE-PLAN-2.md
+++ b/plans/PERFORMANCE-PLAN-2.md
@@ -109,7 +109,7 @@ Three medium-sized improvements that each unlock a parallel path.
 
 ---
 
-## Phase 3 — `_find_existing_artifacts` skip-pass
+## ✅ Phase 3 — `_find_existing_artifacts` skip-pass
 
 - **File:** `server.py:653-664`.
 - **Today:** Linear scan over `_generated_artifacts` + per-candidate `Path(...).is_file()`. Called once per cell during Phase 1 of `/api/generate`.
@@ -156,7 +156,7 @@ Two larger frontend changes. Each is its own session.
 
 Items surfaced by the deep audit that look real but were not exhaustively re-read by the reviewer. Each starts with a short verification step before the diff. None is a single-line fix; each is its own small PR.
 
-### 5.1 Debounce Screenspace manifest writes
+### ✅ 5.1 Debounce Screenspace manifest writes
 
 - **File:** `screenspace_server.py` (calls to `_persist_manifest(drain_events=False)` around 1419, 1433, 1437, 1452, 1463, 1474 — verify exact lines before editing).
 - **Today:** Every task enqueue / cancel / reorder / pause / resume calls `_persist_manifest()`, which serializes and disk-writes the full JSON.

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -40,6 +40,7 @@ API endpoints (all under /screenspace/):
   PUT  /api/events/bulk-include            – bulk include events by task/time range
 """
 
+import atexit
 import binascii
 import copy
 import json
@@ -1435,7 +1436,7 @@ def api_tasks_create() -> FlaskResponse:
         )
 
     _worker.enqueue(task)
-    _persist_manifest(drain_events=False)
+    _schedule_persist()
     _notify_sse_clients("task_created")
 
     return jsonify({"ok": True, "task": _clean_task(task)})
@@ -1449,11 +1450,11 @@ def api_tasks_cancel(task_id: str) -> FlaskResponse:
     if request.args.get("dismiss") == "true":
         if not _worker.remove_task(task_id):
             return jsonify({"ok": False, "error": "Task not found"}), 404
-        _persist_manifest(drain_events=False)
+        _schedule_persist()
         _notify_sse_clients("task_dismissed")
         return jsonify({"ok": True})
     if _worker.cancel(task_id):
-        _persist_manifest(drain_events=False)
+        _schedule_persist()
         _notify_sse_clients("task_cancelled")
         return jsonify({"ok": True})
     return jsonify({"ok": False, "error": "Task not found or already finished"}), 400
@@ -1468,7 +1469,7 @@ def api_tasks_reorder() -> FlaskResponse:
     if not data or "task_ids" not in data:
         return jsonify({"ok": False, "error": "task_ids list required"}), 400
     _worker.reorder(data["task_ids"])
-    _persist_manifest(drain_events=False)
+    _schedule_persist()
     _notify_sse_clients("reorder")
     return jsonify({"ok": True})
 
@@ -1479,7 +1480,7 @@ def api_tasks_pause() -> FlaskResponse:
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
     _worker.pause()
-    _persist_manifest(drain_events=False)
+    _schedule_persist()
     _notify_sse_clients("pause")
     return jsonify({"ok": True, "paused": True})
 
@@ -1490,7 +1491,7 @@ def api_tasks_resume() -> FlaskResponse:
     if not _worker:
         return jsonify({"ok": False, "error": "Worker not initialized"}), 500
     _worker.resume()
-    _persist_manifest(drain_events=False)
+    _schedule_persist()
     _notify_sse_clients("resume")
     return jsonify({"ok": True, "paused": False})
 
@@ -1845,7 +1846,69 @@ def _do_persist(*, drain_events: bool = True) -> None:
     )
 
 
+# Manifest-write debounce: rapid UI mutations (enqueue / cancel / reorder /
+# pause / resume) coalesce into one disk write after a short quiet period.
+# atexit fires the pending flush on normal exit / SIGINT / SIGTERM, but not
+# on SIGKILL or hard power-loss — accepted because screenspace manifest is
+# recreatable analysis state.
+_PERSIST_DEBOUNCE_SECONDS = 2.0
+_persist_timer: threading.Timer | None = None
+_persist_timer_lock = threading.Lock()
+_persist_dirty = False
+
+
+def _cancel_pending_persist_timer() -> bool:
+    """Cancel the debounce timer and clear the dirty flag. Returns prior dirty state."""
+    global _persist_timer, _persist_dirty
+    with _persist_timer_lock:
+        timer = _persist_timer
+        _persist_timer = None
+        was_dirty = _persist_dirty
+        _persist_dirty = False
+    if timer is not None:
+        timer.cancel()
+    return was_dirty
+
+
+def _on_persist_timer() -> None:
+    global _persist_timer, _persist_dirty
+    with _persist_timer_lock:
+        _persist_timer = None
+        if not _persist_dirty:
+            return
+        _persist_dirty = False
+    with _manifest_lock:
+        _do_persist(drain_events=False)
+
+
+def _schedule_persist() -> None:
+    """Mark the manifest dirty and (re)arm the debounce timer."""
+    global _persist_timer, _persist_dirty
+    with _persist_timer_lock:
+        _persist_dirty = True
+        if _persist_timer is not None:
+            _persist_timer.cancel()
+        _persist_timer = threading.Timer(_PERSIST_DEBOUNCE_SECONDS, _on_persist_timer)
+        _persist_timer.daemon = True
+        _persist_timer.start()
+
+
+def _flush_pending_persist() -> None:
+    """Cancel any pending debounced write and persist immediately if dirty."""
+    if _cancel_pending_persist_timer():
+        with _manifest_lock:
+            _do_persist(drain_events=False)
+
+
+atexit.register(_flush_pending_persist)
+
+
 def _persist_manifest(*, drain_events: bool = True) -> None:
-    """Persist the current manifest state through a single synchronized path."""
+    """Persist the current manifest state through a single synchronized path.
+
+    Synchronous callers (task completion, atexit flush) supersede any pending
+    debounced write — cancel the timer here so we don't double-flush.
+    """
+    _cancel_pending_persist_timer()
     with _manifest_lock:
         _do_persist(drain_events=drain_events)

--- a/server.py
+++ b/server.py
@@ -80,6 +80,9 @@ _sheet_context: spreadsheet.SheetContext | None = None
 # picker; CLI-loaded sheets leave this None.
 _active_sheet_meta: dict[str, str] | None = None
 _generated_artifacts: list[dict[str, Any]] = []
+# Index by (cellRow, cellCol, type) for O(1) lookup in /api/generate Phase 1.
+# Mutated under _generated_output_lock together with _generated_artifacts.
+_generated_artifacts_index: dict[tuple[int, int, str], list[dict[str, Any]]] = {}
 _generated_reels: list[dict[str, Any]] = []
 # Bounded LRU so long sessions don't grow unbounded; entries are JPEG bytes
 # (tens of KB each), so a few hundred is plenty.
@@ -216,16 +219,36 @@ def _parse_titlecard_request(
     return enabled, duration
 
 
+def _index_artifact(a: dict[str, Any]) -> None:
+    """Insert *a* into _generated_artifacts_index. Caller must hold the lock."""
+    row = a.get("cellRow")
+    col = a.get("cellCol")
+    type_ = a.get("type")
+    if row is None or col is None or type_ is None:
+        return
+    _generated_artifacts_index.setdefault((row, col, type_), []).append(a)
+
+
+def _rebuild_artifact_index() -> None:
+    """Clear and repopulate the index from _generated_artifacts. Caller holds lock."""
+    _generated_artifacts_index.clear()
+    for a in _generated_artifacts:
+        _index_artifact(a)
+
+
 def _extend_generated_artifacts(artifacts: list[dict[str, Any]]) -> None:
     if not artifacts:
         return
     with _generated_output_lock:
         _generated_artifacts.extend(artifacts)
+        for a in artifacts:
+            _index_artifact(a)
 
 
 def _append_generated_artifact(artifact: dict[str, Any]) -> None:
     with _generated_output_lock:
         _generated_artifacts.append(artifact)
+        _index_artifact(artifact)
 
 
 def _extend_generated_reels(reels: list[dict[str, Any]]) -> None:
@@ -912,19 +935,37 @@ def _save_studio_settings(overrides: dict[str, Any]) -> Path | None:
 
 
 def _find_existing_artifacts(
-    cell_row: int, cell_col: int, artifact_type: str
+    cell_row: int,
+    cell_col: int,
+    artifact_type: str,
+    existence_cache: dict[str, bool] | None = None,
 ) -> list[dict[str, Any]]:
-    """Return cached artifact records for a cell+type whose files still exist on disk."""
+    """Return cached artifact records for a cell+type whose files still exist on disk.
+
+    *existence_cache* memoizes path → is_file() within a single caller scope
+    (e.g. one /api/generate Phase 1 pass), so the same artifact path doesn't
+    hit the disk twice. Pass None for one-shot callers.
+    """
     with _generated_output_lock:
-        artifacts_snapshot = list(_generated_artifacts)
-    matches = [
-        a
-        for a in artifacts_snapshot
-        if a.get("cellRow") == cell_row
-        and a.get("cellCol") == cell_col
-        and a.get("type") == artifact_type
-    ]
-    return [a for a in matches if Path(utils.resolve_output_path(a["file"])).is_file()]
+        matches = list(
+            _generated_artifacts_index.get((cell_row, cell_col, artifact_type), [])
+        )
+    if not matches:
+        return []
+    results: list[dict[str, Any]] = []
+    for a in matches:
+        resolved = str(utils.resolve_output_path(a["file"]))
+        if existence_cache is not None:
+            cached = existence_cache.get(resolved)
+            if cached is None:
+                cached = Path(resolved).is_file()
+                existence_cache[resolved] = cached
+            exists = cached
+        else:
+            exists = Path(resolved).is_file()
+        if exists:
+            results.append(a)
+    return results
 
 
 def _stream_process_reel(
@@ -1048,12 +1089,16 @@ def api_generate() -> FlaskResponse:
 
         # Pass 1: yield already-existing artifacts, collect clips that need generation
         to_generate: list[tuple[Any, str]] = []
+        existence_cache: dict[str, bool] = {}
         for clip in clips:
             cell_str = clip["participant"] + "." + str(clip["cell"].row)
             clip_cells.add(cell_str)
 
             existing = _find_existing_artifacts(
-                clip["cell"].row, clip["cell"].col, output_format
+                clip["cell"].row,
+                clip["cell"].col,
+                output_format,
+                existence_cache=existence_cache,
             )
             # A cached clip is only reusable when its recorded titlecard state
             # matches the request; mismatched ones are discarded and regenerated
@@ -1093,11 +1138,12 @@ def api_generate() -> FlaskResponse:
                             for a in _generated_artifacts
                             if a.get("id") not in stale_ids
                         ]
+                        _rebuild_artifact_index()
                     for a in stale:
+                        resolved = str(utils.resolve_output_path(a["file"]))
+                        existence_cache[resolved] = False
                         try:
-                            Path(utils.resolve_output_path(a["file"])).unlink(
-                                missing_ok=True
-                            )
+                            Path(resolved).unlink(missing_ok=True)
                         except OSError:
                             pass
                 to_generate.append((clip, cell_str))
@@ -2198,6 +2244,7 @@ def _init_studio_state(worksheet: Any) -> None:
     # generate/intake append can't run against a half-swapped reference.
     with _generated_output_lock:
         _generated_artifacts, _generated_reels = viewer._load_manifest_both()
+        _rebuild_artifact_index()
     with _thumbnail_cache_lock:
         _thumbnail_cache = OrderedDict()
 
@@ -2291,6 +2338,7 @@ def _swap_worksheet(new_worksheet: Any) -> None:
         with _generated_output_lock:
             _generated_artifacts = prev_artifacts
             _generated_reels = prev_reels
+            _rebuild_artifact_index()
         # Best-effort: re-pin the two sister blueprints to the restored state.
         # If these themselves throw, swallow — the studio state is already
         # consistent and the original exception is what we want to surface.

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -833,7 +833,8 @@ def test_dismiss_queued_task(client):
     assert resp.get_json()["ok"] is True
     # Task removed from worker
     assert worker.get_task(task["id"]) is None
-    # Task removed from manifest
+    # Task removed from manifest (flush the debounced persist first)
+    screenspace_server._flush_pending_persist()
     assert all(t["id"] != task["id"] for t in screenspace_server._manifest["tasks"])
 
 
@@ -851,6 +852,7 @@ def test_dismiss_completed_task(client):
     resp = client.delete(f"/screenspace/api/tasks/{task['id']}?dismiss=true")
     assert resp.status_code == 200
     assert worker.get_task(task["id"]) is None
+    screenspace_server._flush_pending_persist()
     assert all(t["id"] != task["id"] for t in screenspace_server._manifest["tasks"])
 
 
@@ -1300,6 +1302,13 @@ def _install_persist_spy(monkeypatch):
         calls.append({"drain_events": drain_events})
 
     monkeypatch.setattr(screenspace_server, "_do_persist", spy)
+    # Debounced task-queue routes go through _schedule_persist → Timer → _do_persist.
+    # Collapse the debounce here so assertions don't race the timer.
+    monkeypatch.setattr(
+        screenspace_server,
+        "_schedule_persist",
+        lambda: spy(drain_events=False),
+    )
     return calls
 
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -7,6 +7,13 @@ Flask = pytest.importorskip("flask").Flask
 import server  # noqa: E402
 
 
+def _set_artifacts(monkeypatch, artifacts):
+    """Patch _generated_artifacts and rebuild the lookup index in lockstep."""
+    monkeypatch.setattr(server, "_generated_artifacts", list(artifacts))
+    monkeypatch.setattr(server, "_generated_artifacts_index", {})
+    server._rebuild_artifact_index()
+
+
 @pytest.fixture
 def client(monkeypatch):
     app = Flask(__name__)
@@ -15,7 +22,7 @@ def client(monkeypatch):
     # Default: no worksheet/context loaded (error state)
     monkeypatch.setattr(server, "_worksheet", None)
     monkeypatch.setattr(server, "_sheet_context", None)
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
     monkeypatch.setattr(server, "_generated_reels", [])
     server._release_busy("generate")
     server._release_busy("reel")
@@ -431,7 +438,7 @@ def test_api_manifest_get_empty(client, monkeypatch):
 
 
 def test_api_manifest_post_still_works(client, monkeypatch):
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
     monkeypatch.setattr(server, "_generated_reels", [])
     resp = client.post("/studio/api/manifest")
     assert resp.status_code == 400
@@ -453,7 +460,7 @@ def test_api_generate_skips_existing_artifacts(client, monkeypatch, tmp_path):
     existing = [
         {"id": "a5c2s0", "type": "clip", "file": "clip.mp4", "cellRow": 5, "cellCol": 2}
     ]
-    monkeypatch.setattr(server, "_generated_artifacts", list(existing))
+    _set_artifacts(monkeypatch, list(existing))
 
     cell = types.SimpleNamespace(row=5, col=2, value="1:00")
 
@@ -494,7 +501,7 @@ def test_api_generate_regenerates_when_file_missing(client, monkeypatch, tmp_pat
     stale = [
         {"id": "a5c2s0", "type": "clip", "file": "gone.mp4", "cellRow": 5, "cellCol": 2}
     ]
-    monkeypatch.setattr(server, "_generated_artifacts", list(stale))
+    _set_artifacts(monkeypatch, list(stale))
 
     cell = types.SimpleNamespace(row=5, col=2, value="1:00")
 
@@ -548,7 +555,7 @@ def test_api_generate_regenerates_when_titlecards_toggled(
             "titlecardDuration": 0,
         }
     ]
-    monkeypatch.setattr(server, "_generated_artifacts", list(existing))
+    _set_artifacts(monkeypatch, list(existing))
 
     cell = types.SimpleNamespace(row=5, col=2, value="1:00")
     monkeypatch.setattr(
@@ -606,7 +613,7 @@ def test_api_generate_skips_when_titlecards_match(client, monkeypatch, tmp_path)
             "titlecardDuration": 2,
         }
     ]
-    monkeypatch.setattr(server, "_generated_artifacts", list(existing))
+    _set_artifacts(monkeypatch, list(existing))
 
     cell = types.SimpleNamespace(row=5, col=2, value="1:00")
     monkeypatch.setattr(
@@ -1241,7 +1248,7 @@ def test_api_generate_passes_titlecard_options_to_pipeline(client, monkeypatch):
     monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
     monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
     monkeypatch.setattr("pipeline.process_clips", fake_process_clips)
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
 
     resp = client.post(
         "/studio/api/generate",
@@ -1284,7 +1291,7 @@ def test_api_generate_titlecard_options_on_pipeline_error(client, monkeypatch):
     monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
     monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
     monkeypatch.setattr("pipeline.process_clips", fake_process_clips)
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
 
     resp = client.post(
         "/studio/api/generate",
@@ -2331,7 +2338,7 @@ def test_api_generate_persists_artifacts_after_disconnect(
 
     monkeypatch.setattr(server, "_worksheet", object())
     monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
     monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
     monkeypatch.setattr("titlecards.clear_endcard_cache", lambda: None)
     # Force the parallel path: pool size > 1, more cells than pool workers so
@@ -2465,7 +2472,7 @@ def test_api_job_status_reflects_generate_progress(client, monkeypatch, tmp_path
 
     monkeypatch.setattr(server, "_worksheet", object())
     monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
     monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
     monkeypatch.setattr("titlecards.clear_endcard_cache", lambda: None)
     monkeypatch.setattr("pipeline._resolve_clip_workers", lambda: 2)
@@ -2575,7 +2582,7 @@ def test_api_generate_explicit_cancel_still_works(client, monkeypatch, tmp_path)
 
     monkeypatch.setattr(server, "_worksheet", object())
     monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
-    monkeypatch.setattr(server, "_generated_artifacts", [])
+    _set_artifacts(monkeypatch, [])
     monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
     monkeypatch.setattr("titlecards.clear_endcard_cache", lambda: None)
     monkeypatch.setattr("pipeline._resolve_clip_workers", lambda: 1)  # sequential


### PR DESCRIPTION
## Summary

- **Phase 3** (`server.py`): index `_generated_artifacts` by `(cellRow, cellCol, type)` and thread a request-scoped existence cache through `/api/generate` Pass 1, so the pre-skip scan is O(N_cells) with at most one `Path.is_file()` syscall per artifact path.
- **Phase 5.1** (`screenspace_server.py`): debounce the six task-queue hot paths (create/cancel/dismiss/reorder/pause/resume) through a 2s `threading.Timer` instead of writing the full manifest JSON synchronously per mutation; synchronous persists (task completion, atexit) cancel any pending timer first.
- Ticks the two boxes in `plans/PERFORMANCE-PLAN-2.md`; test fixtures updated to keep the new index in lockstep and to flush the debounce before assertions.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite passes
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [ ] Manual: Studio `/api/generate` on a sheet with many cached artifacts — Phase 1 should feel snappier
- [ ] Manual: rapid Screenspace enqueue/reorder/pause — `screenspace_manifest.json` mtime updates at most ~once per 2s instead of per-action