### PR TITLE
fix(transcripts): distinguish queued state in pill-dot hover tooltip

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1222,6 +1222,11 @@ body {
   animation: pill-dot-pulse 1.4s ease-in-out infinite;
 }
 
+.pill-dot--queued {
+  background: var(--color-text-dim);
+  border-color: var(--color-text-dim);
+}
+
 @keyframes pill-dot-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2588,7 +2588,8 @@
   state.pillOptionsOpen = null; // pid of the pill whose options pane is open
 
   function _dotStateTranscription(p, task) {
-    if (task && (task.status === "running" || task.status === "queued")) return "running";
+    if (task && task.status === "queued") return "queued";
+    if (task && task.status === "running") return "running";
     if (task && task.status === "failed") return "failed";
     if (p.has_transcript) return "done";
     return "idle";
@@ -2724,6 +2725,7 @@
   function _dotStateLabel(st) {
     if (st === "done") return "done";
     if (st === "running") return "in progress\u2026";
+    if (st === "queued") return "queued";
     if (st === "failed") return "failed";
     return "not started";
   }


### PR DESCRIPTION
## Summary
- Hovering a queued transcript's pill dots showed "Transcription: in progress…" because `_dotStateTranscription` collapsed both `queued` and `running` Whisper task statuses into a single `"running"` dot-state.
- Preserve the queued state through `_dotStateTranscription` and add a matching label in `_dotStateLabel` so the tooltip now reads "Transcription: queued".
- Add `.pill-dot--queued` (dim, non-pulsing) so the queued dot is visually distinct from idle (outline) and running (solid + pulse).

## Test plan
- [ ] Start two transcripts back-to-back; while the second is queued, hover its dot row and confirm "Transcription: queued".
- [ ] When it transitions to running, hover again and confirm "Transcription: in progress…".