### PR TITLE
fix(screenspace): align analysis frame timestamps with preview seek

### DIFF
--- a/screenspace.py
+++ b/screenspace.py
@@ -682,8 +682,19 @@ def _ffmpeg_pipe_frames(
     if not shutil.which("ffmpeg"):
         return
 
-    # Determine output dimensions
-    filters = [f"fps=1/{interval_seconds}"]
+    # Determine output dimensions.
+    #
+    # `select` instead of `fps`: at interval N, fps=1/N picks the *last*
+    # source frame whose PTS rounds to each output slot — for 30 fps source
+    # that's ~0.5 s past the slot — and assigns it the slot's PTS in the
+    # output. The preview path seeks to that slot PTS and lands on a
+    # different source frame, hence the long-running click-vs-preview drift.
+    # `select` passes the chosen frame through with its original PTS, which
+    # showinfo (below) reports verbatim. Paired with `-fps_mode vfr` below to
+    # stop ffmpeg from duplicating frames to fill the source rate.
+    filters = [
+        f"select='isnan(prev_selected_t)+gte(t-prev_selected_t,{interval_seconds})'"
+    ]
 
     if region:
         filters.append(f"crop={region['w']}:{region['h']}:{region['x']}:{region['y']}")
@@ -714,31 +725,61 @@ def _ffmpeg_pipe_frames(
         out_h += out_h % 2
         filters.append(f"scale={out_w}:{out_h}")
 
-    # Two-stage seek so each yielded frame's synthetic ts (computed below as
-    # start_seconds + frame_idx * interval_seconds) lines up with the actual
-    # decoded PTS instead of the nearest preceding key-frame.
-    pre_seek, post_seek = video.accurate_seek_args(max(0.0, start_seconds))
-    cmd: list[str] = ["ffmpeg", *pre_seek, "-i", video_path, *post_seek]
+    # showinfo last so its `pts_time:` lines correspond 1-to-1 with the
+    # rawvideo frames pushed to stdout. The drain thread below parses these
+    # and queues them so each yielded frame is tagged with its actual source
+    # PTS instead of a synthetic frame_idx*interval.
+    filters.append("showinfo")
+
+    cmd: list[str] = ["ffmpeg"]
+    if start_seconds > 0:
+        cmd += ["-ss", str(start_seconds)]
+    cmd += ["-i", video_path]
     if end_seconds > start_seconds:
         cmd += ["-t", str(end_seconds - start_seconds)]
     cmd += [
         "-vf",
         ",".join(filters),
+        # `select` keeps source PTS, so without `vfr` ffmpeg pads the output
+        # back up to the source frame rate by duplicating each kept frame
+        # (~30 dupes per kept frame at 30 fps). vfr emits only the actual
+        # kept frames, one-to-one with the showinfo log lines.
+        "-fps_mode",
+        "vfr",
         "-pix_fmt",
         "bgr24",
         "-f",
         "rawvideo",
+        # showinfo emits at the `info` level; with `error` its lines never
+        # reach stderr and we'd have no PTS data to read.
         "-loglevel",
-        "error",
+        "info",
         "pipe:1",
     ]
 
     frame_size = out_w * out_h * 3
-    # stderr → DEVNULL: we only read stdout, so a PIPE'd stderr could fill
-    # its 64 KB OS buffer on a chatty codec error and deadlock ffmpeg.
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    pts_re = re.compile(rb"pts_time:(\S+)")
+    pts_q: queue.Queue[float] = queue.Queue(maxsize=256)
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert proc.stdout is not None  # guaranteed by stdout=PIPE
-    frame_idx = 0
+    assert proc.stderr is not None  # guaranteed by stderr=PIPE
+
+    # Daemon thread drains stderr so the OS buffer never blocks ffmpeg, and
+    # forwards every `pts_time:` line to the read loop as a float (seconds
+    # since the seek point).
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            m = pts_re.search(line)
+            if m:
+                try:
+                    pts_q.put(float(m.group(1)))
+                except ValueError:
+                    pass
+
+    threading.Thread(target=_drain_stderr, daemon=True).start()
+
     try:
         while True:
             raw = proc.stdout.read(frame_size)
@@ -747,11 +788,16 @@ def _ffmpeg_pipe_frames(
             # Read-only view on the ffmpeg pipe bytes; callers treat frames as
             # read-only and must .copy() if they retain past the next yield.
             frame = np.frombuffer(raw, dtype=np.uint8).reshape((out_h, out_w, 3))
-            ts = start_seconds + frame_idx * interval_seconds
-            if end_seconds > 0 and ts > end_seconds:
+            try:
+                relative_pts = pts_q.get(timeout=5.0)
+            except queue.Empty:
+                # Stderr stalled or showinfo missing — bail out rather than
+                # yield a frame with a misaligned synthetic timestamp.
                 break
-            yield (ts, frame)
-            frame_idx += 1
+            actual_ts = start_seconds + relative_pts
+            if end_seconds > 0 and actual_ts > end_seconds:
+                break
+            yield (actual_ts, frame)
     finally:
         if proc.stdout:
             proc.stdout.close()

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1587,16 +1587,21 @@ class TestFastScanDispatchIntervalMultiplier:
 
 
 class TestFfmpegPipeFrames:
-    def test_yields_frames_from_raw_bytes(self, monkeypatch):
-        """Generator yields correct (ts, frame) tuples from raw BGR pipe."""
+    def test_yields_frames_with_pts_from_stderr(self, monkeypatch):
+        """Generator pairs each raw BGR frame with the pts_time read from stderr."""
         w, h = 4, 2
-        # Two solid-color frames
         frame1 = np.full((h, w, 3), 100, dtype=np.uint8)
         frame2 = np.full((h, w, 3), 200, dtype=np.uint8)
         raw = frame1.tobytes() + frame2.tobytes()
+        # Two showinfo lines with PTS 0 and 1 (relative to the seek point of 5.0).
+        stderr_lines = (
+            b"[Parsed_showinfo_1 @ 0x0] n: 0 pts: 0 pts_time:0 ...\n"
+            b"[Parsed_showinfo_1 @ 0x0] n: 1 pts: 1 pts_time:1 ...\n"
+        )
 
         fake_proc = mock.MagicMock()
         fake_proc.stdout = io.BytesIO(raw)
+        fake_proc.stderr = io.BytesIO(stderr_lines)
         fake_proc.terminate = mock.MagicMock()
         fake_proc.wait = mock.MagicMock()
 
@@ -1614,6 +1619,7 @@ class TestFfmpegPipeFrames:
             )
         )
         assert len(frames) == 2
+        # Yielded ts = start_seconds + pts_time (relative).
         assert frames[0][0] == 5.0
         assert frames[1][0] == 6.0
         assert frames[0][1].shape == (h, w, 3)
@@ -1629,14 +1635,18 @@ class TestFfmpegPipeFrames:
         )
         assert frames == []
 
-    def test_uses_two_stage_seek_for_far_start(self, monkeypatch):
-        """Analysis pipe should two-stage seek so synthetic ts == decoded PTS."""
+    def test_uses_single_preinput_seek_with_select_filter(self, monkeypatch):
+        """Analysis pipe uses a single pre-input -ss plus the select filter +
+        fps_mode vfr. The previous two-stage seek silently dropped its post-input
+        -ss when paired with -vf in modern ffmpeg, and the fps filter chose a
+        different source frame than the preview's accurate seek did."""
         captured: dict = {}
 
         def fake_popen(cmd, *a, **kw):
             captured["cmd"] = list(cmd)
             proc = mock.MagicMock()
             proc.stdout = io.BytesIO(b"")
+            proc.stderr = io.BytesIO(b"")
             proc.terminate = mock.MagicMock()
             proc.wait = mock.MagicMock()
             return proc
@@ -1656,8 +1666,15 @@ class TestFfmpegPipeFrames:
         )
         cmd = captured["cmd"]
         i_idx = cmd.index("-i")
-        assert "-ss" in cmd[:i_idx], "expected fast pre-input seek"
-        assert "-ss" in cmd[i_idx + 2 :], "expected accurate post-input seek"
+        # One pre-input -ss, nothing after -i.
+        assert cmd[:i_idx].count("-ss") == 1
+        assert "-ss" not in cmd[i_idx + 2 :]
+        vf = cmd[cmd.index("-vf") + 1]
+        assert "select=" in vf
+        assert "showinfo" in vf
+        # vfr is what stops ffmpeg from duplicating the kept frame to fill the
+        # source frame rate.
+        assert "-fps_mode" in cmd and cmd[cmd.index("-fps_mode") + 1] == "vfr"
 
 
 class TestScanViaFfmpegPipe:
@@ -1680,9 +1697,13 @@ class TestScanViaFfmpegPipe:
         w, h = 4, 2
         frame_data = np.full((h, w, 3), 42, dtype=np.uint8)
         raw = frame_data.tobytes()
+        # showinfo emits one line per yielded frame; pts_time is relative to
+        # the seek point (here 0).
+        stderr_lines = b"[Parsed_showinfo_1 @ 0x0] n: 0 pts: 0 pts_time:0 ...\n"
 
         fake_proc = mock.MagicMock()
         fake_proc.stdout = io.BytesIO(raw)
+        fake_proc.stderr = io.BytesIO(stderr_lines)
         fake_proc.terminate = mock.MagicMock()
         fake_proc.wait = mock.MagicMock()
 
@@ -1739,9 +1760,14 @@ class TestScanViaFfmpegPipe:
         w, h = 4, 2
         frame = np.full((h, w, 3), 1, dtype=np.uint8)
         raw = frame.tobytes() * 5  # 5 frames
+        stderr_lines = b"".join(
+            b"[Parsed_showinfo_1 @ 0x0] n: %d pts_time:%d ...\n" % (i, i)
+            for i in range(5)
+        )
 
         fake_proc = mock.MagicMock()
         fake_proc.stdout = io.BytesIO(raw)
+        fake_proc.stderr = io.BytesIO(stderr_lines)
         fake_proc.terminate = mock.MagicMock()
         fake_proc.wait = mock.MagicMock()
 
@@ -1764,6 +1790,101 @@ class TestScanViaFfmpegPipe:
         )
         assert result is True
         assert call_count[0] == 2
+
+
+class TestAnalysisPreviewAlignment:
+    """End-to-end: each ts yielded by `_ffmpeg_pipe_frames` must point at the
+    exact same source frame that `video.extract_frame_at_timestamp(ts)` returns,
+    so clicking a result in Screenspace shows the analysed frame instead of a
+    drifted neighbour.
+
+    Requires a real ffmpeg binary on PATH; skipped otherwise.
+    """
+
+    @staticmethod
+    def _have_ffmpeg() -> bool:
+        import shutil as _shutil
+
+        return (
+            _shutil.which("ffmpeg") is not None and _shutil.which("ffprobe") is not None
+        )
+
+    @staticmethod
+    def _synthesize(path: str, vf_extra: str = "") -> None:
+        import subprocess as _sp
+
+        vf = "testsrc=duration=12:size=320x240:rate=30"
+        if vf_extra:
+            vf += f",{vf_extra}"
+        _sp.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                vf,
+                "-fps_mode",
+                "vfr",
+                "-c:v",
+                "libx264",
+                "-g",
+                "30",
+                "-pix_fmt",
+                "yuv420p",
+                path,
+            ],
+            check=True,
+            stdout=_sp.DEVNULL,
+            stderr=_sp.DEVNULL,
+        )
+
+    @staticmethod
+    def _assert_aligned(video_path: str) -> None:
+        import hashlib
+
+        import video as video_mod
+
+        frames = list(
+            screenspace._ffmpeg_pipe_frames(
+                video_path,
+                interval_seconds=1.0,
+                start_seconds=0.0,
+                end_seconds=10.0,
+                frame_width=320,
+                frame_height=240,
+            )
+        )
+        assert frames, "expected at least one analysed frame"
+        for ts, analysis_frame in frames:
+            preview = video_mod.extract_frame_at_timestamp(video_path, ts)
+            assert preview is not None, f"preview extraction failed at ts={ts}"
+            h_a = hashlib.md5(analysis_frame.tobytes()).hexdigest()
+            h_p = hashlib.md5(preview.tobytes()).hexdigest()
+            assert h_a == h_p, (
+                f"analysed frame and preview differ at ts={ts:.4f} "
+                f"(analysis={h_a[:8]} preview={h_p[:8]})"
+            )
+
+    def test_cfr_source_alignment(self, tmp_path):
+        if not self._have_ffmpeg():
+            pytest.skip("ffmpeg/ffprobe required for end-to-end alignment test")
+        video_path = str(tmp_path / "cfr.mp4")
+        self._synthesize(video_path)
+        self._assert_aligned(video_path)
+
+    def test_vfr_source_alignment(self, tmp_path):
+        if not self._have_ffmpeg():
+            pytest.skip("ffmpeg/ffprobe required for end-to-end alignment test")
+        video_path = str(tmp_path / "vfr.mp4")
+        # Drop ~2/7 of frames at non-uniform positions so the kept frames don't
+        # land on integer second boundaries — the case where the old fps filter
+        # picked a different source frame than the preview's accurate seek.
+        self._synthesize(
+            video_path,
+            vf_extra="select='not(eq(mod(n,7),3))*not(eq(mod(n,11),5))'",
+        )
+        self._assert_aligned(video_path)
 
 
 class TestScanVideoFramesFfmpegIntegration:


### PR DESCRIPTION
## Summary
- Stop trusting the synthetic `start + idx*interval` timestamp in `_ffmpeg_pipe_frames`: yield each frame's actual source PTS read from a `showinfo` filter via a daemon thread on stderr.
- Switch `fps=1/N` → `select='isnan(prev_selected_t)+gte(t-prev_selected_t,N)'` + `-fps_mode vfr` so kept frames pass through with their real PTS instead of being re-stamped to the slot.
- Drop the broken two-stage seek (post-input `-ss` is silently ignored by ffmpeg 8.x once `-vf` is present, which was adding a separate ~2 s drift on top of the fps-filter mismatch).

This eliminates the recurring "click an OCR result, preview shows a nearby frame where the word isn't visible" bug. The previous fix (#267) hit only one of the two contributing causes.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite green (1052 tests).
- [x] New `TestAnalysisPreviewAlignment` (CFR + VFR fixtures) asserts byte-identical match between `_ffmpeg_pipe_frames` output and `extract_frame_at_timestamp` at every yielded ts.
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check` all pass.
- [ ] Manual: `--screenspace` on a Loom/QuickTime VFR recording, run OCR @ 1 s, click 5–10 results, confirm preview matches the detected text.