### PR TITLE
fix(ui): darken Critical/Very Positive severities; unbold count/pill text

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -514,7 +514,7 @@ body[data-active-tab]:not([data-active-tab="sheet"]) #studioSidebar {
   border-radius: var(--radius-full);
   background: var(--color-accent);
   color: var(--accent-fg);
-  font-weight: 600;
+  font-weight: 500;
   margin-left: var(--space-1);
 }
 
@@ -879,7 +879,10 @@ body.bottom-animating #stashedArtifactsArea {
   flex-shrink: 0;
 }
 
-.sev-pill.sev-critical,
+.sev-pill.sev-critical {
+  color: var(--severity-critical);
+  background: color-mix(in srgb, var(--severity-critical) 18%, transparent);
+}
 .sev-pill.sev-high {
   color: var(--severity-high);
   background: color-mix(in srgb, var(--severity-high) 18%, transparent);
@@ -894,10 +897,13 @@ body.bottom-animating #stashedArtifactsArea {
   color: var(--fg-muted);
   background: rgba(255, 255, 255, 0.06);
 }
-.sev-pill.sev-positive,
-.sev-pill.sev-very-positive {
+.sev-pill.sev-positive {
   color: var(--severity-positive);
   background: color-mix(in srgb, var(--severity-positive) 18%, transparent);
+}
+.sev-pill.sev-very-positive {
+  color: var(--severity-very-positive);
+  background: color-mix(in srgb, var(--severity-very-positive) 18%, transparent);
 }
 
 html[data-theme="light"] .sev-pill.sev-na,
@@ -909,13 +915,17 @@ html[data-theme="light"] .sev-pill.sev-unknown,
 
 /* Positive pill in light mode — match the cell-data-positive override
  * (#16a34a) since the dark-theme positive token (#4ade80) washes out on a
- * light background. */
+ * light background. Very-positive uses a slightly darker green so it stays
+ * distinct from positive (mirrors the dark-theme differentiation). */
 html[data-theme="light"] .sev-pill.sev-positive,
-html[data-theme="light"] .sev-pill.sev-very-positive,
-.theme-light .sev-pill.sev-positive,
-.theme-light .sev-pill.sev-very-positive {
+.theme-light .sev-pill.sev-positive {
   color: #16a34a;
   background: color-mix(in srgb, #16a34a 18%, transparent);
+}
+html[data-theme="light"] .sev-pill.sev-very-positive,
+.theme-light .sev-pill.sev-very-positive {
+  color: #15803d;
+  background: color-mix(in srgb, #15803d 18%, transparent);
 }
 
 /* Clickable header cells */
@@ -1022,12 +1032,12 @@ body.dragging .ts-cell:hover {
 
 /* Severity-tinted timestamp chips. N/A, Unknown, and undefined fall through
  * to the default cyan rule above. .ts-cell.has-text wins (rule below). */
-.ts-cell[data-severity="critical"] .ts-chip,
-.ts-cell[data-severity="high"]     .ts-chip { background: var(--cell-data-high-bg);     color: var(--cell-data-high-fg); }
-.ts-cell[data-severity="medium"]   .ts-chip,
-.ts-cell[data-severity="low"]      .ts-chip { background: var(--cell-data-medium-bg);   color: var(--cell-data-medium-fg); }
-.ts-cell[data-severity="positive"]      .ts-chip,
-.ts-cell[data-severity="very-positive"] .ts-chip { background: var(--cell-data-positive-bg); color: var(--cell-data-positive-fg); }
+.ts-cell[data-severity="critical"]      .ts-chip { background: var(--cell-data-critical-bg);      color: var(--cell-data-critical-fg); }
+.ts-cell[data-severity="high"]          .ts-chip { background: var(--cell-data-high-bg);          color: var(--cell-data-high-fg); }
+.ts-cell[data-severity="medium"]        .ts-chip,
+.ts-cell[data-severity="low"]           .ts-chip { background: var(--cell-data-medium-bg);        color: var(--cell-data-medium-fg); }
+.ts-cell[data-severity="positive"]      .ts-chip { background: var(--cell-data-positive-bg);      color: var(--cell-data-positive-fg); }
+.ts-cell[data-severity="very-positive"] .ts-chip { background: var(--cell-data-very-positive-bg); color: var(--cell-data-very-positive-fg); }
 
 /* "Has text but invalid timestamp" — show muted, dashed-border outline */
 .ts-cell.has-text .ts-chip {

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -116,21 +116,29 @@
   /* Severity-tinted cell data — chip bg uses transparent so the cell-hover
    * background shows through; float bg is opaque (mixed with --bg) so
    * floating popovers don't reveal whatever they overlay. fg is shared. */
-  --cell-data-high-bg:           color-mix(in srgb, var(--severity-high) 18%, transparent);
-  --cell-data-high-bg-solid:     color-mix(in srgb, var(--severity-high) 18%, var(--bg));
-  --cell-data-high-fg:           var(--severity-high);
-  --cell-data-medium-bg:         color-mix(in srgb, var(--severity-medium) 18%, transparent);
-  --cell-data-medium-bg-solid:   color-mix(in srgb, var(--severity-medium) 18%, var(--bg));
-  --cell-data-medium-fg:         var(--severity-medium);
-  --cell-data-positive-bg:       color-mix(in srgb, var(--severity-positive) 18%, transparent);
-  --cell-data-positive-bg-solid: color-mix(in srgb, var(--severity-positive) 18%, var(--bg));
-  --cell-data-positive-fg:       var(--severity-positive);
+  --cell-data-critical-bg:            color-mix(in srgb, var(--severity-critical) 18%, transparent);
+  --cell-data-critical-bg-solid:      color-mix(in srgb, var(--severity-critical) 18%, var(--bg));
+  --cell-data-critical-fg:            var(--severity-critical);
+  --cell-data-high-bg:                color-mix(in srgb, var(--severity-high) 18%, transparent);
+  --cell-data-high-bg-solid:          color-mix(in srgb, var(--severity-high) 18%, var(--bg));
+  --cell-data-high-fg:                var(--severity-high);
+  --cell-data-medium-bg:              color-mix(in srgb, var(--severity-medium) 18%, transparent);
+  --cell-data-medium-bg-solid:        color-mix(in srgb, var(--severity-medium) 18%, var(--bg));
+  --cell-data-medium-fg:              var(--severity-medium);
+  --cell-data-positive-bg:            color-mix(in srgb, var(--severity-positive) 18%, transparent);
+  --cell-data-positive-bg-solid:      color-mix(in srgb, var(--severity-positive) 18%, var(--bg));
+  --cell-data-positive-fg:            var(--severity-positive);
+  --cell-data-very-positive-bg:       color-mix(in srgb, var(--severity-very-positive) 18%, transparent);
+  --cell-data-very-positive-bg-solid: color-mix(in srgb, var(--severity-very-positive) 18%, var(--bg));
+  --cell-data-very-positive-fg:       var(--severity-very-positive);
 
   /* Severity (prototype palette) */
-  --severity-positive: #4ade80;
-  --severity-medium:   #fbbf24;
-  --severity-high:     #f87171;
-  --severity-na:       rgba(255, 255, 255, 0.35);
+  --severity-positive:      #4ade80;
+  --severity-very-positive: #22c55e;
+  --severity-medium:        #fbbf24;
+  --severity-high:          #f87171;
+  --severity-critical:      #ef4444;
+  --severity-na:            rgba(255, 255, 255, 0.35);
 
   /* Pop shadow — used by popovers, dropdowns, the annotation editor */
   --shadow-pop: 0 12px 36px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -159,13 +167,13 @@
   --shadow-focus: 0 0 0 2px var(--accent);
 
   /* Severity legacy aliases (--sev-* → --severity-*) */
-  --sev-critical:      var(--severity-high);
+  --sev-critical:      var(--severity-critical);
   --sev-high:          var(--severity-high);
   --sev-medium:        var(--severity-medium);
   --sev-low:           var(--severity-medium);
   --sev-na:            var(--severity-na);
   --sev-positive:      var(--severity-positive);
-  --sev-very-positive: var(--severity-positive);
+  --sev-very-positive: var(--severity-very-positive);
   --sev-unknown:       var(--fg-faint);
 
   /* Content-type colors (kept distinct from severity for export viewers etc.) */

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1287,10 +1287,6 @@ body {
   box-shadow: 0 0 0 1px var(--border-strong) inset;
 }
 
-.pill--active .pill-id {
-  font-weight: 600;
-}
-
 .pill--failed {
   border-color: color-mix(in srgb, var(--sev-critical) 45%, var(--color-border));
 }

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -1158,13 +1158,13 @@ html[data-theme="dark"] {
   --color-panel-shadow: rgba(0, 0, 0, 0.7);
   --color-selected-ring: #0b1120;
   --color-tooltip-shadow: rgba(0, 0, 0, 0.7);
-  --sev-critical: #f87171;
+  --sev-critical: #ef4444;
   --sev-high: #fb7185;
   --sev-medium: #fdba74;
   --sev-low: #fde047;
   --sev-na: #67e8f9;
   --sev-positive: #86efac;
-  --sev-very-positive: #4ade80;
+  --sev-very-positive: #22c55e;
   --sev-unknown: #94a3b8;
 }
 


### PR DESCRIPTION
## Summary
- Give Critical (red) and Very Positive (green) their own slightly darker base tokens in `tokens.css` so they read as distinct from High and Positive across cells, sidebar dots, metadata bars, viewer markers, and screenspace dots; split the grouped `sev-pill`, `ts-cell[data-severity]`, and light-theme overrides in `studio.css` and update `viewer.css` standalone fallbacks to match.
- Drop the Studio Intake tab badge and the selected Transcripts participant pill from `font-weight: 600` to `500` so the numbers/IDs no longer read as bold.

## Test plan
- [ ] `uv run clipgen.py --studio` — confirm Critical reads darker than High and Very Positive darker than Positive in cells, sidebar dots, and metadata severity bars; check both dark and light themes; verify the Intake tab badge count is no longer bold.
- [ ] `uv run clipgen.py --transcripts -i DIR -o DIR` — click between participant pills and confirm the selected pill's ID text is not heavier than the inactive pills.
- [ ] Open an exported viewer HTML against a manifest containing Critical and Very Positive entries — confirm standalone fallback tokens picked up the darker shades.