### PR TITLE
fix(screenspace): refresh blink comparator cache when playhead moves

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -129,6 +129,7 @@
     overlayBlinkActive: false,
     overlayImage: null,
     overlayImageObjectUrl: null,
+    overlayImageTimestamp: null,
     overlayLayerSpec: {},
     rightPaneTab: "queue",
     resultsSwitcherOpen: false,
@@ -3917,7 +3918,10 @@
       toggle.addEventListener("change", function () {
         state.overlayEnabled = !!toggle.checked;
         try { sessionStorage.setItem("ss_overlayEnabled", state.overlayEnabled ? "1" : "0"); } catch (_) { /* ignore */ }
-        if (state.overlayEnabled && !state.overlayImage) refreshModelView();
+        var curTs = Number(state.currentTimestamp || 0).toFixed(3);
+        if (state.overlayEnabled && (!state.overlayImage || state.overlayImageTimestamp !== curTs)) {
+          refreshModelView();
+        }
         renderOverlay();
       });
     }
@@ -3933,6 +3937,7 @@
           state.overlayImageObjectUrl = null;
         }
         state.overlayImage = null;
+        state.overlayImageTimestamp = null;
         refreshModelView();
         renderOverlay();
       });
@@ -4191,6 +4196,7 @@
           state.overlayImageObjectUrl = null;
         }
         state.overlayImage = null;
+        state.overlayImageTimestamp = null;
         return;
       }
       var layerQs = qsParts.concat(["layer=" + encodeURIComponent(resolved.id)]);
@@ -4209,6 +4215,7 @@
           if (gen !== _modelViewGen) return;
           state.overlayImage = oi;
           state.overlayImageScope = resolved.scope;
+          state.overlayImageTimestamp = ts;
           renderOverlay();
         };
         oi.src = ou;
@@ -6292,7 +6299,10 @@
         if (!_overlayEligibleForActiveTool()) return;
         e.preventDefault();
         state.overlayBlinkActive = true;
-        if (!state.overlayImage) refreshModelView();
+        var curTs = Number(state.currentTimestamp || 0).toFixed(3);
+        if (!state.overlayImage || state.overlayImageTimestamp !== curTs) {
+          refreshModelView();
+        }
         renderOverlay();
       } else if (e.key === "Escape") {
         if (state.pipetteActive) {


### PR DESCRIPTION
## Summary
- After dragging the timeline (or any path that updates the playhead without watching the overlay), pressing **B** painted the previous frame's blink comparator on top of the new frame. The bandwidth-saving early-return in `refreshModelView()` was leaving `state.overlayImage` stale; the B-keydown handler only refreshed when the cache was missing, not when it was out of date.
- Track the `ts` string the overlay was fetched at (`state.overlayImageTimestamp`), clear it everywhere `overlayImage` is cleared, and re-fetch on B keydown and on enabling the persistent overlay when the cached ts doesn't match the current playhead.
- Model view panel open already worked (it defeats the early-return) and is unchanged.

## Test plan
- [ ] `uv run clipgen.py --screenspace -i <dir> -o <dir>`, pick a participant, select a tool with overlay layers (e.g. **color** or **change**), draw a region; Model view panel closed and persistent overlay off.
- [ ] Hold **B** at T0, release, drag the playhead to T1, press **B** again — overlay matches T1 (regression case).
- [ ] With Model view panel open, drag the playhead — overlay still re-fetches on every drag (unchanged behaviour).
- [ ] Toggle persistent overlay on after dragging — fetches at the new timestamp.
- [ ] Switch overlay layer in the dropdown — still fetches fresh.