### PR TITLE
fix(transcripts): auto-refresh from transcription to summary step

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1686,6 +1686,9 @@
     var empty = qs("#transcriptEmpty");
     state.editingTextEl = null;
     _cachedSegmentRows = null;
+    // We're rendering the finalized transcript — drop any queued streaming
+    // indicator so a paused-tab RAF can't re-insert it over the real segments.
+    _cancelStreamingIndicator();
 
     if (state.segments.length === 0) {
       container.innerHTML = "";
@@ -1807,6 +1810,19 @@
 
   var _streamIndicatorRaf = null;
   var _streamIndicatorPending = null;
+
+  // Cancel a queued streaming-indicator insert. requestAnimationFrame callbacks
+  // are paused while the tab is backgrounded, so a RAF scheduled during the last
+  // streaming poll can outlive the transcript being finalized and re-insert a
+  // stale "Transcribing… X%" row when the user returns. Call this whenever the
+  // finalized transcript replaces the streaming view.
+  function _cancelStreamingIndicator() {
+    if (_streamIndicatorRaf) {
+      cancelAnimationFrame(_streamIndicatorRaf);
+      _streamIndicatorRaf = null;
+    }
+    _streamIndicatorPending = null;
+  }
 
   function _updateStreamingIndicator(container, progress) {
     _streamIndicatorPending = { container: container, progress: progress };
@@ -3913,6 +3929,11 @@
   }
 
   var _refreshedCompletedPids = {};
+  // After a whisper task flips to "completed", keep the main poll loop alive
+  // for a few cycles so the summary "Generating…" state surfaces even if the
+  // next /api/participants or /api/summary response races the in-flight slot.
+  var _postCompletionGrace = 0;
+  var POST_COMPLETION_GRACE_CYCLES = 4; // ~12s at POLL_INTERVAL=3000ms
 
   function _anyAgentActive() {
     for (var i = 0; i < state.participants.length; i++) {
@@ -3920,6 +3941,20 @@
       if (ag && (ag.summary === "running" || ag.citations === "running" || ag.friction === "running")) return true;
     }
     return false;
+  }
+
+  // During the post-completion grace window an agent may register as running a
+  // cycle or two after the whisper task completes. Re-load the selected
+  // participant's summary so renderSummaryGenerating()/_startSummaryPoll fire
+  // once the backend reports it generating; also refresh friction when its dep
+  // is met. Guarded so it won't stomp an already-armed/rendered panel.
+  function _rearmSelectedAgentPanels() {
+    var pid = state.selectedParticipant;
+    if (!pid) return;
+    var p = _currentParticipant();
+    var summaryRunning = !!(p && p.agents && p.agents.summary === "running");
+    if (summaryRunning && !_summaryPollTimer && !state.summaryText) loadSummary(pid);
+    if (!state.frictionData && !state.frictionGenerating && _frictionDepMet()) loadFriction(pid);
   }
 
   // Called from pill agent onStart/onStop after the API POST resolves.
@@ -3974,8 +4009,14 @@
       // Thinking-agents (summary → citations) are spawned on whisper completion
       // and on server startup, so we always refresh after anything completes
       // or if any agent is currently running on any pill.
-      var needsRefresh = newlyCompleted.length > 0 || _anyAgentActive();
+      // Refresh during the grace window too, so participants are re-fetched each
+      // cycle until the summary agent registers as running (or grace expires).
+      var needsRefresh =
+        newlyCompleted.length > 0 || _anyAgentActive() || _postCompletionGrace > 0;
       if (newlyCompleted.length > 0) {
+        // Re-arm on every fresh completion so a multi-participant queue keeps
+        // extending the grace window.
+        _postCompletionGrace = POST_COMPLETION_GRACE_CYCLES;
         _streamingMarks = {};
         _streamingMarksLoaded = false;
         _bumpStreamingMarksVersion();
@@ -3988,17 +4029,18 @@
             loadTranscript(state.selectedParticipant);
             loadSummary(state.selectedParticipant);
             loadFriction(state.selectedParticipant);
-          } else if (_anyAgentActive() && state.selectedParticipant &&
-              !state.frictionData && _frictionDepMet()) {
+          } else if (state.selectedParticipant) {
             // Summary/citations/friction may be auto-chaining server-side after
-            // an earlier completion; refresh friction so an auto-run result
-            // surfaces without a manual poll.
-            loadFriction(state.selectedParticipant);
+            // an earlier completion, or registering during the grace window;
+            // re-arm the selected participant's panels so the running state
+            // surfaces without a manual reload.
+            _rearmSelectedAgentPanels();
           }
           updateStatusIndicator();
           // Agents typically kick in right after whisper completes; keep the
-          // poll alive so dot transitions (running → done → next) are seen.
-          if (_anyAgentActive()) startPolling();
+          // poll alive across the grace window so dot transitions (running →
+          // done → next) are seen even before the agent registers as running.
+          if (_anyAgentActive() || _postCompletionGrace > 0) startPolling();
           else if (!hasActive) {
             stopPolling();
             _refreshedCompletedPids = {};
@@ -4006,7 +4048,7 @@
         });
       }
 
-      if (hasActive || _anyAgentActive()) {
+      if (hasActive || _anyAgentActive() || _postCompletionGrace > 0) {
         startPolling();
       } else if (!needsRefresh) {
         stopPolling();
@@ -4017,6 +4059,10 @@
         refreshTranscriptionModelHintOnce();
       }
       _hadActiveTranscriptionLastPoll = hasActive;
+
+      // Count down the grace window at the end so the current cycle still
+      // counts as "in grace" for the decisions above.
+      if (_postCompletionGrace > 0) _postCompletionGrace--;
 
       renderPills();
     });

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -830,3 +830,70 @@ def test_summary_regenerate_marks_friction_stale(
     assert entry["friction"]["stale"] is True
     assert entry["summary"] == ""
     assert "citations" not in entry  # citations invalidated alongside friction
+
+
+def test_on_task_complete_registers_summary_before_disk_write(
+    tr_client, _agent_state_clean, monkeypatch
+):
+    """Regression: when whisper finishes, the summary agent must read as
+    in-flight (the UI's "generating" state) *before* the manifest disk write
+    runs — not only after it. Otherwise the frontend can observe the task as
+    completed with no agent running and stop polling until a manual reload.
+    """
+    monkeypatch.setattr(config, "OLLAMA_SUMMARY_ENABLED", True)
+
+    pid = "P01"
+    completed_task = {
+        "id": "tr_x",
+        "participant": pid,
+        "status": transcripts.TASK_STATUS_COMPLETED,
+        "result": {
+            "segments": [{"id": f"{pid}:0", "start": 0.0, "end": 1.0, "text": "hi"}],
+            "language": "en",
+            "model": "m",
+            "source_file": "study_P01.mp4",
+            "transcribed_at": "2026-06-18T00:00:00Z",
+        },
+    }
+
+    class _FakeWorker:
+        def get_all_tasks(self):
+            return [dict(completed_task)]
+
+    monkeypatch.setattr(transcripts_server, "_worker", _FakeWorker())
+
+    # When the (mocked) disk write runs, the summary agent must already be
+    # registered as in-flight. This assertion fires while persist runs.
+    persisted = {"flag": False}
+
+    def _spy_save(*args, **kwargs):
+        assert transcripts_server._orchestrator.is_generating(pid, "summary"), (
+            "summary must be in-flight before the manifest disk write"
+        )
+        persisted["flag"] = True
+        return None  # avoid touching disk
+
+    monkeypatch.setattr(transcripts, "save_transcripts_manifest", _spy_save)
+
+    # Block the summary agent so its in-flight slot stays claimed while we assert.
+    started = threading.Event()
+    release = threading.Event()
+
+    def _blocking_summary(snapshot, cancel_event):
+        started.set()
+        release.wait(2.0)
+        return None  # don't commit/chain; the finally{} block releases the slot
+
+    summary_agent = thinking_agents.get_agent("summary")
+    assert summary_agent is not None
+    monkeypatch.setitem(summary_agent, "run", _blocking_summary)
+
+    try:
+        transcripts_server._on_task_complete()
+
+        assert started.wait(2.0), "summary agent thread did not start"
+        assert transcripts_server._orchestrator.is_generating(pid, "summary")
+        assert persisted["flag"], "manifest persist did not run"
+    finally:
+        release.set()
+        _join_orchestrator_threads(transcripts_server._orchestrator)

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1217,22 +1217,29 @@ def _persist_manifest() -> None:
         _do_persist()
 
 
+def _merge_completed_results_locked() -> None:
+    """Merge completed task results into the in-memory manifest.
+
+    Caller must hold _manifest_lock. Merges (not replaces) so that extra keys
+    like "summary" added by other threads are preserved. Kept separate from the
+    disk write so callers can register the thinking-agent chain off the freshly
+    merged segments *before* the (slower) persist.
+    """
+    if not _worker:
+        return
+    for task in _worker.get_all_tasks():
+        if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get("result"):
+            pid = task["participant"]
+            src = _manifest.setdefault("source_transcripts", {})
+            existing = src.get(pid, {})
+            existing.update(task["result"])
+            src[pid] = existing
+    _manifest["tasks"] = _worker.get_all_tasks()
+
+
 def _do_persist() -> None:
     """Persist manifest to disk - caller must hold _manifest_lock."""
-    # Collect completed task results into source_transcripts (merge, not replace,
-    # so that extra keys like "summary" added by other threads are preserved)
-    if _worker:
-        for task in _worker.get_all_tasks():
-            if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get(
-                "result"
-            ):
-                pid = task["participant"]
-                src = _manifest.setdefault("source_transcripts", {})
-                existing = src.get(pid, {})
-                existing.update(task["result"])
-                src[pid] = existing
-        _manifest["tasks"] = _worker.get_all_tasks()
-
+    _merge_completed_results_locked()
     transcripts.save_transcripts_manifest(
         _manifest.get("source_transcripts", {}),
         _manifest.get("corrections", []),
@@ -1244,24 +1251,33 @@ def _do_persist() -> None:
 
 
 def _on_task_complete() -> None:
-    """Persist manifest, then trigger the thinking-agent chain for newly
-    completed participants (those without a summary yet)."""
+    """Merge completed results into memory, start the thinking-agent chain for
+    newly completed participants, then persist to disk.
+
+    Ordering matters: run_chain registers the summary agent in _in_flight (which
+    drives the UI's "generating" state) *before* the slow disk write, shrinking
+    the window where a task reads as completed but no agent reads as running.
+    """
     newly_completed: list[str] = []
-    if _worker:
-        for task in _worker.get_all_tasks():
-            if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get(
-                "result"
-            ):
-                pid = task["participant"]
-                with _manifest_lock:
-                    existing = _manifest.get("source_transcripts", {}).get(pid, {})
-                    if not existing.get("summary"):
+    with _manifest_lock:
+        # Merge first so next_eligible() sees the freshly completed segments.
+        _merge_completed_results_locked()
+        src = _manifest.get("source_transcripts", {})
+        if _worker:
+            for task in _worker.get_all_tasks():
+                if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get(
+                    "result"
+                ):
+                    pid = task["participant"]
+                    if not src.get(pid, {}).get("summary"):
                         newly_completed.append(pid)
 
-    _persist_manifest()
-
-    for pid in newly_completed:
+    # run_chain -> next_eligible/run_agent re-acquire _manifest_lock, so this
+    # must run OUTSIDE the block above (the lock is non-reentrant).
+    for pid in dict.fromkeys(newly_completed):
         _orchestrator.run_chain(pid)
+
+    _persist_manifest()
 
 
 def _agent_enabled(agent: thinking_agents.Agent) -> bool:


### PR DESCRIPTION
## Summary

The Transcripts UI stayed stuck near the end of transcription and never showed the summary step until a manual reload, caused by a race between a whisper task flipping to `completed` and the summary agent registering as in-flight. This keeps the main poll loop alive for a short grace window after completion (re-arming the selected participant's summary/friction panels once an agent registers), reorders the backend so the thinking-agent chain registers *before* the manifest disk write, and clears a stale `Transcribing… X%` indicator that a paused-tab `requestAnimationFrame` could re-insert over the finalized transcript.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check`, and full `pytest` suite all green
- [x] Added regression test asserting the summary agent is in-flight before the manifest disk write (verified it fails on the old ordering)
- [ ] ⚠️ UI not browser-verified: confirm the summary shows "Generating…" with no manual reload, and that the stale indicator is gone after backgrounding the tab during completion