### PR TITLE
fix: review follow-ups for studio generation and reel output

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -968,7 +968,8 @@
       .then(function (data) {
         if (!data.ok || !state.sheetData) return;
         var artifacts = data.artifacts || [];
-        if (artifacts.length === 0) return;
+        var reels = data.reels || [];
+        if (artifacts.length === 0 && reels.length === 0) return;
 
         var seen = {};
         for (var i = 0; i < artifacts.length; i++) {
@@ -1027,7 +1028,6 @@
           var rk = pr.id || pr.file;
           if (rk) seenReel[rk] = true;
         }
-        var reels = data.reels || [];
         for (var ri = 0; ri < reels.length; ri++) {
           var reel = reels[ri];
           var rk2 = reel.id || reel.file;
@@ -1036,9 +1036,9 @@
           state.generatedReels.push(stampLog(reel));
         }
 
-
         renderArtifactQueue();
         updateCellClasses();
+        renderLog();
       })
       .catch(function () {});
   }
@@ -1090,6 +1090,24 @@
       loadManifestState();
     }
     state._jobStatusGenerateWasInProgress = !!gen.in_progress;
+
+    // ---- Intake generate (api/generate-intake) ----
+    var intake = status.intake || {};
+    if (intake.in_progress) {
+      if (!state.artifactGenerating) setArtifactGenerating(true);
+      qs("#cancelGenerateBtn").classList.remove("hidden");
+      var intakeTotal = intake.total || 0;
+      var intakeDone = intake.done || 0;
+      if (intakeTotal > 0) {
+        setButtonProgress("generateBtn", Math.min(intakeDone / intakeTotal, 1));
+      }
+    } else if (state._jobStatusIntakeWasInProgress) {
+      setArtifactGenerating(false);
+      qs("#cancelGenerateBtn").classList.add("hidden");
+      setButtonProgress("generateBtn", null);
+      loadManifestState();
+    }
+    state._jobStatusIntakeWasInProgress = !!intake.in_progress;
   }
 
   function pollJobStatus() {
@@ -1101,7 +1119,8 @@
         // page doesn't hammer the server when nothing is happening.
         var stillBusy =
           (data.reel && data.reel.in_progress) ||
-          (data.generate && data.generate.in_progress);
+          (data.generate && data.generate.in_progress) ||
+          (data.intake && data.intake.in_progress);
         if (stillBusy) {
           startJobStatusPoll();
         } else {
@@ -3043,8 +3062,14 @@
     el.textContent = done + " / " + total + " cells";
   }
 
+  function isGenerateFetchAborted(err) {
+    if (state.generateCancelledByUser) return true;
+    return !!(err && err.name === "AbortError");
+  }
+
   function onGenerate() {
     if (state.artifactGenerating || state.artifactQueue.length === 0) return;
+    state.generateCancelledByUser = false;
     setArtifactGenerating(true);
     qs("#cancelGenerateBtn").classList.remove("hidden");
 
@@ -3195,7 +3220,16 @@
           if (!response.ok) throw new Error("Server error " + response.status);
           return readNDJSONStream(response, handleLine).then(finishBranch);
         })
-        .catch(function () {
+        .catch(function (err) {
+          if (isGenerateFetchAborted(err)) {
+            cancelled = true;
+            for (var sq = 0; sq < sheetCardEls.length; sq++) {
+              var sc = sheetCardEls[sq];
+              if (sc && sc.classList.contains("queue-card-queued")) clearCardStatus(sc);
+            }
+            finishBranch();
+            return;
+          }
           // Mark every captured sheet card as failed so they don't stay
           // visually queued; finishBranch reports the failure tally.
           for (var j = 0; j < sheetCardEls.length; j++) {
@@ -3266,7 +3300,16 @@
           if (!response.ok) throw new Error("Server error " + response.status);
           return readNDJSONStream(response, handleIntakeLine).then(finishBranch);
         })
-        .catch(function () {
+        .catch(function (err) {
+          if (isGenerateFetchAborted(err)) {
+            cancelled = true;
+            for (var iq = 0; iq < intakeCardEls.length; iq++) {
+              var ic = intakeCardEls[iq];
+              if (ic && ic.classList.contains("queue-card-queued")) clearCardStatus(ic);
+            }
+            finishBranch();
+            return;
+          }
           for (var j = 0; j < intakeCardEls.length; j++) {
             if (intakeCardEls[j]) setCardResult(intakeCardEls[j], false);
           }
@@ -3282,6 +3325,7 @@
   }
 
   function onCancelGenerate() {
+    state.generateCancelledByUser = true;
     qs("#cancelGenerateBtn").classList.add("hidden");
     var aborts = state.activeGenerateAborts || [];
     for (var i = 0; i < aborts.length; i++) {

--- a/cli.py
+++ b/cli.py
@@ -2605,21 +2605,24 @@ def run_cli_mode(worksheet: Any, args: Any, cli_mode_args: CliModeArgs) -> None:
     is_excel = clipgen._is_excel_worksheet(worksheet)
     effective_mode = output_format if output_format != "clip" else "batch"
 
-    if (
-        getattr(args, "viewer", False) or getattr(args, "manifest", False)
-    ) and artifacts:
-        study = artifacts[0].get("study", "")
-        participant = artifacts[0].get("participant", "")
+    wants_viewer_or_manifest = getattr(args, "viewer", False) or getattr(
+        args, "manifest", False
+    )
+    if wants_viewer_or_manifest and (artifacts or reel_records):
+        primary = artifacts[0] if artifacts else reel_records[0]
+        study = primary.get("study", "")
+        participant = primary.get("participant", "")
 
         if getattr(args, "viewer", False):
             ss_events = viewer.load_screenspace_events_for_viewer()
             data = viewer.finalize_timeline_data(
                 artifacts,
+                reels=reel_records or None,
                 study=study,
                 participant=participant,
                 worksheet_title=ws_title,
                 is_excel=is_excel,
-                mode=effective_mode,
+                mode="reel" if is_reel and not artifacts else effective_mode,
                 output_format=output_format,
                 screenspace_events=ss_events or None,
             )
@@ -2635,24 +2638,11 @@ def run_cli_mode(worksheet: Any, args: Any, cli_mode_args: CliModeArgs) -> None:
                 participant=participant,
                 worksheet_title=ws_title,
                 is_excel=is_excel,
-                mode=effective_mode,
+                mode="reel" if is_reel and not artifacts else effective_mode,
                 output_format=output_format,
             )
             if manifest_path:
                 utils.info_print(f"Manifest updated: {manifest_path}")
-
-    elif getattr(args, "manifest", False) and reel_records:
-        study = reel_records[0].get("study", "")
-        manifest_path = viewer.save_manifest(
-            [],
-            new_reels=reel_records,
-            study=study,
-            worksheet_title=ws_title,
-            is_excel=is_excel,
-            mode="reel",
-        )
-        if manifest_path:
-            utils.info_print(f"Manifest updated: {manifest_path}")
 
 
 # ---- Main entry point ----
@@ -3075,8 +3065,8 @@ def _dispatch_standalone_mode(
     """
     # Standalone viewer: regenerate viewer from saved manifest
     if getattr(args, "viewer", False) and not cli_mode:
-        existing_artifacts = viewer.load_manifest_artifacts()
-        if not existing_artifacts:
+        existing_artifacts, existing_reels = viewer._load_manifest_both()
+        if not existing_artifacts and not existing_reels:
             utils.error_print(
                 "No manifest found or manifest is empty.",
                 [
@@ -3084,11 +3074,13 @@ def _dispatch_standalone_mode(
                 ],
             )
             sys.exit(1)
-        study = existing_artifacts[0].get("study", "")
-        participant = existing_artifacts[0].get("participant", "")
+        primary = existing_artifacts[0] if existing_artifacts else existing_reels[0]
+        study = primary.get("study", "")
+        participant = primary.get("participant", "")
         ss_events = viewer.load_screenspace_events_for_viewer()
         data = viewer.finalize_timeline_data(
             existing_artifacts,
+            reels=existing_reels or None,
             study=study,
             participant=participant,
             mode="manifest",

--- a/pipeline.py
+++ b/pipeline.py
@@ -340,6 +340,8 @@ def _process_single_clip_segments(
             except OSError:
                 pass
             break
+        else:
+            files.release_reservation(out_name)
     return (generated, output_paths)
 
 
@@ -1143,10 +1145,13 @@ def process_reel(
         utils.warning_print("No clips were generated for the reel.")
         return (0, [])
 
+    reserved_output = False
     if output_file is None and study_name:
         output_file = files.get_unique_filename(f"{study_name}_reel{config.FILEFORMAT}")
+        reserved_output = True
     elif output_file is None:
         output_file = files.get_unique_filename(f"reel{config.FILEFORMAT}")
+        reserved_output = True
 
     # Check cancel flag before starting concatenation
     if cancel_flag and cancel_flag():
@@ -1209,8 +1214,13 @@ def process_reel(
             )
 
     if not ok:
+        if reserved_output:
+            files.release_reservation(output_file)
         return (0, [])
 
+    cards_enabled, card_duration = _resolve_titlecard_options(
+        titlecards_enabled, titlecard_duration_seconds
+    )
     reel_id = compute_reel_id(components)
     reel_record: dict[str, Any] = {
         "id": reel_id,
@@ -1218,6 +1228,8 @@ def process_reel(
         "study": study_name,
         "description": f"Reel: {len(components)} segments",
         "components": components,
+        "titlecards": cards_enabled,
+        "titlecardDuration": card_duration if cards_enabled else 0,
     }
 
     reel_transcript = _build_reel_transcript(

--- a/server.py
+++ b/server.py
@@ -127,6 +127,10 @@ _generate_job_state: dict[str, Any] = {
     "total": 0,
     "done": 0,
 }
+_intake_job_state: dict[str, Any] = {
+    "total": 0,
+    "done": 0,
+}
 
 
 # Cached gspread client + threaded-auth state for the Start overlay's Google
@@ -326,6 +330,19 @@ def _increment_generate_done(n: int = 1) -> None:
     """Advance the generate-job 'done' counter by n (one per yielded line)."""
     with _job_state_lock:
         _generate_job_state["done"] += n
+
+
+def _reset_intake_job_state(total: int) -> None:
+    """Initialize the intake progress snapshot when /api/generate-intake starts."""
+    with _job_state_lock:
+        _intake_job_state["total"] = max(0, int(total))
+        _intake_job_state["done"] = 0
+
+
+def _increment_intake_done(n: int = 1) -> None:
+    """Advance the intake-job 'done' counter by n (one per yielded line)."""
+    with _job_state_lock:
+        _intake_job_state["done"] += n
 
 
 def _mark_intake_active(active: bool) -> None:
@@ -735,6 +752,8 @@ def _process_intake_item(
     if not video_path:
         return {"_ok": False, "_error": f"No video for {participant}"}
 
+    out_path: str | None = None
+
     span_hash = hashlib.md5(f"{participant}_{start}_{end}".encode()).hexdigest()[:8]
     # Two intake events can cover the same participant span (e.g. distinct
     # Screenspace events at the same timestamp). Fold source metadata and the
@@ -765,6 +784,7 @@ def _process_intake_item(
     end_str = utils.seconds_to_timestamp(int(round(end)))
 
     if cancel_flag and cancel_flag():
+        files.release_reservation(out_path)
         return {"_ok": False, "_error": "cancelled", "_cancelled": True}
 
     success = video.run_ffmpeg(
@@ -777,6 +797,7 @@ def _process_intake_item(
     )
 
     if not success:
+        files.release_reservation(out_path)
         return {"_ok": False, "_error": "ffmpeg failed"}
 
     default_desc = (
@@ -1410,15 +1431,23 @@ def api_reel() -> FlaskResponse:
                         components.append(
                             utils.build_reel_component(clip, "", start_str, end_str)
                         )
+                req_cards, req_dur = pipeline._resolve_titlecard_options(
+                    titlecards_enabled, titlecard_duration_seconds
+                )
                 if components:
                     expected_id = pipeline.compute_reel_id(components)
                     with _generated_output_lock:
                         reels_snapshot = list(_generated_reels)
                     for reel in reels_snapshot:
-                        if (
-                            reel.get("id") == expected_id
-                            and Path(utils.resolve_output_path(reel["file"])).is_file()
-                        ):
+                        if reel.get("id") != expected_id:
+                            continue
+                        reel_path = Path(utils.resolve_output_path(reel["file"]))
+                        if not reel_path.is_file():
+                            continue
+                        matches = bool(reel.get("titlecards", False)) == req_cards and (
+                            not req_cards or reel.get("titlecardDuration") == req_dur
+                        )
+                        if matches:
                             yield (
                                 json.dumps(
                                     {
@@ -1431,6 +1460,16 @@ def api_reel() -> FlaskResponse:
                                 + "\n"
                             )
                             return
+                        # Stale reel (e.g. titlecards toggled): drop record + file.
+                        with _generated_output_lock:
+                            stale_id = reel.get("id")
+                            _generated_reels[:] = [
+                                r for r in _generated_reels if r.get("id") != stale_id
+                            ]
+                        try:
+                            reel_path.unlink(missing_ok=True)
+                        except OSError:
+                            pass
 
                 _reel_cancel_event.clear()
                 _reset_reel_job_state("reel")
@@ -1980,6 +2019,7 @@ def api_generate_intake() -> FlaskResponse:
             return json.dumps({"index": idx, "ok": False, "error": error}) + "\n"
 
         _mark_intake_active(True)
+        _reset_intake_job_state(len(items))
         try:
             workers = pipeline._resolve_clip_workers()
             if workers >= 2 and len(items) >= 2:
@@ -2007,6 +2047,7 @@ def api_generate_intake() -> FlaskResponse:
                                 + "\n"
                             )
                             continue
+                        _increment_intake_done()
                         yield _emit(idx, result)
                         if cancel_flag():
                             # Drain remaining submitted futures so workers can
@@ -2026,6 +2067,7 @@ def api_generate_intake() -> FlaskResponse:
                         index=idx,
                         cancel_flag=cancel_flag,
                     )
+                    _increment_intake_done()
                     yield _emit(idx, result)
             if cancel_flag():
                 yield json.dumps({"cancelled": True}) + "\n"
@@ -2223,11 +2265,14 @@ def api_reel_direct() -> FlaskResponse:
                         "file": Path(reel_name).name,
                         "source": "intake",
                         "description": f"Intake reel ({len(clip_paths)} segments)",
+                        "titlecards": cards_enabled,
+                        "titlecardDuration": card_duration if cards_enabled else 0,
                     }
                     _append_generated_reel(reel_record)
                     _save_manifest_quiet()
                     emit_event({"ok": True, "generated": 1, "reels": [reel_record]})
                 else:
+                    files.release_reservation(reel_name)
                     emit_event({"ok": False, "error": "Reel concatenation failed"})
             except Exception as exc:
                 emit_event({"ok": False, "error": str(exc)})
@@ -2278,9 +2323,11 @@ def api_job_status() -> FlaskResponse:
     with _busy_lock:
         reel_busy = _reel_in_progress
         generate_busy = _generate_in_progress
+        intake_busy = _intake_active > 0
     with _job_state_lock:
         reel_snapshot = dict(_reel_job_state)
         generate_snapshot = dict(_generate_job_state)
+        intake_snapshot = dict(_intake_job_state)
     return jsonify(
         {
             "ok": True,
@@ -2293,6 +2340,11 @@ def api_job_status() -> FlaskResponse:
                 "in_progress": generate_busy,
                 "cancelling": generate_busy and _generate_cancel_event.is_set(),
                 **generate_snapshot,
+            },
+            "intake": {
+                "in_progress": intake_busy,
+                "cancelling": intake_busy and _intake_cancel_event.is_set(),
+                **intake_snapshot,
             },
         }
     )

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -5,6 +5,7 @@ import pytest
 
 import cli
 import clipgen
+import config
 import viewer as viewer_mod
 
 
@@ -73,15 +74,58 @@ def test_run_cli_mode_chronologic_reel_and_viewer(monkeypatch):
     clips = [{"study": "study", "participant": "P01"}]
     monkeypatch.setattr(cli, "_generate_cli_clips", lambda _ws, _a, _p: clips)
 
-    process_reel = Mock(return_value=(1, [{"study": "study", "participant": "P01"}]))
+    reel_records = [
+        {
+            "id": "reel_abc",
+            "file": "study_reel.mp4",
+            "study": "study",
+            "components": [],
+        }
+    ]
+    process_reel = Mock(return_value=(1, reel_records))
     monkeypatch.setattr(clipgen, "process_reel", process_reel)
 
+    viewer_calls = []
     viewer_path = "clips_viewer.html"
-    monkeypatch.setattr(
-        viewer_mod, "generate_timeline_viewer", lambda _data: viewer_path
-    )
+
+    def capture_viewer(data):
+        viewer_calls.append(data)
+        return viewer_path
+
+    monkeypatch.setattr(viewer_mod, "generate_timeline_viewer", capture_viewer)
     monkeypatch.setattr(cli.utils, "info_print", lambda _msg: None)
 
     cli.run_cli_mode(worksheet, args, parsed)
 
     process_reel.assert_called_once()
+    assert len(viewer_calls) == 1
+    assert viewer_calls[0]["artifacts"] == []
+    assert viewer_calls[0]["reels"] == reel_records
+
+
+def test_standalone_viewer_from_reel_only_manifest(monkeypatch, tmp_path):
+    import viewer
+
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    reel = {
+        "id": "reel_only",
+        "file": "only_reel.mp4",
+        "study": "study",
+        "components": [],
+    }
+    viewer.save_manifest([], new_reels=[reel], study="study", mode="reel")
+
+    viewer_calls = []
+    monkeypatch.setattr(
+        viewer_mod,
+        "generate_timeline_viewer",
+        lambda data: viewer_calls.append(data) or "viewer.html",
+    )
+    monkeypatch.setattr(cli.utils, "info_print", lambda _msg: None)
+
+    args = _args(viewer=True)
+    assert cli._dispatch_standalone_mode(args, cli_mode=False, gallery_arg=None) is True
+    assert len(viewer_calls) == 1
+    assert viewer_calls[0]["artifacts"] == []
+    assert len(viewer_calls[0]["reels"]) == 1
+    assert viewer_calls[0]["reels"][0]["id"] == "reel_only"

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -515,6 +515,53 @@ def test_build_reel_transcript_uses_request_titlecard_duration(monkeypatch):
     assert merged[0]["end"] == 9.0
 
 
+def test_process_single_clip_segments_releases_reservation_on_ffmpeg_failure(
+    monkeypatch, make_clip, tmp_path
+):
+    """Failed segment encodes must not leave get_unique_filename placeholders."""
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    (input_dir / "study_P01.mp4").write_bytes(b"\x00")
+    monkeypatch.setattr(config, "INPUT_DIR", str(input_dir), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(output_dir), raising=False)
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", lambda **_k: False)
+
+    raw_clip = pipeline.files.prepare_clip(make_clip())
+    generated, paths = pipeline._process_single_clip_segments(
+        raw_clip, str(input_dir / "study_P01.mp4"), set(), output_format="clip"
+    )
+
+    assert generated == 0
+    assert paths == []
+    assert list(output_dir.iterdir()) == []
+
+
+def test_process_reel_releases_reservation_on_concat_failure(
+    monkeypatch, make_clip, tmp_path
+):
+    """Concat failure must release the reserved final reel path placeholder."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    part_path = output_dir / "part.mp4"
+    part_path.write_bytes(b"clip")
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(output_dir), raising=False)
+    monkeypatch.setattr(
+        pipeline,
+        "_run_clip_pipeline",
+        lambda clips_list, **kwargs: ([([(str(part_path), 0)], [])], set()),
+    )
+    monkeypatch.setattr(pipeline.video, "concatenate_clips", lambda *a, **k: False)
+    monkeypatch.setattr(pipeline.utils, "use_progress", lambda: False)
+
+    clips = [make_clip()]
+    result, records = clipgen.process_reel(clips)
+    assert result == 0
+    assert records == []
+    assert list(output_dir.iterdir()) == []
+
+
 def test_regenerate_reel_releases_reservation_on_ffmpeg_failure(monkeypatch, tmp_path):
     """A reel part whose ffmpeg encode fails must not leave a 0-byte placeholder
     behind from get_unique_filename's atomic reservation."""

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -642,6 +642,70 @@ def test_api_generate_skips_when_titlecards_match(client, monkeypatch, tmp_path)
     assert (tmp_path / "clip.mp4").exists()
 
 
+def test_api_reel_regenerates_when_titlecards_toggled(client, monkeypatch, tmp_path):
+    """Toggling titlecards on must not reuse a cached reel built without them."""
+    import types
+
+    import pipeline
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+
+    (tmp_path / "study_reel.mp4").write_bytes(b"old-reel")
+    cell = types.SimpleNamespace(row=5, col=2, value="1:00-1:30")
+    components = [{"cellRow": 5, "cellCol": 2, "start": 60.0, "end": 90.0}]
+    expected_id = pipeline.compute_reel_id(components)
+
+    existing_reel = {
+        "id": expected_id,
+        "file": "study_reel.mp4",
+        "study": "study",
+        "components": components,
+        "titlecards": False,
+        "titlecardDuration": 0,
+    }
+    monkeypatch.setattr(server, "_generated_reels", [existing_reel])
+
+    def fake_generate_list(ws, mode, *, ctx=None, reel_input, skip_prompts):
+        return [
+            {
+                "participant": "P01",
+                "cell": cell,
+                "desc": "test",
+                "category": "cat",
+                "study": "study",
+                "severity": "",
+                "times": [("1:00", "1:30")],
+            }
+        ]
+
+    monkeypatch.setattr("spreadsheet.generate_list", fake_generate_list)
+    monkeypatch.setattr("files.prepare_clip", lambda clip: clip)
+
+    process_called = []
+
+    def fake_stream(clips, cancel_flag, **kwargs):
+        process_called.append(kwargs)
+        yield (
+            json.dumps({"ok": True, "generated": 1, "reels": [{"id": expected_id}]})
+            + "\n"
+        )
+
+    monkeypatch.setattr(server, "_stream_process_reel", fake_stream)
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+
+    resp = client.post(
+        "/studio/api/reel",
+        json={"cells": ["P01.5"], "titlecards_enabled": True, "titlecard_duration": 2},
+    )
+    assert resp.status_code == 200
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+    assert lines[-1]["ok"] is True
+    assert process_called
+    assert process_called[0]["titlecards_enabled"] is True
+    assert not (tmp_path / "study_reel.mp4").exists()
+
+
 def test_api_reel_skips_existing_reel(client, monkeypatch, tmp_path):
     """An identical reel is returned without re-running process_reel."""
     import types
@@ -665,6 +729,8 @@ def test_api_reel_skips_existing_reel(client, monkeypatch, tmp_path):
         "file": "study_reel.mp4",
         "study": "study",
         "components": components,
+        "titlecards": False,
+        "titlecardDuration": 0,
     }
     monkeypatch.setattr(server, "_generated_reels", [existing_reel])
 
@@ -688,7 +754,10 @@ def test_api_reel_skips_existing_reel(client, monkeypatch, tmp_path):
         lambda *a, **kw: process_called.append(1) or (1, []),
     )
 
-    resp = client.post("/studio/api/reel", json={"cells": ["P01.5"]})
+    resp = client.post(
+        "/studio/api/reel",
+        json={"cells": ["P01.5"], "titlecards_enabled": False},
+    )
     assert resp.status_code == 200
     lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
     final = lines[-1]
@@ -2407,6 +2476,9 @@ def test_api_job_status_idle(client):
     assert data["ok"] is True
     assert data["reel"]["in_progress"] is False
     assert data["generate"]["in_progress"] is False
+    assert data["intake"]["in_progress"] is False
+    assert "done" in data["intake"]
+    assert "total" in data["intake"]
     # Snapshot fields are always present so the client can render without
     # null-checks.
     assert "phase" in data["reel"]
@@ -2686,6 +2758,63 @@ def test_api_generate_discards_artifacts_completed_after_cancel(
 
 
 # ---- /api/generate-intake cancellation ----
+
+
+def test_api_job_status_reflects_intake_progress(client, monkeypatch, tmp_path):
+    """While /api/generate-intake is running, job-status reports intake progress."""
+    import threading
+
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    proceed = threading.Event()
+    started = threading.Event()
+
+    def slow_item(item, output_format, study, index=0, *, cancel_flag=None):
+        started.set()
+        proceed.wait(timeout=5)  # hold worker until status is polled
+        return {
+            "id": f"intake_{index}",
+            "type": "clip",
+            "file": f"clip_{index}.mp4",
+            "study": study,
+            "participant": item["participant"],
+            "_ok": True,
+            "_error": "",
+        }
+
+    monkeypatch.setattr(server, "_process_intake_item", slow_item)
+    monkeypatch.setattr(server, "_resolve_intake_video_path", lambda p, s="": "vid.mp4")
+    monkeypatch.setattr("pipeline._resolve_clip_workers", lambda: 1)
+
+    items = [{"participant": "P01", "start": 0, "end": 5, "source": "screenspace"}]
+    stream_error = []
+
+    def run_intake():
+        try:
+            with client.post(
+                "/studio/api/generate-intake",
+                json={"items": items, "format": "clip"},
+                buffered=False,
+            ) as resp:
+                list(resp.iter_encoded())
+        except Exception as exc:
+            stream_error.append(exc)
+
+    worker = threading.Thread(target=run_intake)
+    worker.start()
+    try:
+        assert started.wait(timeout=5)
+        status = client.get("/studio/api/job-status").get_json()
+        assert status["intake"]["in_progress"] is True
+        assert status["intake"]["total"] == 1
+        assert status["intake"]["done"] == 0
+        proceed.set()
+    finally:
+        worker.join(timeout=10)
+    assert not stream_error
+
+    assert _poll_until(lambda: server._intake_active == 0)
+    final = client.get("/studio/api/job-status").get_json()
+    assert final["intake"]["in_progress"] is False
 
 
 def test_api_generate_intake_cancel_endpoint_returns_ok(client):

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -102,6 +102,27 @@ def test_sheet_branch_catch_marks_failures():
     assert "totalFail += sheetItems.length;" in src
 
 
+def test_generate_abort_treated_as_cancel_not_failure():
+    """Aborting the generate fetch (Cancel button) must set cancelled and must
+    not mark every card failed or increment totalFail in the catch path."""
+    src = _studio_js()
+    assert "state.generateCancelledByUser = true" in src
+    assert "function isGenerateFetchAborted(err)" in src
+    assert 'err.name === "AbortError"' in src
+    start = src.index("function onGenerate()")
+    end = src.index("function onCancelReel()", start)
+    body = src[start:end]
+    assert "if (isGenerateFetchAborted(err))" in body
+    assert "cancelled = true" in body
+    # Abort path clears queued cards; real failures still use setCardResult(..., false).
+    abort_blocks = body.split("if (isGenerateFetchAborted(err))")
+    assert len(abort_blocks) >= 3
+    for block in abort_blocks[1:]:
+        abort_section = block.split("finishBranch();")[0]
+        assert "setCardResult" not in abort_section
+        assert "totalFail +=" not in abort_section
+
+
 def test_finish_branch_handles_zero_zero_case():
     """Stream that ends with no successes and no failures (not cancelled)
     should surface an error, not silently report '0 artifacts'."""
@@ -126,6 +147,27 @@ def test_cancel_cleanup_uses_queue_card_queued_selector():
     src = _studio_js()
     assert ".queue-card.queued" not in src
     assert 'querySelectorAll(".queue-card-queued")' in src
+
+
+def test_load_manifest_state_hydrates_reels_without_artifacts():
+    """Reel-only manifests must still populate generatedReels and renderLog."""
+    src = _studio_js()
+    start = src.index("function loadManifestState()")
+    end = src.index("function applyJobStatus(", start)
+    body = src[start:end]
+    assert "var reels = data.reels || [];" in body
+    assert "artifacts.length === 0 && reels.length === 0" in body
+    assert "state.generatedReels.push(stampLog(reel))" in body
+    assert "renderLog();" in body
+    assert "if (artifacts.length === 0) return;" not in body
+
+
+def test_job_status_poll_includes_intake():
+    """Re-attach polling must keep running while intake generation is active."""
+    src = _studio_js()
+    assert "var intake = status.intake || {};" in src
+    assert "data.intake && data.intake.in_progress" in src
+    assert "state._jobStatusIntakeWasInProgress" in src
 
 
 def test_reel_409_treated_as_json_error():

--- a/video.py
+++ b/video.py
@@ -1971,6 +1971,8 @@ def _parallel_extract_gifs(
                             "duration": gif_dur,
                         }
                     )
+                else:
+                    files.release_reservation(output_path)
                 utils.standard_print(f"  Captured {completed}/{total} at {ts_str}")
     except (OSError, RuntimeError) as exc:
         utils.debug_print(f"Parallel GIF extraction failed: {exc}")
@@ -2072,6 +2074,8 @@ def generate_interval_captures(
                     "duration": gif_dur,
                 }
             )
+        else:
+            files.release_reservation(output_path)
         utils.standard_print(f"  Captured {i + 1}/{total} at {ts_str}")
 
     utils.info_print(


### PR DESCRIPTION
## Summary
- Studio Generate Cancel now reports cancellation instead of marking every queued card failed when fetches abort.
- Atomic filename reservations are released on failed or cancelled encodes (clips, intake, reels, gallery).
- Reel cache reuse respects titlecard settings; stale reels are discarded and rebuilt.
- Reel-only manifests hydrate in Studio; intake generation appears in `/api/job-status` for re-attach after navigation.
- CLI `--viewer` works for reel-only runs and standalone manifests that contain reels but no artifacts.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`
- [ ] Manual: Studio Generate Cancel shows "Generation cancelled" (not "All generations failed")
- [ ] Manual: Rebuild reel with titlecards toggled regenerates instead of skipping
- [ ] Manual: Reel-only manifest shows reels in artifact log after reload
- [ ] Manual: Navigate away during intake generate, return — progress/cancel reappear