### PR TITLE
fix(studio): streaming, cancellation, and reel-direct titlecard fixes

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2923,6 +2923,36 @@
 
   var setButtonProgress = ClipgenPrimitives.setButtonProgress;
 
+  // Shared NDJSON streaming reader used by generate/intake/reel fetches.
+  // Returns a Promise that resolves when the stream is fully drained. Guards
+  // against responses without a streamable body (e.g. older browsers, or
+  // unexpected non-streaming responses that the caller should have caught
+  // with response.ok before reaching here).
+  function readNDJSONStream(response, onLine) {
+    if (!response.body || typeof response.body.getReader !== "function") {
+      return Promise.reject(new Error("Streaming response not supported"));
+    }
+    var reader = response.body.getReader();
+    var decoder = new TextDecoder();
+    var buffer = "";
+    function pump() {
+      return reader.read().then(function (result) {
+        if (result.done) {
+          if (buffer.trim()) onLine(buffer.trim());
+          return;
+        }
+        buffer += decoder.decode(result.value, { stream: true });
+        var lines = buffer.split("\n");
+        buffer = lines.pop();
+        for (var i = 0; i < lines.length; i++) {
+          if (lines[i].trim()) onLine(lines[i].trim());
+        }
+        return pump();
+      });
+    }
+    return pump();
+  }
+
   function createPulserOverlay() {
     var overlay = el("div", "card-gen-overlay");
     overlay.innerHTML =
@@ -2953,7 +2983,7 @@
     card.classList.remove("queue-card-queued", "queue-card-success", "queue-card-fail");
     var overlay = card.querySelector(".card-gen-overlay");
     if (overlay) overlay.remove();
-    var badge = card.querySelector(".card-result-badge");
+    var badge = card.querySelector(".card-gen-badge");
     if (badge) badge.remove();
   }
 
@@ -3018,6 +3048,13 @@
     setArtifactGenerating(true);
     qs("#cancelGenerateBtn").classList.remove("hidden");
 
+    // Per-branch AbortControllers let onCancelGenerate stop the network
+    // fetches immediately; the server-side cancel endpoints also trip the
+    // cancel events so in-flight ffmpeg subprocesses get terminated.
+    var sheetAbort = new AbortController();
+    var intakeAbort = new AbortController();
+    state.activeGenerateAborts = [sheetAbort, intakeAbort];
+
     var format = qs("#artifactFormat").value;
     var list = qs("#artifactsList");
     var items = state.artifactQueue.slice();
@@ -3034,6 +3071,7 @@
     // element parallel to its item array so the resolve handler can match
     // by index against the captured card list (immune to later re-renders).
     var sheetItems = [];
+    var sheetCardEls = [];
     var intakeItems = [];
     var intakeCardEls = [];
     for (var ci = 0; ci < items.length; ci++) {
@@ -3042,6 +3080,7 @@
         intakeCardEls.push(allCards[ci]);
       } else {
         sheetItems.push(items[ci]);
+        sheetCardEls.push(allCards[ci]);
       }
     }
 
@@ -3075,6 +3114,11 @@
           ? "Cancelled after " + clipgenPluralUnit(totalSuccess, "artifact", "artifacts")
           : null;
         err = totalSuccess > 0 ? null : "Generation cancelled";
+      } else if (totalSuccess === 0 && totalFail === 0) {
+        // Stream ended without any per-item results — treat as an error
+        // rather than silently reporting "Generated 0 artifacts".
+        msg = null;
+        err = "No artifacts were generated";
       } else {
         msg = "Generated " + clipgenPluralUnit(totalSuccess, "artifact", "artifacts");
         if (totalFail > 0) msg += ", " + totalFail + " failed";
@@ -3105,7 +3149,7 @@
         if (!data) return;
         if (data.cancelled) {
           cancelled = true;
-          var queuedCards = list.querySelectorAll(".queue-card.queued");
+          var queuedCards = list.querySelectorAll(".queue-card-queued");
           for (var qi = 0; qi < queuedCards.length; qi++) {
             clearCardStatus(queuedCards[qi]);
           }
@@ -3145,33 +3189,19 @@
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(genBody),
+        signal: sheetAbort.signal,
       })
         .then(function (response) {
           if (!response.ok) throw new Error("Server error " + response.status);
-          var reader = response.body.getReader();
-          var decoder = new TextDecoder();
-          var buffer = "";
-
-          function read() {
-            return reader.read().then(function (result) {
-              if (result.done) {
-                if (buffer.trim()) handleLine(buffer.trim());
-                finishBranch();
-                return;
-              }
-              buffer += decoder.decode(result.value, { stream: true });
-              var lines = buffer.split("\n");
-              buffer = lines.pop();
-              for (var li = 0; li < lines.length; li++) {
-                if (lines[li].trim()) handleLine(lines[li].trim());
-              }
-              return read();
-            });
-          }
-
-          return read();
+          return readNDJSONStream(response, handleLine).then(finishBranch);
         })
         .catch(function () {
+          // Mark every captured sheet card as failed so they don't stay
+          // visually queued; finishBranch reports the failure tally.
+          for (var j = 0; j < sheetCardEls.length; j++) {
+            if (sheetCardEls[j]) setCardResult(sheetCardEls[j], false);
+          }
+          totalFail += sheetItems.length;
           finishBranch();
         });
     }
@@ -3193,7 +3223,21 @@
       function handleIntakeLine(line) {
         var data;
         try { data = JSON.parse(line); } catch (_) { return; }
-        if (!data || typeof data.index !== "number") return;
+        if (!data) return;
+        if (data.cancelled) {
+          cancelled = true;
+          // Clear queued state from any intake card that hasn't received a
+          // per-item result yet, so the cards don't stay visually queued
+          // after the server short-circuits on cancel.
+          for (var qi = 0; qi < intakeCardEls.length; qi++) {
+            var qcard = intakeCardEls[qi];
+            if (qcard && qcard.classList.contains("queue-card-queued")) {
+              clearCardStatus(qcard);
+            }
+          }
+          return;
+        }
+        if (typeof data.index !== "number") return;
         var card = intakeCardEls[data.index];
         if (data.ok) {
           totalSuccess++;
@@ -3216,31 +3260,11 @@
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ items: intakePayload, format: format }),
+        signal: intakeAbort.signal,
       })
         .then(function (response) {
           if (!response.ok) throw new Error("Server error " + response.status);
-          var reader = response.body.getReader();
-          var decoder = new TextDecoder();
-          var buffer = "";
-
-          function read() {
-            return reader.read().then(function (result) {
-              if (result.done) {
-                if (buffer.trim()) handleIntakeLine(buffer.trim());
-                finishBranch();
-                return;
-              }
-              buffer += decoder.decode(result.value, { stream: true });
-              var lines = buffer.split("\n");
-              buffer = lines.pop();
-              for (var li = 0; li < lines.length; li++) {
-                if (lines[li].trim()) handleIntakeLine(lines[li].trim());
-              }
-              return read();
-            });
-          }
-
-          return read();
+          return readNDJSONStream(response, handleIntakeLine).then(finishBranch);
         })
         .catch(function () {
           for (var j = 0; j < intakeCardEls.length; j++) {
@@ -3259,7 +3283,13 @@
 
   function onCancelGenerate() {
     qs("#cancelGenerateBtn").classList.add("hidden");
+    var aborts = state.activeGenerateAborts || [];
+    for (var i = 0; i < aborts.length; i++) {
+      try { aborts[i].abort(); } catch (_) {}
+    }
+    state.activeGenerateAborts = [];
     apiPost("api/generate/cancel").catch(function () {});
+    apiPost("api/generate-intake/cancel").catch(function () {});
   }
 
   // ---- API: reel + standalone viewers (timeline / HTML viewer) ----
@@ -3396,7 +3426,9 @@
       body: JSON.stringify(reelBody),
     })
       .then(function (response) {
-        if (!response.ok && response.status >= 400 && response.status !== 409) {
+        // Any 4xx/5xx (including 409 "reel already in progress") is a JSON
+        // error body, not an NDJSON stream — parse it as text/JSON.
+        if (!response.ok && response.status >= 400) {
           return response.text().then(function (txt) {
             try {
               finalPayload = JSON.parse(txt);
@@ -3409,26 +3441,7 @@
             finish();
           });
         }
-        var reader = response.body.getReader();
-        var decoder = new TextDecoder();
-        var buffer = "";
-        function read() {
-          return reader.read().then(function (result) {
-            if (result.done) {
-              if (buffer.trim()) handleLine(buffer.trim());
-              finish();
-              return;
-            }
-            buffer += decoder.decode(result.value, { stream: true });
-            var lines = buffer.split("\n");
-            buffer = lines.pop();
-            for (var li = 0; li < lines.length; li++) {
-              if (lines[li].trim()) handleLine(lines[li].trim());
-            }
-            return read();
-          });
-        }
-        return read();
+        return readNDJSONStream(response, handleLine).then(finish);
       })
       .catch(function (err) {
         finalPayload = { ok: false, error: "Request failed: " + err };

--- a/plans/STREAMING-FIXES.md
+++ b/plans/STREAMING-FIXES.md
@@ -312,7 +312,7 @@ Tests:
 - [x] Add atomic output reservation to `files.py`.
 - [x] Update ffmpeg call sites that use reserved paths to clean up unused placeholders on early failure.
 - [x] Add a manifest write lock to `viewer.save_manifest()`.
-- [ ] Run:
+- [x] Run:
 
 ```bash
 uv run --extra dev pytest -c tests/pytest.ini tests/test_manifest.py tests/test_clip_pipeline.py
@@ -322,11 +322,11 @@ uv run --extra dev pytest -c tests/pytest.ini tests/test_manifest.py tests/test_
 
 - [x] Fix titlecard cache lifecycle for parallel Studio generation.
 - [x] Forward reel cancellation/titlecard kwargs into `_process_single_clip_segments()`.
-- [ ] Apply titlecard settings to `/studio/api/reel-direct`.
-- [ ] Pass generate cancellation into running ffmpeg workers and clean up cancelled outputs.
-- [ ] Add intake cancellation support and a busy-slot decision.
+- [x] Apply titlecard settings to `/studio/api/reel-direct`.
+- [x] Pass generate cancellation into running ffmpeg workers and clean up cancelled outputs.
+- [x] Add intake cancellation support and a busy-slot decision.
 - [x] Persist streamed successes in generator `finally` blocks.
-- [ ] Run:
+- [x] Run:
 
 ```bash
 uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_api.py tests/test_clip_pipeline.py tests/test_studio_frontend_source.py
@@ -334,11 +334,11 @@ uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_api.py tests/tes
 
 ### Task 3: Studio Frontend Stream Handling
 
-- [ ] Add or inline a shared NDJSON reader helper with `response.body` checks.
-- [ ] Fix sheet branch failure accounting and zero-result messaging.
-- [ ] Fix queued/result badge selectors.
-- [ ] Normalize 409/error handling for reel streams.
-- [ ] Run:
+- [x] Add or inline a shared NDJSON reader helper with `response.body` checks.
+- [x] Fix sheet branch failure accounting and zero-result messaging.
+- [x] Fix queued/result badge selectors.
+- [x] Normalize 409/error handling for reel streams.
+- [x] Run:
 
 ```bash
 uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_frontend_source.py
@@ -350,7 +350,7 @@ uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_frontend_source.
 - [x] Snapshot Screenspace manifest reads under `_manifest_lock`.
 - [x] Coalesce Screenspace SSE queue overflow into a later full state update.
 - [x] Improve transcript cancellation checks.
-- [ ] Run:
+- [x] Run:
 
 ```bash
 uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace_api.py tests/test_transcripts_api.py tests/test_transcripts.py
@@ -358,8 +358,8 @@ uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace_api.py test
 
 ### Task 5: Full Verification
 
-- [ ] Run focused tests from Tasks 1-4.
-- [ ] Run full checks:
+- [x] Run focused tests from Tasks 1-4.
+- [x] Run full checks:
 
 ```bash
 uv run --extra dev pytest -c tests/pytest.ini

--- a/server.py
+++ b/server.py
@@ -92,6 +92,11 @@ _thumbnail_cache_lock = threading.Lock()
 # shared cancel event; reject with 409 instead while one is in flight.
 _reel_cancel_event = threading.Event()
 _generate_cancel_event = threading.Event()
+# Independent cancel event for /api/generate-intake — sheet and intake
+# branches run concurrently from one Studio Generate click but have
+# separate streams, so the Cancel button posts to both /api/generate/cancel
+# and /api/generate-intake/cancel.
+_intake_cancel_event = threading.Event()
 _busy_lock = threading.Lock()
 _generate_in_progress = False
 _reel_in_progress = False
@@ -681,12 +686,18 @@ def _process_intake_item(
     output_format: str,
     study: str,
     index: int = 0,
+    *,
+    cancel_flag: Any = None,
 ) -> dict[str, Any]:
     """Process a single intake item; returns one dict with _ok/_error keys.
 
     *index* is the item's position in the request batch — folded into the
     artifact id so two intake events covering the same participant span do not
     hash to the same id and get collapsed by manifest dedup.
+
+    *cancel_flag* is an optional callable that returns True when the request
+    has been cancelled. Checked before ffmpeg is launched and forwarded into
+    ``video.run_ffmpeg`` so an in-flight encode can be terminated.
     """
     participant = item.get("participant", "")
     start = float(item.get("start", 0))
@@ -730,8 +741,16 @@ def _process_intake_item(
     start_str = utils.seconds_to_timestamp(int(round(start)))
     end_str = utils.seconds_to_timestamp(int(round(end)))
 
+    if cancel_flag and cancel_flag():
+        return {"_ok": False, "_error": "cancelled", "_cancelled": True}
+
     success = video.run_ffmpeg(
-        video_path, out_path, start_str, end_str, config.REENCODING
+        video_path,
+        out_path,
+        start_str,
+        end_str,
+        config.REENCODING,
+        cancel_flag=cancel_flag,
     )
 
     if not success:
@@ -1117,6 +1136,19 @@ def api_generate() -> FlaskResponse:
                 titlecard_duration_seconds=titlecard_duration_seconds,
                 clear_titlecard_cache=False,
             )
+            # A future that happened to finish concurrently with the cancel
+            # signal still produces (generated, artifacts); per the streaming
+            # contract we must not append those to the manifest after cancel.
+            # Drop the files on disk too so the user does not see orphan media.
+            if cancel_flag():
+                for a in artifacts:
+                    try:
+                        Path(utils.resolve_output_path(a["file"])).unlink(
+                            missing_ok=True
+                        )
+                    except OSError:
+                        pass
+                return 0, []
             if generated > 0:
                 _extend_generated_artifacts(artifacts)
             return generated, artifacts
@@ -1875,15 +1907,32 @@ def api_generate_intake() -> FlaskResponse:
     output_format = data.get("format", "clip")
     study = _sheet_context.study_name if _sheet_context else ""
 
-    def _emit(idx: int, result: dict[str, Any]) -> str:
-        ok = result.pop("_ok", False)
-        error = result.pop("_error", "")
-        if ok:
-            _append_generated_artifact(result)
-            return json.dumps({"index": idx, "ok": True, "artifact": result}) + "\n"
-        return json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
-
     def stream() -> Iterator[str]:
+        _intake_cancel_event.clear()
+        cancel_flag = _intake_cancel_event.is_set
+
+        def _emit(idx: int, result: dict[str, Any]) -> str:
+            ok = result.pop("_ok", False)
+            error = result.pop("_error", "")
+            result.pop("_cancelled", None)
+            # Drop artifacts that finished after cancel was set: don't append
+            # to the manifest and unlink the produced file so cancelled
+            # intake work leaves no orphan media.
+            if ok and cancel_flag():
+                try:
+                    Path(utils.resolve_output_path(result.get("file", ""))).unlink(
+                        missing_ok=True
+                    )
+                except OSError:
+                    pass
+                return (
+                    json.dumps({"index": idx, "ok": False, "error": "cancelled"}) + "\n"
+                )
+            if ok:
+                _append_generated_artifact(result)
+                return json.dumps({"index": idx, "ok": True, "artifact": result}) + "\n"
+            return json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
+
         _mark_intake_active(True)
         try:
             workers = pipeline._resolve_clip_workers()
@@ -1896,6 +1945,7 @@ def api_generate_intake() -> FlaskResponse:
                             output_format,
                             study,
                             index=idx,
+                            cancel_flag=cancel_flag,
                         ): idx
                         for idx, item in enumerate(items)
                     }
@@ -1912,10 +1962,27 @@ def api_generate_intake() -> FlaskResponse:
                             )
                             continue
                         yield _emit(idx, result)
+                        if cancel_flag():
+                            # Drain remaining submitted futures so workers can
+                            # observe cancel_flag and terminate ffmpeg, but
+                            # short-circuit yielding once the event is set.
+                            for f in future_to_idx:
+                                f.cancel()
+                            break
             else:
                 for idx, item in enumerate(items):
-                    result = _process_intake_item(item, output_format, study, index=idx)
+                    if cancel_flag():
+                        break
+                    result = _process_intake_item(
+                        item,
+                        output_format,
+                        study,
+                        index=idx,
+                        cancel_flag=cancel_flag,
+                    )
                     yield _emit(idx, result)
+            if cancel_flag():
+                yield json.dumps({"cancelled": True}) + "\n"
         finally:
             # Persist whatever completed even if the client disconnects or a
             # later item raises mid-stream.
@@ -1947,6 +2014,11 @@ def api_reel_direct() -> FlaskResponse:
     _reel_cancel_event.clear()
     _reset_reel_job_state("reel-direct")
 
+    titlecards_enabled, titlecard_duration_seconds = _parse_titlecard_request(data)
+    cards_enabled, card_duration = pipeline._resolve_titlecard_options(
+        titlecards_enabled, titlecard_duration_seconds
+    )
+
     def stream() -> Iterator[str]:
         # The worker thread does the actual ffmpeg work and owns the busy
         # slot. The generator just drains its event queue so that a client
@@ -1963,6 +2035,9 @@ def api_reel_direct() -> FlaskResponse:
             output_dir = Path(utils.get_effective_output_dir())
             clip_paths: list[str] = []
             temp_clips: list[str] = []
+            # Cache (w x h) per source video so wrap_clip_with_cards doesn't
+            # re-probe per segment. Same source can appear many times.
+            resolution_cache: dict[str, str | None] = {}
             # Throttle concat progress emissions to ~5 Hz, same as before.
             concat_last_emit = [0.0]
 
@@ -2036,6 +2111,25 @@ def api_reel_direct() -> FlaskResponse:
                         config.REENCODING,
                         cancel_flag=_reel_cancel_event.is_set,
                     )
+                    if ok and cards_enabled:
+                        if video_path not in resolution_cache:
+                            probed = video.probe_video_properties(video_path)
+                            resolution_cache[video_path] = (
+                                f"{probed['width']}x{probed['height']}"
+                                if probed
+                                else None
+                            )
+                        wrap_clip: utils.ClipRecord = {
+                            "desc": seg.get("event_type") or seg.get("desc") or "",
+                        }
+                        ok = titlecards.wrap_clip_with_cards(
+                            wrap_clip,
+                            tmp_path,
+                            resolution=resolution_cache[video_path],
+                            cancel_flag=_reel_cancel_event.is_set,
+                            titlecards_enabled=cards_enabled,
+                            titlecard_duration_seconds=card_duration,
+                        )
                     if ok:
                         clip_paths.append(tmp_path)
                     completed += 1
@@ -2092,6 +2186,10 @@ def api_reel_direct() -> FlaskResponse:
             except Exception as exc:
                 emit_event({"ok": False, "error": str(exc)})
             finally:
+                # Endcard temp files are cached per-process across all wrap
+                # calls; purge them here so per-request cards do not leak
+                # between consecutive reel builds.
+                titlecards.clear_endcard_cache()
                 for tmp in temp_clips:
                     try:
                         Path(tmp).unlink(missing_ok=True)
@@ -2165,6 +2263,18 @@ def api_reel_cancel() -> FlaskResponse:
 def api_generate_cancel() -> FlaskResponse:
     """Signal cancellation for the in-progress clip generation."""
     _generate_cancel_event.set()
+    return jsonify({"ok": True})
+
+
+@studio_bp.route("/api/generate-intake/cancel", methods=["POST"])
+def api_generate_intake_cancel() -> FlaskResponse:
+    """Signal cancellation for the in-progress intake generation.
+
+    Sheet and intake branches run in parallel from a single Studio Generate
+    click and have independent streams, so the Cancel button must hit both
+    endpoints to stop the full set of in-flight ffmpeg subprocesses.
+    """
+    _intake_cancel_event.set()
     return jsonify({"ok": True})
 
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -2620,3 +2620,300 @@ def test_api_generate_explicit_cancel_still_works(client, monkeypatch, tmp_path)
     lines = [json.loads(ln) for ln in text.strip().split("\n") if ln.strip()]
     assert any(ln.get("cancelled") is True for ln in lines)
     assert _poll_until(lambda: server._generate_in_progress is False)
+
+
+# ---- /api/reel-direct titlecards ----
+
+
+def _drain_ndjson(resp):
+    """Drain an NDJSON streaming response into a list of parsed dicts."""
+    text = resp.data.decode()
+    return [json.loads(ln) for ln in text.strip().split("\n") if ln.strip()]
+
+
+def test_api_generate_discards_artifacts_completed_after_cancel(
+    client, monkeypatch, tmp_path
+):
+    """A worker whose ffmpeg wraps up just as the cancel event is set must
+    drop its produced artifact (no manifest append, file unlinked)."""
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr(server, "_find_existing_artifacts", lambda *a, **kw: [])
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+
+    cell = types.SimpleNamespace(row=5, col=2)
+
+    def fake_generate_list(ws, mode, **kwargs):
+        return [{"participant": "P01", "cell": cell, "times": [("0:00", "0:05")]}]
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+
+    file_a = tmp_path / "a.mp4"
+    file_a.write_bytes(b"x")
+
+    # Worker returns its artifact and ALSO trips the cancel event mid-call —
+    # simulates a worker whose ffmpeg subprocess finished successfully just
+    # as the cancel signal was set. The drop-after-cancel guard inside
+    # _generate_and_persist should reject the artifact and unlink the file.
+    def fake_process_clips(clips, *, cancel_flag=None, **kwargs):
+        server._generate_cancel_event.set()
+        return (1, [{"id": "a", "type": "clip", "file": "a.mp4"}])
+
+    monkeypatch.setattr("pipeline.process_clips", fake_process_clips)
+    server._generate_cancel_event.clear()
+
+    resp = client.post(
+        "/studio/api/generate",
+        json={"cells": ["P01.5"], "format": "clip"},
+    )
+    resp.data  # drain stream
+    server._generate_cancel_event.clear()
+
+    assert _poll_until(lambda: server._generate_in_progress is False)
+    ids = [a.get("id") for a in server._generated_artifacts]
+    assert "a" not in ids
+    assert not file_a.exists()
+
+
+# ---- /api/generate-intake cancellation ----
+
+
+def test_api_generate_intake_cancel_endpoint_returns_ok(client):
+    """POST /api/generate-intake/cancel sets the cancel event and returns ok."""
+    server._intake_cancel_event.clear()
+    resp = client.post("/studio/api/generate-intake/cancel")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+    assert server._intake_cancel_event.is_set() is True
+    server._intake_cancel_event.clear()
+
+
+def test_api_generate_intake_passes_cancel_flag_to_run_ffmpeg(
+    client, monkeypatch, tmp_path
+):
+    """_process_intake_item must forward cancel_flag into video.run_ffmpeg
+    so an in-flight ffmpeg encode can be terminated."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr(
+        "files.get_unique_filename", lambda name, file_format=None: name
+    )
+
+    captured = {}
+
+    def fake_run_ffmpeg(*args, **kwargs):
+        captured["cancel_flag"] = kwargs.get("cancel_flag")
+        return True
+
+    monkeypatch.setattr("video.run_ffmpeg", fake_run_ffmpeg)
+    server._intake_cancel_event.clear()
+
+    resp = client.post(
+        "/studio/api/generate-intake",
+        json={"items": [{"participant": "P01", "start": 0, "end": 5}]},
+    )
+    resp.data
+    cb = captured.get("cancel_flag")
+    assert callable(cb)
+    # Verify the callable tracks the intake cancel event.
+    assert cb() is False
+    server._intake_cancel_event.set()
+    try:
+        assert cb() is True
+    finally:
+        server._intake_cancel_event.clear()
+
+
+def test_api_generate_intake_short_circuits_after_cancel(client, monkeypatch, tmp_path):
+    """When cancel is signaled before the worker starts, no ffmpeg is
+    invoked and a {cancelled: true} marker is yielded."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr(
+        "files.get_unique_filename", lambda name, file_format=None: name
+    )
+
+    ffmpeg_calls = []
+
+    def fake_run_ffmpeg(*args, **kwargs):
+        ffmpeg_calls.append(args)
+        return True
+
+    monkeypatch.setattr("video.run_ffmpeg", fake_run_ffmpeg)
+
+    # Set cancel event inside _process_intake_item to simulate cancel arriving
+    # during the first worker. Use a wrapper that flips the event then calls
+    # through to the real function.
+    real_process = server._process_intake_item
+
+    def wrapped(item, output_format, study, index=0, *, cancel_flag=None):
+        server._intake_cancel_event.set()
+        return real_process(
+            item, output_format, study, index=index, cancel_flag=cancel_flag
+        )
+
+    monkeypatch.setattr(server, "_process_intake_item", wrapped)
+    server._intake_cancel_event.clear()
+
+    try:
+        resp = client.post(
+            "/studio/api/generate-intake",
+            json={
+                "items": [
+                    {"participant": "P01", "start": 0, "end": 5},
+                    {"participant": "P01", "start": 10, "end": 15},
+                    {"participant": "P01", "start": 20, "end": 25},
+                ]
+            },
+        )
+        text = resp.data.decode()
+    finally:
+        server._intake_cancel_event.clear()
+
+    lines = [json.loads(ln) for ln in text.strip().split("\n") if ln.strip()]
+    assert any(ln.get("cancelled") is True for ln in lines), lines
+    # Only the first item should have invoked ffmpeg; remaining items must
+    # short-circuit via the pre-ffmpeg cancel check.
+    assert len(ffmpeg_calls) <= 1
+
+
+def test_api_reel_direct_wraps_segments_when_titlecards_enabled(
+    client, monkeypatch, tmp_path
+):
+    """Each segment must be wrapped via titlecards.wrap_clip_with_cards with the
+    per-request duration before the concat list is assembled."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr("video.concatenate_clips", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "files.get_unique_filename", lambda name, file_format=None: name
+    )
+    monkeypatch.setattr(
+        "video.probe_video_properties",
+        lambda path: {"width": 1280, "height": 720, "audio_codec": "aac"},
+    )
+
+    wrap_calls: list[dict] = []
+
+    def fake_wrap(clip, clip_path, *, resolution=None, **kwargs):
+        wrap_calls.append(
+            {
+                "desc": clip.get("desc"),
+                "resolution": resolution,
+                "duration": kwargs.get("titlecard_duration_seconds"),
+                "enabled": kwargs.get("titlecards_enabled"),
+            }
+        )
+        return True
+
+    monkeypatch.setattr("titlecards.wrap_clip_with_cards", fake_wrap)
+    server._reel_cancel_event.clear()
+
+    resp = client.post(
+        "/studio/api/reel-direct",
+        json={
+            "segments": [
+                {
+                    "participant": "P01",
+                    "start": 0,
+                    "end": 5,
+                    "event_type": "first",
+                },
+                {
+                    "participant": "P01",
+                    "start": 10,
+                    "end": 20,
+                    "event_type": "second",
+                },
+            ],
+            "titlecards_enabled": True,
+            "titlecard_duration": 3,
+        },
+    )
+    _drain_ndjson(resp)
+    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert len(wrap_calls) == 2
+    assert wrap_calls[0]["duration"] == 3
+    assert wrap_calls[0]["enabled"] is True
+    assert wrap_calls[0]["resolution"] == "1280x720"
+    assert wrap_calls[0]["desc"] == "first"
+    assert wrap_calls[1]["desc"] == "second"
+
+
+def test_api_reel_direct_skips_wrap_when_titlecards_disabled(
+    client, monkeypatch, tmp_path
+):
+    """No wrap_clip_with_cards calls when titlecards_enabled is False."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr("video.concatenate_clips", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "files.get_unique_filename", lambda name, file_format=None: name
+    )
+
+    wrap_calls: list[dict] = []
+    monkeypatch.setattr(
+        "titlecards.wrap_clip_with_cards",
+        lambda *a, **kw: wrap_calls.append(kw) or True,
+    )
+    server._reel_cancel_event.clear()
+
+    resp = client.post(
+        "/studio/api/reel-direct",
+        json={
+            "segments": [{"participant": "P01", "start": 0, "end": 5}],
+            "titlecards_enabled": False,
+        },
+    )
+    _drain_ndjson(resp)
+    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert wrap_calls == []
+
+
+def test_api_reel_direct_clears_endcard_cache(client, monkeypatch, tmp_path):
+    """The worker's finally block must purge the endcard cache so per-request
+    titlecard temp files don't leak between reel builds."""
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_path", lambda p, s="": "/fake/video.mp4"
+    )
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr("video.concatenate_clips", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "files.get_unique_filename", lambda name, file_format=None: name
+    )
+
+    clear_calls = []
+    monkeypatch.setattr("titlecards.clear_endcard_cache", lambda: clear_calls.append(1))
+    server._reel_cancel_event.clear()
+
+    resp = client.post(
+        "/studio/api/reel-direct",
+        json={"segments": [{"participant": "P01", "start": 0, "end": 5}]},
+    )
+    _drain_ndjson(resp)
+    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert len(clear_calls) == 1

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -49,3 +49,87 @@ def test_studio_css_does_not_freeze_drop_targets_during_generation():
     css = STUDIO_CSS.read_text(encoding="utf-8")
     assert ".studio-generating .drop-target" not in css
     assert "studio-generating" not in css
+
+
+def test_studio_generate_uses_abort_controllers_for_both_branches():
+    """Generate sheet + intake fetches must be cancellable via AbortController
+    so the network connections are torn down promptly on cancel."""
+    src = _studio_js()
+    assert "new AbortController()" in src
+    assert "sheetAbort = new AbortController()" in src
+    assert "intakeAbort = new AbortController()" in src
+    assert "signal: sheetAbort.signal" in src
+    assert "signal: intakeAbort.signal" in src
+
+
+def test_on_cancel_generate_aborts_and_posts_intake_cancel():
+    """Cancel button must abort live fetches AND post both server cancel
+    endpoints so in-flight ffmpeg subprocesses get terminated."""
+    src = _studio_js()
+    start = src.index("function onCancelGenerate()")
+    end = src.index("\n  }", start)
+    body = src[start:end]
+    assert "aborts[i].abort()" in body
+    assert 'apiPost("api/generate/cancel")' in body
+    assert 'apiPost("api/generate-intake/cancel")' in body
+
+
+# ---- Task 3: studio streaming, selectors, finishBranch ----
+
+
+def test_studio_defines_shared_ndjson_reader():
+    """One shared NDJSON helper guards response.body and is reused by the
+    sheet/intake/reel readers (the three sites used to duplicate the loop)."""
+    src = _studio_js()
+    assert "function readNDJSONStream(response, onLine)" in src
+    # response.body guard
+    assert "if (!response.body" in src
+    # The duplicated raw .getReader() blocks should be gone (only the helper
+    # itself calls it). Allow the helper to be the sole getReader site.
+    assert src.count("response.body.getReader()") == 1
+    # Used by all three streaming endpoints.
+    assert "readNDJSONStream(response, handleLine).then(finishBranch)" in src
+    assert "readNDJSONStream(response, handleIntakeLine).then(finishBranch)" in src
+    assert "readNDJSONStream(response, handleLine).then(finish)" in src
+
+
+def test_sheet_branch_catch_marks_failures():
+    """A fetch failure on the sheet branch must mark captured sheet cards as
+    failed (not leave them visually queued) and tally totalFail."""
+    src = _studio_js()
+    assert "var sheetCardEls = [];" in src
+    assert "setCardResult(sheetCardEls[j], false)" in src
+    assert "totalFail += sheetItems.length;" in src
+
+
+def test_finish_branch_handles_zero_zero_case():
+    """Stream that ends with no successes and no failures (not cancelled)
+    should surface an error, not silently report '0 artifacts'."""
+    src = _studio_js()
+    assert "No artifacts were generated" in src
+
+
+def test_clear_card_status_selects_card_gen_badge():
+    """clearCardStatus must select .card-gen-badge (the class actually set
+    by createResultBadge), not the stale .card-result-badge name."""
+    src = _studio_js()
+    assert ".card-result-badge" not in src
+    start = src.index("function clearCardStatus")
+    end = src.index("\n  }", start)
+    body = src[start:end]
+    assert ".card-gen-badge" in body
+
+
+def test_cancel_cleanup_uses_queue_card_queued_selector():
+    """Cancel cleanup must query .queue-card-queued (the actual class set
+    by setCardQueued), not the broken compound .queue-card.queued."""
+    src = _studio_js()
+    assert ".queue-card.queued" not in src
+    assert 'querySelectorAll(".queue-card-queued")' in src
+
+
+def test_reel_409_treated_as_json_error():
+    """409 from /api/reel-direct (reel busy) is a JSON error, not NDJSON —
+    the previous status !== 409 exemption was a bug."""
+    src = _studio_js()
+    assert "response.status !== 409" not in src


### PR DESCRIPTION
## Summary

Wraps the remaining unchecked items in `plans/STREAMING-FIXES.md` (P0/P1 work on the streaming Studio paths): `/studio/api/reel-direct` now applies per-request titlecards and clears the endcard cache between builds; `/api/generate` discards artifacts whose worker happened to finish concurrently with the cancel signal (files unlinked, no manifest append); new `/api/generate-intake/cancel` endpoint plus a `_intake_cancel_event` plumbed through `_process_intake_item` and `video.run_ffmpeg` so intake stops promptly; Studio frontend extracts a shared `readNDJSONStream` helper with a `response.body` guard and uses it from the sheet/intake/reel readers, adds `AbortController` per generate branch wired up in `onCancelGenerate`, fixes the broken `.card-gen-badge` / `.queue-card-queued` selectors, treats 409 from `/api/reel-direct` as a JSON error rather than NDJSON, and reports the previously-silent zero-success/zero-failure case as an error. Adds 7 new tests in `tests/test_studio_api.py` and 8 new source-string checks in `tests/test_studio_frontend_source.py`.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 968 passed
- [x] `uv run ruff format --check` — clean
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [ ] Manual browser pass: Studio → mix sheet + intake items, click Generate, click Cancel mid-stream, verify both branches stop, queue cards clear, no orphan files remain
- [ ] Manual: build an intake-only reel from `/api/reel-direct` with Titlecards toggled on, verify each segment has its title/end cards