### PR TITLE
fix(screenspace): don't trigger blink shortcut while editing stash names

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -6270,7 +6270,8 @@
   function initKeyboard() {
     function onKeyDown(e) {
       // Don't capture when typing in inputs
-      if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.tagName === "SELECT") return;
+      var t = e.target;
+      if (t && t.matches && t.matches("input, textarea, select, [contenteditable=true]")) return;
 
       if (e.key === "ArrowLeft") {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- The Screenspace `B` blink-comparator shortcut fired while typing in inline-editable stash names because the keyboard focus guard only checked `INPUT`/`TEXTAREA`/`SELECT` and ignored `contenteditable` elements.
- Widen the guard in `onKeyDown` to also match `[contenteditable=true]`, matching the pattern already used in `transcripts.js`.

## Test plan
- [ ] Edit a stash name inline and type a word containing "b" — letter appears, blink stays off
- [ ] Press and hold B outside any input with an overlay-eligible tool — blink still activates and clears on release
- [ ] Arrow keys / space still work outside textboxes and are suppressed inside the rename span