### PR TITLE
feat(start): show output dir in recent projects when it differs from input

### DIFF
--- a/assets/web/start-overlay.css
+++ b/assets/web/start-overlay.css
@@ -301,12 +301,20 @@
   border-radius: 8px;
   cursor: pointer;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   font-family: inherit;
   transition: background 120ms, border-color 120ms;
   position: relative;
+}
+
+.start-overlay .rail-recent__paths {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
 }
 
 .start-overlay .rail-recent:hover {
@@ -341,13 +349,18 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
-  flex: 1;
+}
+
+.start-overlay .rail-recent__path--secondary {
+  font-size: 11px;
+  color: var(--fg-faint);
 }
 
 .start-overlay .rail-recent__when {
   font-size: 11px;
   color: var(--fg-faint);
   flex-shrink: 0;
+  align-self: flex-start;
 }
 
 .start-overlay .rail-recent--empty {

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -520,7 +520,12 @@
         btn.classList.add("is-current");
         btn.title = "Currently loaded";
       }
-      btn.appendChild(el("span", "rail-recent__path mono", project.input || ""));
+      var paths = el("span", "rail-recent__paths");
+      paths.appendChild(el("span", "rail-recent__path mono", project.input || ""));
+      if (project.output && project.output !== project.input) {
+        paths.appendChild(el("span", "rail-recent__path rail-recent__path--secondary mono", project.output));
+      }
+      btn.appendChild(paths);
       var when = formatWhen(project.last_opened);
       if (when) btn.appendChild(el("span", "rail-recent__when", when));
       btn.addEventListener("click", function () {


### PR DESCRIPTION
## Summary
- The Start page "Recently opened" rail rendered only the input path, so two recent projects with the same source folder but different output folders looked identical.
- `renderRailRecents()` now adds a second, dimmer line with the output path when `project.output` differs from `project.input`; same-folder entries stay single-line.
- CSS: `.rail-recent` switches to top-aligned flex with a new `.rail-recent__paths` column wrapper; new `.rail-recent__path--secondary` (11px, `--fg-faint`); timestamp pinned to the input line via `align-self: flex-start`.

## Test plan
- [x] Manual: opened Start overlay with mixed recent sessions — single-line for same-folder, two-line for differing folders, timestamp aligned with input line, `is-current` highlight spans full row.