### PR TITLE
fix(transcripts): render gutter cross-reference icons instead of colored blocks

### DIFF
--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -204,8 +204,8 @@ if (document.readyState === "loading") {
 // ---- Mask-image icon helpers ----
 //
 // Apply both `mask-image` and `-webkit-mask-image` to a DOM element. `urlValue`
-// is a CSS url(...) string such as 'url("icons/check.svg")' or
-// 'url("/screenspace/icons/eye.svg")'. The element's `mask-size`,
+// is a CSS url(...) string such as "url('icons/check.svg')" or
+// "url('/screenspace/icons/eye.svg')". The element's `mask-size`,
 // `mask-repeat`, and `background-color: currentColor` should come from a CSS
 // class on the element (see .xref-badge-icon, .cg-icon, .ss-task-icon, etc).
 
@@ -227,9 +227,11 @@ var maskIconStyle = function (urlValue) {
 // (the common relative case). Pages with a different icon route pass their own
 // (e.g. "/screenspace/icons/", "../screenspace/icons/").
 
-// Full CSS url(...) string for an icon basename.
+// Full CSS url(...) string for an icon basename. Single-quoted so the result is
+// safe to embed inside a double-quoted HTML style attribute (e.g.
+// `style="..."`); a double-quoted url() would terminate the attribute early.
 var iconMaskUrl = function (name, basePath) {
-  return 'url("' + (basePath || "icons/") + name + '.svg")';
+  return "url('" + (basePath || "icons/") + name + ".svg')";
 };
 
 // Inline-style string for embedding in HTML strings.


### PR DESCRIPTION
## What & why

The Transcripts gutter cross-reference ("cross-over") badges — shown when a segment overlaps a Screenspace event or a Studio sheet observation — rendered as solid colored blocks with no glyph after the SVG-rendering refactor (#388). That refactor routed the badges through `iconMaskUrl`, which emitted the path in **double quotes** (`url("icons/squares-2x2.svg")`); since `transcripts.js` embeds that string into a double-quoted `style="..."` HTML attribute, the inner `"` closed the attribute early, so `mask-image` never applied and the icon span fell back to its `background-color: currentColor`.

## Fix

`iconMaskUrl` (`assets/web/utils.js`) now emits a **single-quoted** `url('...')`, which is valid CSS and safe inside double-quoted HTML attributes, while remaining valid for the DOM `cssText`/`maskImage` call sites (topnav.js, `applyMaskIcon`) — so this single-source change covers every embedding context. Verified with the full check pipeline (ruff format/lint, ty, pytest all pass); `fix:` change, no VERSION bump.