### PR TITLE
fix(transcripts): skip videos with no audio stream and surface tracebacks

### DIFF
--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -315,6 +315,35 @@ class TestTranscribeVideoWhisperKwargs:
         assert captured["vad_filter"] is True
         assert "word_timestamps" not in captured
 
+    def test_no_audio_stream_returns_none_without_loading_model(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(config, "DEBUGGING", False)
+
+        def _fake_probe(_path):
+            return {
+                "width": 1920,
+                "height": 1080,
+                "video_codec": "h264",
+                "audio_codec": None,
+                "fps": 60.0,
+                "duration": 10.0,
+                "nb_frames": 600,
+            }
+
+        import video as video_mod
+
+        monkeypatch.setattr(video_mod, "probe_video_properties", _fake_probe)
+
+        def _fail_load(model_name=None):  # noqa: ARG001
+            raise AssertionError("_load_model must not be called when audio is absent")
+
+        monkeypatch.setattr(transcripts, "_load_model", _fail_load)
+
+        result = transcripts.transcribe_video("/fake/no_audio.mp4")
+        assert result is None
+        assert "No audio stream" in capsys.readouterr().out
+
 
 # ---------------------------------------------------------------------------
 # transcribe_video in debug mode
@@ -668,7 +697,7 @@ class TestTranscriptWorker:
         monkeypatch.setattr(
             video_mod,
             "probe_video_properties",
-            lambda *_a, **_k: {"duration": 100.0},
+            lambda *_a, **_k: {"duration": 100.0, "audio_codec": "aac"},
         )
         monkeypatch.setattr(
             transcripts, "load_transcripts_manifest", lambda: {"corrections": []}
@@ -701,6 +730,36 @@ class TestTranscriptWorker:
 
         assert task["status"] == "cancelled"
         assert task["partial_segments"] == []
+
+    def test_execute_task_fails_fast_when_video_has_no_audio(self, monkeypatch):
+        """A video with no audio stream fails immediately with a friendly error
+        and never loads the Whisper model."""
+        from unittest.mock import Mock
+
+        import video as video_mod
+
+        monkeypatch.setattr(config, "DEBUGGING", False)
+        monkeypatch.setattr(
+            video_mod,
+            "probe_video_properties",
+            lambda *_a, **_k: {"duration": 100.0, "audio_codec": None},
+        )
+        monkeypatch.setattr(
+            transcripts, "load_transcripts_manifest", lambda: {"corrections": []}
+        )
+        load_model = Mock()
+        monkeypatch.setattr(transcripts, "_load_model", load_model)
+
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", "/v.mp4")
+        task["status"] = "running"
+
+        worker._execute_task(task)
+
+        assert task["status"] == "failed"
+        assert "No audio stream" in task["error"]
+        assert task["partial_segments"] == []
+        load_model.assert_not_called()
 
     def test_remove_task(self):
         worker = transcripts.TranscriptWorker()

--- a/transcripts.py
+++ b/transcripts.py
@@ -240,6 +240,17 @@ def transcribe_video(
     if _is_cancelled():
         raise _TranscriptionCancelled
 
+    # Short-circuit when the file has no audio stream — faster-whisper raises
+    # an opaque "tuple index out of range" from its decoder in that case.
+    import video as video_mod
+
+    props = video_mod.probe_video_properties(video_path)
+    if props is not None and not props.get("audio_codec"):
+        utils.warning_print(
+            f"No audio stream in {Path(video_path).name} — skipping transcription."
+        )
+        return None
+
     model = _load_model(resolved_model)
     if model is None:
         return None
@@ -281,7 +292,12 @@ def transcribe_video(
     except _TranscriptionCancelled:
         raise
     except Exception as exc:
-        utils.warning_print(f"Transcription failed for {Path(video_path).name}: {exc}")
+        import traceback
+
+        utils.warning_print(
+            f"Transcription failed for {Path(video_path).name}: {exc}",
+            details=traceback.format_exc().rstrip().splitlines(),
+        )
         return None
 
 
@@ -846,6 +862,16 @@ class TranscriptWorker:
         props = video_mod.probe_video_properties(video_path)
         if props:
             duration = props.get("duration", 0.0)
+
+        if props is not None and not props.get("audio_codec"):
+            with self._lock:
+                task["status"] = TASK_STATUS_FAILED
+                task["error"] = (
+                    "No audio stream — this video has no audio track to transcribe."
+                )
+                task["partial_segments"] = []
+                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+            return
 
         # Load corrections for context keywords
         manifest = load_transcripts_manifest()


### PR DESCRIPTION
## Summary
- faster-whisper raises an opaque `tuple index out of range` on videos with no audio track (e.g. `clipgen-test_P05.mp4` had `nb_streams=1`, video only); `transcribe_video()` now probes ahead of the model load, short-circuits with a clear `No audio stream in {file} — skipping transcription.` warning, and the `TranscriptWorker` surfaces the same message as the task error so the UI explains the failure instead of stalling on a doomed model load.
- The catch-all exception handler now includes the full traceback via `warning_print(..., details=...)` so the next opaque faster-whisper failure is debuggable from the log alone.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` (980 passed)
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [ ] Manual: queue P05 (no audio) in `--transcripts` UI → task fails fast with the friendly error; P04 (with audio) still transcribes normally.