### PR TITLE
chore(server): quiet Werkzeug access logs for Studio poll routes

### DIFF
--- a/interactive.py
+++ b/interactive.py
@@ -493,7 +493,7 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
         category_col = category_cell.col - 1
         desc_col = observation_cell.col - 1
 
-        rows_data = []
+        rows_data: list[utils.BrowseRow] = []
         for i in range(num_rows):
             row_idx = start_row + i
             if row_idx > last_data_row:

--- a/server.py
+++ b/server.py
@@ -58,6 +58,7 @@ from flask import (
     redirect,
     request,
 )
+from werkzeug.serving import WSGIRequestHandler
 
 import config
 import files
@@ -3042,6 +3043,39 @@ def build_combined_app(
     return combined
 
 
+# Successful (GET + 2xx) hits on these exact paths are suppressed from the
+# Werkzeug access log because Studio polls them every 5–10s and the noise
+# drowns out real activity. 4xx/5xx still surface, so a silently-failing
+# poll endpoint won't be hidden. With VERBOSITY >= VERBOSE everything logs.
+_QUIET_POLL_PATHS: frozenset[str] = frozenset(
+    {
+        "/screenspace/api/tasks",
+        "/screenspace/api/events",
+        "/transcripts/api/marks",
+        "/transcripts/api/transcribe/status",
+        "/transcripts/api/transcribe/model-status",
+        "/transcripts/api/participants",
+        "/studio/api/job-status",
+    }
+)
+
+
+class QuietWSGIRequestHandler(WSGIRequestHandler):
+    def log_request(self, code: int | str = "-", size: int | str = "-") -> None:
+        if config.VERBOSITY < config.VERBOSE:
+            try:
+                status = int(code)
+            except (TypeError, ValueError):
+                status = 0
+            if (
+                self.command == "GET"
+                and 200 <= status < 300
+                and self.path.split("?", 1)[0] in _QUIET_POLL_PATHS
+            ):
+                return
+        super().log_request(code, size)
+
+
 def start_combined_server(
     worksheet: Any = None,
     port: int | None = None,
@@ -3070,4 +3104,10 @@ def start_combined_server(
     utils.info_print(f"clipgen server running at http://127.0.0.1:{port}")
     webbrowser.open(url)
 
-    combined.run(host="127.0.0.1", port=port, debug=False, threaded=True)
+    combined.run(
+        host="127.0.0.1",
+        port=port,
+        debug=False,
+        threaded=True,
+        request_handler=QuietWSGIRequestHandler,
+    )

--- a/utils.py
+++ b/utils.py
@@ -966,7 +966,7 @@ def add_duration(start_time: str) -> str | None:
     )
 
 
-def _parse_single_timestamp_token(token: str) -> tuple[str, str | None] | None:
+def _parse_single_timestamp_token(token: str) -> tuple[str, str] | None:
     """Parse one token into a (start_time, end_time) pair, or None if invalid/skip.
 
     Handles: dash range (start-end), single timestamp with colon (add default


### PR DESCRIPTION
## Summary
- Adds a `QuietWSGIRequestHandler` that suppresses successful (`GET` + 2xx) Werkzeug access lines for the 7 status/data endpoints Studio polls every 5–10s (`screenspace/api/tasks`, `screenspace/api/events`, `transcripts/api/{marks,transcribe/status,transcribe/model-status,participants}`, `studio/api/job-status`).
- 4xx/5xx responses, non-GET traffic, and any non-poll route still log, so silently-failing pollers stay visible. Filter is bypassed entirely when `config.VERBOSITY >= VERBOSE`.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini -k server` (10 passed)
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [ ] Manual: launch `uv run clipgen.py --studio`, idle browser on `/studio/`, confirm terminal stops printing poll lines while non-poll traffic still logs