### PR TITLE
refactor(web): low-risk frontend DRY (intake clustering, toast, video controls)

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -221,9 +221,7 @@
 
     // Screenspace events (clustered)
     var clusterSec = cvState.filters.clusterSec;
-    var ssClusters = window._studioClusterIntakeEvents
-      ? window._studioClusterIntakeEvents(state.intakeEvents, clusterSec)
-      : [];
+    var ssClusters = window.ClipgenIntakeCluster.clusterIntakeEvents(state.intakeEvents, clusterSec);
     for (var i = 0; i < ssClusters.length; i++) {
       var cl = ssClusters[i];
       var clCount = cl.events ? cl.events.length : 1;
@@ -246,9 +244,7 @@
     }
 
     // Transcript marks (clustered)
-    var trClusters = window._studioClusterTranscriptMarks
-      ? window._studioClusterTranscriptMarks(state.trIntakeMarks, clusterSec)
-      : [];
+    var trClusters = window.ClipgenIntakeCluster.clusterTranscriptMarks(state.trIntakeMarks, clusterSec);
     for (var j = 0; j < trClusters.length; j++) {
       var tc = trClusters[j];
       var tcCount = tc.marks ? tc.marks.length : 1;

--- a/assets/web/intake-cluster.js
+++ b/assets/web/intake-cluster.js
@@ -1,0 +1,106 @@
+/* Shared intake clustering for Studio.
+ *
+ * Pure grouping helpers used by the Studio page (studio.js) and its sub-tabs
+ * (convergence.js, metadata.js) to collapse raw Screenspace events and
+ * Transcript marks into time-adjacent clusters. No DOM, no module state —
+ * each function takes its data plus a threshold (in seconds) and returns a
+ * fresh list of clusters.
+ *
+ * Loaded before studio.js so the consumers can read it on init.
+ *
+ * Public API on window.ClipgenIntakeCluster:
+ *   clusterIntakeEvents(events, thresholdSec)    — group Screenspace events by
+ *                                                  participant + event_type, merging
+ *                                                  runs closer than thresholdSec.
+ *   clusterTranscriptMarks(marks, thresholdSec)  — group Transcript marks by
+ *                                                  participant, merging runs closer
+ *                                                  than thresholdSec.
+ */
+(function () {
+  "use strict";
+
+  function clusterIntakeEvents(events, thresholdSec) {
+    if (!events.length) return [];
+    var sorted = events.slice().sort(function (a, b) {
+      if (a.participant !== b.participant) return a.participant < b.participant ? -1 : 1;
+      if (a.event_type !== b.event_type) return a.event_type < b.event_type ? -1 : 1;
+      return a.time_in - b.time_in;
+    });
+    var clusters = [];
+    var cur = null;
+    for (var i = 0; i < sorted.length; i++) {
+      var ev = sorted[i];
+      if (
+        !cur ||
+        ev.participant !== cur.participant ||
+        ev.event_type !== cur.event_type ||
+        ev.time_in - cur.end > thresholdSec
+      ) {
+        if (cur) clusters.push(cur);
+        cur = {
+          participant: ev.participant,
+          source_video: ev.source_video,
+          start: ev.time_in,
+          end: ev.time_out,
+          event_type: ev.event_type,
+          detector: ev.detector,
+          region: ev.region,
+          events: [ev],
+          confidence_avg: ev.confidence,
+        };
+      } else {
+        cur.end = Math.max(cur.end, ev.time_out);
+        cur.events.push(ev);
+        var sum = 0;
+        for (var j = 0; j < cur.events.length; j++) sum += cur.events[j].confidence;
+        cur.confidence_avg = sum / cur.events.length;
+      }
+    }
+    if (cur) clusters.push(cur);
+    for (var k = 0; k < clusters.length; k++) {
+      var c = clusters[k];
+      if (c.start === c.end) {
+        c.start = Math.max(0, c.start - 5);
+        c.end = c.end + 5;
+      }
+    }
+    return clusters;
+  }
+
+  function clusterTranscriptMarks(marks, thresholdSec) {
+    if (!marks.length) return [];
+    var sorted = marks.slice().sort(function (a, b) {
+      if (a.participant !== b.participant) return a.participant < b.participant ? -1 : 1;
+      return a.start - b.start;
+    });
+    var clusters = [];
+    var cur = null;
+    for (var i = 0; i < sorted.length; i++) {
+      var m = sorted[i];
+      if (!cur || m.participant !== cur.participant || m.start - cur.end > thresholdSec) {
+        if (cur) clusters.push(cur);
+        cur = {
+          participant: m.participant,
+          start: m.start,
+          end: m.end,
+          marks: [m],
+          category: m.category || "bookmark",
+          label: m.label || "",
+          text: m.text || "",
+        };
+      } else {
+        cur.end = Math.max(cur.end, m.end);
+        cur.marks.push(m);
+        if (m.text) cur.text += " " + m.text;
+        if (m.label && !cur.label) cur.label = m.label;
+      }
+    }
+    if (cur) clusters.push(cur);
+    return clusters;
+  }
+
+  window.ClipgenIntakeCluster = {
+    clusterIntakeEvents: clusterIntakeEvents,
+    clusterTranscriptMarks: clusterTranscriptMarks,
+  };
+})();

--- a/assets/web/metadata.js
+++ b/assets/web/metadata.js
@@ -1662,8 +1662,8 @@
     if (!state) {
       state = window._studioState;
       parseClipTimestamps = window._studioParseClipTimestamps;
-      clusterIntakeEvents = window._studioClusterIntakeEvents;
-      clusterTranscriptMarks = window._studioClusterTranscriptMarks;
+      clusterIntakeEvents = window.ClipgenIntakeCluster.clusterIntakeEvents;
+      clusterTranscriptMarks = window.ClipgenIntakeCluster.clusterTranscriptMarks;
       ROW_FUNCTIONS = window._studioROW_FUNCTIONS;
     }
     if (mdState._snapshot) {

--- a/assets/web/primitives.css
+++ b/assets/web/primitives.css
@@ -771,24 +771,4 @@
   opacity: 0.85;
 }
 
-/* ---- Toast ---- */
-
-.toast {
-  position: fixed;
-  bottom: var(--space-5);
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--text-sm);
-  box-shadow: var(--shadow-lg);
-  z-index: var(--z-toast, 3000);
-  transition: opacity var(--duration-fast);
-}
-
-.toast.hidden {
-  display: none;
-}
+/* Toast styling now lives in topnav.css (shared chrome on every page). */

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -17,7 +17,6 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="topnav.css">
-  <link rel="stylesheet" href="primitives.css">
   <link rel="stylesheet" href="screenspace.css">
   <link rel="stylesheet" href="settings-modal.css">
   <link rel="stylesheet" href="start-overlay.css">

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -300,6 +300,7 @@
   <script src="start-overlay.js"></script>
   <script src="dev-token-tweak.js" data-dev-only></script>
   <script src="settings-modal.js"></script>
+  <script src="video-controls.js"></script>
   <script src="screenspace.js"></script>
 </body>
 </html>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1164,8 +1164,7 @@
     });
 
     qs("#videoSpeedBtn").addEventListener("click", function () {
-      var idx = VIDEO_SPEEDS.indexOf(state.videoPlaybackRate);
-      state.videoPlaybackRate = VIDEO_SPEEDS[(idx + 1) % VIDEO_SPEEDS.length];
+      state.videoPlaybackRate = window.ClipgenVideoControls.nextSpeed(VIDEO_SPEEDS, state.videoPlaybackRate);
       applyPlaybackRate();
       updateVideoButtons();
     });
@@ -1243,14 +1242,7 @@
   }
 
   function applyPlaybackRate() {
-    var v = qs("#videoPlayer");
-    v.defaultPlaybackRate = state.videoPlaybackRate;
-    v.playbackRate = state.videoPlaybackRate;
-    // Disable pitch preservation: the time-stretch filter is CPU-heavy and
-    // causes visible judder at >=3x. Audio pitch will rise at high speeds.
-    v.preservesPitch = false;
-    v.mozPreservesPitch = false;
-    v.webkitPreservesPitch = false;
+    window.ClipgenVideoControls.applyPlaybackRate(qs("#videoPlayer"), state.videoPlaybackRate);
   }
 
   function updateVideoButtons() {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -286,6 +286,7 @@
   <script src="start-overlay.js"></script>
   <script src="dev-token-tweak.js" data-dev-only></script>
   <script src="settings-modal.js"></script>
+  <script src="intake-cluster.js"></script>
   <script src="studio.js"></script>
   <script src="convergence.js"></script>
   <script src="metadata.js"></script>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -23,6 +23,11 @@
 
   var QUEUE_STORAGE_KEY = "clipgen-studio-queues";
 
+  // Pure intake clustering lives in intake-cluster.js (loaded first) so the
+  // Convergence/Metadata sub-tabs can share it without reaching into Studio.
+  var clusterIntakeEvents = window.ClipgenIntakeCluster.clusterIntakeEvents;
+  var clusterTranscriptMarks = window.ClipgenIntakeCluster.clusterTranscriptMarks;
+
   // Build a mask-image icon span as an HTML string. Sizing comes from a
   // parent rule (e.g. .cg-btn-icon) or from extraClass. See
   // .cg-icon family in studio.css.
@@ -4110,54 +4115,6 @@
     _ssThumbQueue = [];
   }
 
-  function clusterIntakeEvents(events, thresholdSec) {
-    if (!events.length) return [];
-    var sorted = events.slice().sort(function (a, b) {
-      if (a.participant !== b.participant) return a.participant < b.participant ? -1 : 1;
-      if (a.event_type !== b.event_type) return a.event_type < b.event_type ? -1 : 1;
-      return a.time_in - b.time_in;
-    });
-    var clusters = [];
-    var cur = null;
-    for (var i = 0; i < sorted.length; i++) {
-      var ev = sorted[i];
-      if (
-        !cur ||
-        ev.participant !== cur.participant ||
-        ev.event_type !== cur.event_type ||
-        ev.time_in - cur.end > thresholdSec
-      ) {
-        if (cur) clusters.push(cur);
-        cur = {
-          participant: ev.participant,
-          source_video: ev.source_video,
-          start: ev.time_in,
-          end: ev.time_out,
-          event_type: ev.event_type,
-          detector: ev.detector,
-          region: ev.region,
-          events: [ev],
-          confidence_avg: ev.confidence,
-        };
-      } else {
-        cur.end = Math.max(cur.end, ev.time_out);
-        cur.events.push(ev);
-        var sum = 0;
-        for (var j = 0; j < cur.events.length; j++) sum += cur.events[j].confidence;
-        cur.confidence_avg = sum / cur.events.length;
-      }
-    }
-    if (cur) clusters.push(cur);
-    for (var k = 0; k < clusters.length; k++) {
-      var c = clusters[k];
-      if (c.start === c.end) {
-        c.start = Math.max(0, c.start - 5);
-        c.end = c.end + 5;
-      }
-    }
-    return clusters;
-  }
-
   function setTabDot(elId, on) {
     var el = document.getElementById(elId);
     if (!el) return;
@@ -4744,38 +4701,6 @@
       .catch(function () {});
   }
 
-  function clusterTranscriptMarks(marks, thresholdSec) {
-    if (!marks.length) return [];
-    var sorted = marks.slice().sort(function (a, b) {
-      if (a.participant !== b.participant) return a.participant < b.participant ? -1 : 1;
-      return a.start - b.start;
-    });
-    var clusters = [];
-    var cur = null;
-    for (var i = 0; i < sorted.length; i++) {
-      var m = sorted[i];
-      if (!cur || m.participant !== cur.participant || m.start - cur.end > thresholdSec) {
-        if (cur) clusters.push(cur);
-        cur = {
-          participant: m.participant,
-          start: m.start,
-          end: m.end,
-          marks: [m],
-          category: m.category || "bookmark",
-          label: m.label || "",
-          text: m.text || "",
-        };
-      } else {
-        cur.end = Math.max(cur.end, m.end);
-        cur.marks.push(m);
-        if (m.text) cur.text += " " + m.text;
-        if (m.label && !cur.label) cur.label = m.label;
-      }
-    }
-    if (cur) clusters.push(cur);
-    return clusters;
-  }
-
   function filteredTranscriptIntakeClusters() {
     var clusters = state.trIntakeClusters;
     var cat = state.trIntakeFilterCategory;
@@ -5232,8 +5157,6 @@
   window._studioBuildXrefBadges = buildXrefBadges;
   window._studioRenderArtifactQueue = renderArtifactQueue;
   window._studioRenderReelQueue = renderReelQueue;
-  window._studioClusterIntakeEvents = clusterIntakeEvents;
-  window._studioClusterTranscriptMarks = clusterTranscriptMarks;
   window._studioROW_FUNCTIONS = ROW_FUNCTIONS;
   window._studioSyncPreviewTab = syncPreviewTab;
 })();

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -301,3 +301,27 @@ body.dragging .topnav {
     transition: none;
   }
 }
+
+/* ---- Toast ----
+ * Shared transient notification, lives here (loaded on every page) rather than
+ * in primitives.css so Screenspace/Transcripts no longer need primitives.css. */
+
+.toast {
+  position: fixed;
+  bottom: var(--space-5);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-toast, 3000);
+  transition: opacity var(--duration-fast);
+}
+
+.toast.hidden {
+  display: none;
+}

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -160,6 +160,7 @@
   <script src="start-overlay.js"></script>
   <script src="dev-token-tweak.js" data-dev-only></script>
   <script src="settings-modal.js"></script>
+  <script src="video-controls.js"></script>
   <script src="transcripts.js"></script>
 </body>
 </html>

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -17,7 +17,6 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="topnav.css">
-  <link rel="stylesheet" href="primitives.css">
   <link rel="stylesheet" href="transcripts.css">
   <link rel="stylesheet" href="settings-modal.css">
   <link rel="stylesheet" href="start-overlay.css">

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1409,15 +1409,7 @@
   }
 
   function applyPlaybackRate() {
-    var v = qs("#videoPlayer");
-    if (!v) return;
-    v.defaultPlaybackRate = state.videoPlaybackRate;
-    v.playbackRate = state.videoPlaybackRate;
-    // Audio pitch will rise at high speeds, but the time-stretch filter is CPU
-    // heavy and causes judder at >=2x.
-    v.preservesPitch = false;
-    v.mozPreservesPitch = false;
-    v.webkitPreservesPitch = false;
+    window.ClipgenVideoControls.applyPlaybackRate(qs("#videoPlayer"), state.videoPlaybackRate);
   }
 
   function updateTimeLabel() {
@@ -1669,8 +1661,7 @@
       updatePlayerButtons();
     });
     qs("#videoSpeedBtn").addEventListener("click", function () {
-      var idx = VIDEO_SPEEDS.indexOf(state.videoPlaybackRate);
-      state.videoPlaybackRate = VIDEO_SPEEDS[(idx + 1) % VIDEO_SPEEDS.length];
+      state.videoPlaybackRate = window.ClipgenVideoControls.nextSpeed(VIDEO_SPEEDS, state.videoPlaybackRate);
       applyPlaybackRate();
       updatePlayerButtons();
     });

--- a/assets/web/video-controls.js
+++ b/assets/web/video-controls.js
@@ -1,0 +1,36 @@
+/* Shared custom video-player speed controls for Screenspace and Transcripts.
+ *
+ * Both pages render their own <video> chrome (play / mute / speed buttons) and
+ * keep their own VIDEO_SPEEDS list + button-label updater, but the speed-cycle
+ * math and playback-rate application are identical. This module owns those two
+ * shared bits.
+ *
+ * Public API on window.ClipgenVideoControls:
+ *   nextSpeed(speeds, current)        — next entry in the cycle (wraps around).
+ *   applyPlaybackRate(videoEl, rate)  — set the playback rate without pitch
+ *                                       preservation. The time-stretch filter is
+ *                                       CPU-heavy and causes visible judder at
+ *                                       high speeds, so audio pitch rises instead.
+ */
+(function () {
+  "use strict";
+
+  function nextSpeed(speeds, current) {
+    var idx = speeds.indexOf(current);
+    return speeds[(idx + 1) % speeds.length];
+  }
+
+  function applyPlaybackRate(videoEl, rate) {
+    if (!videoEl) return;
+    videoEl.defaultPlaybackRate = rate;
+    videoEl.playbackRate = rate;
+    videoEl.preservesPitch = false;
+    videoEl.mozPreservesPitch = false;
+    videoEl.webkitPreservesPitch = false;
+  }
+
+  window.ClipgenVideoControls = {
+    nextSpeed: nextSpeed,
+    applyPlaybackRate: applyPlaybackRate,
+  };
+})();

--- a/plans/FRONTEND-REFACTOR-PLAN.md
+++ b/plans/FRONTEND-REFACTOR-PLAN.md
@@ -208,10 +208,10 @@ Use this when executing waves; check items in PR descriptions.
 
 ### Wave 2
 
-- [ ] A5 CSS include audit (Transcripts/Screenspace)
-- [ ] A6 Card-scrubber: integrate or remove
-- [ ] B1 `video-controls.js`
-- [ ] B2 `intake-cluster.js`
+- [x] A5 CSS include audit (Transcripts/Screenspace) — toast moved to `topnav.css`; `primitives.css` dropped from both
+- [ ] A6 Card-scrubber: integrate or remove — deferred, left parked (unused; re-hook when filmstrip thumbnails return)
+- [x] B1 `video-controls.js` — shared `nextSpeed`/`applyPlaybackRate`
+- [x] B2 `intake-cluster.js` — `window.ClipgenIntakeCluster`; drops `window._studioCluster*`
 
 ### Wave 3
 


### PR DESCRIPTION
Picks the three lowest-conflict items from the frontend refactor plan's Wave 2, chosen to avoid the files the parallel Screenspace false-positives work is editing. Extracts the pure intake-clustering helpers out of `studio.js` into a shared `intake-cluster.js` (`window.ClipgenIntakeCluster`), so the Convergence/Metadata sub-tabs no longer depend on the implicit `window._studioCluster*` globals. Relocates the `.toast` rules into `topnav.css` (shared chrome on every page) and drops the otherwise-unused `primitives.css` link from `screenspace.html` and `transcripts.html`, with Studio keeping it for its component factories. Extracts the duplicated video speed-cycle / `applyPlaybackRate` logic into a shared `video-controls.js` used by both Screenspace and Transcripts, and updates the plan checklist (A5/B1/B2 done, A6 left parked). No behaviour change — 1007 tests pass, and the only Screenspace-file edits are tiny, in cold regions far from the OCR/results hot zones, to merge cleanly alongside the false-positives branch.