### PR TITLE
fix: address code-review findings on friction + screenspace commits

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1560,6 +1560,12 @@
     if (!btn) return;
     var has = !!(state.frictionData && state.frictionData.segments && state.frictionData.segments.length);
     btn.disabled = !has;
+    // Only show the pressed/active styling when the toggle is both enabled and
+    // actionable — otherwise a stored-enabled toggle renders active-but-greyed
+    // on load before friction data arrives.
+    var showActive = has && state.frictionHeatmapEnabled;
+    btn.classList.toggle("active", showActive);
+    btn.setAttribute("aria-pressed", showActive ? "true" : "false");
   }
 
   function initFriction() {
@@ -1579,19 +1585,24 @@
     if (!btn) return;
     var stored = getStoredUIState("transcripts");
     state.frictionHeatmapEnabled = !!(stored && stored.frictionHeatmapEnabled);
-    btn.classList.toggle("active", state.frictionHeatmapEnabled);
-    btn.setAttribute("aria-pressed", state.frictionHeatmapEnabled ? "true" : "false");
+    // Defer the active/aria-pressed visual to _refreshHeatmapAffordances so it
+    // only lights up once friction data is actually present.
+    _refreshHeatmapAffordances();
     btn.addEventListener("click", function () {
       state.frictionHeatmapEnabled = !state.frictionHeatmapEnabled;
-      btn.classList.toggle("active", state.frictionHeatmapEnabled);
-      btn.setAttribute("aria-pressed", state.frictionHeatmapEnabled ? "true" : "false");
       setStoredUIStateField("transcripts", "frictionHeatmapEnabled", state.frictionHeatmapEnabled);
+      _refreshHeatmapAffordances();
       renderSegments();
       renderTimeline();
     });
   }
 
   // Friction tooltip on hot segments (reuses the shared #trTooltip element).
+  // _frictionTooltipShown lets hideTimelineTooltip yield while a friction
+  // tooltip owns #trTooltip (mirror of _hideFrictionTooltip's _lastTimelineHit
+  // guard); _segTooltipRaf coalesces the segment-list mousemove like the canvas.
+  var _frictionTooltipShown = false;
+  var _segTooltipRaf = 0;
 
   function _showFrictionTooltip(frow, clientX, clientY) {
     var tip = qs("#trTooltip");
@@ -1622,9 +1633,11 @@
     if (y < 8) y = clientY + 16;
     tip.style.left = x + "px";
     tip.style.top = y + "px";
+    _frictionTooltipShown = true;
   }
 
   function _hideFrictionTooltip() {
+    _frictionTooltipShown = false;
     var tip = qs("#trTooltip");
     if (tip && !_lastTimelineHit) tip.classList.add("hidden");
   }
@@ -1969,15 +1982,22 @@
     });
 
     // Friction tooltip on hot segments (only while the heatmap is on).
+    // RAF-coalesced like the timeline canvas so getBoundingClientRect isn't
+    // called on every mousemove event.
     container.addEventListener("mousemove", function (e) {
-      if (!state.frictionHeatmapEnabled) { _hideFrictionTooltip(); return; }
-      var row = e.target.closest(".segment-row");
-      if (!row) { _hideFrictionTooltip(); return; }
-      var idx = parseInt(row.getAttribute("data-index"), 10);
-      var seg = state.segments[idx];
-      var frow = seg ? state.frictionBySegId[seg.id] : null;
-      if (!frow || !(frow.score > 0)) { _hideFrictionTooltip(); return; }
-      _showFrictionTooltip(frow, e.clientX, e.clientY);
+      if (_segTooltipRaf) return;
+      var cx = e.clientX, cy = e.clientY, tgt = e.target;
+      _segTooltipRaf = requestAnimationFrame(function () {
+        _segTooltipRaf = 0;
+        if (!state.frictionHeatmapEnabled) { _hideFrictionTooltip(); return; }
+        var row = tgt.closest && tgt.closest(".segment-row");
+        if (!row) { _hideFrictionTooltip(); return; }
+        var idx = parseInt(row.getAttribute("data-index"), 10);
+        var seg = state.segments[idx];
+        var frow = seg ? state.frictionBySegId[seg.id] : null;
+        if (!frow || !(frow.score > 0)) { _hideFrictionTooltip(); return; }
+        _showFrictionTooltip(frow, cx, cy);
+      });
     });
     container.addEventListener("mouseleave", function () { _hideFrictionTooltip(); });
   }
@@ -2285,6 +2305,9 @@
   }
 
   function hideTimelineTooltip() {
+    // Yield if a friction (hot-segment) tooltip currently owns the shared
+    // element, so a canvas mouseleave doesn't clobber it mid-display.
+    if (_frictionTooltipShown) return;
     var tip = qs("#trTooltip");
     if (tip) tip.classList.add("hidden");
   }

--- a/friction.py
+++ b/friction.py
@@ -164,7 +164,7 @@ def select_candidates(
     """Return the top-*n* scored rows (score > 0) for the LLM stage.
 
     Sorted by score descending, breaking ties by total match count so denser
-    segments win. Rows with no markers are excluded.
+    segments win. Rows that scored zero (no category matches) are excluded.
     """
     candidates = [row for row in scored if row.get("score", 0) > 0]
     candidates.sort(

--- a/screenspace.py
+++ b/screenspace.py
@@ -146,10 +146,11 @@ class _ConsecutiveBuffer:
     """Emit one event only after N consecutive matching sampled frames.
 
     ``push()`` records a matching frame; once ``size`` matches accumulate it
-    returns a single event -- the middle frame's payload, re-stamped with the
-    median timestamp of the run -- and resets. ``reset()`` (called on any
-    non-match) discards a partial run. ``size == 1`` emits on every push, so the
-    default reproduces pre-temporal-coherence behavior exactly.
+    returns a single event -- re-stamped with the median timestamp of the run and
+    carrying the payload of the frame nearest that median -- and resets.
+    ``reset()`` (called on any non-match) discards a partial run. ``size == 1``
+    emits on every push, so the default reproduces pre-temporal-coherence
+    behavior exactly.
     """
 
     def __init__(self, size: int) -> None:
@@ -161,11 +162,34 @@ class _ConsecutiveBuffer:
         self._events.append(event)
         self._timestamps.append(ts)
         if len(self._events) >= self.size:
-            emitted = dict(self._events[len(self._events) // 2])
-            emitted["timestamp"] = statistics.median(self._timestamps)
+            median_ts = statistics.median(self._timestamps)
+            # Pair the median timestamp with the payload of the frame closest to
+            # it. For odd-length runs this is the exact middle frame; for even
+            # lengths (the median is interpolated between two frames) it picks
+            # the nearer real frame instead of an arbitrary upper-middle one.
+            nearest = min(
+                range(len(self._timestamps)),
+                key=lambda i: abs(self._timestamps[i] - median_ts),
+            )
+            emitted = dict(self._events[nearest])
+            emitted["timestamp"] = median_ts
             self.reset()
             return emitted
         return None
+
+    def carry(self, ts: float) -> dict[str, Any] | None:
+        """Extend an active run when a frame is skipped as static.
+
+        A static frame is near-identical to the last processed frame, so a match
+        that was on screen is still there -- the run should continue, not break.
+        Re-pushes the most recent matched event under *ts* (returning an emit if
+        that completes the run). No-op when no run is active (nothing to carry),
+        which keeps ``size == 1`` -- where ``push`` emits and resets every frame
+        -- on its legacy path.
+        """
+        if not self._events:
+            return None
+        return self.push(ts, self._events[-1])
 
     def reset(self) -> None:
         self._events = []
@@ -1352,6 +1376,13 @@ def scan_text(
         if prev_gray[0] is not None:
             diff = float(np.mean(cv2.absdiff(prev_gray[0], gray)))
             if diff < config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD:
+                # Static frame: content (and any active match) is unchanged, so
+                # continue a require_consecutive run rather than break it.
+                emitted = buf.carry(ts)
+                if emitted is not None:
+                    results.append(emitted)
+                    if on_result:
+                        on_result(emitted)
                 if on_progress and total_range > 0:
                     on_progress((ts - start_seconds) / total_range)
                 return None
@@ -1500,6 +1531,13 @@ def scan_numbers(
         if prev_gray[0] is not None:
             diff = float(np.mean(cv2.absdiff(prev_gray[0], gray)))
             if diff < config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD:
+                # Static frame: content (and any active match) is unchanged, so
+                # continue a require_consecutive run rather than break it.
+                emitted = buf.carry(ts)
+                if emitted is not None:
+                    results.append(emitted)
+                    if on_result:
+                        on_result(emitted)
                 if on_progress and total_range > 0:
                     on_progress((ts - start_seconds) / total_range)
                 return None

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -1178,6 +1178,46 @@ class TestScanText:
         assert len(coalesced) == 1
         assert coalesced[0]["timestamp"] == 1.0  # median([0.0, 1.0, 2.0])
 
+    def test_require_consecutive_survives_static_frames(self, monkeypatch):
+        """Static (skipped) frames carry an active run forward instead of starving it.
+
+        The first frame matches and is OCR'd; the next two are identical to it,
+        so the static-frame-skip drops them before OCR. Carry-over keeps the
+        require_consecutive=3 run alive, so one event still emits (the old
+        behavior would have stalled at one push and emitted nothing)."""
+        base = np.full((20, 60, 3), 40, dtype=np.uint8)
+        frames = [base, base.copy(), base.copy()]  # identical → static-skip fires
+
+        reads = {"n": 0}
+
+        class _FakeReader:
+            def readtext(self_inner, _pixels, **_kwargs):
+                reads["n"] += 1
+                return [([(0, 0), (10, 0), (10, 10), (0, 10)], "hello", 0.9)]
+
+        monkeypatch.setattr(
+            screenspace, "_get_ocr_reader", lambda _langs: _FakeReader()
+        )
+        monkeypatch.setattr(screenspace, "_probe_video_meta", lambda p: (30.0, 1.0))
+
+        def fake_scan(video_path, region, interval, callback, **kwargs):
+            for i, frame in enumerate(frames):
+                callback(float(i), frame)
+
+        monkeypatch.setattr(screenspace, "scan_video_frames", fake_scan)
+
+        region = {"x": 0, "y": 0, "w": 60, "h": 20}
+        out = screenspace.scan_text(
+            "/fake.mp4",
+            region,
+            search_string="hello",
+            fuzzy_threshold=0.8,
+            require_consecutive=3,
+        )
+        assert reads["n"] == 1  # frames 2 & 3 were skipped as static (no OCR)
+        assert len(out) == 1
+        assert out[0]["timestamp"] == 1.0  # median([0, 1, 2]) across carried frames
+
 
 class TestConsecutiveBuffer:
     def test_n1_emits_immediately(self):
@@ -1209,6 +1249,39 @@ class TestConsecutiveBuffer:
         # 0 / negative sizes clamp to 1 (passthrough behavior).
         buf = screenspace._ConsecutiveBuffer(0)
         assert buf.push(7.0, {"timestamp": 7.0}) is not None
+
+    def test_carry_continues_active_run(self):
+        # A static (skipped) frame carries the last match forward so the run
+        # still reaches the threshold on stable content.
+        buf = screenspace._ConsecutiveBuffer(3)
+        assert buf.push(0.0, {"timestamp": 0.0, "text_found": "Save"}) is None
+        assert buf.carry(1.0) is None  # static frame #1
+        out = buf.carry(2.0)  # static frame #2 completes the run
+        assert out is not None
+        assert out["text_found"] == "Save"
+        assert out["timestamp"] == 1.0  # median([0, 1, 2])
+
+    def test_carry_noop_when_no_active_run(self):
+        # Nothing to carry before any match has been pushed.
+        buf = screenspace._ConsecutiveBuffer(3)
+        assert buf.carry(5.0) is None
+
+    def test_carry_noop_for_size_one(self):
+        # size==1 emits and resets on every push, so no run is ever active to
+        # carry — keeps the legacy passthrough path unchanged.
+        buf = screenspace._ConsecutiveBuffer(1)
+        assert buf.push(1.0, {"timestamp": 1.0}) is not None
+        assert buf.carry(2.0) is None
+
+    def test_even_size_pairs_median_with_nearest_frame(self):
+        # Even runs interpolate the median between two frames; the payload comes
+        # from the nearer real frame, not an arbitrary upper-middle one.
+        buf = screenspace._ConsecutiveBuffer(2)
+        assert buf.push(0.0, {"timestamp": 0.0, "v": "a"}) is None
+        out = buf.push(4.0, {"timestamp": 4.0, "v": "b"})
+        assert out is not None
+        assert out["timestamp"] == 2.0  # median([0, 4])
+        assert out["v"] in ("a", "b")  # nearest real frame to the median
 
 
 def test_static_skip_uses_config():

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -587,6 +587,18 @@ def _seed_friction_entry(pid="P01", **extra):
     return entry
 
 
+def _join_orchestrator_threads(orch, timeout=2.0):
+    """Wait for all daemon agent threads (and any cascade they spawn) to finish.
+
+    Two passes because a worker can spawn a cascade thread while we are mid-join;
+    the second pass catches it.
+    """
+    for _ in range(2):
+        for key in list(orch._threads):
+            for t in list(orch._threads[key]):
+                t.join(timeout)
+
+
 def test_friction_get_404_when_absent_and_idle(tr_client, _agent_state_clean):
     _seed_friction_entry()
     resp = tr_client.get("/transcripts/api/friction/P01")
@@ -758,3 +770,63 @@ def test_participants_includes_friction_step_state(tr_client):
     assert resp.status_code == 200
     by_id = {p["id"]: p for p in resp.get_json()["participants"]}
     assert by_id["P01"]["agents"]["friction"] == "idle"
+
+
+def test_citations_regenerate_does_not_run_disabled_friction(
+    tr_client, _agent_state_clean, monkeypatch
+):
+    """Regression (H1): a manual single-agent regenerate must not cascade into a
+    disabled sibling. The post-success chain advance is force=False, so with
+    friction off, regenerating citations recomputes only citations."""
+    monkeypatch.setattr(config, "OLLAMA_FRICTION_ENABLED", False)
+    monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
+    # summary + citations present, friction absent — friction is the only empty field.
+    _seed_friction_entry(citations=[{"sentence": "s", "refs": []}])
+
+    friction_ran = threading.Event()
+
+    def cit_stub(snapshot, cancel_event):
+        return [{"sentence": "s2", "refs": []}]  # non-None → commits → cascade fires
+
+    def fr_stub(snapshot, cancel_event):
+        friction_ran.set()
+        return None
+
+    cit_agent = thinking_agents.get_agent("citations")
+    fr_agent = thinking_agents.get_agent("friction")
+    assert cit_agent is not None and fr_agent is not None
+    monkeypatch.setitem(cit_agent, "run", cit_stub)
+    monkeypatch.setitem(fr_agent, "run", fr_stub)
+
+    resp = tr_client.post("/transcripts/api/citations/P01/regenerate")
+    assert resp.status_code == 200
+
+    _join_orchestrator_threads(transcripts_server._orchestrator)
+    assert not friction_ran.is_set(), (
+        "regenerating citations must not trigger the disabled friction agent"
+    )
+    assert "friction" not in transcripts_server._manifest["source_transcripts"]["P01"]
+
+
+def test_summary_regenerate_marks_friction_stale(
+    tr_client, _agent_state_clean, monkeypatch
+):
+    """Regression (M1): regenerating the summary invalidates friction (the new
+    summary feeds the friction prompt), mirroring the summary-edit path."""
+    monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
+    # Don't spawn real agent threads — we only assert the endpoint's synchronous
+    # manifest mutation.
+    monkeypatch.setattr(
+        transcripts_server._orchestrator, "run_chain", lambda *a, **k: None
+    )
+    _seed_friction_entry(
+        citations=[{"sentence": "s", "refs": []}],
+        friction={"stale": False, "moments": []},
+    )
+
+    resp = tr_client.post("/transcripts/api/summary/P01/regenerate")
+    assert resp.status_code == 200
+    entry = transcripts_server._manifest["source_transcripts"]["P01"]
+    assert entry["friction"]["stale"] is True
+    assert entry["summary"] == ""
+    assert "citations" not in entry  # citations invalidated alongside friction

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -558,6 +558,7 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
             return jsonify({"ok": False, "error": "No transcript found"}), 404
         entry["summary"] = ""
         entry.pop("citations", None)
+        _mark_friction_stale(entry)  # the new summary feeds the friction prompt
     _persist_manifest()
     _orchestrator.run_chain(participant, force=True)
     return jsonify({"ok": True, "generating": True})
@@ -1423,9 +1424,13 @@ class AgentOrchestrator:
                 if committed:
                     _persist_manifest()
                     # Chain into the next eligible agent (e.g. summary →
-                    # citations). Propagate *force* so a manual run cascades
-                    # through disabled downstream agents too.
-                    self.run_chain(participant, force=force)
+                    # citations). The auto-advance is always force=False: a manual
+                    # trigger forces only the one agent the user asked for (it ran
+                    # above with its own *force*); downstream agents should still
+                    # respect their enabled config. Otherwise a single-agent
+                    # regenerate (e.g. Citations) would cross-trigger a disabled
+                    # sibling (e.g. Friction), since they share depends_on=["summary"].
+                    self.run_chain(participant, force=False)
             except Exception as exc:
                 utils.warning_print(
                     f"{agent_key} generation failed for {participant}: {exc}"


### PR DESCRIPTION
Remediates issues found in a review of today's commits (#388–#391).

- **transcripts_server**: a manual single-agent regenerate no longer force-cascades into a disabled sibling — with Friction off (the default), "Regenerate Citations" stops silently kicking off a Friction run; and regenerating the summary now marks Friction stale, matching the summary-edit path.
- **screenspace**: a static (skipped) frame now carries an active `require_consecutive` run forward instead of starving it on stable Text/Numbers content, and the even-N coherence buffer pairs the median timestamp with the nearest real frame's payload.
- **transcripts.js**: RAF-throttled the friction segment tooltip with a reciprocal hide guard, and the heatmap toggle no longer renders active-while-disabled before data loads (plus a `friction.py` docstring fix).
- Added regression tests for the cascade, stale-on-regenerate, and static-frame carry-over (1105 pass; ruff + ty clean).