### PR TITLE
fix(screenspace): honor region_ref when re-running saved tasks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1851,7 +1851,7 @@ def _ss_rehydrate_task_media(
     parameters: dict[str, Any],
     video_path: str,
     region_coords: dict[str, int],
-    known_regions: dict[str, dict[str, Any]],
+    manifest: dict[str, Any],
     dims: tuple[int, int] | None,
 ) -> None:
     """Re-extract reference frames/templates/scenes into a saved task's parameters.
@@ -1900,10 +1900,18 @@ def _ss_rehydrate_task_media(
         for i, step in enumerate(steps):
             stype = step.get("type", "")
             step_region_name = (step.get("region") or "").strip()
-            if step_region_name and step_region_name in known_regions and dims:
-                step_coords = screenspace.denormalize_region(
-                    known_regions[step_region_name], dims[0], dims[1]
+            step_region_ref = step.get("region_ref")
+            if step_region_name or step_region_ref is not None:
+                resolved_name, resolved_region = screenspace.resolve_region_request(
+                    step_region_name, step_region_ref, manifest
                 )
+                step["region"] = resolved_name
+                if dims is not None:
+                    step_coords = screenspace.denormalize_region(
+                        resolved_region, dims[0], dims[1]
+                    )
+                else:
+                    step_coords = region_coords
             else:
                 step_coords = region_coords
             step["region_coords"] = step_coords
@@ -1965,21 +1973,31 @@ def _run_ss_rerun_task(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     props = video.probe_video_properties(video_path)
-    known_regions = _ss_load_known_regions(manifest)
     dims: tuple[int, int] | None = None
     if props and props.get("width") and props.get("height"):
         dims = (int(props["width"]), int(props["height"]))
 
-    rd = known_regions.get(region_name)
-    if rd is not None and dims is not None:
-        region_coords = screenspace.denormalize_region(rd, dims[0], dims[1])
-    elif isinstance(saved.get("region_coords"), dict):
+    # Prefer region_ref-aware resolution (honors source/stash_id, never flattens
+    # stashes), then fall back to the saved top-level region_coords (un-stripped on
+    # save) for older tasks, per-step multitools, or when dims are unavailable.
+    region_coords: dict[str, int] | None = None
+    try:
+        _, resolved_region = screenspace.resolve_region_request(
+            region_name, saved.get("region_ref"), manifest
+        )
+        if dims is not None:
+            region_coords = screenspace.denormalize_region(
+                resolved_region, dims[0], dims[1]
+            )
+    except ValueError:
+        pass  # fall through to saved coords below
+    if region_coords is None and isinstance(saved.get("region_coords"), dict):
         region_coords = {
             k: int(saved["region_coords"][k])
             for k in ("x", "y", "w", "h")
             if k in saved["region_coords"]
         }
-    else:
+    if region_coords is None:
         utils.error_print(
             f"Region {region_name!r} for task {task_id!r} could not be resolved.",
             [
@@ -1990,7 +2008,7 @@ def _run_ss_rerun_task(args: argparse.Namespace) -> None:
 
     try:
         _ss_rehydrate_task_media(
-            task_type, parameters, video_path, region_coords, known_regions, dims
+            task_type, parameters, video_path, region_coords, manifest, dims
         )
     except ValueError as exc:
         utils.error_print(f"Cannot re-run task {task_id!r}: {exc}")

--- a/screenspace.py
+++ b/screenspace.py
@@ -253,6 +253,81 @@ def denormalize_region(
     }
 
 
+FULL_FRAME_REGION_NAME = "full_frame"
+FULL_FRAME_REGION: dict[str, Any] = {
+    "x": 0.0,
+    "y": 0.0,
+    "w": 1.0,
+    "h": 1.0,
+    "source_width": 0,
+    "source_height": 0,
+}
+
+
+def resolve_region_request(
+    region_name: str,
+    region_ref: Any,
+    manifest: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Resolve a (region_name, region_ref) request to (resolved_name, normalized_region).
+
+    Mirrors the active/stash/full_frame precedence the Screenspace server and CLI both
+    rely on: a ``region_ref`` (``{source: "active"|"stash"|"full_frame", name?, stash_id?}``)
+    pins the lookup to a specific source, while a bare ``region_name`` falls back to
+    active-regions-first then stashes. Pure — reads only the passed ``manifest`` and never
+    flattens stashes, so duplicate region names across stashes stay distinguishable.
+
+    Returns the resolved name and the normalized (0–1) region dict. Raises ``ValueError``
+    with a human-readable message on any failure (caller maps it to a 400 or a CLI error).
+    """
+    active_regions = manifest.get("regions", {})
+    if not isinstance(active_regions, dict):
+        active_regions = {}
+
+    if region_ref is None:
+        if region_name == FULL_FRAME_REGION_NAME:
+            return FULL_FRAME_REGION_NAME, dict(FULL_FRAME_REGION)
+        if region_name in active_regions:
+            return region_name, active_regions[region_name]
+        for stash in manifest.get("stashes", []):
+            stash_regions = stash.get("regions", {})
+            if isinstance(stash_regions, dict) and region_name in stash_regions:
+                return region_name, stash_regions[region_name]
+        raise ValueError(f"Region '{region_name}' not found")
+
+    if not isinstance(region_ref, dict):
+        raise ValueError("region_ref must be an object")
+
+    source = str(region_ref.get("source", "")).strip()
+
+    if source == "full_frame":
+        return FULL_FRAME_REGION_NAME, dict(FULL_FRAME_REGION)
+
+    name = str(region_ref.get("name", "")).strip()
+    if not name:
+        raise ValueError("region_ref.name is required")
+
+    if source == "active":
+        if name not in active_regions:
+            raise ValueError(f"Region '{name}' not found")
+        return name, active_regions[name]
+
+    if source == "stash":
+        stash_id = str(region_ref.get("stash_id", "")).strip()
+        if not stash_id:
+            raise ValueError("region_ref.stash_id is required")
+        for stash in manifest.get("stashes", []):
+            if stash.get("id") != stash_id:
+                continue
+            stash_regions = stash.get("regions", {})
+            if not isinstance(stash_regions, dict) or name not in stash_regions:
+                raise ValueError(f"Region '{name}' not found in stash '{stash_id}'")
+            return name, stash_regions[name]
+        raise ValueError(f"Stash '{stash_id}' not found")
+
+    raise ValueError("region_ref.source must be 'active', 'stash', or 'full_frame'")
+
+
 def average_color_hsv(region_pixels: np.ndarray) -> dict[str, float]:
     """Compute mean HSV color of a region.
 

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -1266,86 +1266,19 @@ def _combined_region_lookup() -> dict[str, Any]:
     return regions
 
 
-_FULL_FRAME_REGION_NAME = "full_frame"
-_FULL_FRAME_REGION: dict[str, Any] = {
-    "x": 0.0,
-    "y": 0.0,
-    "w": 1.0,
-    "h": 1.0,
-    "source_width": 0,
-    "source_height": 0,
-}
-
-
 def _resolve_region_request(
     region_name: str,
     region_ref: Any,
 ) -> tuple[str, dict[str, Any]] | FlaskResponse:
-    """Resolve a task region request without flattening active/stashed duplicates."""
-    active_regions = _manifest.get("regions", {})
-    if not isinstance(active_regions, dict):
-        active_regions = {}
+    """Resolve a task region request without flattening active/stashed duplicates.
 
-    if region_ref is None:
-        if region_name == _FULL_FRAME_REGION_NAME:
-            return _FULL_FRAME_REGION_NAME, dict(_FULL_FRAME_REGION)
-        if region_name in active_regions:
-            return region_name, cast(dict[str, Any], active_regions[region_name])
-        for stash in _manifest.get("stashes", []):
-            stash_regions = stash.get("regions", {})
-            if isinstance(stash_regions, dict) and region_name in stash_regions:
-                return region_name, cast(dict[str, Any], stash_regions[region_name])
-        return jsonify({"ok": False, "error": f"Region '{region_name}' not found"}), 400
-
-    if not isinstance(region_ref, dict):
-        return jsonify({"ok": False, "error": "region_ref must be an object"}), 400
-
-    source = str(region_ref.get("source", "")).strip()
-
-    if source == "full_frame":
-        return _FULL_FRAME_REGION_NAME, dict(_FULL_FRAME_REGION)
-
-    name = str(region_ref.get("name", "")).strip()
-    if not name:
-        return jsonify({"ok": False, "error": "region_ref.name is required"}), 400
-
-    if source == "active":
-        if name not in active_regions:
-            return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 400
-        return name, cast(dict[str, Any], active_regions[name])
-
-    if source == "stash":
-        stash_id = str(region_ref.get("stash_id", "")).strip()
-        if not stash_id:
-            return jsonify(
-                {"ok": False, "error": "region_ref.stash_id is required"}
-            ), 400
-        for stash in _manifest.get("stashes", []):
-            if stash.get("id") != stash_id:
-                continue
-            stash_regions = stash.get("regions", {})
-            if not isinstance(stash_regions, dict) or name not in stash_regions:
-                return (
-                    jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Region '{name}' not found in stash '{stash_id}'",
-                        }
-                    ),
-                    400,
-                )
-            return name, cast(dict[str, Any], stash_regions[name])
-        return jsonify({"ok": False, "error": f"Stash '{stash_id}' not found"}), 400
-
-    return (
-        jsonify(
-            {
-                "ok": False,
-                "error": "region_ref.source must be 'active', 'stash', or 'full_frame'",
-            }
-        ),
-        400,
-    )
+    Thin Flask wrapper over the shared, pure ``screenspace.resolve_region_request`` so the
+    server and the CLI re-run path can never drift on region semantics.
+    """
+    try:
+        return screenspace.resolve_region_request(region_name, region_ref, _manifest)
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
 
 
 def _is_flask_error_response(value: Any) -> TypeGuard[FlaskResponse]:

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -778,3 +778,169 @@ def test_ss_run_task_uploaded_template_step_errors(monkeypatch, capsys):
         cli._run_ss_rerun_task(_ss_args(ss_run_task="ss_mt02"))
     assert exc.value.code == 1
     assert "cannot be re-run" in capsys.readouterr().out.lower()
+
+
+def test_ss_run_task_multitool_full_frame_step(monkeypatch):
+    """A full_frame step resolves to the whole frame, not the parent task's region."""
+    fake_manifest = {
+        "regions": {"btn": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}},
+        "stashes": [],
+        "tasks": [
+            {
+                "id": "ss_ff01",
+                "type": "multitool",
+                "participant": "P01",
+                "region": "btn",
+                "region_coords": {"x": 0, "y": 0, "w": 50, "h": 50},
+                "parameters": {
+                    "steps": [
+                        {
+                            "type": "color",
+                            "region": "full_frame",
+                            "region_ref": {"source": "full_frame"},
+                            "target_color": {"h": 0, "s": 255, "v": 255},
+                            "tolerance": {"h": 10, "s": 40, "v": 40},
+                        }
+                    ]
+                },
+                "status": "completed",
+            }
+        ],
+        "events": [],
+    }
+    saved_tasks = _install_ss_stubs(monkeypatch, fake_manifest)
+
+    cli._run_ss_rerun_task(_ss_args(ss_run_task="ss_ff01"))
+
+    assert saved_tasks
+    step = saved_tasks[0]["parameters"]["steps"][0]
+    # Probe stub reports 100x100, so full frame is {0,0,100,100}, not parent's {0,0,50,50}.
+    assert step["region_coords"] == {"x": 0, "y": 0, "w": 100, "h": 100}
+    assert step["region"] == "full_frame"
+
+
+def test_ss_run_task_multitool_stash_step_disambiguates(monkeypatch):
+    """A stash-backed step honors stash_id instead of a last-write-wins name merge."""
+    fake_manifest = {
+        "regions": {"btn": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}},
+        "stashes": [
+            {
+                "id": "stash_a",
+                "regions": {"hud": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}},
+            },
+            {
+                "id": "stash_b",
+                "regions": {"hud": {"x": 0.2, "y": 0.2, "w": 0.2, "h": 0.2}},
+            },
+        ],
+        "tasks": [
+            {
+                "id": "ss_stash01",
+                "type": "multitool",
+                "participant": "P01",
+                "region": "btn",
+                "region_coords": {"x": 0, "y": 0, "w": 50, "h": 50},
+                "parameters": {
+                    "steps": [
+                        {
+                            "type": "color",
+                            "region": "hud",
+                            # Points at stash_a (the non-last stash); a last-write-wins
+                            # merge would wrongly pick stash_b's "hud".
+                            "region_ref": {
+                                "source": "stash",
+                                "stash_id": "stash_a",
+                                "name": "hud",
+                            },
+                            "target_color": {"h": 0, "s": 255, "v": 255},
+                            "tolerance": {"h": 10, "s": 40, "v": 40},
+                        }
+                    ]
+                },
+                "status": "completed",
+            }
+        ],
+        "events": [],
+    }
+    saved_tasks = _install_ss_stubs(monkeypatch, fake_manifest)
+
+    cli._run_ss_rerun_task(_ss_args(ss_run_task="ss_stash01"))
+
+    assert saved_tasks
+    step = saved_tasks[0]["parameters"]["steps"][0]
+    # stash_a's hud {0.1,0.1,0.1,0.1} at 100x100 -> {10,10,10,10}, not stash_b's {20,...}.
+    assert step["region_coords"] == {"x": 10, "y": 10, "w": 10, "h": 10}
+
+
+def test_ss_run_task_multitool_step_missing_region_errors(monkeypatch, capsys):
+    """A step whose region is gone fails loudly instead of silently using parent coords."""
+    fake_manifest = {
+        "regions": {"btn": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}},
+        "stashes": [],
+        "tasks": [
+            {
+                "id": "ss_gone01",
+                "type": "multitool",
+                "participant": "P01",
+                "region": "btn",
+                "region_coords": {"x": 0, "y": 0, "w": 50, "h": 50},
+                "parameters": {
+                    "steps": [
+                        {
+                            "type": "color",
+                            "region": "ghost",
+                            "target_color": {"h": 0, "s": 255, "v": 255},
+                            "tolerance": {"h": 10, "s": 40, "v": 40},
+                        }
+                    ]
+                },
+                "status": "completed",
+            }
+        ],
+        "events": [],
+    }
+    _install_ss_stubs(monkeypatch, fake_manifest)
+    with pytest.raises(SystemExit) as exc:
+        cli._run_ss_rerun_task(_ss_args(ss_run_task="ss_gone01"))
+    assert exc.value.code == 1
+    assert "not found" in capsys.readouterr().out.lower()
+
+
+def test_ss_run_task_parent_stash_disambiguates(monkeypatch):
+    """The parent task honors a saved region_ref instead of a last-write-wins merge."""
+    fake_manifest = {
+        "regions": {},
+        "stashes": [
+            {
+                "id": "stash_a",
+                "regions": {"hud": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}},
+            },
+            {
+                "id": "stash_b",
+                "regions": {"hud": {"x": 0.2, "y": 0.2, "w": 0.2, "h": 0.2}},
+            },
+        ],
+        "tasks": [
+            {
+                "id": "ss_parent01",
+                "type": "color",
+                "participant": "P01",
+                "region": "hud",
+                "region_ref": {"source": "stash", "stash_id": "stash_a", "name": "hud"},
+                "region_coords": {"x": 20, "y": 20, "w": 20, "h": 20},
+                "parameters": {
+                    "target_color": {"h": 0, "s": 255, "v": 255},
+                    "tolerance": {"h": 10, "s": 40, "v": 40},
+                },
+                "status": "completed",
+            }
+        ],
+        "events": [],
+    }
+    saved_tasks = _install_ss_stubs(monkeypatch, fake_manifest)
+
+    cli._run_ss_rerun_task(_ss_args(ss_run_task="ss_parent01"))
+
+    assert saved_tasks
+    # stash_a's hud -> {10,10,10,10}, not stash_b's {20,...} nor the stale saved coords.
+    assert saved_tasks[0]["region_coords"] == {"x": 10, "y": 10, "w": 10, "h": 10}

--- a/tests/test_screenspace.py
+++ b/tests/test_screenspace.py
@@ -44,6 +44,84 @@ class TestExtractRegion:
         assert np.all(cropped == 42)
 
 
+class TestResolveRegionRequest:
+    MANIFEST = {
+        "regions": {"hud": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}},
+        "stashes": [
+            {
+                "id": "stash_a",
+                "regions": {"hud": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}},
+            },
+            {
+                "id": "stash_b",
+                "regions": {"hud": {"x": 0.2, "y": 0.2, "w": 0.2, "h": 0.2}},
+            },
+        ],
+    }
+
+    def test_bare_name_prefers_active_over_stash(self):
+        name, region = screenspace.resolve_region_request("hud", None, self.MANIFEST)
+        assert name == "hud"
+        assert region["w"] == 0.5  # active "hud", not a stashed one
+
+    def test_bare_name_falls_back_to_stash(self):
+        manifest = {"regions": {}, "stashes": self.MANIFEST["stashes"]}
+        name, region = screenspace.resolve_region_request("hud", None, manifest)
+        assert name == "hud"
+        # No active match: first stash wins (no flattening, but order is preserved).
+        assert region["w"] == 0.1
+
+    def test_full_frame_by_bare_name(self):
+        name, region = screenspace.resolve_region_request(
+            "full_frame", None, self.MANIFEST
+        )
+        assert name == screenspace.FULL_FRAME_REGION_NAME
+        assert region == screenspace.FULL_FRAME_REGION
+
+    def test_full_frame_by_ref(self):
+        name, region = screenspace.resolve_region_request(
+            "", {"source": "full_frame"}, self.MANIFEST
+        )
+        assert name == screenspace.FULL_FRAME_REGION_NAME
+        assert region["w"] == 1.0
+
+    def test_active_ref(self):
+        name, region = screenspace.resolve_region_request(
+            "", {"source": "active", "name": "hud"}, self.MANIFEST
+        )
+        assert region["w"] == 0.5
+
+    def test_stash_ref_honors_stash_id(self):
+        _, region = screenspace.resolve_region_request(
+            "", {"source": "stash", "stash_id": "stash_a", "name": "hud"}, self.MANIFEST
+        )
+        assert region["w"] == 0.1  # stash_a, not last-write-wins stash_b
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="Region 'ghost' not found"):
+            screenspace.resolve_region_request("ghost", None, self.MANIFEST)
+
+    def test_stash_ref_missing_stash_id_raises(self):
+        with pytest.raises(ValueError, match="region_ref.stash_id is required"):
+            screenspace.resolve_region_request(
+                "", {"source": "stash", "name": "hud"}, self.MANIFEST
+            )
+
+    def test_unknown_stash_raises(self):
+        with pytest.raises(ValueError, match="Stash 'nope' not found"):
+            screenspace.resolve_region_request(
+                "",
+                {"source": "stash", "stash_id": "nope", "name": "hud"},
+                self.MANIFEST,
+            )
+
+    def test_invalid_source_raises(self):
+        with pytest.raises(ValueError, match="region_ref.source must be"):
+            screenspace.resolve_region_request(
+                "", {"source": "bogus", "name": "hud"}, self.MANIFEST
+            )
+
+
 class TestAverageColorHsv:
     def test_returns_correct_keys(self):
         region = np.full((10, 10, 3), 128, dtype=np.uint8)


### PR DESCRIPTION
## Summary

CLI `--ss-run-task` re-runs ignored each task's and step's `region_ref` and resolved regions by name against a stash-flattened (last-write-wins) map with no `full_frame` entry — and since `save_screenspace_manifest` strips per-step `region_coords`, that left full_frame steps silently using the parent region and duplicate-named stash regions resolving to the wrong stash. This extracts the resolution logic plus `full_frame` constants into a shared pure `screenspace.resolve_region_request`, makes the server's `_resolve_region_request` a thin wrapper over it (identical error messages preserve the 400 contract), and routes both CLI re-run paths through it so a missing region/stash now fails loudly instead of using the wrong region.

## Test plan

- [x] Full `pytest` suite green (1261 passed), including new CLI re-run regression tests (full_frame step, stash `stash_id` disambiguation, loud failure, parent-task disambiguation) and pure-function resolver unit tests
- [x] `ruff format --check`, `ruff check`, and `ty check` all clean
- [ ] Not exercised end-to-end against a live manifest/video (covered by stubbed tests)