### PR TITLE
Fix Screenspace review findings

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1793,7 +1793,13 @@
       dot.style.background = color;
       chip.appendChild(dot);
       chip.appendChild(document.createTextNode(name));
-      chip.addEventListener("click", function () {
+      chip.addEventListener("click", function (e) {
+        if (_regionSuppressNextClick) {
+          _regionSuppressNextClick = false;
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
         if (state.activeRegion === name) {
           state.activeRegion = null;
         } else {
@@ -1991,9 +1997,19 @@
   // render, but the element itself is reused).
   var _stashDragOverCard = null;
 
+  function clearStashDragIndicators() {
+    if (_stashDragOverCard) {
+      _stashDragOverCard.classList.remove("drag-over");
+      _stashDragOverCard = null;
+    }
+    qsa(".stash-card.drag-over").forEach(function (card) {
+      card.classList.remove("drag-over");
+    });
+  }
+
   function bindStashDrop(area) {
     area.addEventListener("dragover", function (e) {
-      if (e.dataTransfer.types.indexOf("application/x-region-name") < 0) return;
+      if (!hasRegionDragPayload(e)) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
       var card = e.target.closest(".stash-card");
@@ -2007,16 +2023,20 @@
     });
     area.addEventListener("dragleave", function (e) {
       var card = e.target.closest(".stash-card");
-      if (card && !card.contains(e.relatedTarget)) card.classList.remove("drag-over");
+      if (card && !card.contains(e.relatedTarget)) {
+        card.classList.remove("drag-over");
+        if (_stashDragOverCard === card) _stashDragOverCard = null;
+      }
     });
     area.addEventListener("drop", function (e) {
-      if (e.dataTransfer.types.indexOf("application/x-region-name") < 0) return;
+      if (!hasRegionDragPayload(e)) return;
       var card = e.target.closest(".stash-card");
       if (!card) return;
       e.preventDefault();
-      card.classList.remove("drag-over");
-      _stashDragOverCard = null;
-      copyRegionToStash(e.dataTransfer.getData("application/x-region-name"), card.dataset.stashId);
+      clearStashDragIndicators();
+      _regionDragDropped = true;
+      var regionName = getDraggedRegionName(e);
+      if (regionName) copyRegionToStash(regionName, card.dataset.stashId);
     });
   }
 
@@ -2024,9 +2044,60 @@
   // Horizontal mirror of the multitool/task vertical drag helpers: midpoints use
   // left+width/2 and compare clientX. Excluding the .dragging chip from the cache
   // keeps the drop index aligned with the post-splice array (no off-by-one).
+  var REGION_DRAG_MIME = "application/x-region-name";
   var _regionDragMidpoints = null;
   var _regionDragOverRaf = null;
   var _regionPendingDragOverX = null;
+  var _regionDragActive = false;
+  var _regionDragMoved = false;
+  var _regionDragDropped = false;
+  var _regionSuppressNextClick = false;
+
+  function dataTransferHasType(dt, type) {
+    if (!dt || !dt.types) return false;
+    if (typeof dt.types.indexOf === "function") return dt.types.indexOf(type) >= 0;
+    if (typeof dt.types.contains === "function") return dt.types.contains(type);
+    for (var i = 0; i < dt.types.length; i++) {
+      if (dt.types[i] === type) return true;
+    }
+    return false;
+  }
+
+  function hasRegionDragPayload(e) {
+    // Firefox/Safari may hide custom MIME types during dragover. Since these
+    // drags start inside this document, the local flag is the reliable signal.
+    return _regionDragActive || dataTransferHasType(e.dataTransfer, REGION_DRAG_MIME);
+  }
+
+  function setRegionDragData(dt, idx, name) {
+    if (!dt) return;
+    dt.setData("text/plain", String(idx));
+    try {
+      dt.setData(REGION_DRAG_MIME, name);
+    } catch (_) {
+      // Some engines reject custom types; text/plain + local state covers us.
+    }
+  }
+
+  function getDraggedRegionName(e) {
+    var name = "";
+    try {
+      name = e.dataTransfer.getData(REGION_DRAG_MIME);
+    } catch (_) {
+      name = "";
+    }
+    if (name && Object.prototype.hasOwnProperty.call(state.regions, name)) return name;
+    var fromIdx = parseInt(e.dataTransfer.getData("text/plain"), 10);
+    if (isNaN(fromIdx)) return "";
+    return Object.keys(state.regions)[fromIdx] || "";
+  }
+
+  function getDraggedRegionIndex(e) {
+    var fromIdx = parseInt(e.dataTransfer.getData("text/plain"), 10);
+    if (!isNaN(fromIdx)) return fromIdx;
+    var name = getDraggedRegionName(e);
+    return name ? Object.keys(state.regions).indexOf(name) : -1;
+  }
 
   function _cacheRegionDragMidpoints(container) {
     var chips = container.querySelectorAll(".region-chip:not(.dragging)");
@@ -2065,9 +2136,11 @@
         e.preventDefault();
         return;
       }
+      _regionDragActive = true;
+      _regionDragMoved = false;
+      _regionDragDropped = false;
       chip.classList.add("dragging");
-      e.dataTransfer.setData("text/plain", chip.dataset.regionIdx);
-      e.dataTransfer.setData("application/x-region-name", chip.dataset.regionName);
+      setRegionDragData(e.dataTransfer, chip.dataset.regionIdx, chip.dataset.regionName);
       e.dataTransfer.effectAllowed = "copyMove";
       _cacheRegionDragMidpoints(chips);
     });
@@ -2081,13 +2154,22 @@
       }
       _regionPendingDragOverX = null;
       clearRegionDragIndicators(chips);
+      clearStashDragIndicators();
       _regionDragMidpoints = null;
+      if (_regionDragMoved || _regionDragDropped) {
+        _regionSuppressNextClick = true;
+        setTimeout(function () { _regionSuppressNextClick = false; }, 250);
+      }
+      _regionDragActive = false;
+      _regionDragMoved = false;
+      _regionDragDropped = false;
     });
 
     chips.addEventListener("dragover", function (e) {
-      if (e.dataTransfer.types.indexOf("application/x-region-name") < 0) return;
+      if (!hasRegionDragPayload(e)) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
+      _regionDragMoved = true;
       _regionPendingDragOverX = e.clientX;
       if (_regionDragOverRaf != null) return; // RAF-debounce ~60Hz dragover
       _regionDragOverRaf = requestAnimationFrame(function () {
@@ -2108,15 +2190,18 @@
     });
 
     chips.addEventListener("drop", function (e) {
-      if (e.dataTransfer.types.indexOf("application/x-region-name") < 0) return;
+      if (!hasRegionDragPayload(e)) return;
       e.preventDefault();
+      _regionDragDropped = true;
       clearRegionDragIndicators(chips);
-      var fromIdx = parseInt(e.dataTransfer.getData("text/plain"), 10);
-      if (isNaN(fromIdx)) return;
+      var fromIdx = getDraggedRegionIndex(e);
+      if (fromIdx < 0) return;
       var toIdx = getRegionDropIndex(chips, e.clientX);
       if (fromIdx === toIdx) return;
       var names = Object.keys(state.regions);
+      var previousRegions = state.regions;
       var moved = names.splice(fromIdx, 1)[0];
+      if (!moved) return;
       names.splice(toIdx, 0, moved);
       // Rebuild state.regions in the new order.
       var reordered = {};
@@ -2128,9 +2213,21 @@
       // recolors regions — intentional. Repaint chips and overlay together.
       renderRegionChips();
       renderOverlay();
-      apiPut("api/regions/reorder", { names: names }).catch(function () {
+      apiPut("api/regions/reorder", { names: names }).then(function (data) {
+        if (!data || !data.ok) throw new Error((data && data.error) || "reorder failed");
+      }).catch(function () {
+        state.regions = previousRegions;
+        renderRegionChips();
+        renderOverlay();
         showToast("Failed to save region order");
       });
+    });
+
+    document.addEventListener("dragend", function () {
+      clearStashDragIndicators();
+    });
+    document.addEventListener("drop", function () {
+      clearStashDragIndicators();
     });
   }
 
@@ -4410,6 +4507,12 @@
     } else if (tool === "flow") {
       var m = qs("#paramFlowMag");
       if (m) out.magnitude = m.value;
+    } else if (tool === "text") {
+      var tp = qs("#paramTextOcrPreprocess");
+      if (tp && tp.checked) out.ocr_preprocess = "1";
+    } else if (tool === "numbers") {
+      var np = qs("#paramNumOcrPreprocess");
+      if (np && np.checked) out.ocr_preprocess = "1";
     }
     return out;
   }

--- a/screenspace.py
+++ b/screenspace.py
@@ -126,6 +126,21 @@ def _normalize_ocr_text(s: str) -> str:
     return s.lower().translate(_OCR_NORMALIZATION_TABLE)
 
 
+def _effective_ocr_confidence_threshold(value: Any = None) -> float:
+    """Return OCR confidence cutoff, using config default only when omitted."""
+    if value is None:
+        return config.SCREENSPACE_OCR_MIN_CONFIDENCE
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("ocr_confidence_threshold must be a number") from exc
+    if not math.isfinite(threshold):
+        raise ValueError("ocr_confidence_threshold must be a finite number")
+    if threshold < 0 or threshold > 1:
+        raise ValueError("ocr_confidence_threshold must be between 0 and 1")
+    return threshold
+
+
 # ---------------------------------------------------------------------------
 # Analysis primitives
 # ---------------------------------------------------------------------------
@@ -1247,7 +1262,7 @@ def scan_text(
     interval_seconds: float = 2.0,
     *,
     fuzzy_threshold: float = 0.0,
-    ocr_confidence_threshold: float = 0.0,
+    ocr_confidence_threshold: float | None = None,
     ocr_preprocess: bool = False,
     ocr_normalize: bool = False,
     languages: list[str] | None = None,
@@ -1263,12 +1278,12 @@ def scan_text(
     EasyOCR is lazy-imported. Raises ``ImportError`` with install
     instructions if missing.
     """
-    utils.require_optional("easyocr", "text scan")
-
     if fuzzy_threshold <= 0:
         fuzzy_threshold = config.SCREENSPACE_OCR_FUZZY_THRESHOLD
-    if ocr_confidence_threshold <= 0:
-        ocr_confidence_threshold = config.SCREENSPACE_OCR_MIN_CONFIDENCE
+    ocr_confidence_threshold = _effective_ocr_confidence_threshold(
+        ocr_confidence_threshold
+    )
+    utils.require_optional("easyocr", "text scan")
     if languages is None:
         languages = ["en"]
 
@@ -1384,7 +1399,7 @@ def scan_numbers(
     *,
     range_min: float | None = None,
     range_max: float | None = None,
-    ocr_confidence_threshold: float = 0.0,
+    ocr_confidence_threshold: float | None = None,
     ocr_preprocess: bool = False,
     languages: list[str] | None = None,
     start_seconds: float = 0.0,
@@ -1404,10 +1419,10 @@ def scan_numbers(
             f"Unknown operator '{operator}'. Must be one of: {', '.join(_VALID_OPERATORS)}"
         )
 
+    ocr_confidence_threshold = _effective_ocr_confidence_threshold(
+        ocr_confidence_threshold
+    )
     utils.require_optional("easyocr", "numbers scan")
-
-    if ocr_confidence_threshold <= 0:
-        ocr_confidence_threshold = config.SCREENSPACE_OCR_MIN_CONFIDENCE
     if languages is None:
         languages = ["en"]
 
@@ -2638,11 +2653,8 @@ class TextTool(AnalysisTool):
         fuzzy_threshold = params.get(
             "fuzzy_threshold", config.SCREENSPACE_OCR_FUZZY_THRESHOLD
         )
-        # 0/absent → config default, matching scan_text's `<= 0` convention so
-        # standalone and multitool paths gate identically.
-        ocr_min_conf = (
+        ocr_min_conf = _effective_ocr_confidence_threshold(
             params.get("ocr_confidence_threshold")
-            or config.SCREENSPACE_OCR_MIN_CONFIDENCE
         )
         languages = params.get("languages") or ["en"]
         reader = _get_ocr_reader(languages)
@@ -2683,7 +2695,7 @@ class TextTool(AnalysisTool):
             search_string=params.get("search_string", ""),
             interval_seconds=params.get("interval", 2.0),
             fuzzy_threshold=params.get("fuzzy_threshold", 0),
-            ocr_confidence_threshold=params.get("ocr_confidence_threshold", 0),
+            ocr_confidence_threshold=params.get("ocr_confidence_threshold"),
             ocr_preprocess=params.get("ocr_preprocess", False),
             ocr_normalize=params.get("ocr_normalize", False),
             languages=params.get("languages"),
@@ -2705,11 +2717,8 @@ class NumbersTool(AnalysisTool):
         target_value = params.get("target_value", 0)
         range_min = params.get("range_min")
         range_max = params.get("range_max")
-        # 0/absent → config default, matching scan_numbers's `<= 0` convention so
-        # standalone and multitool paths gate identically.
-        ocr_min_conf = (
+        ocr_min_conf = _effective_ocr_confidence_threshold(
             params.get("ocr_confidence_threshold")
-            or config.SCREENSPACE_OCR_MIN_CONFIDENCE
         )
         languages = params.get("languages") or ["en"]
         reader = _get_ocr_reader(languages)
@@ -2750,7 +2759,7 @@ class NumbersTool(AnalysisTool):
             interval_seconds=params.get("interval", 2.0),
             range_min=params.get("range_min"),
             range_max=params.get("range_max"),
-            ocr_confidence_threshold=params.get("ocr_confidence_threshold", 0),
+            ocr_confidence_threshold=params.get("ocr_confidence_threshold"),
             ocr_preprocess=params.get("ocr_preprocess", False),
             languages=params.get("languages"),
             start_seconds=params.get("start_seconds", 0.0),

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -160,6 +160,8 @@ def build_overlay_layer(
         return _gray_to_bgr(gray)
 
     if tool in ("text", "numbers") and layer == "gray":
+        if params.get("ocr_preprocess"):
+            pixels = screenspace._preprocess_for_ocr(pixels)
         return _gray_to_bgr(cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY))
 
     if tool == "scene" and layer == "edges":
@@ -623,8 +625,12 @@ def _preview_text_numbers(
     pixels = _clip_region_pixels(frame, region)
     if pixels is None:
         return _placeholder("Select a region to preview")
+    label = "OCR input (gray)"
+    if params.get("ocr_preprocess"):
+        pixels = screenspace._preprocess_for_ocr(pixels)
+        label = "OCR input (enhanced)"
     gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
-    return _label_panel(_fit_width(gray, 300), "OCR input (gray)")
+    return _label_panel(_fit_width(gray, 300), label)
 
 
 def _preview_timelapse(

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -446,6 +446,7 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
       noise=<int>          change tool's noise_threshold override
       h,s,v=<int>          color tool's target HSV override
       magnitude=<float>    flow tool's magnitude threshold override
+      ocr_preprocess=<bool> text/numbers ROI enhancement override
       layer=<id>           if set, return that single overlay layer at native
                            region/frame resolution instead of the labeled
                            composite. See ``screenspace_preview.OVERLAY_LAYERS``
@@ -531,6 +532,10 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
                 params["magnitude_threshold"] = float(raw)
             except ValueError:
                 pass
+    elif tool in ("text", "numbers"):
+        raw = (request.args.get("ocr_preprocess") or "").strip().lower()
+        if raw in ("1", "true", "yes", "on"):
+            params["ocr_preprocess"] = True
     elif tool == "similarity":
         ref_ts_raw = request.args.get("ref")
         if ref_ts_raw is not None and region_coords is not None:
@@ -925,7 +930,10 @@ def api_regions_reorder() -> FlaskResponse:
     with _manifest_lock:
         regions = _manifest.get("regions", {})
         names = data["names"]
-        if set(names) != set(regions.keys()):
+        if not all(isinstance(name, str) for name in names):
+            return jsonify({"ok": False, "error": "names must be strings"}), 400
+        region_names = list(regions.keys())
+        if len(names) != len(region_names) or set(names) != set(region_names):
             return (
                 jsonify(
                     {"ok": False, "error": "names must match current regions exactly"}
@@ -1251,6 +1259,8 @@ def _coerce_task_params(
             parameters["scene_references"] = _validate_scene_references(
                 parameters.get("scene_references")
             )
+        elif task_type in ("text", "numbers"):
+            _coerce_ocr_controls(parameters)
         elif task_type == "multitool":
             for i, step in enumerate(parameters.get("steps", [])):
                 step_context = f"Step {i}: "
@@ -1275,6 +1285,8 @@ def _coerce_task_params(
                     )
                 if step.get("type") == "template":
                     _coerce_template_controls(step)
+                if step.get("type") in ("text", "numbers"):
+                    _coerce_ocr_controls(step, context=step_context)
         if task_type == "template":
             _coerce_template_controls(parameters)
     except ValueError as exc:
@@ -1796,6 +1808,21 @@ def _coerce_template_controls(params: dict[str, Any], *, context: str = "") -> N
         lo = config.SCREENSPACE_TEMPLATE_SCALE_MIN
         hi = config.SCREENSPACE_TEMPLATE_SCALE_MAX
         params["template_scale"] = max(lo, min(hi, scale))
+
+
+def _coerce_ocr_controls(params: dict[str, Any], *, context: str = "") -> None:
+    """Validate optional OCR controls shared by Text and Numbers tools."""
+    if "ocr_confidence_threshold" not in params:
+        return
+    threshold = _coerce_float(
+        params.get("ocr_confidence_threshold"),
+        "ocr_confidence_threshold",
+        required=True,
+        context=context,
+    )
+    if threshold is None or threshold < 0 or threshold > 1:
+        raise ValueError(f"{context}ocr_confidence_threshold must be between 0 and 1")
+    params["ocr_confidence_threshold"] = threshold
 
 
 def _validate_scene_references(

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1209,6 +1209,14 @@ class TestScanNumbers:
 
         monkeypatch.setattr(screenspace, "scan_video_frames", fake_scan)
 
+        default_rejected = screenspace.scan_numbers(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 60, "h": 20},
+            operator="gte",
+            target_value=5,
+        )
+        assert default_rejected == []
+
         rejected = screenspace.scan_numbers(
             "/fake.mp4",
             {"x": 0, "y": 0, "w": 60, "h": 20},
@@ -1228,6 +1236,27 @@ class TestScanNumbers:
         assert len(accepted) == 1
         assert accepted[0]["number_found"] == 5.0
         assert accepted[0]["confidence"] == 0.2
+
+        accepted_zero = screenspace.scan_numbers(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 60, "h": 20},
+            operator="gte",
+            target_value=5,
+            ocr_confidence_threshold=0.0,
+        )
+        assert len(accepted_zero) == 1
+
+    @pytest.mark.parametrize("threshold", [-0.1, 1.1])
+    def test_invalid_ocr_confidence_threshold_raises(self, monkeypatch, threshold):
+        monkeypatch.setattr(screenspace, "_probe_video_meta", lambda p: (30.0, 1.0))
+        with pytest.raises(ValueError, match="ocr_confidence_threshold"):
+            screenspace.scan_numbers(
+                "/fake.mp4",
+                {"x": 0, "y": 0, "w": 60, "h": 20},
+                operator="gte",
+                target_value=5,
+                ocr_confidence_threshold=threshold,
+            )
 
     def test_allowlist_passed(self, monkeypatch):
         """Digit allowlist is forwarded to EasyOCR for English, omitted otherwise."""
@@ -1454,6 +1483,44 @@ class TestCheckFrameForTool:
         assert passed is True
         assert result is not None
         assert "score" in result
+
+    def test_numbers_check_frame_honors_zero_ocr_threshold(self, monkeypatch):
+        frame = np.full((20, 60, 3), 128, dtype=np.uint8)
+        region = {"x": 0, "y": 0, "w": 60, "h": 20}
+
+        class _FakeReader:
+            def readtext(self, _pixels, **_kwargs):
+                return [([(0, 0), (10, 0), (10, 10), (0, 10)], "5", 0.2)]
+
+        monkeypatch.setattr(
+            screenspace, "_get_ocr_reader", lambda _langs: _FakeReader()
+        )
+
+        passed, result = screenspace.check_frame_for_tool(
+            frame,
+            None,
+            region,
+            "numbers",
+            {"operator": "gte", "target_value": 5},
+        )
+        assert passed is False
+        assert result is None
+
+        passed, result = screenspace.check_frame_for_tool(
+            frame,
+            None,
+            region,
+            "numbers",
+            {
+                "operator": "gte",
+                "target_value": 5,
+                "ocr_confidence_threshold": 0.0,
+            },
+        )
+        assert passed is True
+        assert result is not None
+        assert result["number_found"] == 5.0
+        assert result["confidence"] == 0.2
 
     def test_flow_needs_prev_frame(self):
         frame = np.zeros((100, 100, 3), dtype=np.uint8)

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -298,9 +298,7 @@ def test_reorder_regions_rejects_mismatched_names(client):
 def test_reorder_regions_rejects_duplicate_names(client):
     _create_region(client, "a")
     _create_region(client, "b")
-    resp = client.put(
-        "/screenspace/api/regions/reorder", json={"names": ["a", "a"]}
-    )
+    resp = client.put("/screenspace/api/regions/reorder", json={"names": ["a", "a"]})
     assert resp.status_code == 400
     keys = list(client.get("/screenspace/api/regions").get_json()["regions"].keys())
     assert keys == ["a", "b"]

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -295,6 +295,17 @@ def test_reorder_regions_rejects_mismatched_names(client):
     assert keys == ["a", "b"]
 
 
+def test_reorder_regions_rejects_duplicate_names(client):
+    _create_region(client, "a")
+    _create_region(client, "b")
+    resp = client.put(
+        "/screenspace/api/regions/reorder", json={"names": ["a", "a"]}
+    )
+    assert resp.status_code == 400
+    keys = list(client.get("/screenspace/api/regions").get_json()["regions"].keys())
+    assert keys == ["a", "b"]
+
+
 def test_reorder_regions_requires_names_list(client):
     _create_region(client, "a")
     assert client.put("/screenspace/api/regions/reorder", json={}).status_code == 400
@@ -469,6 +480,48 @@ def test_create_task_numbers_type_accepted(client):
     assert "video" in data["error"].lower()
 
 
+@pytest.mark.parametrize("value", [None, -0.1, 1.1, "not-a-number"])
+def test_create_ocr_task_rejects_invalid_confidence_threshold(
+    client, monkeypatch, value
+):
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "text",
+            "participant": "P01",
+            "region": "r",
+            "parameters": {
+                "search_string": "score",
+                "ocr_confidence_threshold": value,
+            },
+        },
+    )
+    assert resp.status_code == 400
+    assert "ocr_confidence_threshold" in resp.get_json()["error"]
+
+
+def test_create_ocr_task_accepts_zero_confidence_threshold(client, monkeypatch):
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "text",
+            "participant": "P01",
+            "region": "r",
+            "parameters": {
+                "search_string": "score",
+                "ocr_confidence_threshold": 0,
+            },
+        },
+    )
+    assert resp.status_code == 200
+    params = resp.get_json()["task"]["parameters"]
+    assert params["ocr_confidence_threshold"] == 0.0
+
+
 @pytest.mark.parametrize("task_type", ["template", "flow", "scene"])
 def test_create_task_new_types_accepted(client, task_type):
     """New phase-4 types pass type validation (fail at video, not type)."""
@@ -589,6 +642,37 @@ def test_api_preview_template_post_invalid_image(client, monkeypatch) -> None:
         json={"template_image_data": "qqqq"},
     )
     assert resp.status_code == 400
+
+
+def test_api_preview_text_preprocess_changes_ocr_input(client, monkeypatch) -> None:
+    import cv2
+    import numpy as np
+    import video
+
+    _enable_video_task_setup(monkeypatch, "P01")
+    frame = np.zeros((80, 120, 3), dtype=np.uint8)
+    monkeypatch.setattr(
+        video, "extract_frame_at_timestamp", lambda _path, _ts: frame.copy()
+    )
+    monkeypatch.setattr(
+        screenspace,
+        "_preprocess_for_ocr",
+        lambda _pixels: np.full((40, 40, 3), 255, dtype=np.uint8),
+    )
+
+    region = "0.0,0.0,0.5,0.5"
+    raw = client.get(f"/screenspace/api/preview/P01/0.0?tool=text&region={region}")
+    enhanced = client.get(
+        f"/screenspace/api/preview/P01/0.0?tool=text&region={region}&ocr_preprocess=1"
+    )
+    assert raw.status_code == 200
+    assert enhanced.status_code == 200
+    raw_img = cv2.imdecode(np.frombuffer(raw.data, np.uint8), cv2.IMREAD_COLOR)
+    enhanced_img = cv2.imdecode(
+        np.frombuffer(enhanced.data, np.uint8), cv2.IMREAD_COLOR
+    )
+    assert raw_img is not None and enhanced_img is not None
+    assert float(enhanced_img.mean()) > float(raw_img.mean())
 
 
 def test_api_preview_layers_catalog(client) -> None:


### PR DESCRIPTION
## Summary
- Fix Screenspace region chip drag/drop reliability, reorder rollback, and backend reorder validation.
- Align OCR confidence threshold semantics across standalone scans, multitool checks, and API validation.
- Make OCR model-view preview reflect Enhance ROI preprocessing and add focused regression coverage.

## Test plan
- `uv run --with pytest pytest tests/test_screenspace_api.py tests/test_screenspace.py -q`
- `node --check assets/web/screenspace.js`
- `git diff --check`