### PR TITLE
fix(screenspace): harden calibration pins and scoring after review

### DIFF
--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -872,7 +872,7 @@ body[data-frontend="screenspace"] {
 .pin-tray-item--negative { --pin-color: var(--color-pin-negative); }
 
 .pin-tray-item:hover,
-.pin-tray-item.highlighted {
+.pin-tray-item:focus-within {
   box-shadow: var(--shadow-focus);
 }
 
@@ -926,11 +926,12 @@ body[data-frontend="screenspace"] {
   background: color-mix(in srgb, var(--color-bg) 70%, transparent);
   color: var(--color-text-dim);
   cursor: pointer;
-  opacity: 0;
+  opacity: 0.72;
   transition: opacity var(--duration-fast), color var(--duration-fast);
 }
 
-.pin-tray-item:hover .pin-tray-remove {
+.pin-tray-item:hover .pin-tray-remove,
+.pin-tray-remove:focus-visible {
   opacity: 1;
 }
 
@@ -1336,7 +1337,7 @@ body[data-frontend="screenspace"] {
   padding: var(--space-3) 0;
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 #workflowActionRow {
@@ -1828,6 +1829,10 @@ body[data-frontend="screenspace"] {
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
   flex-shrink: 0;
+}
+
+.cal-panel.collapsed .cal-icon {
+  opacity: 0.6;
 }
 
 .cal-label {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1110,7 +1110,11 @@
     var ts = state.currentTimestamp;
     apiPost("api/pins/" + encodeURIComponent(pid), { timestamp: ts, polarity: polarity })
       .then(function (data) {
-        if (!data.ok || pid !== state.selectedParticipant) return;
+        if (!data.ok) {
+          showToast(data.error || "Failed to pin frame");
+          return;
+        }
+        if (pid !== state.selectedParticipant) return;
         state.pins.push(data.pin);
         renderPinTray();
         updatePinButtons();
@@ -1124,7 +1128,10 @@
   function removePin(pinId) {
     apiDelete("api/pins/" + encodeURIComponent(pinId))
       .then(function (data) {
-        if (!data.ok) return;
+        if (!data.ok) {
+          showToast(data.error || "Failed to remove pin");
+          return;
+        }
         state.pins = state.pins.filter(function (p) { return p.id !== pinId; });
         renderPinTray();
         updatePinButtons();
@@ -1141,7 +1148,10 @@
     var next = pin.polarity === "positive" ? "negative" : "positive";
     apiPut("api/pins/" + encodeURIComponent(pinId), { polarity: next })
       .then(function (data) {
-        if (!data.ok || !data.pin) return;
+        if (!data.ok || !data.pin) {
+          showToast(data.error || "Failed to update pin");
+          return;
+        }
         pin.polarity = data.pin.polarity;
         renderPinTray();
         renderTimeline();
@@ -5343,7 +5353,8 @@
     var text = posPass + "/" + posTotal + " positives pass · "
       + negPass + "/" + negTotal + " negatives pass";
     if (na) text += " · " + na + " not evaluable";
-    var pass = posTotal > 0 && posPass === posTotal && negPass === negTotal;
+    var evaluableTotal = posTotal + negTotal;
+    var pass = evaluableTotal > 0 && na === 0 && posPass === posTotal && negPass === negTotal;
     return { text: text, pass: pass };
   }
 
@@ -5511,7 +5522,7 @@
           if (k > 0 && logic) {
             label.appendChild(el("span", "cal-track-logic" + (logic === "NOT" ? " is-not" : ""), logic));
           }
-          var built = _calBuildTrack(rows, stepType, axis, sliderId, label);
+          var built = _calBuildTrack(rows, stepType, axis, sliderId, label, !!sliderId);
           frag.appendChild(built.track);
           if (built.note) notes.push((k + 1) + ". " + built.note);
         })(k);

--- a/cli.py
+++ b/cli.py
@@ -1687,7 +1687,7 @@ def _run_ss_task(args: argparse.Namespace) -> None:
             events,
             stashes=manifest.get("stashes", []),
             per_participant=manifest.get("per_participant", {}),
-            pins=manifest.get("pins", {}),
+            pins=manifest.get("pins") or {},
         )
         worker.stop()
 

--- a/data_export.py
+++ b/data_export.py
@@ -207,6 +207,8 @@ def build_screenspace_pins(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     against (and with what polarity) when reviewing the chosen parameters.
     """
     pins_by_participant = manifest.get("pins", {}) or {}
+    if not isinstance(pins_by_participant, dict):
+        return []
     records: list[dict[str, Any]] = []
     for participant_id, pins in pins_by_participant.items():
         if not isinstance(pins, list):

--- a/screenspace.py
+++ b/screenspace.py
@@ -2764,10 +2764,12 @@ def _score_text_readings(
 def _score_numbers_readings(
     readings: list[Any], params: dict[str, Any]
 ) -> tuple[bool, dict[str, Any]]:
-    """Score numbers OCR readings: best OCR conf of any reading is the scalar.
+    """Score numbers OCR readings by the best condition-matching OCR confidence.
 
-    ``passed`` records the *polarity expectation* — whether a reading clearing
-    min conf also satisfied the operator / target_value / range comparison.
+    ``confidence`` is the calibration scalar for the OCR-confidence slider: it
+    reflects the best reading that satisfies operator / target_value / range,
+    not an unrelated high-confidence number. ``passed`` then applies the current
+    confidence threshold to that matching reading.
     """
     operator = params.get("operator", "gt")
     target_value = params.get("target_value", 0)
@@ -2776,14 +2778,9 @@ def _score_numbers_readings(
     ocr_min_conf = _effective_ocr_confidence_threshold(
         params.get("ocr_confidence_threshold")
     )
-    best_conf = 0.0
     matched_number: float | None = None
     matched_conf = 0.0
     for _, text, conf in readings:
-        if conf > best_conf:
-            best_conf = conf
-        if conf < ocr_min_conf:
-            continue
         cleaned = text.replace(",", "")
         for match in _NUMBERS_RE.findall(cleaned):
             num = float(match)
@@ -2791,10 +2788,10 @@ def _score_numbers_readings(
                 if matched_number is None or conf > matched_conf:
                     matched_number = num
                     matched_conf = conf
-    detail: dict[str, Any] = {"confidence": round(best_conf, 4)}
+    detail: dict[str, Any] = {"confidence": round(matched_conf, 4)}
     if matched_number is not None:
         detail["number_found"] = matched_number
-    return matched_number is not None, detail
+    return matched_number is not None and matched_conf >= ocr_min_conf, detail
 
 
 def run_calibration_ocr(
@@ -3975,6 +3972,13 @@ def save_screenspace_manifest(
                 {k: v for k, v in r.items() if k != "flow_grid"} for r in ct["result"]
             ]
         clean_tasks.append(ct)
+    if pins is None:
+        existing = load_screenspace_manifest()
+        existing_pins = existing.get("pins")
+        pins_payload = existing_pins if isinstance(existing_pins, dict) else {}
+    else:
+        pins_payload = pins
+
     payload = _sanitize_manifest_floats(
         {
             "regions": regions,
@@ -3982,7 +3986,7 @@ def save_screenspace_manifest(
             "events": events or [],
             "stashes": stashes or [],
             "per_participant": per_participant or {},
-            "pins": pins or {},
+            "pins": pins_payload,
         }
     )
     return utils.save_json_manifest(

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -56,6 +56,7 @@ import threading
 import uuid
 from collections import OrderedDict
 from datetime import datetime, timezone
+from numbers import Integral, Real
 from pathlib import Path
 from typing import Any, Callable, TypeGuard, cast
 
@@ -358,6 +359,29 @@ _PIN_POLARITIES = ("positive", "negative")
 _PIN_LABEL_MAX_CHARS = 120
 
 
+def _pin_manifest() -> dict[str, list[dict[str, Any]]]:
+    """Return the manifest's pin map, replacing malformed roots with empty state."""
+    pins = _manifest.get("pins")
+    if isinstance(pins, dict):
+        return pins
+    _manifest["pins"] = {}
+    return _manifest["pins"]
+
+
+def _participant_pin_list(
+    participant_id: str, *, create: bool = False
+) -> list[dict[str, Any]]:
+    """Return a participant's pin list; malformed entries behave like no pins."""
+    pins_by_participant = _pin_manifest()
+    pins = pins_by_participant.get(participant_id)
+    if isinstance(pins, list):
+        return pins
+    if create:
+        pins_by_participant[participant_id] = []
+        return pins_by_participant[participant_id]
+    return []
+
+
 def _annotate_pin_staleness(
     participant_id: str, pins: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
@@ -370,6 +394,8 @@ def _annotate_pin_staleness(
     duration = _participant_video_duration(participant_id)
     out: list[dict[str, Any]] = []
     for pin in pins:
+        if not isinstance(pin, dict):
+            continue
         entry = dict(pin)
         entry["stale"] = duration is not None and pin.get("timestamp", 0.0) > duration
         out.append(entry)
@@ -382,9 +408,11 @@ def _find_pin(pin_id: str) -> tuple[str, list[dict[str, Any]], int] | None:
     Returns ``(participant_id, pin_list, index)`` or ``None``. Caller holds
     ``_manifest_lock``.
     """
-    for participant_id, pins in _manifest.get("pins", {}).items():
+    for participant_id, pins in _pin_manifest().items():
+        if not isinstance(pins, list):
+            continue
         for idx, pin in enumerate(pins):
-            if pin.get("id") == pin_id:
+            if isinstance(pin, dict) and pin.get("id") == pin_id:
                 return participant_id, pins, idx
     return None
 
@@ -397,7 +425,7 @@ def api_pins_list(participant: str) -> FlaskResponse:
             {"ok": False, "error": f"Unknown participant {participant}"}
         ), 404
     with _manifest_lock:
-        pins = copy.deepcopy(_manifest.get("pins", {}).get(participant, []))
+        pins = copy.deepcopy(_participant_pin_list(participant))
     return jsonify(
         {
             "ok": True,
@@ -445,7 +473,7 @@ def api_pins_create(participant: str) -> FlaskResponse:
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     with _manifest_lock:
-        pins = _manifest.setdefault("pins", {}).setdefault(participant, [])
+        pins = _participant_pin_list(participant, create=True)
         if len(pins) >= config.SCREENSPACE_MAX_PINS:
             return jsonify(
                 {
@@ -492,7 +520,7 @@ def api_pins_delete(pin_id: str) -> FlaskResponse:
         participant_id, pins, idx = found
         pins.pop(idx)
         if not pins:
-            _manifest.get("pins", {}).pop(participant_id, None)
+            _pin_manifest().pop(participant_id, None)
         _do_persist(drain_events=False)
     return jsonify({"ok": True})
 
@@ -622,7 +650,8 @@ def api_calibrate() -> FlaskResponse:
     )
     if _is_flask_error_response(validated):
         return validated
-    assert isinstance(validated, tuple) and len(validated) == 6  # success tuple
+    if not (isinstance(validated, tuple) and len(validated) == 6):
+        return jsonify({"ok": False, "error": "Invalid calibration request"}), 400
     (
         task_type,
         participant,
@@ -679,9 +708,13 @@ def api_calibrate() -> FlaskResponse:
             return prepared
         parameters = cast(dict[str, Any], prepared)
 
-    with _manifest_lock:
-        all_pins = copy.deepcopy(_manifest.get("pins", {}).get(participant, []))
     pin_ids = data.get("pin_ids")
+    if pin_ids is not None and not isinstance(pin_ids, list):
+        return jsonify({"ok": False, "error": "pin_ids must be a list"}), 400
+
+    with _manifest_lock:
+        all_pins = copy.deepcopy(_participant_pin_list(participant))
+    all_pins = [p for p in all_pins if isinstance(p, dict)]
     if isinstance(pin_ids, list):
         wanted = set(pin_ids)
         all_pins = [p for p in all_pins if p.get("id") in wanted]
@@ -2328,8 +2361,18 @@ def _validate_scene_references(
 
 def _sanitize_floats(obj: Any) -> Any:
     """Replace non-finite floats (inf, nan) with None for JSON safety."""
-    if isinstance(obj, float) and not math.isfinite(obj):
-        return None
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, Integral):
+        return int(obj)
+    if isinstance(obj, Real):
+        value = float(obj)
+        return value if math.isfinite(value) else None
+    if hasattr(obj, "item") and callable(obj.item):
+        try:
+            return _sanitize_floats(obj.item())
+        except (TypeError, ValueError):
+            pass
     if isinstance(obj, dict):
         return {k: _sanitize_floats(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -2389,7 +2432,7 @@ def _backfill_missing_events(manifest: dict[str, Any]) -> None:
             events,
             stashes=manifest.get("stashes", []),
             per_participant=manifest.get("per_participant", {}),
-            pins=manifest.get("pins", {}),
+            pins=manifest.get("pins") or {},
         )
 
 
@@ -2458,7 +2501,7 @@ def _do_persist(*, drain_events: bool = True) -> None:
         _manifest.get("events", []),
         stashes=_manifest.get("stashes", []),
         per_participant=_manifest.get("per_participant", {}),
-        pins=_manifest.get("pins", {}),
+        pins=_pin_manifest(),
     )
 
 

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -463,6 +463,32 @@ def test_screenspace_pins_builder_no_pins(screenspace_manifest):
     assert data_export.build_screenspace_pins(screenspace_manifest) == []
 
 
+@pytest.mark.parametrize(
+    "pins_value",
+    [
+        None,
+        [],
+        {"P01": {"id": "pin_bad"}},
+        {"P01": [None, "bad", {"id": "pin_ok", "timestamp": 1.0}]},
+    ],
+)
+def test_screenspace_pins_builder_handles_malformed_shapes(pins_value):
+    rows = data_export.build_screenspace_pins({"pins": pins_value})
+    if isinstance(pins_value, dict) and isinstance(pins_value.get("P01"), list):
+        assert rows == [
+            {
+                "participant": "P01",
+                "id": "pin_ok",
+                "timestamp": 1.0,
+                "polarity": "",
+                "label": "",
+                "created_at": "",
+            }
+        ]
+    else:
+        assert rows == []
+
+
 def test_bundle_writer_includes_pins(tmp_path):
     _write_manifest(
         tmp_path, config.SCREENSPACE_MANIFEST_FILENAME, _ss_manifest_with_pins()

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -482,6 +482,44 @@ class TestManifest:
         assert loaded["pins"]["P01"][0]["polarity"] == "positive"
         assert loaded["pins"]["P01"][0]["timestamp"] == 12.5
 
+    def test_omitting_pins_preserves_existing_pins(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        pins = {
+            "P01": [
+                {
+                    "id": "pin_keep",
+                    "timestamp": 12.5,
+                    "polarity": "positive",
+                    "label": "",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+        screenspace.save_screenspace_manifest({}, [], pins=pins)
+        screenspace.save_screenspace_manifest({"new": {"x": 0}}, [])
+        loaded = screenspace.load_screenspace_manifest()
+        assert loaded["pins"] == pins
+
+    def test_explicit_empty_pins_clears_existing_pins(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        screenspace.save_screenspace_manifest(
+            {},
+            [],
+            pins={
+                "P01": [
+                    {
+                        "id": "pin_clear",
+                        "timestamp": 1.0,
+                        "polarity": "positive",
+                        "label": "",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ]
+            },
+        )
+        screenspace.save_screenspace_manifest({}, [], pins={})
+        assert screenspace.load_screenspace_manifest()["pins"] == {}
+
 
 # ---------------------------------------------------------------------------
 # Events
@@ -2191,7 +2229,7 @@ class TestScoreOcrReadings:
         assert detail["fuzzy_ratio"] == 0.0
         assert detail["text_found"] == ""
 
-    def test_numbers_best_conf_is_scalar_operator_is_polarity(self):
+    def test_numbers_matching_conf_is_scalar_operator_is_polarity(self):
         readings = [(None, "5", 0.9), (None, "99", 0.6)]
         params = {
             "operator": "gte",
@@ -2199,8 +2237,8 @@ class TestScoreOcrReadings:
             "ocr_confidence_threshold": 0.5,
         }
         passed, detail = screenspace._score_numbers_readings(readings, params)
-        # Scalar = best OCR conf among ALL readings; operator is the polarity.
-        assert detail["confidence"] == 0.9
+        # Scalar = best OCR confidence among readings satisfying the operator.
+        assert detail["confidence"] == 0.6
         assert passed is True
         assert detail["number_found"] == 99.0
 
@@ -2213,8 +2251,20 @@ class TestScoreOcrReadings:
         }
         passed, detail = screenspace._score_numbers_readings(readings, params)
         assert passed is False
-        assert detail["confidence"] == 0.9
+        assert detail["confidence"] == 0.0
         assert "number_found" not in detail
+
+    def test_numbers_low_confidence_operator_match_still_scores(self):
+        readings = [(None, "99", 0.4)]
+        params = {
+            "operator": "gte",
+            "target_value": 50,
+            "ocr_confidence_threshold": 0.5,
+        }
+        passed, detail = screenspace._score_numbers_readings(readings, params)
+        assert passed is False
+        assert detail["confidence"] == 0.4
+        assert detail["number_found"] == 99.0
 
 
 class TestScoreMultitoolFrame:
@@ -2263,6 +2313,48 @@ class TestScoreMultitoolFrame:
         res = screenspace.score_multitool_frame(red, None, steps)
         assert res["steps"][1]["status"] == "not_evaluable"
         assert res["passed"] is None
+
+    def test_not_step_passes_chain_when_condition_misses(self):
+        red = np.full((100, 100, 3), [0, 0, 255], dtype=np.uint8)
+        steps = [
+            {
+                "type": "color",
+                "region_coords": self.region,
+                "target_color": screenspace.average_color_hsv(red),
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+            },
+            {
+                "type": "color",
+                "logic": "NOT",
+                "region_coords": self.region,
+                "target_color": {"h": 60, "s": 255, "v": 255},
+                "tolerance": {"h": 5, "s": 10, "v": 10},
+            },
+        ]
+        res = screenspace.score_multitool_frame(red, None, steps)
+        assert res["steps"][1]["passed"] is False
+        assert res["passed"] is True
+
+    def test_not_step_fails_chain_when_condition_matches(self):
+        red = np.full((100, 100, 3), [0, 0, 255], dtype=np.uint8)
+        steps = [
+            {
+                "type": "color",
+                "region_coords": self.region,
+                "target_color": screenspace.average_color_hsv(red),
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+            },
+            {
+                "type": "color",
+                "logic": "NOT",
+                "region_coords": self.region,
+                "target_color": screenspace.average_color_hsv(red),
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+            },
+        ]
+        res = screenspace.score_multitool_frame(red, None, steps)
+        assert res["steps"][1]["passed"] is True
+        assert res["passed"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -140,6 +140,20 @@ def test_pins_list_default_empty(client):
     assert data["max_pins"] == config.SCREENSPACE_MAX_PINS
 
 
+def test_pins_list_tolerates_null_manifest_root(client):
+    screenspace_server._manifest["pins"] = None
+    resp = client.get("/screenspace/api/pins/P01")
+    assert resp.status_code == 200
+    assert resp.get_json()["pins"] == []
+
+
+def test_pins_list_tolerates_malformed_participant_value(client):
+    screenspace_server._manifest["pins"] = {"P01": {"id": "pin_bad"}}
+    resp = client.get("/screenspace/api/pins/P01")
+    assert resp.status_code == 200
+    assert resp.get_json()["pins"] == []
+
+
 def test_pins_list_unknown_participant(client):
     resp = client.get("/screenspace/api/pins/PNOPE")
     assert resp.status_code == 404
@@ -161,6 +175,27 @@ def test_pins_create_and_list(client):
     assert listed[0]["label"] == "health red"
     # No source video in the fixture, so staleness is undeterminable -> False.
     assert listed[0]["stale"] is False
+
+
+def test_pins_create_replaces_null_manifest_root(client):
+    screenspace_server._manifest["pins"] = None
+    resp = client.post(
+        "/screenspace/api/pins/P01",
+        json={"timestamp": 1.0, "polarity": "positive"},
+    )
+    assert resp.status_code == 200
+    assert isinstance(screenspace_server._manifest["pins"], dict)
+    assert len(screenspace_server._manifest["pins"]["P01"]) == 1
+
+
+def test_pins_create_truncates_label(client):
+    label = "x" * 200
+    resp = client.post(
+        "/screenspace/api/pins/P01",
+        json={"timestamp": 1.0, "polarity": "positive", "label": label},
+    )
+    assert resp.status_code == 200
+    assert len(resp.get_json()["pin"]["label"]) == 120
 
 
 def test_pins_create_rejects_bad_polarity(client):
@@ -244,6 +279,7 @@ def test_pins_delete(client):
     ).get_json()["pin"]
     assert client.delete(f"/screenspace/api/pins/{pin['id']}").status_code == 200
     assert client.get("/screenspace/api/pins/P01").get_json()["pins"] == []
+    assert "P01" not in screenspace_server._manifest["pins"]
 
 
 def test_pins_delete_unknown_id(client):
@@ -2109,6 +2145,36 @@ def test_calibrate_no_pins(calib_client):
     assert data["pins"] == []
 
 
+def test_calibrate_tolerates_null_pins(calib_client):
+    screenspace_server._manifest["pins"] = None
+    resp = calib_client.post(
+        "/screenspace/api/calibrate",
+        json={
+            "participant": "P01",
+            "tool": "color",
+            "region_ref": {"source": "full_frame"},
+            "parameters": {},
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["pins"] == []
+
+
+def test_calibrate_rejects_non_list_pin_ids(calib_client):
+    resp = calib_client.post(
+        "/screenspace/api/calibrate",
+        json={
+            "participant": "P01",
+            "tool": "color",
+            "region_ref": {"source": "full_frame"},
+            "parameters": {},
+            "pin_ids": "pin_123",
+        },
+    )
+    assert resp.status_code == 400
+    assert "pin_ids" in resp.get_json()["error"]
+
+
 def test_calibrate_change_first_pin_not_evaluable(calib_client, monkeypatch):
     import numpy as np
     import video
@@ -2231,6 +2297,73 @@ def test_calibrate_respects_pin_ids_filter(calib_client, monkeypatch):
     pins = resp.get_json()["pins"]
     assert len(pins) == 1
     assert pins[0]["pin_id"] == keep["id"]
+
+
+def test_calibrate_frame_cache_reuses_decoded_pin_frame(calib_client, monkeypatch):
+    import numpy as np
+    import video
+
+    frame = np.full((100, 100, 3), [0, 0, 255], dtype=np.uint8)
+    calls = []
+
+    def fake_extract(path, ts):
+        calls.append(ts)
+        return frame
+
+    monkeypatch.setattr(video, "extract_frame_at_timestamp", fake_extract)
+    _make_pin(calib_client, 1.0, "positive")
+    body = {
+        "participant": "P01",
+        "tool": "color",
+        "region_ref": {"source": "full_frame"},
+        "parameters": {},
+    }
+    assert calib_client.post("/screenspace/api/calibrate", json=body).status_code == 200
+    assert calib_client.post("/screenspace/api/calibrate", json=body).status_code == 200
+    assert calls == [1.0]
+
+
+def test_calibrate_text_ocr_cache_rescores_threshold(calib_client, monkeypatch):
+    import numpy as np
+    import video
+
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    monkeypatch.setattr(video, "extract_frame_at_timestamp", lambda p, ts: frame)
+    calls = []
+
+    def fake_ocr(frame_arg, region, tool_type, params):
+        calls.append((tool_type, params.get("fuzzy_threshold")))
+        return [(None, "hellx", 0.9)]
+
+    monkeypatch.setattr(screenspace, "run_calibration_ocr", fake_ocr)
+    _make_pin(calib_client, 1.0, "positive")
+    body = {
+        "participant": "P01",
+        "tool": "text",
+        "region_ref": {"source": "full_frame"},
+        "parameters": {
+            "search_string": "hello",
+            "fuzzy_threshold": 0.7,
+            "ocr_confidence_threshold": 0.5,
+        },
+    }
+    first = calib_client.post("/screenspace/api/calibrate", json=body)
+    assert first.status_code == 200
+    assert first.get_json()["pins"][0]["passed"] is True
+    body["parameters"]["fuzzy_threshold"] = 0.9
+    second = calib_client.post("/screenspace/api/calibrate", json=body)
+    assert second.status_code == 200
+    assert second.get_json()["pins"][0]["passed"] is False
+    assert calls == [("text", 0.7)]
+
+
+def test_sanitize_floats_handles_numpy_scalars():
+    import numpy as np
+
+    out = screenspace_server._sanitize_floats(
+        {"ok": np.bool_(True), "score": np.float32("nan"), "detail": {"n": np.int64(3)}}
+    )
+    assert out == {"ok": True, "score": None, "detail": {"n": 3}}
 
 
 def test_calibrate_caps_at_max_pins(calib_client, monkeypatch):

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -260,6 +260,7 @@ def test_load_screenspace_events_for_viewer_caches_by_mtime(tmp_path, monkeypatc
     assert len(load_calls) == 1
 
     # Rewriting the manifest bumps its mtime and invalidates the cache.
+    # Pass pins explicitly so save does not read the manifest (this test counts loads).
     screenspace.save_screenspace_manifest(
         {},
         [],
@@ -273,6 +274,7 @@ def test_load_screenspace_events_for_viewer_caches_by_mtime(tmp_path, monkeypatc
                 "excluded": False,
             }
         ],
+        pins={},
     )
     manifest_path = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
     st = manifest_path.stat()


### PR DESCRIPTION
## Summary
- Harden pin manifest access so `pins: null` and malformed participant entries do not crash pin or calibration routes.
- Fix number OCR calibration scoring, tighten `/api/calibrate` validation/sanitization, and preserve pins when manifest saves omit the `pins` argument.
- Surface pin API failures in the UI, improve workflow panel scrolling, and add focused regression coverage.

## Test plan
- [x] `uv run python -m pytest tests/test_screenspace_api.py tests/test_screenspace.py tests/test_data_export.py tests/test_cli_screenspace_args.py` (395 passed)
- [x] `uv run ruff format --check`, `uv run ruff check`, `uv run ty check`
- [ ] Manual browser check: pin CRUD error toasts, calibration green state with not-evaluable pins, multitool Apply-suggest, workflow panel scrolling