### PR TITLE
fix(screenspace): widen interval picker input to prevent value clipping

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1219,7 +1219,7 @@ body {
 }
 
 #workflowIntervalSlot .param-control input[type="number"] {
-  width: 3rem;
+  width: 4.5rem;
   height: 28px;
   border-radius: 0 calc(var(--radius) - 2px) calc(var(--radius) - 2px) 0;
   text-align: center;


### PR DESCRIPTION
Increases the Screenspace tool parameters interval picker width from `3rem` to `4.5rem` so the numeric value is not cut off by the browser's up/down spinner arrows.