### PR TITLE
refactor(web): Wave 1 of frontend refactor — shared chrome helpers

### DIFF
--- a/assets/web/export-actions.js
+++ b/assets/web/export-actions.js
@@ -1,0 +1,63 @@
+/* Shared Export quick-action wiring for Studio / Screenspace / Transcripts.
+ *
+ * Endpoints /api/export and /api/export/status are registered on the combined
+ * Flask app (server.py), so the same client logic drives all three surfaces.
+ *
+ * Depends on globals from utils.js: apiGet, showToast, clipgenPluralUnit.
+ *
+ * Public API on window.ClipgenExportActions:
+ *   runExport()                   — POST /api/export, toast the result
+ *   exportQuickAction()           — TopNav quick-action item with current enabled state
+ *   refreshExportStatus(rebuild)  — GET /api/export/status; calls rebuild() on flag flip
+ */
+(function () {
+  "use strict";
+
+  var _enabled = false;
+
+  function runExport() {
+    // Manual fetch (not apiPost) so a server-supplied j.error on non-2xx still
+    // surfaces in the toast — apiPost would throw "Server error <code>" and
+    // drop the body.
+    fetch("/api/export", { method: "POST" })
+      .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+      .then(function (res) {
+        if (res.ok && res.j && res.j.ok) {
+          var n = (res.j.written || []).length;
+          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
+        } else {
+          showToast((res.j && res.j.error) || "Export failed");
+        }
+      })
+      .catch(function (err) { showToast("Export failed: " + err.message); });
+  }
+
+  function exportQuickAction() {
+    return {
+      icon: "arrow-down-tray",
+      label: "Export",
+      action: runExport,
+      disabled: !_enabled,
+      title: _enabled
+        ? "Write JSON+CSV exports of Screenspace and Transcripts manifests"
+        : "Run a Screenspace task or transcribe a video first to enable Export.",
+    };
+  }
+
+  function refreshExportStatus(rebuild) {
+    return apiGet("/api/export/status")
+      .then(function (j) {
+        var next = !!(j && j.any);
+        if (next === _enabled) return;
+        _enabled = next;
+        if (typeof rebuild === "function") rebuild();
+      })
+      .catch(function () {});
+  }
+
+  window.ClipgenExportActions = {
+    runExport: runExport,
+    exportQuickAction: exportQuickAction,
+    refreshExportStatus: refreshExportStatus,
+  };
+})();

--- a/assets/web/primitives.css
+++ b/assets/web/primitives.css
@@ -770,3 +770,25 @@
   height: 30px;
   opacity: 0.85;
 }
+
+/* ---- Toast ---- */
+
+.toast {
+  position: fixed;
+  bottom: var(--space-5);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-toast, 3000);
+  transition: opacity var(--duration-fast);
+}
+
+.toast.hidden {
+  display: none;
+}

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -3012,28 +3012,6 @@ body.panel-dragging #bottomPanel {
   margin-top: var(--space-1);
 }
 
-/* Toast */
-
-.toast {
-  position: fixed;
-  bottom: var(--space-5);
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-text);
-  color: var(--color-bg);
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius);
-  font-size: var(--text-sm);
-  z-index: var(--z-dropdown);
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity var(--duration-normal);
-}
-
-.toast:not(.hidden) {
-  opacity: 1;
-}
-
 /* Screenspace timeline tooltip */
 
 .ss-tooltip {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -296,6 +296,7 @@
 
   <!-- Deps order: utils → chrome → settings → page script -->
   <script src="utils.js"></script>
+  <script src="export-actions.js"></script>
   <script src="topnav.js"></script>
   <script src="start-overlay.js"></script>
   <script src="dev-token-tweak.js" data-dev-only></script>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -6526,51 +6526,18 @@
 
   // ---- Init ----
 
-  function runExport() {
-    fetch("/api/export", { method: "POST" })
-      .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
-      .then(function (res) {
-        if (res.ok && res.j && res.j.ok) {
-          var n = (res.j.written || []).length;
-          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
-        } else {
-          showToast((res.j && res.j.error) || "Export failed");
-        }
-      })
-      .catch(function (err) { showToast("Export failed: " + err.message); });
-  }
-
-  var _exportEnabled = false;
-
   function initTopNavActions() {
     if (!window.ClipgenTopNav) return;
     function rebuild() {
       window.ClipgenTopNav.setQuickActions([
-        {
-          icon: "arrow-down-tray",
-          label: "Export",
-          action: runExport,
-          disabled: !_exportEnabled,
-          title: _exportEnabled
-            ? "Write JSON+CSV exports of Screenspace and Transcripts manifests"
-            : "Run a Screenspace task or transcribe a video first to enable Export.",
-        },
+        window.ClipgenExportActions.exportQuickAction(),
       ]);
     }
-    function refreshExportStatus() {
-      fetch("/api/export/status")
-        .then(function (r) { return r.json(); })
-        .then(function (j) {
-          var next = !!(j && j.any);
-          if (next === _exportEnabled) return;
-          _exportEnabled = next;
-          rebuild();
-        })
-        .catch(function () {});
-    }
     rebuild();
-    refreshExportStatus();
-    window.ClipgenTopNav.onBeforeOpen(refreshExportStatus);
+    window.ClipgenExportActions.refreshExportStatus(rebuild);
+    window.ClipgenTopNav.onBeforeOpen(function () {
+      window.ClipgenExportActions.refreshExportStatus(rebuild);
+    });
   }
 
   document.addEventListener("DOMContentLoaded", function () {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -159,29 +159,37 @@
   var _resultsRequestVersion = 0;
   var _heatmapOverlayRequestVersion = 0;
 
-  var _cachedThemeColors = null;
+  // Region palette is screenspace-specific (REGION_COLOR_COUNT entries from
+  // --region-color-1..N); the common canvas colors come from the shared
+  // getCanvasThemeColors() cache in utils.js, which auto-invalidates on
+  // theme toggle.
+  var _cachedRegionPalette = null;
 
   function refreshThemeColors() {
-    var cs = getComputedStyle(document.documentElement);
-    var regionPalette = [];
-    for (var i = 1; i <= REGION_COLOR_COUNT; i++) {
-      regionPalette.push(cs.getPropertyValue("--region-color-" + i).trim() || "#3b82f6");
-    }
-    _cachedThemeColors = {
-      fg: cs.getPropertyValue("--fg").trim() || "#ffffff",
-      bg: cs.getPropertyValue("--bg").trim() || "#0d0e10",
-      surfaceAlt: cs.getPropertyValue("--color-surface-alt").trim() || "#f1ece4",
-      border: cs.getPropertyValue("--color-border").trim() || "#e0ddd7",
-      textDim: cs.getPropertyValue("--color-text-dim").trim() || "#6b7280",
-      accent: cs.getPropertyValue("--color-accent").trim() || "#1d4f72",
-      fontMono: cs.getPropertyValue("--font-mono").trim() || "monospace",
-      regionPalette: regionPalette,
-    };
+    invalidateCanvasThemeColors();
+    _cachedRegionPalette = null;
   }
 
   function getThemeColors() {
-    if (!_cachedThemeColors) refreshThemeColors();
-    return _cachedThemeColors;
+    var base = getCanvasThemeColors();
+    if (!_cachedRegionPalette) {
+      var cs = getComputedStyle(document.documentElement);
+      var palette = [];
+      for (var i = 1; i <= REGION_COLOR_COUNT; i++) {
+        palette.push(cs.getPropertyValue("--region-color-" + i).trim() || "#3b82f6");
+      }
+      _cachedRegionPalette = palette;
+    }
+    return {
+      fg: base.fg,
+      bg: base.bg,
+      surfaceAlt: base.surfaceAlt,
+      border: base.border,
+      textDim: base.textDim,
+      accent: base.accent,
+      fontMono: base.fontMono,
+      regionPalette: _cachedRegionPalette,
+    };
   }
 
   // ---- Helpers ----

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2716,22 +2716,3 @@ html[data-theme="dark"] .log-panel {
   height: 10px;
 }
 
-.toast {
-  position: fixed;
-  bottom: var(--space-5);
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--text-sm);
-  box-shadow: var(--shadow-lg);
-  z-index: var(--z-toast, 3000);
-  transition: opacity var(--duration-fast);
-}
-
-.toast.hidden {
-  display: none;
-}

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -281,6 +281,7 @@
   <!-- Deps: utils → primitives → chrome → settings → studio + panels -->
   <script src="utils.js"></script>
   <script src="primitives.js"></script>
+  <script src="export-actions.js"></script>
   <script src="topnav.js"></script>
   <script src="start-overlay.js"></script>
   <script src="dev-token-tweak.js" data-dev-only></script>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -5158,20 +5158,6 @@
     });
   }
 
-  var _exportEnabled = false;
-
-  function _exportItem() {
-    return {
-      icon: "arrow-down-tray",
-      label: "Export",
-      action: runExport,
-      disabled: !_exportEnabled,
-      title: _exportEnabled
-        ? "Write JSON+CSV exports of Screenspace and Transcripts manifests"
-        : "Run a Screenspace task or transcribe a video first to enable Export.",
-    };
-  }
-
   function initTopNavActions() {
     if (!window.ClipgenTopNav) return;
     function clickIfExists(id) {
@@ -5183,38 +5169,15 @@
         { icon: "eye",        label: "Build Viewer",  action: onBuildViewer },
         { icon: "film",       label: "Open Timeline", action: onBuildTimelineViewer },
         { icon: "photo",      label: "Open Gallery",  action: openGalleryDialog },
-        _exportItem(),
+        window.ClipgenExportActions.exportQuickAction(),
         { icon: "arrow-path", label: "Refresh sheet", action: function () { clickIfExists("refreshSheet"); } },
       ]);
     }
-    function refreshExportStatus() {
-      fetch("/api/export/status")
-        .then(function (r) { return r.json(); })
-        .then(function (j) {
-          var next = !!(j && j.any);
-          if (next === _exportEnabled) return;
-          _exportEnabled = next;
-          rebuild();
-        })
-        .catch(function () {});
-    }
     rebuild();
-    refreshExportStatus();
-    window.ClipgenTopNav.onBeforeOpen(refreshExportStatus);
-  }
-
-  function runExport() {
-    fetch("/api/export", { method: "POST" })
-      .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
-      .then(function (res) {
-        if (res.ok && res.j && res.j.ok) {
-          var n = (res.j.written || []).length;
-          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
-        } else {
-          showToast((res.j && res.j.error) || "Export failed");
-        }
-      })
-      .catch(function (err) { showToast("Export failed: " + err.message); });
+    window.ClipgenExportActions.refreshExportStatus(rebuild);
+    window.ClipgenTopNav.onBeforeOpen(function () {
+      window.ClipgenExportActions.refreshExportStatus(rebuild);
+    });
   }
 
   // Apply mask-image to every static [data-icon] element (mirrors what

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -58,7 +58,6 @@
     intakeEvents: [],
     intakeClusters: [],
     intakeSeenIds: {},
-    intakePollTimer: null,
     intakeFilterText: "",
     intakeFilterDetector: "",
     intakeFilterNew: false,
@@ -67,9 +66,6 @@
     activePreviewTab: "sheet",
     trIntakeMarks: [],
     trIntakeClusters: [],
-    trIntakePollTimer: null,
-    intakeStatusTimer: null,
-    trIntakeStatusTimer: null,
     trIntakeFilterCategory: "",
     trIntakeFilterParticipants: [],
     trIntakeFilterText: "",
@@ -4650,16 +4646,6 @@
       });
     }
 
-    // Polling runs whenever the page is visible so the intake-tab counter
-    // badge stays live regardless of which sub-tab the user is currently on.
-    document.addEventListener("visibilitychange", function () {
-      if (document.hidden) {
-        if (state.intakePollTimer) { clearInterval(state.intakePollTimer); state.intakePollTimer = null; }
-      } else {
-        pollIntakeEvents();
-        if (!state.intakePollTimer) state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
-      }
-    });
   }
 
   // ---- Transcript Intake ----
@@ -5130,16 +5116,6 @@
       });
     }
 
-    // Visibility change — pause/resume polling. Runs whenever the page is
-    // visible so the transcript-intake counter badge stays live across tabs.
-    document.addEventListener("visibilitychange", function () {
-      if (document.hidden) {
-        if (state.trIntakePollTimer) { clearInterval(state.trIntakePollTimer); state.trIntakePollTimer = null; }
-      } else {
-        pollTranscriptIntakeMarks();
-        if (!state.trIntakePollTimer) state.trIntakePollTimer = setInterval(pollTranscriptIntakeMarks, 10000);
-      }
-    });
   }
 
   function initTooltipToggle() {
@@ -5217,38 +5193,23 @@
     initTopNavActions();
     initIntake();
     initTranscriptIntake();
-    pollIntakeStatus();
-    pollTrIntakeStatus();
+    // Live counter polls — intake-status / tr-intake-status (5s) keep the
+    // start-overlay's status pill fresh; intake-events / tr-intake-marks
+    // (10s) keep the sub-tab counter badges live regardless of which
+    // sub-tab is currently visible. createPoller handles visibility-pause.
+    createPoller(pollIntakeStatus, 5000).start();
+    createPoller(pollTrIntakeStatus, 5000).start();
+    createPoller(pollIntakeEvents, 10000).start();
+    createPoller(pollTranscriptIntakeMarks, 10000).start();
     // One-shot job-status fetch on page load picks up any reel/generate
     // build that's still running in the background after the user navigated
     // away to a sibling frontend and back. The poll's own success handler
     // starts the recurring timer if a job is still in flight.
     pollJobStatus();
-    if (!document.hidden) {
-      state.intakeStatusTimer = setInterval(pollIntakeStatus, 5000);
-      state.trIntakeStatusTimer = setInterval(pollTrIntakeStatus, 5000);
-    }
     document.addEventListener("visibilitychange", function () {
-      if (document.hidden) {
-        if (state.intakeStatusTimer) { clearInterval(state.intakeStatusTimer); state.intakeStatusTimer = null; }
-        if (state.trIntakeStatusTimer) { clearInterval(state.trIntakeStatusTimer); state.trIntakeStatusTimer = null; }
-        stopJobStatusPoll();
-      } else {
-        if (!state.intakeStatusTimer) { pollIntakeStatus(); state.intakeStatusTimer = setInterval(pollIntakeStatus, 5000); }
-        if (!state.trIntakeStatusTimer) { pollTrIntakeStatus(); state.trIntakeStatusTimer = setInterval(pollTrIntakeStatus, 5000); }
-        pollJobStatus();
-      }
+      if (document.hidden) stopJobStatusPoll();
+      else pollJobStatus();
     });
-    // Start intake event polls immediately so the sub-tab counter badges
-    // populate on page load and update live regardless of which sub-tab the
-    // user is currently viewing. Visibility-change handlers in
-    // initIntake / initTranscriptIntake pause + resume them with the page.
-    if (!document.hidden) {
-      pollIntakeEvents();
-      state.intakePollTimer = setInterval(pollIntakeEvents, 10000);
-      pollTranscriptIntakeMarks();
-      state.trIntakePollTimer = setInterval(pollTranscriptIntakeMarks, 10000);
-    }
     window.addEventListener("resize", function () {
       if (window.convergenceResize) window.convergenceResize();
       if (window.metadataResize) window.metadataResize();

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1592,25 +1592,3 @@ body {
   background: rgba(239, 68, 68, 0.1);
 }
 
-/* Toast */
-
-.toast {
-  position: fixed;
-  bottom: var(--space-5);
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--text-sm);
-  box-shadow: var(--shadow-lg);
-  z-index: var(--z-toast, 3000);
-  transition: opacity var(--duration-fast);
-}
-
-.toast.hidden {
-  display: none;
-}
-

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -156,6 +156,7 @@
 
   <!-- Deps order: utils → chrome → settings → page script -->
   <script src="utils.js"></script>
+  <script src="export-actions.js"></script>
   <script src="topnav.js"></script>
   <script src="start-overlay.js"></script>
   <script src="dev-token-tweak.js" data-dev-only></script>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1472,18 +1472,15 @@
     var cssH = canvas.offsetHeight;
     ctx.clearRect(0, 0, cssW, cssH);
 
-    var isDark = (document.documentElement.getAttribute("data-theme") || "").toLowerCase() === "dark";
-    var surfaceAlt = getCSSVar("--color-surface-alt", isDark ? "#1f2937" : "#f1ece4");
-    var border = getCSSVar("--color-border", isDark ? "#374151" : "#e0ddd7");
-    var textDim = getCSSVar("--color-text-dim", isDark ? "#9ca3af" : "#6b7280");
+    var theme = getCanvasThemeColors();
 
-    ctx.fillStyle = surfaceAlt;
+    ctx.fillStyle = theme.surfaceAlt;
     ctx.fillRect(0, 0, cssW, cssH);
 
     var dur = v && isFinite(v.duration) ? v.duration : 0;
     if (dur <= 0) {
       _markerHitRects = [];
-      ctx.fillStyle = textDim;
+      ctx.fillStyle = theme.textDim;
       ctx.font = "11px -apple-system, sans-serif";
       ctx.textAlign = "center";
       ctx.fillText(state.selectedParticipant ? "Loading…" : "No video", cssW / 2, cssH / 2 + 4);
@@ -1496,9 +1493,9 @@
 
     var tickInterval = computeTickInterval(dur);
     var firstTick = Math.ceil(0 / tickInterval) * tickInterval;
-    ctx.strokeStyle = border;
-    ctx.fillStyle = textDim;
-    ctx.font = "10px " + getCSSVar("--font-mono", "monospace");
+    ctx.strokeStyle = theme.border;
+    ctx.fillStyle = theme.textDim;
+    ctx.font = "10px " + theme.fontMono;
     ctx.textAlign = "center";
     ctx.lineWidth = 1;
     for (var t = firstTick; t <= dur; t += tickInterval) {
@@ -1550,8 +1547,7 @@
     var dur = isFinite(v.duration) ? v.duration : 0;
     if (dur <= 0) return;
     var px = (v.currentTime / dur) * cssW;
-    var accent = getCSSVar("--color-accent", "#1d4f72");
-    ctx.strokeStyle = accent;
+    ctx.strokeStyle = getCanvasThemeColors().accent;
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(px, 0);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -3488,20 +3488,6 @@
 
   // ---- Boot ----
 
-  function runExport() {
-    fetch("/api/export", { method: "POST" })
-      .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
-      .then(function (res) {
-        if (res.ok && res.j && res.j.ok) {
-          var n = (res.j.written || []).length;
-          showToast("Exported " + clipgenPluralUnit(n, "file", "files") + " to " + res.j.output_dir);
-        } else {
-          showToast((res.j && res.j.error) || "Export failed");
-        }
-      })
-      .catch(function (err) { showToast("Export failed: " + err.message); });
-  }
-
   function runEmbedSubtitle() {
     var pid = state.selectedParticipant;
     if (!pid) return;
@@ -3530,7 +3516,6 @@
       .catch(function (err) { showToast("Embed failed: " + err.message); });
   }
 
-  var _exportEnabled = false;
   var _rebuildTopNavActions = function () {};
 
   function _currentParticipantHasTranscript() {
@@ -3578,32 +3563,18 @@
             ? "Mux every participant's transcript into a subtitled copy of their video"
             : "Transcribe at least one video to enable this.",
         },
-        {
-          icon: "arrow-down-tray",
-          label: "Export",
-          action: runExport,
-          disabled: !_exportEnabled,
-          title: _exportEnabled
-            ? "Write JSON+CSV exports of Screenspace and Transcripts manifests"
-            : "Run a Screenspace task or transcribe a video first to enable Export.",
-        },
+        window.ClipgenExportActions.exportQuickAction(),
       ]);
     }
     _rebuildTopNavActions = rebuild;
-    function refreshExportStatus() {
-      fetch("/api/export/status")
-        .then(function (r) { return r.json(); })
-        .then(function (j) {
-          var next = !!(j && j.any);
-          if (next === _exportEnabled) { rebuild(); return; }
-          _exportEnabled = next;
-          rebuild();
-        })
-        .catch(function () {});
-    }
     rebuild();
-    refreshExportStatus();
-    window.ClipgenTopNav.onBeforeOpen(refreshExportStatus);
+    window.ClipgenExportActions.refreshExportStatus(rebuild);
+    // Always rebuild on menu open so Embed-Subtitle items pick up
+    // participant-selection changes; also refresh export-enabled state.
+    window.ClipgenTopNav.onBeforeOpen(function () {
+      rebuild();
+      window.ClipgenExportActions.refreshExportStatus(rebuild);
+    });
   }
 
   document.addEventListener("DOMContentLoaded", function () {

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -524,6 +524,36 @@ var getCSSVar = function (name, fallback) {
   }
 };
 
+// Cached snapshot of the theme tokens that canvas renderers (Screenspace
+// timeline, Transcripts ruler, Studio heatmap) read on every frame. The cache
+// is invalidated automatically when initThemeToggle()'s click handler fires;
+// callers can also invalidate manually via invalidateCanvasThemeColors().
+var _canvasThemeColorsCache = null;
+
+var getCanvasThemeColors = function () {
+  if (_canvasThemeColorsCache) return _canvasThemeColorsCache;
+  var cs = getComputedStyle(document.documentElement);
+  function v(name, fallback) {
+    var x = cs.getPropertyValue(name).trim();
+    return x || fallback;
+  }
+  _canvasThemeColorsCache = {
+    fg:         v("--fg",                "#ffffff"),
+    bg:         v("--bg",                "#0d0e10"),
+    surfaceAlt: v("--color-surface-alt", "#f1ece4"),
+    border:     v("--color-border",      "#e0ddd7"),
+    textDim:    v("--color-text-dim",    "#6b7280"),
+    accent:     v("--color-accent",      "#1d4f72"),
+    heatmap:    v("--color-heatmap",     "#3b82f6"),
+    fontMono:   v("--font-mono",         "monospace"),
+  };
+  return _canvasThemeColorsCache;
+};
+
+var invalidateCanvasThemeColors = function () {
+  _canvasThemeColorsCache = null;
+};
+
 var SHOW_TOAST_DEFAULT_MS = 3000;
 
 var showToast = function (msg, opts) {
@@ -624,6 +654,67 @@ var apiDelete = function (path) {
 // ---- Polling ----
 
 var POLL_INTERVAL = 3000;
+
+// Generic poller. Encapsulates the recurring `setInterval` + `visibilitychange`
+// + `document.hidden` dance used by Studio intake counters, Screenspace task
+// status, and similar live-refresh loops.
+//
+//   var poller = createPoller(fn, ms, opts);
+//   poller.start();   // arm; pauses automatically when tab hidden
+//   poller.stop();    // disarm; safe to call multiple times
+//
+// Options:
+//   pauseWhenHidden (default true)  — pause when document.hidden, resume on
+//                                     visibilitychange and run fn() once to
+//                                     catch up.
+//   runImmediately  (default true)  — run fn() once on start (and again on
+//                                     resume) before the next interval tick.
+//
+// fn exceptions are swallowed so a transient error does not kill the loop.
+var createPoller = function (fn, intervalMs, opts) {
+  opts = opts || {};
+  var pauseWhenHidden = opts.pauseWhenHidden !== false;
+  var runImmediately = opts.runImmediately !== false;
+  var timer = null;
+  var visListener = null;
+  var wantRunning = false;
+
+  function safeFn() {
+    try { fn(); } catch (_) {}
+  }
+  function arm() {
+    if (timer != null) return;
+    if (pauseWhenHidden && document.hidden) return;
+    if (runImmediately) safeFn();
+    timer = setInterval(safeFn, intervalMs);
+  }
+  function disarm() {
+    if (timer != null) { clearInterval(timer); timer = null; }
+  }
+  function onVisibility() {
+    if (!wantRunning) return;
+    if (document.hidden) disarm(); else arm();
+  }
+  return {
+    start: function () {
+      if (wantRunning) return;
+      wantRunning = true;
+      arm();
+      if (pauseWhenHidden && !visListener) {
+        visListener = onVisibility;
+        document.addEventListener("visibilitychange", visListener);
+      }
+    },
+    stop: function () {
+      wantRunning = false;
+      disarm();
+      if (visListener) {
+        document.removeEventListener("visibilitychange", visListener);
+        visListener = null;
+      }
+    },
+  };
+};
 
 // ---- Mark categories ----
 // Hardcoded fallback that mirrors config.MARK_CATEGORIES defaults; the live
@@ -850,6 +941,7 @@ var initThemeToggle = function (onToggle) {
   if (!btn) return;
   btn.addEventListener("click", function () {
     toggleThemePreference();
+    invalidateCanvasThemeColors();
     if (onToggle) onToggle();
   });
 };

--- a/plans/FRONTEND-REFACTOR-PLAN.md
+++ b/plans/FRONTEND-REFACTOR-PLAN.md
@@ -203,8 +203,8 @@ Use this when executing waves; check items in PR descriptions.
 
 - [x] A1 `export-actions.js` + TopNav wiring on all three surfaces
 - [x] A2 Shared toast CSS + consistent hide behavior
-- [ ] A3 `createPoller` in `utils.js`; adopt in hot paths
-- [ ] A4 `getCanvasThemeColors` in `utils.js`; Screenspace + Transcripts canvases
+- [x] A3 `createPoller` in `utils.js`; adopt in hot paths
+- [x] A4 `getCanvasThemeColors` in `utils.js`; Screenspace + Transcripts canvases
 
 ### Wave 2
 

--- a/plans/FRONTEND-REFACTOR-PLAN.md
+++ b/plans/FRONTEND-REFACTOR-PLAN.md
@@ -201,8 +201,8 @@ Use this when executing waves; check items in PR descriptions.
 
 ### Wave 1
 
-- [ ] A1 `export-actions.js` + TopNav wiring on all three surfaces
-- [ ] A2 Shared toast CSS + consistent hide behavior
+- [x] A1 `export-actions.js` + TopNav wiring on all three surfaces
+- [x] A2 Shared toast CSS + consistent hide behavior
 - [ ] A3 `createPoller` in `utils.js`; adopt in hot paths
 - [ ] A4 `getCanvasThemeColors` in `utils.js`; Screenspace + Transcripts canvases
 


### PR DESCRIPTION
## Summary

First wave of [plans/FRONTEND-REFACTOR-PLAN.md](plans/FRONTEND-REFACTOR-PLAN.md) — extracts cross-page duplication into shared modules in \`assets/web/\` with no feature changes:

- **A1** \`export-actions.js\` centralizes the Export quick-action / status polling shared by Studio, Screenspace, and Transcripts via \`window.ClipgenExportActions\`.
- **A2** Consolidates the \`.toast\` rule into \`primitives.css\` using the Studio/Transcripts variant as canonical, which incidentally fixes a Screenspace z-index bug (\`--z-dropdown\` → \`--z-toast\`) where toasts could be obscured by open dropdowns.
- **A3** Adds \`createPoller(fn, ms, opts)\` to \`utils.js\` (visibility-aware setInterval wrapper) and adopts it for Studio's four intake/status pollers, collapsing the pause/resume boilerplate.
- **A4** Adds cached \`getCanvasThemeColors()\` to \`utils.js\` with auto-invalidation hooked into \`initThemeToggle\`; adopted in Screenspace and Transcripts canvas renderers.

## Test plan

- [x] \`uv run --extra dev pytest -c tests/pytest.ini\` — 976 passed
- [ ] Open \`/studio/\`, \`/screenspace/\`, \`/transcripts/\` and verify Export menu enable/disable and toast appearance look identical across pages
- [ ] On Screenspace, open a TopNav dropdown then trigger a toast — toast should sit above the dropdown (exercises the z-index fix)
- [ ] Toggle dark/light theme on Screenspace and Transcripts — canvas timelines should recolor on next redraw
- [ ] Hide/show the browser tab on Studio — intake counter badges should pause then catch up on resume