### PR TITLE
fix(screenspace): invalidate video caches when source file mtime changes

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -148,6 +148,11 @@
   }
   var _lastPollFingerprint = "";
   var _preloadedFrames = {};
+  // Per-participant source-video mtime_ns, sourced from /api/participants and
+  // /api/video/info. Used as a ?v= cache-bust suffix on frame and stream URLs
+  // so a re-encoded or replaced source file invalidates HTTP, backend, and
+  // blob caches together. Empty string means "no version known yet".
+  var _videoVersions = {};
 
   window.addEventListener("pagehide", function () {
     Object.keys(_preloadedFrames).forEach(function (pid) {
@@ -279,11 +284,15 @@
   }
 
   function frameUrl(pid, ts) {
-    return "api/video/frame/" + encodeURIComponent(pid) + "/" + Number(ts).toFixed(6);
+    var base = "api/video/frame/" + encodeURIComponent(pid) + "/" + Number(ts).toFixed(6);
+    var v = _videoVersions[pid];
+    return v ? base + "?v=" + encodeURIComponent(v) : base;
   }
 
   function videoStreamUrl(pid) {
-    return "api/video/stream/" + encodeURIComponent(pid);
+    var base = "api/video/stream/" + encodeURIComponent(pid);
+    var v = _videoVersions[pid];
+    return v ? base + "?v=" + encodeURIComponent(v) : base;
   }
 
   // ---- Participants ----
@@ -850,6 +859,16 @@
         if (participantRequestVersion !== _participantRequestVersion || pid !== state.selectedParticipant) return;
         if (!data.ok) return;
         state.videoInfo = data.info;
+        // If the server reports a different mtime than we last saw, the
+        // source file was replaced \u2014 drop the stale frame-0 blob so the
+        // next loadFrame(0) hits the API and the new ?v= URL.
+        var newVersion = data.info.version != null ? String(data.info.version) : "";
+        var prevVersion = _videoVersions[pid] || "";
+        _videoVersions[pid] = newVersion;
+        if (newVersion !== prevVersion && _preloadedFrames[pid]) {
+          try { URL.revokeObjectURL(_preloadedFrames[pid]); } catch (_) {}
+          delete _preloadedFrames[pid];
+        }
         var parts = [];
         if (data.info.duration) parts.push(formatDuration(data.info.duration));
         if (data.info.width && data.info.height) parts.push(data.info.width + "x" + data.info.height);
@@ -6716,6 +6735,11 @@
       .then(function (data) {
         if (!data.ok) return;
         state.participants = (data.participants || []).filter(function (p) { return p.has_video; });
+        // Seed _videoVersions before any frameUrl/videoStreamUrl call so the
+        // preload loop below already includes the ?v= cache-bust suffix.
+        state.participants.forEach(function (p) {
+          if (p.version != null) _videoVersions[p.id] = String(p.version);
+        });
         renderParticipantSelect();
         // Preload frame 0 for all participants (instant first-frame display)
         state.participants.forEach(function (p) {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -542,9 +542,13 @@
       _pendingSeekListener = null;
     }
 
-    // Set video source
+    // Set video source. ?v=<mtime_ns> mirrors the screenspace cache-bust so
+    // a re-encoded or replaced source file invalidates the browser HTTP cache
+    // instead of relying on send_from_directory's Last-Modified revalidation.
     if (p.has_video) {
-      video.src = "media/" + p.video_filename;
+      var mediaUrl = "media/" + p.video_filename;
+      if (p.video_version != null) mediaUrl += "?v=" + encodeURIComponent(p.video_version);
+      video.src = mediaUrl;
       video.classList.remove("hidden");
       videoEmpty.classList.add("hidden");
 

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -128,12 +128,15 @@ _manifest: dict[str, Any] = {}
 _worker: "screenspace.ScreenspaceWorker | None" = None
 _output_dir: str = ""
 _participants: list[dict[str, Any]] = []
-_video_metadata_cache: dict[str, dict[str, Any]] = {}
+# Values are (mtime_ns, info) so a stale file is re-probed automatically.
+_video_metadata_cache: dict[str, tuple[int, dict[str, Any]]] = {}
 _video_metadata_cache_lock = threading.Lock()
 # Bounded LRU so long scrub sessions don't grow unbounded; entries are
-# JPEG bytes (tens of KB each), so a few hundred is plenty.
+# JPEG bytes (tens of KB each), so a few hundred is plenty. Cache key
+# includes ``mtime_ns`` so a re-encoded source file is treated as a
+# distinct entry rather than served from stale bytes.
 _FRAME_CACHE_MAX = 256
-_frame_cache: "OrderedDict[tuple[str, float, int], bytes]" = OrderedDict()
+_frame_cache: "OrderedDict[tuple[str, int, float, int], bytes]" = OrderedDict()
 _frame_cache_lock = threading.Lock()
 
 # ---- SSE (Server-Sent Events) client registry ----
@@ -204,8 +207,19 @@ def _participant_exists(pid: str) -> bool:
 
 @screenspace_bp.route("/api/participants")
 def api_participants() -> FlaskResponse:
-    """List participants with source video availability."""
-    return jsonify({"ok": True, "participants": _participants})
+    """List participants with source video availability.
+
+    Each entry includes a ``version`` field (``st_mtime_ns`` of the source
+    file) so the frontend can cache-bust the preloaded frame-0 URL from the
+    first paint instead of waiting on a follow-up ``/api/video/info`` call.
+    """
+    payload: list[dict[str, Any]] = []
+    for p in _participants:
+        entry = dict(p)
+        if p.get("has_video"):
+            entry["version"] = _participant_video_version(p["id"])
+        payload.append(entry)
+    return jsonify({"ok": True, "participants": payload})
 
 
 @screenspace_bp.route("/api/participants/<pid>/notes")
@@ -324,27 +338,55 @@ def _find_participant_video(participant_id: str) -> str | None:
     return None
 
 
+def _find_participant_video_with_mtime(participant_id: str) -> tuple[str, int] | None:
+    """Resolve participant video path and stat its ``mtime_ns`` together.
+
+    Returns ``(path, mtime_ns)`` or ``None`` if the participant has no video or
+    the file no longer exists. Acts as the cache-version source for all video
+    routes: when the user replaces the source file, ``mtime_ns`` changes and
+    every cache keyed on it is naturally invalidated.
+    """
+    path = _find_participant_video(participant_id)
+    if path is None:
+        return None
+    try:
+        return path, Path(path).stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _participant_video_version(participant_id: str) -> int | None:
+    """Return ``mtime_ns`` for a participant's source video, or ``None``."""
+    result = _find_participant_video_with_mtime(participant_id)
+    return result[1] if result is not None else None
+
+
 @screenspace_bp.route("/api/video/frame/<participant>/<timestamp>")
 def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     """Extract and return a single JPEG frame at the given timestamp.
 
     Optional query parameter ``w`` requests a scaled-down thumbnail
     (e.g. ``?w=200`` for a 200 px-wide JPEG).  Without ``w`` the frame
-    is returned at full resolution.  Results are cached in-memory.
+    is returned at full resolution.  Results are cached in-memory and the
+    cache key includes the source file's ``mtime_ns`` so a re-encoded video
+    yields fresh bytes. Frontend pairs the URL with ``?v=<mtime>`` so the
+    browser HTTP cache invalidates on the same boundary, enabling the long
+    ``immutable`` ``Cache-Control`` below.
     """
     try:
         ts = float(timestamp)
     except (ValueError, TypeError):
         return jsonify({"ok": False, "error": "Invalid timestamp"}), 400
 
-    video_path = _find_participant_video(participant)
-    if video_path is None:
+    resolved = _find_participant_video_with_mtime(participant)
+    if resolved is None:
         return jsonify(
             {"ok": False, "error": f"No video for participant {participant}"}
         ), 404
+    video_path, mtime_ns = resolved
 
     width = request.args.get("w", 0, type=int)
-    cache_key = (video_path, round(ts, 3), width)
+    cache_key = (video_path, mtime_ns, round(ts, 3), width)
     with _frame_cache_lock:
         cached = _frame_cache.get(cache_key)
         if cached is not None:
@@ -354,7 +396,7 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
         return Response(
             cached,
             mimetype="image/jpeg",
-            headers={"Cache-Control": "public, max-age=86400"},
+            headers={"Cache-Control": "public, max-age=86400, immutable"},
         )
 
     if width > 0:
@@ -382,7 +424,7 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     return Response(
         jpeg_bytes,
         mimetype="image/jpeg",
-        headers={"Cache-Control": "public, max-age=86400"},
+        headers={"Cache-Control": "public, max-age=86400, immutable"},
     )
 
 
@@ -611,17 +653,23 @@ def api_preview_layers() -> FlaskResponse:
 
 @screenspace_bp.route("/api/video/info/<participant>")
 def api_video_info(participant: str) -> FlaskResponse:
-    """Return video metadata (duration, resolution, fps)."""
-    with _video_metadata_cache_lock:
-        cached_info = _video_metadata_cache.get(participant)
-    if cached_info is not None:
-        return jsonify({"ok": True, "info": cached_info})
+    """Return video metadata (duration, resolution, fps).
 
-    video_path = _find_participant_video(participant)
-    if video_path is None:
+    Includes a ``version`` field carrying the source file's ``st_mtime_ns``.
+    The frontend appends ``?v=<version>`` to frame and stream URLs so HTTP,
+    backend, and blob caches all invalidate together when the file changes.
+    """
+    resolved = _find_participant_video_with_mtime(participant)
+    if resolved is None:
         return jsonify(
             {"ok": False, "error": f"No video for participant {participant}"}
         ), 404
+    video_path, mtime_ns = resolved
+
+    with _video_metadata_cache_lock:
+        cached = _video_metadata_cache.get(participant)
+    if cached is not None and cached[0] == mtime_ns:
+        return jsonify({"ok": True, "info": cached[1]})
 
     props = video.probe_video_properties(video_path)
     if props is None:
@@ -641,23 +689,34 @@ def api_video_info(participant: str) -> FlaskResponse:
         "height": height if height > 0 else None,
         "nb_frames": props.get("nb_frames", 0) or 0,
         "video_codec": props.get("video_codec") or "",
+        "version": mtime_ns,
     }
     with _video_metadata_cache_lock:
-        _video_metadata_cache[participant] = info
+        _video_metadata_cache[participant] = (mtime_ns, info)
 
     return jsonify({"ok": True, "info": info})
 
 
 @screenspace_bp.route("/api/video/stream/<participant>")
 def api_video_stream(participant: str) -> FlaskResponse:
-    """Stream the source video file for a participant (range-request aware)."""
+    """Stream the source video file for a participant (range-request aware).
+
+    ``conditional=True`` lets Flask set ``Last-Modified``/``ETag`` from the
+    file stat and answer ``If-Modified-Since`` with a cheap 304. We add
+    ``Cache-Control: no-cache`` so the browser always revalidates, which
+    pairs with the frontend's ``?v=<mtime>`` cache-bust to guarantee a fresh
+    stream after a source-file replacement even when range requests are in
+    flight.
+    """
     video_path = _find_participant_video(participant)
     if video_path is None:
         return (
             jsonify({"ok": False, "error": f"No video for participant {participant}"}),
             404,
         )
-    return send_file(video_path, mimetype="video/mp4", conditional=True)
+    response = send_file(video_path, mimetype="video/mp4", conditional=True)
+    response.headers["Cache-Control"] = "no-cache"
+    return response
 
 
 # ---- Region coordinate normalization ----

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -947,6 +947,129 @@ def test_video_info_participant_without_video(client):
     assert resp.status_code == 404
 
 
+def test_participants_payload_includes_version(client, tmp_path, monkeypatch):
+    """/api/participants enriches has_video entries with the file's mtime_ns."""
+    video_file = tmp_path / "study_P03.mp4"
+    video_file.write_bytes(b"\x00fake")
+    monkeypatch.setattr(
+        screenspace_server,
+        "_participants",
+        [
+            {"id": "P01", "video_path": "/tmp/none.mp4", "has_video": False},
+            {"id": "P03", "video_path": str(video_file), "has_video": True},
+        ],
+    )
+
+    resp = client.get("/screenspace/api/participants")
+    assert resp.status_code == 200
+    by_id = {p["id"]: p for p in resp.get_json()["participants"]}
+    assert by_id["P01"].get("version") is None
+    assert by_id["P03"]["version"] == video_file.stat().st_mtime_ns
+
+
+def test_video_frame_cache_invalidates_on_mtime_change(client, tmp_path, monkeypatch):
+    """Re-encoding the source file gives a fresh frame; same URL+v hits the cache."""
+    import video as video_mod
+
+    video_file = tmp_path / "study_P04.mp4"
+    video_file.write_bytes(b"\x00original")
+    monkeypatch.setattr(
+        screenspace_server,
+        "_participants",
+        [{"id": "P04", "video_path": str(video_file), "has_video": True}],
+    )
+    monkeypatch.setattr(
+        screenspace_server, "_frame_cache", type(screenspace_server._frame_cache)()
+    )
+
+    calls = []
+
+    def _fake_extract(path, ts):
+        calls.append((path, ts, video_file.stat().st_mtime_ns))
+        # Return a 1x1 BGR ndarray-like; cv2.imencode needs a real ndarray.
+        import numpy as np
+
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(video_mod, "extract_frame_at_timestamp", _fake_extract)
+
+    first = client.get("/screenspace/api/video/frame/P04/0.0")
+    assert first.status_code == 200
+    first_bytes = first.data
+    assert len(calls) == 1
+
+    # Same URL — should hit the cache, no new extraction.
+    again = client.get("/screenspace/api/video/frame/P04/0.0")
+    assert again.status_code == 200
+    assert again.data == first_bytes
+    assert len(calls) == 1
+
+    # Bump mtime forward by 1 second to simulate a re-encode. The cache key
+    # includes mtime_ns, so this is a fresh entry and we re-extract.
+    new_mtime = video_file.stat().st_mtime_ns + 10**9
+    import os
+
+    os.utime(video_file, ns=(new_mtime, new_mtime))
+    third = client.get("/screenspace/api/video/frame/P04/0.0")
+    assert third.status_code == 200
+    assert len(calls) == 2
+
+
+def test_video_info_reprobes_on_mtime_change(client, tmp_path, monkeypatch):
+    """info response carries current mtime as version and re-probes on change."""
+    import video as video_mod
+
+    video_file = tmp_path / "study_P05.mp4"
+    video_file.write_bytes(b"\x00v1")
+    monkeypatch.setattr(
+        screenspace_server,
+        "_participants",
+        [{"id": "P05", "video_path": str(video_file), "has_video": True}],
+    )
+    monkeypatch.setattr(screenspace_server, "_video_metadata_cache", {})
+
+    probe_calls = []
+
+    def _fake_probe(path):
+        probe_calls.append(path)
+        # Simulate that duration grew after the user re-encoded.
+        duration = 30.0 if len(probe_calls) == 1 else 45.0
+        return {
+            "width": 1920,
+            "height": 1080,
+            "video_codec": "h264",
+            "audio_codec": "aac",
+            "fps": 30.0,
+            "duration": duration,
+            "nb_frames": int(duration * 30),
+        }
+
+    monkeypatch.setattr(video_mod, "probe_video_properties", _fake_probe)
+
+    first = client.get("/screenspace/api/video/info/P05").get_json()
+    assert first["ok"] is True
+    first_version = first["info"]["version"]
+    assert first_version == video_file.stat().st_mtime_ns
+    assert first["info"]["duration"] == 30
+    assert len(probe_calls) == 1
+
+    # Cache hit (same mtime).
+    cached = client.get("/screenspace/api/video/info/P05").get_json()
+    assert cached["info"]["version"] == first_version
+    assert len(probe_calls) == 1
+
+    # Mtime change forces a re-probe and a new version in the response.
+    new_mtime = first_version + 10**9
+    import os
+
+    os.utime(video_file, ns=(new_mtime, new_mtime))
+    fresh = client.get("/screenspace/api/video/info/P05").get_json()
+    assert fresh["info"]["version"] == new_mtime
+    assert fresh["info"]["version"] != first_version
+    assert fresh["info"]["duration"] == 45
+    assert len(probe_calls) == 2
+
+
 # ---- Static serving ----
 
 

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -56,6 +56,21 @@ def test_prewarm_invalid_config_normalized_in_participants(tr_client, monkeypatc
     assert resp.get_json()["transcribe_prewarm"] == "queue_open"
 
 
+def test_participants_includes_video_version(tr_client, tmp_path):
+    """video_version (mtime_ns) drives the frontend's media/<file>?v=… cache-bust."""
+    video_file = tmp_path / "study_P09.mp4"
+    video_file.write_bytes(b"\x00data")
+    transcripts_server._participants = [
+        {"id": "P09", "video_path": str(video_file), "has_video": True},
+        {"id": "P10", "video_path": str(tmp_path / "missing.mp4"), "has_video": False},
+    ]
+    resp = tr_client.get("/transcripts/api/participants")
+    assert resp.status_code == 200
+    by_id = {p["id"]: p for p in resp.get_json()["participants"]}
+    assert by_id["P09"]["video_version"] == video_file.stat().st_mtime_ns
+    assert by_id["P10"]["video_version"] is None
+
+
 def test_participants_stale_artifact_detection(tr_client, monkeypatch):
     transcripts_server._participants = [
         {"id": "P01", "video_path": "study_P01.mp4", "has_video": True},

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -70,8 +70,10 @@ def test_concatenate_clips_reencode_fallback(monkeypatch):
 # -- probe_video_properties tests --
 
 
-def test_probe_video_properties_parses_output(monkeypatch):
+def test_probe_video_properties_parses_output(monkeypatch, tmp_path):
     video._video_properties_cache.clear()
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"x")
     fake_json = json.dumps(
         {
             "streams": [
@@ -85,10 +87,9 @@ def test_probe_video_properties_parses_output(monkeypatch):
             ]
         }
     )
-    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
     monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: fake_json)
 
-    result = video.probe_video_properties("clip.mp4")
+    result = video.probe_video_properties(str(clip))
     assert result == {
         "width": 1920,
         "height": 1080,
@@ -100,8 +101,10 @@ def test_probe_video_properties_parses_output(monkeypatch):
     }
 
 
-def test_probe_video_properties_no_audio(monkeypatch):
+def test_probe_video_properties_no_audio(monkeypatch, tmp_path):
     video._video_properties_cache.clear()
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"x")
     fake_json = json.dumps(
         {
             "streams": [
@@ -114,31 +117,76 @@ def test_probe_video_properties_no_audio(monkeypatch):
             ]
         }
     )
-    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
     monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: fake_json)
 
-    result = video.probe_video_properties("clip.mp4")
+    result = video.probe_video_properties(str(clip))
     assert result is not None
     assert result["audio_codec"] is None
     assert result["video_codec"] == "hevc"
     assert result["width"] == 1280
 
 
-def test_probe_video_properties_failure(monkeypatch):
+def test_probe_video_properties_failure(monkeypatch, tmp_path):
     video._video_properties_cache.clear()
-    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"x")
 
     def raise_cpe(_cmd, **_kw):
         raise subprocess.CalledProcessError(returncode=1, cmd="ffprobe")
 
     monkeypatch.setattr(video.subprocess, "check_output", raise_cpe)
-    assert video.probe_video_properties("clip.mp4") is None
+    assert video.probe_video_properties(str(clip)) is None
 
 
-def test_probe_video_properties_file_not_found(monkeypatch):
+def test_probe_video_properties_file_not_found():
     video._video_properties_cache.clear()
-    monkeypatch.setattr(video.Path, "is_file", lambda self: False)
-    assert video.probe_video_properties("missing.mp4") is None
+    assert video.probe_video_properties("/nonexistent/missing.mp4") is None
+
+
+def test_probe_video_properties_reprobes_after_mtime_change(monkeypatch, tmp_path):
+    """A re-encoded file (new mtime_ns) invalidates the cached props."""
+    import os
+
+    video._video_properties_cache.clear()
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"original")
+
+    fake_streams = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "r_frame_rate": "30/1",
+            },
+        ],
+        "format": {},
+    }
+    call_count = {"n": 0}
+
+    def fake_check_output(_cmd, **_kw):
+        call_count["n"] += 1
+        # Second probe sees a different width to prove we re-probed.
+        if call_count["n"] >= 2:
+            fake_streams["streams"][0]["width"] = 1280
+        return json.dumps(fake_streams)
+
+    monkeypatch.setattr(video.subprocess, "check_output", fake_check_output)
+
+    first = video.probe_video_properties(str(clip))
+    assert first is not None and first["width"] == 1920
+    cached = video.probe_video_properties(str(clip))
+    assert cached is first  # same dict object — cache hit
+    assert call_count["n"] == 1
+
+    # Bump mtime forward to simulate a re-encode in place.
+    bumped = clip.stat().st_mtime_ns + 10**9
+    os.utime(clip, ns=(bumped, bumped))
+
+    fresh = video.probe_video_properties(str(clip))
+    assert fresh is not None and fresh["width"] == 1280
+    assert call_count["n"] == 2
 
 
 # -- concatenate mismatch detection tests --
@@ -374,11 +422,8 @@ def test_get_file_duration_returns_rounded_probe_duration(monkeypatch, tmp_path)
     """After probe_video_properties, duration must not depend on a prior cache hit."""
     video_f = tmp_path / "video.mp4"
     video_f.write_bytes(b"x")
-    resolved = str(video_f.resolve())
-    video._file_duration_cache.pop(resolved, None)
-    video._video_properties_cache.pop(resolved, None)
-
-    monkeypatch.setattr(video.os.path, "isfile", lambda _path: True)
+    video._file_duration_cache.clear()
+    video._video_properties_cache.clear()
 
     def fake_probe(_path: str) -> dict:
         return {
@@ -393,7 +438,8 @@ def test_get_file_duration_returns_rounded_probe_duration(monkeypatch, tmp_path)
 
     monkeypatch.setattr(video, "probe_video_properties", fake_probe)
     assert video.get_file_duration(str(video_f)) == 99
-    assert video._file_duration_cache[resolved] == 99
+    key = (str(video_f.resolve()), video_f.stat().st_mtime_ns)
+    assert video._file_duration_cache[key] == 99
 
 
 def test_get_file_duration_error_paths(monkeypatch):

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -176,6 +176,12 @@ def api_participants() -> FlaskResponse:
             pid = p["id"]
             entry = src.get(pid, {})
             has_transcript = bool(entry.get("segments"))
+            video_version: int | None = None
+            if p["has_video"]:
+                try:
+                    video_version = Path(p["video_path"]).stat().st_mtime_ns
+                except OSError:
+                    video_version = None
             info: dict[str, Any] = {
                 "id": pid,
                 "video_path": p["video_path"],
@@ -183,6 +189,7 @@ def api_participants() -> FlaskResponse:
                 "has_transcript": has_transcript,
                 "segment_count": len(entry.get("segments", [])),
                 "video_filename": Path(p["video_path"]).name,
+                "video_version": video_version,
                 "agents": {
                     "transcription": _step_state_transcription(entry),
                     "summary": _step_state_agent(pid, entry, "summary"),

--- a/video.py
+++ b/video.py
@@ -29,8 +29,25 @@ INVALID_END_TIMESTAMP = None
 # the caller asked for, instead of the nearest preceding key-frame.
 FFMPEG_PRESEEK_SECONDS = 2.0
 
-_file_duration_cache: dict[str, int] = {}
-_video_properties_cache: dict[str, dict[str, Any]] = {}
+# Caches are keyed on (resolved_path, mtime_ns) so a re-encoded or replaced
+# source file naturally yields a fresh entry instead of stale data. Mirrors
+# the pattern in viewer.py and pipeline.py.
+_file_duration_cache: dict[tuple[str, int], int] = {}
+_video_properties_cache: dict[tuple[str, int], dict[str, Any]] = {}
+
+
+def _resolved_path_and_mtime(filepath: str) -> tuple[str, int] | None:
+    """Return ``(resolved_path_str, mtime_ns)`` or ``None`` if the file is missing.
+
+    Used as a cache-version source: callers key per-file caches on the tuple
+    so the cache invalidates automatically when the file changes on disk.
+    """
+    path = Path(filepath)
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return str(path.resolve()), st.st_mtime_ns
 
 
 def accurate_seek_args(timestamp_seconds: float) -> tuple[list[str], list[str]]:
@@ -1029,11 +1046,8 @@ def get_file_duration(filepath: str) -> int | None:
     Returns:
         The duration in seconds, or None if the file cannot be probed.
     """
-    resolved = str(Path(filepath).resolve())
-    if resolved in _file_duration_cache:
-        return _file_duration_cache[resolved]
-
-    if not Path(filepath).is_file():
+    key = _resolved_path_and_mtime(filepath)
+    if key is None:
         utils.error_print(
             f"Video file not found: '{filepath}'",
             [
@@ -1042,13 +1056,16 @@ def get_file_duration(filepath: str) -> int | None:
             ],
         )
         return None
+    cached_dur = _file_duration_cache.get(key)
+    if cached_dur is not None:
+        return cached_dur
 
-    cached_props = _video_properties_cache.get(resolved)
+    cached_props = _video_properties_cache.get(key)
     if cached_props is not None:
         dur_f = float(cached_props.get("duration") or 0)
         if dur_f > 0:
             rounded = round(dur_f)
-            _file_duration_cache[resolved] = rounded
+            _file_duration_cache[key] = rounded
             return rounded
 
     probed = probe_video_properties(filepath)
@@ -1056,12 +1073,12 @@ def get_file_duration(filepath: str) -> int | None:
         dur_f = float(probed.get("duration") or 0)
         if dur_f > 0:
             rounded = round(dur_f)
-            _file_duration_cache[resolved] = rounded
+            _file_duration_cache[key] = rounded
             return rounded
 
     dur = _probe_duration_seconds_ffprobe_format(filepath)
     if dur is not None:
-        _file_duration_cache[resolved] = dur
+        _file_duration_cache[key] = dur
     return dur
 
 
@@ -1075,8 +1092,6 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         'nb_frames' (int, 0 if unknown),
         or None if probe fails.
     """
-    resolved = str(Path(filepath).resolve())
-
     if config.DEBUGGING:
         result = {
             "width": 1920,
@@ -1087,15 +1102,18 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
             "duration": 300.0,
             "nb_frames": 9000,
         }
-        _video_properties_cache[resolved] = result
-        _file_duration_cache[resolved] = round(result["duration"])
+        # In DEBUGGING mode the file may not exist on disk; fall back to a
+        # synthetic key so callers still get a cached result.
+        key = _resolved_path_and_mtime(filepath) or (str(Path(filepath).resolve()), 0)
+        _video_properties_cache[key] = result
+        _file_duration_cache[key] = round(result["duration"])
         return result
 
-    if resolved in _video_properties_cache:
-        return _video_properties_cache[resolved]
-
-    if not Path(filepath).is_file():
+    key = _resolved_path_and_mtime(filepath)
+    if key is None:
         return None
+    if key in _video_properties_cache:
+        return _video_properties_cache[key]
 
     probe_command = [
         "ffprobe",
@@ -1170,9 +1188,9 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         "duration": fmt_duration,
         "nb_frames": nb_frames,
     }
-    _video_properties_cache[resolved] = result
+    _video_properties_cache[key] = result
     if fmt_duration > 0:
-        _file_duration_cache[resolved] = round(fmt_duration)
+        _file_duration_cache[key] = round(fmt_duration)
     return result
 
 


### PR DESCRIPTION
## Summary
- Source video replacements were invisible to the Screenspace player: the cached first frame survived reloads because every cache layer (frontend `_preloadedFrames` blob, backend `_frame_cache`, `_video_metadata_cache`, `video.py` probe cache, browser `max-age=86400`) keyed on file path alone with no mtime check.
- Apply the project's existing `(path, mtime_ns)` invalidation pattern (mirroring `viewer.py:150-216` and `pipeline.py:78-112`) to every video-derived cache, and propagate the source `mtime_ns` to the frontend as a `?v=<mtime>` URL suffix so HTTP, backend, and blob caches invalidate on the same boundary.
- Same fix applied symmetrically to the transcripts `media/<filename>` URL.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini` (987 passed)
- [x] `uvx ruff check && uvx ruff format --check && uvx ty check`
- [ ] Manual: `uv run clipgen.py --screenspace -i $INPUT -o $OUTPUT`, replace a source `.mp4` in place (e.g. `ffmpeg -ss 60 -i in.mp4 -c copy /tmp/new.mp4 && mv /tmp/new.mp4 in.mp4`), hard-reload — first frame and duration should reflect the new file.
- [ ] Manual: replace the file again while the page is open, re-select the participant without reloading — first frame should update.
- [ ] Manual: same check against `--transcripts` — replacing the source then reloading should load the new video.