### PR TITLE
docs: add PR template and contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--
+Title: type(scope): imperative summary   e.g. feat(screenspace): add scene boundary detector
+Keep this tight. Drop a section that adds nothing. Delete these comments before submitting.
+Guidelines: agents/CONTRIBUTING.md
+-->
+
+## Summary
+
+<!-- What changed and why, in 1–2 sentences. One bullet per part if there are several. -->
+
+## Test plan
+
+<!-- [x] automated checks you ran  ·  [ ] manual steps still needed. Note anything unverified. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Always use `uv run` instead of `python`. Use `uv add` to add dependencies.
 @agents/ARCHITECTURE.md — module roles and subsystem launch notes.
 @agents/PERFORMANCE.md — I/O, parallelism, and hot-loop patterns.
 @agents/CODE-REVIEW.md — recurring frontend, backend, ty, and integration checks.
+@agents/CONTRIBUTING.md — PR/commit conventions and the pre-merge checklist.
 @agents/skills/README.md — development and CLI skill procedures.
 
 ## Key data structures

--- a/agents/CONTRIBUTING.md
+++ b/agents/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Pull requests
+
+How we write PRs and commits — for agents and humans. Aim for **minimal, structured, scannable**.
+The PR body lives in [.github/PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md); agents
+mirror it when passing `--body` to `gh pr create`.
+
+## Title
+
+`type(scope): imperative description`
+
+- **type** — one of `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `ci`, `build`, `style`.
+- **scope** (optional) — the subsystem: `screenspace`, `transcripts`, `studio`, `web`, `server`,
+  `viewer`, `files`, … Lowercase and singular. Omit for cross-cutting changes.
+- Imperative mood ("add", not "added"), no trailing period, ≤ ~70 chars.
+- GitHub appends `(#NNN)` on squash-merge — don't hand-add the PR number.
+
+## Body
+
+Two sections, each kept only if it earns its place:
+
+- **Summary** — what changed and *why*, in 1–2 sentences. Add one bullet per part only when there
+  are several distinct parts. Backtick paths, endpoints, and config keys.
+- **Test plan** — `[x]` for automated checks you ran, `[ ]` for manual steps still needed. Be
+  honest about what isn't verified (e.g. "⚠️ UI not browser-checked").
+
+Cut anything that doesn't help a reviewer: no Motivation/Solution/Alternatives scaffolding, and
+don't restate the diff in prose.
+
+## Commits
+
+Commit subjects use the same `type(scope): imperative description` rules as PR titles (above) —
+on squash-merge the PR title becomes the commit subject and GitHub appends `(#NNN)`. Add a body
+for non-trivial changes (bullet the notable changes; flag regressions or gotchas); keep simple
+fixes to a single line. The `type` also drives versioning: `feat:` bumps the patch in
+[build/VERSION](../build/VERSION), others don't — see [skills/bump/SKILL.md](skills/bump/SKILL.md).
+
+## Before opening
+
+- `/check` is green — ruff format + lint, ty, full test suite. See [skills/check/SKILL.md](skills/check/SKILL.md).
+- `feat:` PRs bump the patch in [build/VERSION](../build/VERSION). See [skills/bump/SKILL.md](skills/bump/SKILL.md).
+- Self-review against [CODE-REVIEW.md](CODE-REVIEW.md).


### PR DESCRIPTION
## Summary

Adds a minimal `.github/PULL_REQUEST_TEMPLATE.md` (just `Summary` + `Test plan`) that GitHub auto-loads into new PRs, plus `agents/CONTRIBUTING.md` documenting the PR/commit title and body conventions and the pre-merge checklist, cross-linked to the existing check, bump, and code-review docs. `AGENTS.md` registers the new doc under "Other files".

## Test plan

- [x] `uv run ruff format --check` · `uv run ruff check` — pass
- [ ] Docs-only (no Python touched), so the pytest suite was not run
- [ ] Manual: confirm GitHub pre-fills the template body when opening a new PR