### PR TITLE
fix(studio): route intake items through addToQueue for Add to Reel

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1783,7 +1783,10 @@
     if (targetQueue === state.artifactQueue && isArtifactQueueLocked()) return;
     if (targetQueue === state.reelQueue && isReelQueueLocked()) return;
     var added = false;
-    if (info.segIdx !== undefined) {
+    if (isIntakeSource(info.source)) {
+      targetQueue.push(info);
+      added = true;
+    } else if (info.segIdx !== undefined) {
       if (!hasSegmentInQueue(targetQueue, info.participant, info.row, info.segIdx)) {
         targetQueue.push(info);
         added = true;
@@ -1797,7 +1800,7 @@
     }
     if (added) {
       renderFn();
-      updateSingleCellClass(info.participant, info.row);
+      if (info.row) updateSingleCellClass(info.participant, info.row);
     }
   }
 
@@ -2156,9 +2159,8 @@
           addToQueue(state.artifactQueue, info.items[i], renderArtifactQueue);
         return;
       }
-      if (info.source === "screenspace" || info.source === "transcript") {
-        state.artifactQueue.push(info);
-        renderArtifactQueue();
+      if (isIntakeSource(info.source)) {
+        addToQueue(state.artifactQueue, info, renderArtifactQueue);
         return;
       }
       if (info.source === "reel") {
@@ -2174,9 +2176,8 @@
           addToQueue(state.reelQueue, info.items[i], renderReelQueue);
         return;
       }
-      if (info.source === "screenspace" || info.source === "transcript") {
-        state.reelQueue.push(info);
-        renderReelQueue();
+      if (isIntakeSource(info.source)) {
+        addToQueue(state.reelQueue, info, renderReelQueue);
         return;
       }
       if (info.source === "artifact") {

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -175,3 +175,30 @@ def test_reel_409_treated_as_json_error():
     the previous status !== 409 exemption was a bug."""
     src = _studio_js()
     assert "response.status !== 409" not in src
+
+
+def test_add_to_queue_handles_intake_sources():
+    """Intake items in the artifact queue must reach the reel via addToQueue(),
+    not expandCellToSegments() which requires spreadsheet row/timestamp shape."""
+    src = _studio_js()
+    start = src.index("function addToQueue(")
+    end = src.index("\n  // Collect selectable timestamp cell infos", start)
+    body = src[start:end]
+    intake_idx = body.index("if (isIntakeSource(info.source))")
+    expand_idx = body.index("expandCellToSegments")
+    assert intake_idx >= 0
+    assert intake_idx < expand_idx
+    assert "if (info.row) updateSingleCellClass" in body
+
+
+def test_intake_drop_targets_route_through_add_to_queue():
+    """Intake drag/drop must use addToQueue(), not duplicate push+render blocks."""
+    src = _studio_js()
+    start = src.index("function initDropTargets()")
+    end = src.index("\n  function setupDropTarget(", start)
+    body = src[start:end]
+    assert "state.artifactQueue.push(info)" not in body
+    assert "state.reelQueue.push(info)" not in body
+    assert body.count("if (isIntakeSource(info.source))") == 2
+    assert body.count("addToQueue(state.artifactQueue, info, renderArtifactQueue)") >= 1
+    assert body.count("addToQueue(state.reelQueue, info, renderReelQueue)") >= 2


### PR DESCRIPTION
## Summary
- Fix "Add to Reel" for intake cards already in the Artifacts queue by teaching `addToQueue()` to handle intake sources directly.
- Route intake drag/drop through `addToQueue()` instead of duplicating push/render logic.
- Add static frontend regression tests for the intake insertion path.

## Test plan
- [ ] Add a Screenspace or Transcript intake card to Artifacts (normal click)
- [ ] Click **Add to Reel** and confirm the card appears in Reel while staying in Artifacts
- [ ] Confirm spreadsheet cells still add to Reel via the same button
- [ ] Confirm drag and shift+click intake paths still work
- [x] `uv run --extra dev pytest tests/test_studio_frontend_source.py`