### PR TITLE
feat(screenspace): show timestamp on sidebar issues, seek on click

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -496,6 +496,29 @@ body {
   min-width: 0;
 }
 
+.ss-info-issue-ts {
+  flex: 0 0 auto;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-dim);
+  margin-top: 0.15em;
+  white-space: nowrap;
+}
+
+.ss-info-issue--clickable {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  margin-left: calc(-1 * var(--space-1));
+  margin-right: calc(-1 * var(--space-1));
+  padding-left: var(--space-1);
+  padding-right: var(--space-1);
+  transition: background var(--transition-fast, 0.1s);
+}
+
+.ss-info-issue--clickable:hover {
+  background: var(--color-surface-alt);
+}
+
 @media (max-width: 1100px) {
   .ss-content-row {
     flex-direction: column;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -887,6 +887,16 @@
       text.textContent = issue.observation || "(no observation)";
       li.appendChild(dot);
       li.appendChild(text);
+      if (issue.timestamp != null) {
+        var ts = document.createElement("span");
+        ts.className = "ss-info-issue-ts";
+        ts.textContent = formatTime(issue.timestamp);
+        li.appendChild(ts);
+        li.classList.add("ss-info-issue--clickable");
+        li.addEventListener("click", (function (t) {
+          return function () { loadFrame(t); };
+        })(issue.timestamp));
+      }
       frag.appendChild(li);
     });
     list.appendChild(frag);

--- a/interactive.py
+++ b/interactive.py
@@ -493,7 +493,7 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
         category_col = category_cell.col - 1
         desc_col = observation_cell.col - 1
 
-        rows_data = []
+        rows_data: list[utils.BrowseRow] = []
         for i in range(num_rows):
             row_idx = start_row + i
             if row_idx > last_data_row:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -279,6 +279,9 @@ def api_participant_issues(pid: str) -> FlaskResponse:
         row_data = ctx.sheet_data[row_idx]
         if col_idx >= len(row_data) or not row_data[col_idx].strip():
             continue
+        raw_cell = row_data[col_idx].strip()
+        ts_pairs = utils.parse_timestamps(raw_cell)
+        ts_seconds = utils.timestamp_to_seconds(ts_pairs[0][0]) if ts_pairs else None
         observation = row_data[obs_col] if obs_col < len(row_data) else ""
         severity = ""
         if (
@@ -292,6 +295,7 @@ def api_participant_issues(pid: str) -> FlaskResponse:
                 "rowNum": row_idx + 1,
                 "observation": observation,
                 "severity": severity,
+                "timestamp": ts_seconds,
                 "_row_idx": row_idx,
             }
         )

--- a/utils.py
+++ b/utils.py
@@ -966,7 +966,7 @@ def add_duration(start_time: str) -> str | None:
     )
 
 
-def _parse_single_timestamp_token(token: str) -> tuple[str, str | None] | None:
+def _parse_single_timestamp_token(token: str) -> tuple[str, str] | None:
     """Parse one token into a (start_time, end_time) pair, or None if invalid/skip.
 
     Handles: dash range (start-end), single timestamp with colon (add default


### PR DESCRIPTION
Each issue in the Screenspace sidebar now shows a small timestamp chip (e.g. `0:45`) sourced from the participant's cell value in the sheet. Clicking an issue with a timestamp seeks the viewer to that time via `loadFrame`. Issues without a parseable timestamp (e.g. cells containing only `x`) render unchanged with no click handler.

**Changes:** `screenspace_server.py` parses the participant cell value and adds a `timestamp` field to each issue in the API response; `screenspace.js` renders the chip and wires the click handler; `screenspace.css` adds styles for the chip and hover state.