### PR TITLE
fix(screenspace): Multitool drag, drop, run-button, and value-preservation fixes

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1626,6 +1626,25 @@ body {
   box-shadow: inset 0 -3px 0 0 var(--color-accent);
 }
 
+.multitool-empty-dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 5rem;
+  padding: var(--space-3);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-dim);
+  font-size: var(--text-xs);
+  text-align: center;
+}
+
+.multitool-steps.drag-over-append .multitool-empty-dropzone {
+  border-style: solid;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
 .multitool-step {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -1617,11 +1617,13 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  /* Vertical padding gives the user a comfortable hit-area for dropping
+     above the first card or below the last, including for task-card imports. */
+  padding: var(--space-2) 0;
 }
 
 .multitool-steps.drag-over-append {
-  border-bottom: 2px solid var(--color-accent);
-  padding-bottom: var(--space-1);
+  box-shadow: inset 0 -3px 0 0 var(--color-accent);
 }
 
 .multitool-step {
@@ -1699,7 +1701,9 @@ body {
 }
 
 .multitool-step.drag-over {
-  border-top: 2px solid var(--color-accent);
+  /* box-shadow renders the insertion bar in the gap above the card without
+     shifting layout — easier to see than a 2px border-top. */
+  box-shadow: 0 -3px 0 0 var(--color-accent);
 }
 
 .multitool-step-body {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3435,14 +3435,16 @@
         return;
       }
 
-      // Step reorder
+      // Step reorder. _cacheMultitoolDragMidpoints excludes the dragging
+      // card, so getMultitoolDropIndex already returns an index aligned with
+      // the array AFTER the dragging step is spliced out — no further
+      // adjustment needed.
       var fromIdx = parseInt(e.dataTransfer.getData("text/plain"), 10);
       if (isNaN(fromIdx)) return;
       var toIdx = getMultitoolDropIndex(stepsDiv, e.clientY);
       if (fromIdx === toIdx) return;
       snapshotMultitoolStepValues();
       var moved = state.multitoolSteps.splice(fromIdx, 1)[0];
-      if (toIdx > fromIdx) toIdx--;
       state.multitoolSteps.splice(toIdx, 0, moved);
       renderWorkflowParams();
     });

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3830,6 +3830,11 @@
       dfCb.type = "checkbox";
       dfCb.id = "paramDetectFirst";
       addParamRow(container, "Detect first", dfCb);
+      // Every multitool mutation funnels through renderWorkflowParams; refresh
+      // the Run button here so task-import / reorder paths (which don't call
+      // updateRunButton explicitly) still enable the button once the list is
+      // long enough.
+      updateRunButton();
       return;
     }
 

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3221,6 +3221,53 @@
     return step;
   }
 
+  // Walk the current step list, read each step's per-input DOM values, and
+  // store them on step._initial in the same shape the _mtRender* helpers
+  // expect. Call before any list mutation (add / remove / reorder / import)
+  // so the upcoming renderWorkflowParams() restores values instead of
+  // collapsing them back to per-input defaults. Region, _refTs and _scenes
+  // already live on the step object, so they don't need snapshotting.
+  function snapshotMultitoolStepValues() {
+    state.multitoolSteps.forEach(function (step, idx) {
+      var sfx = "_mt" + idx;
+      var init = step._initial || {};
+      if (step.type === "color") {
+        var prevColor = init.target_color || {};
+        init.target_color = {
+          h: numberOrDefault((qs("#paramColorH" + sfx) || {}).value, prevColor.h || 0),
+          s: numberOrDefault((qs("#paramColorS" + sfx) || {}).value, prevColor.s || 0),
+          v: numberOrDefault((qs("#paramColorV" + sfx) || {}).value, prevColor.v || 0),
+        };
+        var tol = numberOrDefault((qs("#paramColorTol" + sfx) || {}).value, 30);
+        init.tolerance = {
+          h: Math.round(tol * 90 / 100),
+          s: Math.round(tol * 128 / 100),
+          v: Math.round(tol * 128 / 100),
+        };
+      } else if (step.type === "change") {
+        init.threshold = numberOrDefault((qs("#paramChangeThresh" + sfx) || {}).value, init.threshold);
+        init.noise_threshold = intOrDefault((qs("#paramChangeNoise" + sfx) || {}).value, init.noise_threshold);
+      } else if (step.type === "similarity") {
+        init.threshold = numberOrDefault((qs("#paramSimThresh" + sfx) || {}).value, init.threshold);
+      } else if (step.type === "text") {
+        var searchEl = qs("#paramTextSearch" + sfx);
+        if (searchEl) init.search_string = searchEl.value;
+        init.fuzzy_threshold = numberOrDefault((qs("#paramTextFuzzy" + sfx) || {}).value, init.fuzzy_threshold);
+      } else if (step.type === "numbers") {
+        var opEl = qs("#paramNumOperator" + sfx);
+        if (opEl) init.operator = opEl.value;
+        init.target_value = numberOrDefault((qs("#paramNumTarget" + sfx) || {}).value, init.target_value);
+      } else if (step.type === "template") {
+        init.threshold = numberOrDefault((qs("#paramTemplateThresh" + sfx) || {}).value, init.threshold);
+      } else if (step.type === "flow") {
+        init.magnitude_threshold = numberOrDefault((qs("#paramFlowMag" + sfx) || {}).value, init.magnitude_threshold);
+      } else if (step.type === "inactivity") {
+        init.threshold = intOrDefault((qs("#paramInactThresh" + sfx) || {}).value, init.threshold);
+      }
+      step._initial = init;
+    });
+  }
+
   function renderMultitoolParams(container) {
     var stepsDiv = el("div", "multitool-steps");
     state.multitoolSteps.forEach(function (step, idx) {
@@ -3278,6 +3325,7 @@
       (function (capturedIdx) {
         removeBtn.addEventListener("click", function (e) {
           e.stopPropagation();
+          snapshotMultitoolStepValues();
           state.multitoolSteps.splice(capturedIdx, 1);
           renderWorkflowParams();
           updateRunButton();
@@ -3380,6 +3428,7 @@
           showToast(task.type + " cannot be added as a multitool step");
           return;
         }
+        snapshotMultitoolStepValues();
         state.multitoolSteps.push(step);
         renderWorkflowParams();
         showToast("Imported " + task.type + " task as step");
@@ -3391,6 +3440,7 @@
       if (isNaN(fromIdx)) return;
       var toIdx = getMultitoolDropIndex(stepsDiv, e.clientY);
       if (fromIdx === toIdx) return;
+      snapshotMultitoolStepValues();
       var moved = state.multitoolSteps.splice(fromIdx, 1)[0];
       if (toIdx > fromIdx) toIdx--;
       state.multitoolSteps.splice(toIdx, 0, moved);
@@ -3412,6 +3462,7 @@
     var addBtn = el("button", "btn btn-small", "+ Add Step");
     addBtn.addEventListener("click", function () {
       var chosen = sel.value;
+      snapshotMultitoolStepValues();
       state.multitoolSteps.push({ type: chosen, collapsed: false, logic: "AND" });
       renderWorkflowParams();
       updateRunButton();

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3299,6 +3299,15 @@
       stepsDiv.appendChild(card);
     });
 
+    if (state.multitoolSteps.length === 0) {
+      // Visible drop target so a Task card has somewhere to land when the
+      // step list is empty (an empty flex container is 0px tall and never
+      // receives dragover events).
+      var emptyDz = el("div", "multitool-empty-dropzone",
+        "Drag a Task here, or use + Add Step below");
+      stepsDiv.appendChild(emptyDz);
+    }
+
     // Drag-and-drop reordering
     stepsDiv.addEventListener("dragstart", function (e) {
       var card = e.target.closest(".multitool-step");
@@ -3410,7 +3419,7 @@
     addRow.appendChild(addBtn);
     container.appendChild(addRow);
 
-    if (state.multitoolSteps.length < 2) {
+    if (state.multitoolSteps.length === 1) {
       container.appendChild(el("div", "multitool-hint", "Add at least 2 tool steps to create a multi-factor filter."));
     }
   }


### PR DESCRIPTION
## Summary

Five related Multitool UX bugs in Screenspace, fixed in separate commits:

- **Drop zones** (`47dbbf3`) — vertical padding on `.multitool-steps` + box-shadow insertion bars give a real hit-area for dragging to the very first or last position.
- **Empty-state dropzone** (`e5da3bf`) — render a visible `.multitool-empty-dropzone` inside the steps container when length === 0 so a Task card can be dropped onto a fresh Multitool tab (an empty flex container is 0px tall and never receives dragover).
- **Run button refresh** (`3f3ba88`) — call `updateRunButton()` before the multitool early return in `renderWorkflowParams`, so task-import / reorder / Edit paths refresh the button.
- **Value preservation** (`ea15511`) — new `snapshotMultitoolStepValues()` reads per-step DOM values back onto `step._initial` before any list mutation (remove, task-import, reorder, +Add Step), so re-renders no longer collapse user-entered values to defaults.
- **Reorder index** (`4ac388a`) — drop the spurious `if (toIdx > fromIdx) toIdx--;` adjustment in the reorder drop handler; `getMultitoolDropIndex` already returns an index aligned with the post-splice array, and the decrement was preventing any step from being dragged past its origin.

## Test plan

- [ ] With zero steps, drag a Task card from the queue onto the empty Multitool — step appears.
- [ ] Drag a second task in — Run button enables (with a region per step) without further clicks.
- [ ] With 3+ steps, drag the middle one above the first card and below the last card — both should land at the new position, with a visible insertion bar.
- [ ] Set distinct hex colors on two color steps; delete one, reorder, add a new step, drag in a new Task — the remaining/edited step's color must survive every mutation.