### PR TITLE
fix: correctness bugs surfaced by code review

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1252,17 +1252,31 @@
     }
     state._jobStatusReelWasInProgress = !!reel.in_progress;
 
-    // ---- Generate side ----
-    if (gen.in_progress) {
+    // ---- Generate side: sheet (/api/generate) and intake (/api/generate-intake)
+    // run concurrently from one Generate click and share the same button,
+    // progress readout, and elapsed clock. Combine their counts into a single
+    // state machine so the two streams don't clobber each other's progress or
+    // fire the idle reset while the other is still running.
+    var intake = status.intake || {};
+    var genActive = !!gen.in_progress || !!intake.in_progress;
+    if (genActive) {
       if (!state.artifactGenerating) setArtifactGenerating(true);
       qs("#cancelGenerateBtn").classList.remove("hidden");
-      var total = gen.total || 0;
-      var done = gen.done || 0;
-      if (total > 0) {
-        setButtonProgress("generateBtn", Math.min(done / total, 1));
+      var combinedTotal = (gen.total || 0) + (intake.total || 0);
+      var combinedDone = (gen.done || 0) + (intake.done || 0);
+      if (combinedTotal > 0) {
+        setButtonProgress("generateBtn", Math.min(combinedDone / combinedTotal, 1));
       }
-      _generateEtaTracker.start(gen.started_at ? gen.started_at * 1000 : undefined);
-      updateGenerateProgress(done, total);
+      // Seed elapsed from the earliest of the two start times; idempotent
+      // start() leaves a live build's own clock untouched.
+      var genStartedAt =
+        gen.started_at && intake.started_at
+          ? Math.min(gen.started_at, intake.started_at)
+          : gen.started_at || intake.started_at;
+      _generateEtaTracker.start(genStartedAt ? genStartedAt * 1000 : undefined);
+      // The "N / M cells" readout counts sheet cells only (intake spans aren't
+      // cells); an intake-only run has no sheet count and shows elapsed alone.
+      updateGenerateProgress(gen.done || 0, gen.total || 0);
       _ensureStudioEtaTicker();
     } else if (state._jobStatusGenerateWasInProgress) {
       setArtifactGenerating(false);
@@ -1272,33 +1286,7 @@
       updateGenerateProgress(0, 0);
       loadManifestState();
     }
-    state._jobStatusGenerateWasInProgress = !!gen.in_progress;
-
-    // ---- Intake generate (api/generate-intake) ----
-    var intake = status.intake || {};
-    if (intake.in_progress) {
-      if (!state.artifactGenerating) setArtifactGenerating(true);
-      qs("#cancelGenerateBtn").classList.remove("hidden");
-      var intakeTotal = intake.total || 0;
-      var intakeDone = intake.done || 0;
-      if (intakeTotal > 0) {
-        setButtonProgress("generateBtn", Math.min(intakeDone / intakeTotal, 1));
-      }
-      // Seed from the server's start time (idempotent — re-seeds only if the
-      // generate branch already reset the shared tracker). Intake jobs have no
-      // cell counter, so _paintGenerateProgress shows the elapsed clock alone.
-      _generateEtaTracker.start(intake.started_at ? intake.started_at * 1000 : undefined);
-      _ensureStudioEtaTicker();
-      _paintGenerateProgress();
-    } else if (state._jobStatusIntakeWasInProgress) {
-      setArtifactGenerating(false);
-      qs("#cancelGenerateBtn").classList.add("hidden");
-      setButtonProgress("generateBtn", null);
-      _generateEtaTracker.reset();
-      _paintGenerateProgress();
-      loadManifestState();
-    }
-    state._jobStatusIntakeWasInProgress = !!intake.in_progress;
+    state._jobStatusGenerateWasInProgress = genActive;
   }
 
   function pollJobStatus() {
@@ -2523,6 +2511,11 @@
           segTotal: reelItem.segTotal,
           source: "reel",
         };
+        // Preserve intake identity for reel items that originated from an
+        // intake cluster, so a drop back into the queue keeps its linkage.
+        if (reelItem.event_type) data.event_type = reelItem.event_type;
+        if (reelItem.event_ids) data.event_ids = reelItem.event_ids;
+        if (reelItem.mark_ids) data.mark_ids = reelItem.mark_ids;
         ev.dataTransfer.setData("application/json", JSON.stringify(data));
       }
     });
@@ -5025,7 +5018,9 @@
   }
 
   function highlightIntakeCard(idx) {
-    var cards = qsa(".intake-queue-card");
+    // Scope to the Screenspace intake panel: transcript cards also carry
+    // .intake-queue-card, so an unscoped query would index across both panels.
+    var cards = qsa("#intakeCards .intake-queue-card");
     for (var i = 0; i < cards.length; i++) {
       if (i === idx) {
         cards[i].classList.add("intake-highlight");

--- a/cli.py
+++ b/cli.py
@@ -1292,14 +1292,6 @@ _SS_VALID_TASK_TYPES = (
 )
 
 
-def _ss_load_known_regions(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Combine active manifest regions with all stash regions (last-write-wins)."""
-    known: dict[str, dict[str, Any]] = dict(manifest.get("regions", {}))
-    for stash in manifest.get("stashes", []):
-        known.update(stash.get("regions", {}))
-    return known
-
-
 def _ss_resolve_videos_for_participant(participant_id: str) -> list[str]:
     """Resolve a participant's ordered source video path(s) via filename discovery.
 
@@ -1726,9 +1718,28 @@ def _run_ss_task(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     manifest = screenspace.load_screenspace_manifest()
-    known_regions = _ss_load_known_regions(manifest)
-    if region_name not in known_regions:
-        available = sorted(known_regions.keys())
+
+    # Resolve the named region with active-first / per-stash precedence (never
+    # flattens stashes with last-write-wins) — the same resolver --ss-run-task uses,
+    # so a name that exists in both an active region and a stash resolves to the
+    # active one instead of being silently shadowed by a stashed copy.
+    try:
+        _, resolved_region = screenspace.resolve_region_request(
+            region_name, None, manifest
+        )
+    except ValueError:
+        # Resolution uses precedence; the error hint may still list every known
+        # name (active + stashed) to help the user pick a valid one.
+        available = sorted(
+            {
+                *manifest.get("regions", {}),
+                *(
+                    name
+                    for stash in manifest.get("stashes", [])
+                    for name in stash.get("regions", {})
+                ),
+            }
+        )
         hint = (
             f"Available regions: {', '.join(available)}"
             if available
@@ -1747,13 +1758,16 @@ def _run_ss_task(args: argparse.Namespace) -> None:
 
     # Parts share resolution; reference frames map global→sub-video via frame_at.
     props = video.probe_video_properties(video_paths[0])
-    rd = known_regions[region_name]
     if props and props.get("width") and props.get("height"):
         region_coords = screenspace.denormalize_region(
-            rd, props["width"], props["height"]
+            resolved_region, int(props["width"]), int(props["height"])
         )
     else:
-        region_coords = {k: int(rd[k]) for k in ("x", "y", "w", "h") if k in rd}
+        region_coords = {
+            k: int(resolved_region[k])
+            for k in ("x", "y", "w", "h")
+            if k in resolved_region
+        }
 
     try:
         parameters = _ss_build_params(

--- a/server.py
+++ b/server.py
@@ -1676,6 +1676,20 @@ def api_viewer() -> FlaskResponse:
         return jsonify({"ok": False, "error": str(e)}), 500
 
 
+def _discard_artifact_files(artifacts: list[dict[str, Any]]) -> None:
+    """Unlink the on-disk media for *artifacts* so a cancelled viewer/gallery
+    build leaves no orphan clips or captures: the manifest is never published in
+    that case, but ffmpeg may have already written files before the cancel."""
+    for art in artifacts:
+        name = art.get("file", "")
+        if not name:
+            continue
+        try:
+            Path(utils.resolve_output_path(name)).unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 @studio_bp.route("/api/timeline-viewer", methods=["POST"])
 def api_timeline_viewer() -> FlaskResponse:
     if _worksheet is None:
@@ -1709,6 +1723,7 @@ def api_timeline_viewer() -> FlaskResponse:
             cancel_flag=_timeline_viewer_cancel_event.is_set,
         )
         if _timeline_viewer_cancel_event.is_set():
+            _discard_artifact_files(artifacts)
             return jsonify({"ok": False, "cancelled": True})
         if not artifacts:
             return jsonify({"ok": False, "error": "No artifacts were generated"}), 400
@@ -1726,11 +1741,11 @@ def api_timeline_viewer() -> FlaskResponse:
                     intake_artifacts.append(r)
             artifacts = artifacts + intake_artifacts
 
-        # Single cancel gate before any publish/disk write. Nothing has entered
-        # _generated_artifacts yet, so a cancel here discards every clip
-        # (discard-on-cancel, like generate) and the viewer HTML is never
-        # written — closing the post-ffmpeg window too.
+        # Cancel gate before any publish. Nothing has entered _generated_artifacts
+        # yet, so discard every clip already written to disk (discard-on-cancel,
+        # like generate) and skip writing the viewer HTML entirely.
         if _timeline_viewer_cancel_event.is_set():
+            _discard_artifact_files(artifacts)
             return jsonify({"ok": False, "cancelled": True})
 
         _extend_generated_artifacts(artifacts)
@@ -1848,6 +1863,7 @@ def api_gallery() -> FlaskResponse:
             source_name = " + ".join(Path(p).name for p, _d, _c in timeline)
 
         if _gallery_cancel_event.is_set():
+            _discard_artifact_files(artifacts)
             return jsonify({"ok": False, "cancelled": True})
         if not artifacts:
             return jsonify({"ok": False, "error": "No captures generated"}), 500
@@ -1864,6 +1880,7 @@ def api_gallery() -> FlaskResponse:
         # where capture extraction finished but the user clicks Cancel during
         # the duration probe / finalize.
         if _gallery_cancel_event.is_set():
+            _discard_artifact_files(artifacts)
             return jsonify({"ok": False, "cancelled": True})
         gallery_path = viewer.generate_gallery_viewer(gallery_data)
         if gallery_path:

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -694,6 +694,37 @@ def test_ss_task_scene_dispatches_and_persists(monkeypatch):
     assert params["threshold"] == 0.9
 
 
+def test_ss_task_region_resolves_active_over_stash(monkeypatch):
+    """A region name present in both active regions and a stash resolves to the
+    active one — regression for the flattened (last-write-wins) lookup that let a
+    stashed region with the same name silently shadow the active geometry."""
+    import screenspace
+
+    active_btn = {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}
+    stash_btn = {"x": 0.5, "y": 0.5, "w": 0.4, "h": 0.4}
+    fake_manifest = {
+        "regions": {"btn": dict(active_btn)},
+        "stashes": [{"id": "s1", "regions": {"btn": dict(stash_btn)}}],
+        "tasks": [],
+        "events": [],
+    }
+    saved_tasks = _install_ss_stubs(monkeypatch, fake_manifest)
+
+    args = _ss_args(
+        ss_task=["color", "P01", "btn"],
+        ss_target_color="#FF0000",
+        ss_tolerance="20,30,30",
+        ss_threshold=0.85,
+    )
+    cli._run_ss_task(args)
+
+    assert saved_tasks
+    # Active geometry wins; the stash copy must not shadow it.
+    assert saved_tasks[0]["region_coords"] == screenspace.denormalize_region(
+        active_btn, 100, 100
+    )
+
+
 def test_ss_task_scene_missing_refs_errors(monkeypatch, capsys):
     fake_manifest = {
         "regions": {"btn": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}},

--- a/tests/test_multi_video.py
+++ b/tests/test_multi_video.py
@@ -388,6 +388,48 @@ def test_artifact_record_screenshot_never_splits(make_clip):
     assert record["localStart"] == 60.0
 
 
+def test_artifact_record_full_path_base_video_normalized_to_basename(make_clip):
+    # Producers may hold a full path in base_video; the persisted sourceVideo must
+    # be a basename (matching pipeline.cut_global_range) so sheet and intake
+    # manifests share one shape. Regression for the path-shape alignment fix.
+    clip = cast(ClipRecord, dict(make_clip()))
+    clip["cell_annotations"] = []
+    record = utils.build_artifact_record(
+        clip,
+        "/srv/input/study_P01.mp4",
+        "out.mp4",
+        "0:10",
+        "0:20",
+        artifact_type="clip",
+        seg_idx=0,
+    )
+    assert record["sourceVideo"] == "study_P01.mp4"
+
+
+def test_artifact_record_full_path_timeline_normalized_to_basenames(make_clip):
+    # Multi-video: full-path source_timeline entries must persist as basenames at
+    # both the top level and inside the boundary-spanning parts list.
+    clip = cast(ClipRecord, dict(make_clip()))
+    clip["cell_annotations"] = []
+    clip["times"] = [("1:00", "1:30")]
+    clip["severity"] = ""
+    clip["source_timeline"] = [
+        ("/srv/input/video1.mp4", 80, 0),
+        ("/srv/input/video2.mp4", 120, 80),
+    ]
+    record = utils.build_artifact_record(
+        clip,
+        "/srv/input/video1.mp4",
+        "out.mp4",
+        "1:00",
+        "1:30",
+        artifact_type="clip",
+        seg_idx=0,
+    )
+    assert record["sourceVideo"] == "video1.mp4"
+    assert [p["sourceVideo"] for p in record["parts"]] == ["video1.mp4", "video2.mp4"]
+
+
 # ---- Regenerate from manifest ----
 
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1085,6 +1085,77 @@ def test_api_gallery_cancel_endpoint(client):
     server._gallery_cancel_event.clear()
 
 
+def test_api_timeline_viewer_cancel_discards_clips(client, monkeypatch, tmp_path):
+    """A cancel mid-build unlinks clips already written to disk, leaving no orphan
+    media (the manifest is never published in that case)."""
+    import pipeline
+    import spreadsheet
+    import utils
+
+    monkeypatch.setattr(server, "_worksheet", type("FakeWS", (), {"title": "S"})())
+
+    clip_file = tmp_path / "clip_a1.mp4"
+    clip_file.write_text("video-bytes")
+    artifacts = [
+        {
+            "id": "a1",
+            "type": "clip",
+            "study": "s",
+            "participant": "P01",
+            "file": "clip_a1.mp4",
+            "start": 0,
+            "end": 5,
+        }
+    ]
+
+    monkeypatch.setattr(spreadsheet, "generate_list", lambda *a, **kw: [{"desc": "x"}])
+    monkeypatch.setattr(utils, "resolve_output_path", lambda name: tmp_path / name)
+
+    def fake_process(clips, **kwargs):
+        # User clicks Cancel while ffmpeg is still writing clips.
+        server._timeline_viewer_cancel_event.set()
+        return (1, artifacts)
+
+    monkeypatch.setattr(pipeline, "process_clips", fake_process)
+
+    resp = client.post("/studio/api/timeline-viewer", json={})
+    assert resp.status_code == 200
+    assert resp.get_json()["cancelled"] is True
+    assert not clip_file.exists()
+    server._timeline_viewer_cancel_event.clear()
+
+
+def test_api_gallery_cancel_discards_captures(client, monkeypatch, tmp_path):
+    """A cancel mid-build unlinks gallery captures already written to disk."""
+    import utils
+    import video
+
+    monkeypatch.setattr(server, "_sheet_context", object())
+    (tmp_path / "v.mp4").write_text("v")
+    cap_file = tmp_path / "gallery_0_05.png"
+    cap_file.write_text("img")
+    artifacts = [{"file": "gallery_0_05.png", "timestamp": 5.0, "type": "screen"}]
+
+    monkeypatch.setattr(
+        server, "_resolve_participant_sources", lambda pid: [tmp_path / "v.mp4"]
+    )
+    monkeypatch.setattr(utils, "resolve_output_path", lambda name: tmp_path / name)
+    monkeypatch.setattr(video, "timeline_or_none", lambda paths: None)
+    monkeypatch.setattr(video, "get_file_duration", lambda p: 10)
+
+    def fake_captures(path, **kwargs):
+        server._gallery_cancel_event.set()
+        return artifacts
+
+    monkeypatch.setattr(video, "generate_interval_captures", fake_captures)
+
+    resp = client.post("/studio/api/gallery", json={"participant": "P01"})
+    assert resp.status_code == 200
+    assert resp.get_json()["cancelled"] is True
+    assert not cap_file.exists()
+    server._gallery_cancel_event.clear()
+
+
 def test_api_timeline_viewer_passes_cancel_flag(client, monkeypatch):
     """process_clips must receive a callable cancel_flag so the build is
     interruptible mid-encode."""

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -163,11 +163,13 @@ def test_load_manifest_state_hydrates_reels_without_artifacts():
 
 
 def test_job_status_poll_includes_intake():
-    """Re-attach polling must keep running while intake generation is active."""
+    """Re-attach polling must keep running while intake generation is active, and
+    sheet + intake (one Generate action) share a single combined progress state
+    rather than two branches that clobber each other's button/elapsed/idle."""
     src = _studio_js()
     assert "var intake = status.intake || {};" in src
     assert "data.intake && data.intake.in_progress" in src
-    assert "state._jobStatusIntakeWasInProgress" in src
+    assert "var genActive = !!gen.in_progress || !!intake.in_progress;" in src
 
 
 def test_reel_409_treated_as_json_error():

--- a/utils.py
+++ b/utils.py
@@ -841,14 +841,16 @@ def _resolve_segment_source_fields(
 ) -> dict[str, Any]:
     """Resolve the source-video fields for one persisted segment record.
 
-    Single-video (no ``source_timeline``): ``sourceVideo`` is *base_video* and
-    the local times equal the global times. Multi-video: the global ``[start,
-    end]`` is mapped onto ``clip['source_timeline']`` into the owning sub-video
-    plus local offsets. When *allow_split* is True (video clips) and the range
-    straddles a recording boundary, a ``parts`` list describes each piece so it
-    can be re-cut and stitched; ``sourceVideo``/``localStart``/``localEnd`` carry
-    the first piece. When *allow_split* is False (screenshots/GIFs/transcripts) a
-    single frame's position maps by start only — never split.
+    ``sourceVideo`` is always a **basename** (matching ``pipeline.cut_global_range``);
+    regeneration resolves it against the input dir via ``resolve_input_path``.
+    Single-video (no ``source_timeline``): ``sourceVideo`` is *base_video*'s
+    basename and the local times equal the global times. Multi-video: the global
+    ``[start, end]`` is mapped onto ``clip['source_timeline']`` into the owning
+    sub-video plus local offsets. When *allow_split* is True (video clips) and the
+    range straddles a recording boundary, a ``parts`` list describes each piece so
+    it can be re-cut and stitched; ``sourceVideo``/``localStart``/``localEnd``
+    carry the first piece. When *allow_split* is False (screenshots/GIFs/
+    transcripts) a single frame's position maps by start only — never split.
 
     ``start``/``end`` (global seconds) stay on the record for the timeline
     viewer; these fields drive regeneration, which re-cuts from ``sourceVideo``.
@@ -858,7 +860,7 @@ def _resolve_segment_source_fields(
     timeline = clip.get("source_timeline")
     if not timeline or len(timeline) < 2:
         return {
-            "sourceVideo": base_video,
+            "sourceVideo": Path(base_video).name,
             "localStart": global_start,
             "localEnd": global_end,
         }
@@ -868,7 +870,7 @@ def _resolve_segment_source_fields(
         if pieces:
             parts = [
                 {
-                    "sourceVideo": timeline[index][0],
+                    "sourceVideo": Path(timeline[index][0]).name,
                     "localStart": local_start,
                     "localEnd": local_end,
                 }
@@ -884,7 +886,7 @@ def _resolve_segment_source_fields(
                 fields["parts"] = parts
             return fields
         return {
-            "sourceVideo": base_video,
+            "sourceVideo": Path(base_video).name,
             "localStart": global_start,
             "localEnd": global_end,
         }
@@ -892,7 +894,7 @@ def _resolve_segment_source_fields(
     mapped = map_global_to_segment(timeline, global_start)
     if mapped is None:
         return {
-            "sourceVideo": base_video,
+            "sourceVideo": Path(base_video).name,
             "localStart": global_start,
             "localEnd": global_end,
         }
@@ -900,7 +902,7 @@ def _resolve_segment_source_fields(
     seg_duration = timeline[index][1]
     local_end = min(float(seg_duration), local_start + (global_end - global_start))
     return {
-        "sourceVideo": timeline[index][0],
+        "sourceVideo": Path(timeline[index][0]).name,
         "localStart": local_start,
         "localEnd": local_end,
     }


### PR DESCRIPTION
## Summary

Fixes the confirmed **P0 correctness bugs** from a review of the last 3 days of work (cross-cutting: Studio frontend, CLI, server, clip pipeline). Verified against the code; one reported "bug" (cellResults pollution) was a false positive and is excluded.

- **studio:** `highlightIntakeCard` scoped to `#intakeCards` — a Screenspace hover no longer highlights transcript intake cards (both share `.intake-queue-card`).
- **studio:** reel drag carries `event_ids`/`mark_ids` so intake-sourced reel items keep their identity when dropped back into the queue.
- **studio:** sheet + intake generate (one Generate action, two concurrent streams) now share one combined `applyJobStatus` progress block instead of two branches that clobbered the shared button/elapsed and fired the idle reset early.
- **pipeline/utils:** `sourceVideo` is emitted as a basename in `_resolve_segment_source_fields` to match `cut_global_range`, so sheet and intake artifacts share one manifest shape.
- **cli:** `--ss-task` resolves regions via `resolve_region_request` (active-first, per-stash) instead of a flattened last-write-wins lookup; drops dead `_ss_load_known_regions`.
- **server:** timeline-viewer/gallery cancel now unlinks clips/captures already written to disk (discard-on-cancel), via a shared `_discard_artifact_files`.

## Test plan

- [x] `ruff format` + `ruff check` + `ty check` clean
- [x] Full `pytest` suite green; added tests: `sourceVideo` basename parity, active-over-stash region resolution, cancel filesystem cleanup; updated the frontend-source test for the combined generate state
- [ ] ⚠️ **Frontend not browser-checked** — please verify in Studio:
  - hover Screenspace intake cards with the Transcript intake panel also populated → only Screenspace cards highlight
  - drag a reel item that originated from intake → drop keeps its linkage
  - run sheet-generate and intake-generate together → progress/elapsed behave; idle fires only when both finish