### PR TITLE
fix(screenspace): refresh CV model preview overlay when active tool changes

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -130,6 +130,7 @@
     overlayImage: null,
     overlayImageObjectUrl: null,
     overlayImageTimestamp: null,
+    overlayImageTool: null,
     overlayLayerSpec: {},
     rightPaneTab: "queue",
     resultsSwitcherOpen: false,
@@ -3997,7 +3998,7 @@
         state.overlayEnabled = !!toggle.checked;
         try { sessionStorage.setItem("ss_overlayEnabled", state.overlayEnabled ? "1" : "0"); } catch (_) { /* ignore */ }
         var curTs = Number(state.currentTimestamp || 0).toFixed(3);
-        if (state.overlayEnabled && (!state.overlayImage || state.overlayImageTimestamp !== curTs)) {
+        if (state.overlayEnabled && (!state.overlayImage || state.overlayImageTimestamp !== curTs || state.overlayImageTool !== state.activeWorkflow)) {
           refreshModelView();
         }
         renderOverlay();
@@ -4016,6 +4017,7 @@
         }
         state.overlayImage = null;
         state.overlayImageTimestamp = null;
+        state.overlayImageTool = null;
         refreshModelView();
         renderOverlay();
       });
@@ -4275,6 +4277,7 @@
         }
         state.overlayImage = null;
         state.overlayImageTimestamp = null;
+        state.overlayImageTool = null;
         return;
       }
       var layerQs = qsParts.concat(["layer=" + encodeURIComponent(resolved.id)]);
@@ -4294,6 +4297,7 @@
           state.overlayImage = oi;
           state.overlayImageScope = resolved.scope;
           state.overlayImageTimestamp = ts;
+          state.overlayImageTool = tool;
           renderOverlay();
         };
         oi.src = ou;
@@ -6388,7 +6392,7 @@
         e.preventDefault();
         state.overlayBlinkActive = true;
         var curTs = Number(state.currentTimestamp || 0).toFixed(3);
-        if (!state.overlayImage || state.overlayImageTimestamp !== curTs) {
+        if (!state.overlayImage || state.overlayImageTimestamp !== curTs || state.overlayImageTool !== state.activeWorkflow) {
           refreshModelView();
         }
         renderOverlay();


### PR DESCRIPTION
## Summary
- The CV model preview overlay (toggled by `B`) cached the rendered image by timestamp and layer, but not by the active tool. Switching tools at the same playhead reused the previous tool's overlay until the preview panel was uncollapsed (which force-refreshed via `toggleModelView`).
- Added `state.overlayImageTool` to the cache key, invalidate on mismatch in both the overlay-enabled toggle and the `B` keydown handler, and clear it alongside the other reset paths.

## Test plan
- [ ] Open Screenspace, collapse the CV model preview panel, select participant.
- [ ] Pick **Flow** → press `B` → see flow overlay.
- [ ] Switch to **Change** (same playhead) → press `B` → overlay should now be the Change preview (was: still Flow).
- [ ] Sanity sweep other tools (Color, Similarity).
- [ ] Edit-restore a task into a different tool, press `B` — overlay matches restored tool.
- [ ] Uncollapsing the preview panel still works.