### PR TITLE
refactor(studio): unify intake cards onto the artifact/reel card design

### DIFF
--- a/assets/web/primitives.css
+++ b/assets/web/primitives.css
@@ -8,8 +8,6 @@
  *   .participant-pill     monospace participant toggle
  *   .density-timeline     SVG bars with tick labels + optional marker
  *   .spark-bars           flex bar chart, hue-driven
- *   .clip-card            16/10 thumb + caption (Screenspace Intake source events)
- *   .transcript-card      same anatomy with timeRange + clamped text (Transcript Intake)
  *   .cg-btn               base button: ghost / solid / bare; sm / md / lg
  *   .skeleton-grid        responsive skeleton row layout (pair with .skeleton cells)
  *
@@ -184,163 +182,6 @@
   flex: 1 1 0;
   min-height: 2px;
   border-radius: 1px;
-}
-
-/* ---- ClipCard / TranscriptCard ---- */
-
-.clip-card,
-.transcript-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  width: 180px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-  cursor: grab;
-  user-select: none;
-  transition: border-color var(--duration-instant) ease-out;
-}
-.clip-card:hover,
-.transcript-card:hover {
-  border-color: var(--border-strong);
-}
-.clip-card:active,
-.transcript-card:active {
-  cursor: grabbing;
-}
-.clip-card.size-sm { width: 120px; }
-.clip-card.size-md { width: 150px; }
-.clip-card.size-lg { width: 180px; }
-.transcript-card { width: 200px; }
-
-.clip-card-thumb,
-.transcript-card-thumb {
-  position: relative;
-  aspect-ratio: 16 / 10;
-  background: var(--cg-card-thumb-bg, radial-gradient(circle at 30% 40%, oklch(0.4 0.12 220), oklch(0.18 0.05 220)));
-  overflow: hidden;
-}
-.clip-card-thumb::after,
-.transcript-card-thumb::after {
-  /* Subtle 1px noise overlay so the gradient does not look pure. */
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.015) 0 1px, transparent 1px 2px),
-                    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.02) 0 1px, transparent 1px 2px);
-  pointer-events: none;
-}
-.clip-card-thumb img,
-.transcript-card-thumb img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.clip-card-dot {
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  width: 6px;
-  height: 6px;
-  border-radius: var(--radius-full);
-  background: var(--cg-card-hue, oklch(0.7 0.16 220));
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.45);
-  z-index: 2;
-  pointer-events: none;
-}
-
-/* Duration badge on the thumb. Sized to match `.queue-card-duration` so
- * intake cards and bottom-strip cards read at the same scale. Participant
- * is rendered in the caption now (see .clip-card-participant), not as a
- * thumbnail badge. */
-.clip-card-pill-br {
-  position: absolute;
-  bottom: 3px;
-  right: 3px;
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 4px;
-  background: rgba(0, 0, 0, 0.7);
-  color: var(--accent-fg);
-  font-family: var(--font-mono);
-  font-feature-settings: "tnum";
-  font-size: var(--text-xs, 11px);
-  line-height: 1.3;
-  border-radius: var(--radius-sm, 3px);
-  z-index: 2;
-  pointer-events: none;
-}
-
-.clip-card-caption,
-.transcript-card-caption {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 6px 8px;
-  font-size: 11px;
-  color: var(--fg);
-}
-.transcript-card-caption {
-  padding: 7px 9px;
-  gap: 3px;
-}
-.clip-card-meta-row,
-.transcript-card-range-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-.clip-card-participant,
-.transcript-card-participant {
-  font-feature-settings: "tnum";
-  font-size: 10px;
-  color: var(--fg-faint);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-.clip-card-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--font-sans);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--cg-card-hue, var(--fg-muted));
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-.clip-card-text {
-  font-size: 11px;
-  color: var(--fg-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.transcript-card-range {
-  font-family: var(--font-mono);
-  font-feature-settings: "tnum";
-  font-size: 10px;
-  color: var(--fg-faint);
-}
-.transcript-card-text {
-  font-size: 12px;
-  line-height: 1.35;
-  color: var(--fg);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
 /* ---- Btn ---- */
@@ -735,8 +576,6 @@
 @media (prefers-reduced-motion: reduce) {
   .filter-chip,
   .participant-pill,
-  .clip-card,
-  .transcript-card,
   .cg-btn,
   .cg-swim-event,
   .cg-swim-cluster-band {

--- a/assets/web/primitives.js
+++ b/assets/web/primitives.js
@@ -12,9 +12,8 @@
  *
  * Surface (window.ClipgenPrimitives):
  *   createFilterChip, createParticipantPill, createDensityTimeline,
- *   createSparkBars, createClipCard, createTranscriptCard, createBtn,
- *   createSwimLane, createKpiCard, createCoverageMatrix,
- *   setButtonProgress
+ *   createSparkBars, createBtn, createSwimLane, createKpiCard,
+ *   createCoverageMatrix, setButtonProgress
  */
 
 (function (global) {
@@ -236,148 +235,6 @@
       wrap.appendChild(bar);
     });
     return wrap;
-  }
-
-  // ---- Card primitives ----
-
-  function applyThumbHue(thumb, hue) {
-    thumb.style.setProperty(
-      "--cg-card-thumb-bg",
-      "radial-gradient(circle at 30% 40%, " + fmtHue(hue, 0.4, 0.12) + ", " + fmtHue(hue, 0.18, 0.05) + ")"
-    );
-  }
-
-  function setThumbImage(thumb, src) {
-    if (!src) return null;
-    var img = document.createElement("img");
-    img.src = src;
-    img.alt = "";
-    img.draggable = false;
-    img.addEventListener("error", function () {
-      // Drop the broken <img> so the gradient bg shows through cleanly.
-      if (img.parentNode) img.parentNode.removeChild(img);
-    });
-    thumb.appendChild(img);
-    return img;
-  }
-
-  function makePill(text, side) {
-    var pill = document.createElement("span");
-    pill.className = "clip-card-pill-" + side;
-    pill.textContent = text;
-    return pill;
-  }
-
-  function buildCardBase(opts, kind) {
-    opts = opts || {};
-    var card = document.createElement("div");
-    card.className = kind === "transcript" ? "transcript-card" : "clip-card";
-    if (kind === "clip" && opts.size) card.classList.add("size-" + opts.size);
-    card.setAttribute("draggable", "true");
-
-    var hue = resolveHue(opts.label, opts.hue);
-    // `opts.color` (CSS color string) overrides the oklch(hue) path so the
-    // hue dot + label colour can pin to the canonical `--color-task-*`
-    // tokens. The thumb backdrop still uses the numeric hue (the fallback
-    // gradient blends across multiple hue stops, which we don't try to
-    // reconstruct from a single token).
-    card.style.setProperty("--cg-card-hue", opts.color || fmtHue(hue));
-
-    var thumb = document.createElement("div");
-    thumb.className = kind === "transcript" ? "transcript-card-thumb" : "clip-card-thumb";
-    applyThumbHue(thumb, hue);
-    card.appendChild(thumb);
-    if (opts.thumbSrc) setThumbImage(thumb, opts.thumbSrc);
-
-    var dot = document.createElement("span");
-    dot.className = "clip-card-dot";
-    thumb.appendChild(dot);
-
-    // Participant moved into the caption (see createClipCard /
-    // createTranscriptCard). Only the duration badge remains on the thumb.
-    if (opts.duration) thumb.appendChild(makePill(opts.duration, "br"));
-
-    setDataset(card, opts.dataset);
-
-    if (typeof opts.onDragStart === "function") {
-      card.addEventListener("dragstart", opts.onDragStart);
-    }
-    if (typeof opts.onClick === "function") {
-      card.addEventListener("click", opts.onClick);
-    }
-    if (typeof opts.onMouseEnter === "function") {
-      card.addEventListener("mouseenter", opts.onMouseEnter);
-    }
-    if (typeof opts.onMouseLeave === "function") {
-      card.addEventListener("mouseleave", opts.onMouseLeave);
-    }
-
-    return { card: card, thumb: thumb };
-  }
-
-  function createClipCard(opts) {
-    var built = buildCardBase(opts, "clip");
-    var caption = document.createElement("div");
-    caption.className = "clip-card-caption";
-
-    if (opts.participant || opts.label) {
-      var topRow = document.createElement("div");
-      topRow.className = "clip-card-meta-row";
-      if (opts.participant) {
-        var pid = document.createElement("span");
-        pid.className = "clip-card-participant cg-mono";
-        pid.textContent = opts.participant;
-        topRow.appendChild(pid);
-      }
-      if (opts.label) {
-        var labelEl = document.createElement("span");
-        labelEl.className = "clip-card-label";
-        labelEl.textContent = opts.label;
-        topRow.appendChild(labelEl);
-      }
-      caption.appendChild(topRow);
-    }
-    if (opts.caption) {
-      var textEl = document.createElement("span");
-      textEl.className = "clip-card-text";
-      textEl.textContent = opts.caption;
-      textEl.title = opts.caption;
-      caption.appendChild(textEl);
-    }
-    built.card.appendChild(caption);
-    return built.card;
-  }
-
-  function createTranscriptCard(opts) {
-    var built = buildCardBase(opts, "transcript");
-    var caption = document.createElement("div");
-    caption.className = "transcript-card-caption";
-
-    if (opts.participant || opts.timeRange) {
-      var rangeRow = document.createElement("div");
-      rangeRow.className = "transcript-card-range-row";
-      if (opts.participant) {
-        var pid = document.createElement("span");
-        pid.className = "transcript-card-participant cg-mono";
-        pid.textContent = opts.participant;
-        rangeRow.appendChild(pid);
-      }
-      if (opts.timeRange) {
-        var range = document.createElement("span");
-        range.className = "transcript-card-range cg-mono";
-        range.textContent = opts.timeRange;
-        rangeRow.appendChild(range);
-      }
-      caption.appendChild(rangeRow);
-    }
-    if (opts.text) {
-      var text = document.createElement("span");
-      text.className = "transcript-card-text";
-      text.textContent = opts.text;
-      caption.appendChild(text);
-    }
-    built.card.appendChild(caption);
-    return built.card;
   }
 
   // ---- SwimLane ----
@@ -885,8 +742,6 @@
     createParticipantPill: createParticipantPill,
     createDensityTimeline: createDensityTimeline,
     createSparkBars: createSparkBars,
-    createClipCard: createClipCard,
-    createTranscriptCard: createTranscriptCard,
     createBtn: createBtn,
     createSwimLane: createSwimLane,
     createKpiCard: createKpiCard,

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1381,6 +1381,7 @@ body.dragging #sheetMain {
 
 .queue-card {
   flex-shrink: 0;
+  width: 150px;
   border: 1px solid var(--color-border);
   border-radius: calc(var(--radius) - 2px);
   background: var(--color-surface);
@@ -2604,9 +2605,7 @@ html[data-theme="dark"] .log-panel {
   align-content: flex-start;
 }
 
-.queue-card.intake-highlight,
-.clip-card.intake-highlight,
-.transcript-card.intake-highlight {
+.queue-card.intake-highlight {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent);
 }
@@ -2627,16 +2626,6 @@ html[data-theme="dark"] .log-panel {
 .intake-density-host {
   padding: var(--space-2) var(--space-3) 0;
   margin-bottom: var(--space-3);
-}
-
-.intake-card-det-dot {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 8px;
-  height: 8px;
-  border-radius: var(--radius-full);
-  z-index: 1;
 }
 
 /* Intake filters — matches `.convergence-filters` so the second toolbar row
@@ -2697,8 +2686,53 @@ html[data-theme="dark"] .log-panel {
   display: block;
 }
 
-.queue-card-intake .queue-card-ref {
+/* Intake-area cards reuse the .queue-card shell but keep a richer, color-tinted
+ * caption (participant + type [+ transcript snippet]). Scoped to
+ * .intake-queue-card so intake-*sourced* artifact/reel cards (.queue-card-intake)
+ * keep their single-line ref meta. */
+.intake-queue-card .queue-card-meta {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+}
+.queue-card-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.queue-card-participant {
+  font-family: var(--font-mono);
+  font-feature-settings: "tnum";
   font-size: var(--text-xs);
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.queue-card-type {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cg-card-hue, var(--fg-muted));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.queue-card-time {
+  font-family: var(--font-mono);
+  font-feature-settings: "tnum";
+  font-size: var(--text-xs);
+  color: var(--fg-faint);
+  white-space: nowrap;
+}
+.queue-card-text {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 /* Transcript Intake */
@@ -2710,31 +2744,6 @@ html[data-theme="dark"] .log-panel {
   gap: 4px;
   cursor: pointer;
   color: var(--color-text-dim);
-}
-
-.tr-intake-queue-card .queue-card-thumb {
-  background: var(--color-surface-alt);
-  min-height: 36px;
-}
-
-.tr-intake-card-category-dot {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 10px;
-  height: 10px;
-  border-radius: var(--radius-full);
-  border: 1px solid rgba(255, 255, 255, 0.5);
-}
-
-.tr-intake-card-text {
-  font-size: var(--text-xs);
-  color: var(--color-text-dim);
-  line-height: 1.3;
-  max-height: 2.6em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
 }
 
 /* Cross-reference badges on intake cards */
@@ -2760,9 +2769,7 @@ html[data-theme="dark"] .log-panel {
   margin-left: -10px;
 }
 
-.queue-card:hover .xref-badge-stack .xref-badge + .xref-badge,
-.clip-card:hover .xref-badge-stack .xref-badge + .xref-badge,
-.transcript-card:hover .xref-badge-stack .xref-badge + .xref-badge {
+.queue-card:hover .xref-badge-stack .xref-badge + .xref-badge {
   margin-left: 3px;
 }
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2001,7 +2001,7 @@
     var n = segments.length;
     for (var i = 0; i < n; i++) {
       var seg = segments[i];
-      var card = el("div", "queue-card clip-card size-md cell-drag-ghost-card");
+      var card = el("div", "queue-card cell-drag-ghost-card");
       card.style.setProperty("--i", i);
 
       var thumb = el("div", "queue-card-thumb");
@@ -2339,7 +2339,7 @@
 
       var card = el(
         "div",
-        "queue-card clip-card size-md" + (isIntake ? " queue-card-intake" : ""),
+        "queue-card" + (isIntake ? " queue-card-intake" : ""),
       );
       card.setAttribute("data-participant", item.participant);
       card.setAttribute("data-row", isIntake ? "" : item.row);
@@ -2472,7 +2472,7 @@
 
       var card = el(
         "div",
-        "queue-card reel-card clip-card size-md" + (isIntake ? " queue-card-intake" : ""),
+        "queue-card reel-card" + (isIntake ? " queue-card-intake" : ""),
       );
       card.setAttribute("data-reel-idx", i);
       card.setAttribute("data-participant", item.participant);
@@ -4144,10 +4144,9 @@
     return "../screenspace/api/video/frame/" + encodeURIComponent(participant) + "/" + timestamp + "?w=200";
   }
 
-  // Thumb element selector covers the legacy `.queue-card-thumb` (artifact /
-  // reel cards in the bottom strip) and the new primitive cards
-  // (`.clip-card-thumb`, `.transcript-card-thumb`) used by Studio Intake.
-  var SS_THUMB_SELECTOR = ".queue-card-thumb, .clip-card-thumb, .transcript-card-thumb";
+  // All cards (artifact / reel bottom-strip and Studio Intake) share the
+  // `.queue-card-thumb` element for lazy source-frame loading.
+  var SS_THUMB_SELECTOR = ".queue-card-thumb";
 
   function ssProcessQueue() {
     while (_ssThumbActive < _SS_THUMB_MAX && _ssThumbQueue.length) {
@@ -4521,49 +4520,53 @@
       return;
     }
     clusters.forEach(function (c, idx) {
-      var segDuration = c.end - c.start;
-      var hueLabel = c.event_type || c.detector || "uncategorized";
+      var typeText = c.event_type || c.detector || "intake";
+      // Carry over the intake font colour: pin to the canonical `--color-task-*`
+      // token for known detectors, else fall back to the category oklch colour.
+      var color = detectorColor(c.detector) || categoryColor(c.event_type || c.detector || "uncategorized");
 
-      var card = ClipgenPrimitives.createClipCard({
-        participant: c.participant,
-        duration: formatDuration(segDuration),
-        label: c.event_type || c.detector || "intake",
-        hue: categoryHue(hueLabel),
-        // Pin the hue dot + label to the canonical `--color-task-*` token
-        // when the event is a known detector — otherwise keep the oklch
-        // fallback so non-detector labels still get a stable colour.
-        color: detectorColor(c.detector),
-        size: "lg",
-        dataset: { intakeIdx: idx },
-        onDragStart: function (ev) {
-          ev.dataTransfer.setData("application/json", JSON.stringify({
-            participant: c.participant,
-            desc: c.event_type,
-            start: c.start,
-            end: c.end,
-            source: "screenspace",
-            event_type: c.event_type,
-            event_ids: c.events.map(function (e) { return e.id; }),
-          }));
-          ev.dataTransfer.effectAllowed = "copyMove";
-          setCardDragImage(ev, this);
-        },
+      var card = el("div", "queue-card intake-queue-card");
+      card.style.setProperty("--cg-card-hue", color);
+      card.dataset.intakeIdx = idx;
+      card.setAttribute("draggable", "true");
+      card.addEventListener("dragstart", function (ev) {
+        ev.dataTransfer.setData("application/json", JSON.stringify({
+          participant: c.participant,
+          desc: c.event_type,
+          start: c.start,
+          end: c.end,
+          source: "screenspace",
+          event_type: c.event_type,
+          event_ids: c.events.map(function (e) { return e.id; }),
+        }));
+        ev.dataTransfer.effectAllowed = "copyMove";
+        setCardDragImage(ev, this);
       });
-      card.classList.add("intake-queue-card");
 
       // Lazy-loaded source-frame thumbnail (existing observer integration).
-      var thumb = card.querySelector(".clip-card-thumb");
+      var thumb = el("div", "queue-card-thumb");
       var img = document.createElement("img");
       img.alt = "";
       img.draggable = false;
-      thumb.insertBefore(img, thumb.firstChild);
+      thumb.appendChild(img);
       ssObserveThumb(card, img, thumb, c.participant, c.start);
+      thumb.appendChild(el("span", "queue-card-duration", formatDuration(c.end - c.start)));
 
       // Cross-reference badges layered over the thumb.
       var xref = findOverlappingData(c.participant, c.start, c.end);
       var ssSelf = { icon: XREF_BADGES.screenspace.icon, color: XREF_BADGES.screenspace.color, title: c.event_type || "Screenspace" };
       var badgeStack = buildXrefBadges(xref, "screenspace", ssSelf);
       if (badgeStack) thumb.appendChild(badgeStack);
+      card.appendChild(thumb);
+
+      var meta = el("div", "queue-card-meta");
+      var row = el("div", "queue-card-meta-row");
+      row.appendChild(el("span", "queue-card-participant", c.participant));
+      row.appendChild(el("span", "queue-card-type", typeText));
+      meta.appendChild(row);
+      meta.appendChild(el("span", "queue-card-time", formatDuration(c.start) + "–" + formatDuration(c.end)));
+      card.appendChild(meta);
+
       if (xref.transcriptSnippets.length > 0) {
         card.dataset.transcriptContext = xref.transcriptSnippets.map(function (s) { return s.text; }).join("\n");
       }
@@ -4864,45 +4867,54 @@
       var segDuration = Math.max(0, c.end - c.start);
       var labelKey = c.category || "bookmark";
       var labelText = (TR_INTAKE_CATEGORIES[labelKey] || TR_INTAKE_CATEGORIES.bookmark).label;
-      var rangeStr = formatDuration(c.start) + "\u2013" + formatDuration(c.end);
       var snippet = c.label || c.text || "";
+      var color = categoryColor(labelKey);
 
-      var card = ClipgenPrimitives.createTranscriptCard({
-        participant: c.participant,
-        timeRange: rangeStr,
-        duration: formatDuration(segDuration),
-        label: labelText,
-        text: snippet,
-        hue: categoryHue(labelKey),
-        dataset: { trIntakeIdx: i },
-        onDragStart: function (ev) {
-          ev.dataTransfer.setData("application/json", JSON.stringify({
-            participant: c.participant,
-            desc: c.category || "transcript",
-            start: c.start,
-            end: c.end,
-            source: "transcript",
-            mark_ids: c.marks.map(function (m) { return m.id; }),
-          }));
-          ev.dataTransfer.effectAllowed = "copyMove";
-          setCardDragImage(ev, this);
-        },
+      var card = el("div", "queue-card intake-queue-card tr-intake-queue-card");
+      card.style.setProperty("--cg-card-hue", color);
+      card.dataset.trIntakeIdx = i;
+      card.setAttribute("draggable", "true");
+      card.addEventListener("dragstart", function (ev) {
+        ev.dataTransfer.setData("application/json", JSON.stringify({
+          participant: c.participant,
+          desc: c.category || "transcript",
+          start: c.start,
+          end: c.end,
+          source: "transcript",
+          mark_ids: c.marks.map(function (m) { return m.id; }),
+        }));
+        ev.dataTransfer.effectAllowed = "copyMove";
+        setCardDragImage(ev, this);
       });
-      card.classList.add("intake-queue-card", "tr-intake-queue-card");
 
       // Lazy-loaded source-frame thumbnail
-      var thumb = card.querySelector(".transcript-card-thumb");
+      var thumb = el("div", "queue-card-thumb");
       var img = document.createElement("img");
       img.alt = "";
       img.draggable = false;
-      thumb.insertBefore(img, thumb.firstChild);
+      thumb.appendChild(img);
       ssObserveThumb(card, img, thumb, c.participant, c.start);
+      thumb.appendChild(el("span", "queue-card-duration", formatDuration(segDuration)));
 
       // Cross-reference badges
       var xref = findOverlappingData(c.participant, c.start, c.end);
       var trSelf = { icon: XREF_BADGES.transcript.icon, color: XREF_BADGES.transcript.color, title: c.label || c.category || "Transcript" };
       var badgeStack = buildXrefBadges(xref, "transcript", trSelf);
       if (badgeStack) thumb.appendChild(badgeStack);
+      card.appendChild(thumb);
+
+      var meta = el("div", "queue-card-meta");
+      var row = el("div", "queue-card-meta-row");
+      row.appendChild(el("span", "queue-card-participant", c.participant));
+      row.appendChild(el("span", "queue-card-type", labelText));
+      meta.appendChild(row);
+      meta.appendChild(el("span", "queue-card-time", formatDuration(c.start) + "–" + formatDuration(c.end)));
+      if (snippet) {
+        var textEl = el("span", "queue-card-text", snippet);
+        textEl.title = snippet;
+        meta.appendChild(textEl);
+      }
+      card.appendChild(meta);
 
       container.appendChild(card);
     });

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -42,7 +42,6 @@
  *
  * LAYOUT:     --layout-max-width | --layout-padding-x
  * SIDEBAR:    --sidebar-width-default | --sidebar-width-wide
- * CARD WIDTH: --card-width-preview (clip-card/transcript-card sizing)
  * PANEL:      --bottom-panel-height
  * ICON SIZE:  --icon-size-xs (12px) | --icon-size-sm (14px) | --icon-size-md (16px) | --icon-size-lg (20px) | --icon-size-xl (24px)
  * BREAKPOINT: --bp-tablet (768px) — documentation/JS-read only, see note below
@@ -248,9 +247,6 @@
   /* Sidebar widths */
   --sidebar-width-default: 340px;
   --sidebar-width-wide: 420px;
-
-  /* Card widths (clip-card / transcript-card sizing tokens) */
-  --card-width-preview: 200px;
 
   /* Bottom panel height (consumed by screenspace.css + screenspace.js) */
   --bottom-panel-height: 400px;


### PR DESCRIPTION
## Summary

Settle Studio on one card design: intake cards (Screenspace events + Transcript marks) now use the `.queue-card` shell — chrome, fonts, 16:9 thumb, 150px width — instead of the separate `.clip-card`/`.transcript-card` primitives, which are removed (along with the unused `--card-width-preview` token). The richer caption is kept (participant + detector/category-tinted type + source-time range + transcript snippet) with multi cross-ref badge support, and stale `clip-card size-md` markup on the artifact/reel cards and the cell drag ghost is cleaned up.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check`, and the full `pytest` suite — all green
- [ ] ⚠️ Browser UI not verified: confirm intake cards visually match Artifact/Reel cards, the `.in-queue` toggle highlight reads well on the new cards, and drag-into-queue still works