### PR TITLE
fix(screenspace): surface Numbers OCR confidence in Results UI

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3125,6 +3125,7 @@
       if (r.confidence !== undefined) details.appendChild(el("span", "", "Confidence: " + (r.confidence * 100).toFixed(0) + "%"));
     } else if (hit.task.type === "numbers" && r.number_found !== undefined) {
       details.appendChild(el("span", "", "Found: " + r.number_found));
+      if (r.confidence !== undefined) details.appendChild(el("span", "", "Confidence: " + (r.confidence * 100).toFixed(0) + "%"));
     } else if (hit.task.type === "template" && r.best_score !== undefined) {
       details.appendChild(el("span", "", "Score: " + (r.best_score * 100).toFixed(1) + "%"));
       if (r.match_count !== undefined) details.appendChild(el("span", "", "Matches: " + r.match_count));
@@ -6665,7 +6666,7 @@
     }
 
     // Show/hide certainty controls based on whether the tool has confidence scores
-    var hasConf = task && { change: 1, similarity: 1, text: 1, template: 1, scene: 1, flow: 1, multitool: 1, inactivity: 1 }[task.type];
+    var hasConf = task && { change: 1, similarity: 1, text: 1, numbers: 1, template: 1, scene: 1, flow: 1, multitool: 1, inactivity: 1 }[task.type];
     var certWrap = qs("#certaintyCutoffWrap");
     var exclBtn = qs("#excludeNonVisibleBtn");
     if (certWrap) certWrap.classList.toggle("hidden", !hasConf);
@@ -6812,6 +6813,7 @@
         if (task.type === "change") confValue = r.magnitude;
         else if (task.type === "similarity") confValue = r.score;
         else if (task.type === "text") confValue = r.confidence;
+        else if (task.type === "numbers") confValue = r.confidence;
         else if (task.type === "template") confValue = r.best_score;
         else if (task.type === "flow") confValue = Math.min(r.magnitude / 10, 1);
         else if (task.type === "scene") confValue = r.score;
@@ -6855,6 +6857,10 @@
         row.dataset.timestamp = r.timestamp;
         row.appendChild(el("span", "result-timestamp", formatTime(r.timestamp, { decimals: 1 })));
         row.appendChild(el("span", "result-detail", String(r.number_found)));
+        if (r.confidence !== undefined) {
+          row.appendChild(buildConfBar(r.confidence, task.type));
+          row.appendChild(el("span", "result-score", (r.confidence * 100).toFixed(0) + "%"));
+        }
       } else if (task.type === "template") {
         row.dataset.timestamp = r.timestamp;
         row.appendChild(el("span", "result-timestamp", formatTime(r.timestamp, { decimals: 1 })));

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -559,10 +559,10 @@ class TestGenerateEventsFromResults:
 
     def test_numbers_events(self):
         worker, task = self._make_worker_and_task("numbers")
-        raw = [{"timestamp": 15.0, "number_found": 42}]
+        raw = [{"timestamp": 15.0, "number_found": 42, "confidence": 0.42}]
         events = worker._generate_events_from_results(task, raw)
         assert len(events) == 1
-        assert events[0]["confidence"] == 1.0
+        assert events[0]["confidence"] == 0.42
         assert events[0]["metadata"]["value"] == 42
 
     def test_color_events(self):


### PR DESCRIPTION
## Summary
- Add Numbers to the Results-panel confidence path so certainty controls, histogram, cutoff filtering, and confidence bars work like Text.
- Show OCR confidence in Numbers timeline tooltips when present.
- Assert Numbers event generation propagates OCR confidence from raw results.

## Test plan
- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace.py -q`
- [x] `uv run ruff format --check` and `uv run ruff check` on touched Python
- [x] `uv run ty check`
- [ ] Manual: enable `SCREENSPACE_SHOW_CONFIDENCE_HISTOGRAM`, open a completed Numbers task, confirm slider + histogram, cutoff filtering, bulk exclude, and tooltip confidence display