### PR TITLE
refactor: dedup float sanitizer and multi-video time mapping

### DIFF
--- a/data_export.py
+++ b/data_export.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import csv
 import io
 import json
-import math
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -94,13 +93,6 @@ _FRICTION_SEGMENT_COLS = (
 # ---- Helpers ------------------------------------------------------------
 
 
-def _scalar_safe(value: Any) -> Any:
-    """Replace non-finite floats with None; pass everything else through."""
-    if isinstance(value, float) and not math.isfinite(value):
-        return None
-    return value
-
-
 def _flatten_value_for_csv(value: Any) -> Any:
     """Coerce list/dict values into CSV-safe strings.
 
@@ -109,13 +101,13 @@ def _flatten_value_for_csv(value: Any) -> Any:
     through.
     """
     if value is None or isinstance(value, (str, int, float, bool)):
-        return _scalar_safe(value)
+        return utils.sanitize_floats(value)
     if isinstance(value, list):
         if all(
             isinstance(item, (str, int, float, bool)) or item is None for item in value
         ):
             return ";".join(
-                "" if (safe := _scalar_safe(item)) is None else str(safe)
+                "" if (safe := utils.sanitize_floats(item)) is None else str(safe)
                 for item in value
             )
         return json.dumps(value, ensure_ascii=False)
@@ -182,10 +174,10 @@ def build_screenspace_events(
             "detector": ev.get("detector", ""),
             "event_type": ev.get("event_type", ""),
             "region": ev.get("region", ""),
-            "time_in": _scalar_safe(time_in),
-            "time_out": _scalar_safe(time_out),
-            "duration": _scalar_safe(round(duration, 4)),
-            "confidence": _scalar_safe(ev.get("confidence", 0.0)),
+            "time_in": utils.sanitize_floats(time_in),
+            "time_out": utils.sanitize_floats(time_out),
+            "duration": utils.sanitize_floats(round(duration, 4)),
+            "confidence": utils.sanitize_floats(ev.get("confidence", 0.0)),
             "excluded": bool(ev.get("excluded", False)),
             "task_id": ev.get("task_id", ""),
         }
@@ -194,7 +186,7 @@ def build_screenspace_events(
             for k, v in metadata.items():
                 if k in record:
                     continue
-                record[k] = _scalar_safe(v)
+                record[k] = utils.sanitize_floats(v)
         records.append(record)
     return records
 
@@ -220,7 +212,7 @@ def build_screenspace_pins(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "participant": participant_id,
                     "id": pin.get("id", ""),
-                    "timestamp": _scalar_safe(pin.get("timestamp", 0.0)),
+                    "timestamp": utils.sanitize_floats(pin.get("timestamp", 0.0)),
                     "polarity": pin.get("polarity", ""),
                     "label": pin.get("label", ""),
                     "created_at": pin.get("created_at", ""),
@@ -266,9 +258,9 @@ def build_transcript_segments(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "participant": participant_id,
                     "segment_id": seg_id,
-                    "start": _scalar_safe(start),
-                    "end": _scalar_safe(end),
-                    "duration": _scalar_safe(round(end - start, 4)),
+                    "start": utils.sanitize_floats(start),
+                    "end": utils.sanitize_floats(end),
+                    "duration": utils.sanitize_floats(round(end - start, 4)),
                     "text": seg.get("text", ""),
                     "language": language,
                     "model": model,
@@ -302,7 +294,7 @@ def build_friction_moments(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                     "segment_ids": [str(s) for s in (moment.get("segment_ids") or [])],
                     "category": moment.get("category", ""),
                     "rationale": moment.get("rationale", ""),
-                    "score": _scalar_safe(moment.get("score", 0.0)),
+                    "score": utils.sanitize_floats(moment.get("score", 0.0)),
                     "model": model,
                     "computed_at": computed_at,
                 }
@@ -335,7 +327,7 @@ def build_friction_segments(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "participant": participant_id,
                     "segment_id": seg.get("id", ""),
-                    "score": _scalar_safe(score),
+                    "score": utils.sanitize_floats(score),
                     "categories": list(seg.get("categories") or []),
                     "markers": list(seg.get("markers") or []),
                 }

--- a/screenspace.py
+++ b/screenspace.py
@@ -4621,22 +4621,6 @@ def load_screenspace_manifest() -> dict[str, Any]:
     )
 
 
-def _sanitize_manifest_floats(obj: Any) -> Any:
-    """Recursively replace non-finite floats (NaN, ±Inf) with None.
-
-    Defense in depth: detectors operating on numpy/cv2 results can produce
-    NaN on degenerate inputs (zero-variance histograms, etc.). NaN survives
-    a min/max clamp and serializes as invalid ``NaN`` in JSON.
-    """
-    if isinstance(obj, float):
-        return obj if math.isfinite(obj) else None
-    if isinstance(obj, dict):
-        return {k: _sanitize_manifest_floats(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_sanitize_manifest_floats(v) for v in obj]
-    return obj
-
-
 def save_screenspace_manifest(
     regions: dict[str, dict[str, Any]],
     tasks: list[dict[str, Any]],
@@ -4683,7 +4667,7 @@ def save_screenspace_manifest(
     else:
         pins_payload = pins
 
-    payload = _sanitize_manifest_floats(
+    payload = utils.sanitize_floats(
         {
             "regions": regions,
             "tasks": clean_tasks,

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -58,7 +58,6 @@ import threading
 import uuid
 from collections import OrderedDict
 from datetime import datetime, timezone
-from numbers import Integral, Real
 from pathlib import Path
 from typing import Any, Callable, TypeGuard, cast
 
@@ -838,7 +837,7 @@ def api_calibrate() -> FlaskResponse:
             entry["status"] = "not_evaluable"
         results.append(entry)
 
-    return jsonify(_sanitize_floats({"ok": True, "tool": tool, "pins": results}))
+    return jsonify(utils.sanitize_floats({"ok": True, "tool": tool, "pins": results}))
 
 
 # ---- Video frame extraction ----
@@ -2311,7 +2310,7 @@ def api_tasks_results(task_id: str) -> FlaskResponse:
     task = _worker.get_task(task_id)
     if task is None:
         return jsonify({"ok": False, "error": "Task not found"}), 404
-    return jsonify({"ok": True, "results": _sanitize_floats(task.get("result"))})
+    return jsonify({"ok": True, "results": utils.sanitize_floats(task.get("result"))})
 
 
 # ---- Events CRUD ----
@@ -2333,7 +2332,7 @@ def api_events_list() -> FlaskResponse:
     task_id = request.args.get("task_id")
     if task_id:
         events = [e for e in events if e.get("task_id") == task_id]
-    return jsonify({"ok": True, "events": _sanitize_floats(events)})
+    return jsonify({"ok": True, "events": utils.sanitize_floats(events)})
 
 
 @screenspace_bp.route("/api/export/events")
@@ -2382,7 +2381,7 @@ def api_export_events() -> FlaskResponse:
         )
         return response
     if fmt == "json":
-        return jsonify({"ok": True, "events": _sanitize_floats(records)})
+        return jsonify({"ok": True, "events": utils.sanitize_floats(records)})
     return jsonify({"ok": False, "error": f"Unsupported format: {fmt}"}), 400
 
 
@@ -2612,27 +2611,6 @@ def _validate_scene_references(
     return validated_refs
 
 
-def _sanitize_floats(obj: Any) -> Any:
-    """Replace non-finite floats (inf, nan) with None for JSON safety."""
-    if isinstance(obj, bool):
-        return obj
-    if isinstance(obj, Integral):
-        return int(obj)
-    if isinstance(obj, Real):
-        value = float(obj)
-        return value if math.isfinite(value) else None
-    if hasattr(obj, "item") and callable(obj.item):
-        try:
-            return _sanitize_floats(obj.item())
-        except (TypeError, ValueError):
-            pass
-    if isinstance(obj, dict):
-        return {k: _sanitize_floats(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_sanitize_floats(v) for v in obj]
-    return obj
-
-
 def _clean_task(task: dict[str, Any]) -> dict[str, Any]:
     """Remove internal fields from a task dict for API responses."""
     cleaned = {k: v for k, v in task.items() if not k.startswith("_")}
@@ -2647,7 +2625,7 @@ def _clean_task(task: dict[str, Any]) -> dict[str, Any]:
                 {k: v for k, v in s.items() if k not in _step_strip_keys}
                 for s in cleaned["parameters"]["steps"]
             ]
-    return _sanitize_floats(cleaned)
+    return utils.sanitize_floats(cleaned)
 
 
 # ---- State initialization ----

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -916,11 +916,7 @@ def _map_participant_time(
     timeline = _participant_timeline(participant_id)
     if timeline is None:
         return None
-    mapped = utils.map_global_to_segment(timeline, global_ts)
-    if mapped is None:
-        return None
-    index, local_ts = mapped
-    return (timeline[index][0], local_ts)
+    return utils.resolve_timeline_segment(timeline, global_ts)
 
 
 def _participant_frame_extractor(

--- a/server.py
+++ b/server.py
@@ -486,12 +486,11 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
         timeline = video.build_source_timeline([str(p) for p in sources])
         if timeline is None:
             return jsonify({"ok": False, "error": "Source video not found"}), 404
-        mapped = utils.map_global_to_segment(timeline, start_sec)
+        mapped = utils.resolve_timeline_segment(timeline, start_sec)
         if mapped is None:
             return jsonify({"ok": False, "error": "Timestamp beyond recording"}), 404
-        seg_index, local_sec = mapped
-        video_path = Path(timeline[seg_index][0])
-        cut_sec = int(local_sec)
+        video_path = Path(mapped[0])
+        cut_sec = int(mapped[1])
 
     try:
         mtime = video_path.stat().st_mtime

--- a/tests/test_multi_video.py
+++ b/tests/test_multi_video.py
@@ -36,6 +36,18 @@ def test_map_global_to_segment_out_of_range():
     assert utils.map_global_to_segment(TIMELINE, 250) is None
 
 
+def test_resolve_timeline_segment_returns_path_and_offset():
+    # 124s global -> video2 at 44s in; boundary belongs to the next segment.
+    assert utils.resolve_timeline_segment(TIMELINE, 124) == ("video2.mp4", 44.0)
+    assert utils.resolve_timeline_segment(TIMELINE, 80) == ("video2.mp4", 0.0)
+    assert utils.resolve_timeline_segment(TIMELINE, 79) == ("video1.mp4", 79.0)
+
+
+def test_resolve_timeline_segment_out_of_range():
+    assert utils.resolve_timeline_segment(TIMELINE, -1) is None
+    assert utils.resolve_timeline_segment(TIMELINE, 200) is None  # at/after total
+
+
 def test_map_global_range_within_one_segment():
     pieces = utils.map_global_range_to_segments(TIMELINE, 124, 130)
     assert pieces == [(1, 44.0, 50.0)]

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -2696,7 +2696,9 @@ def test_calibrate_text_ocr_cache_rescores_threshold(calib_client, monkeypatch):
 def test_sanitize_floats_handles_numpy_scalars():
     import numpy as np
 
-    out = screenspace_server._sanitize_floats(
+    import utils
+
+    out = utils.sanitize_floats(
         {"ok": np.bool_(True), "score": np.float32("nan"), "detail": {"n": np.int64(3)}}
     )
     assert out == {"ok": True, "score": None, "detail": {"n": 3}}

--- a/utils.py
+++ b/utils.py
@@ -1382,6 +1382,23 @@ def map_global_to_segment(
     return None
 
 
+def resolve_timeline_segment(
+    timeline: list[tuple[str, int, int]], global_seconds: float
+) -> tuple[str, float] | None:
+    """Map *global_seconds* to ``(sub_video_path, local_seconds)`` within a built
+    source *timeline*, or ``None`` if it falls at/beyond the recording.
+
+    Companion to :func:`map_global_to_segment` that also resolves the owning
+    sub-video's path — the shared step behind multi-video thumbnail and frame
+    lookups. Callers that already hold a (cached) timeline pass it straight in.
+    """
+    mapped = map_global_to_segment(timeline, global_seconds)
+    if mapped is None:
+        return None
+    index, local_seconds = mapped
+    return (timeline[index][0], local_seconds)
+
+
 def map_global_range_to_segments(
     timeline: list[tuple[str, int, int]],
     start_seconds: float,

--- a/utils.py
+++ b/utils.py
@@ -4,9 +4,11 @@
 import difflib
 import functools
 import json
+import math
 import subprocess
 import sys
 from datetime import datetime
+from numbers import Integral, Real
 from pathlib import Path
 from typing import Any, Callable, TypedDict, TypeVar
 
@@ -599,6 +601,33 @@ def terminate_subprocess(proc: subprocess.Popen, timeout: int = 5) -> None:
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait()
+
+
+def sanitize_floats(obj: Any) -> Any:
+    """Recursively replace non-finite floats (NaN, ±Inf) with ``None`` and
+    normalise numpy/Integral scalars to plain Python numbers, for JSON safety.
+
+    Use before any ``jsonify`` response or manifest write that may carry numpy
+    or cv2-derived values: NaN survives min/max clamps and serialises as invalid
+    ``NaN`` in JSON, and raw numpy scalars are not JSON-serialisable.
+    """
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, Integral):
+        return int(obj)
+    if isinstance(obj, Real):
+        value = float(obj)
+        return value if math.isfinite(value) else None
+    if hasattr(obj, "item") and callable(obj.item):
+        try:
+            return sanitize_floats(obj.item())
+        except (TypeError, ValueError):
+            pass
+    if isinstance(obj, dict):
+        return {k: sanitize_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitize_floats(v) for v in obj]
+    return obj
 
 
 # ---- Filename and study name helpers ----


### PR DESCRIPTION
## Summary
Backend dedup of two genuinely-duplicated helpers (confirmed real after auditing the review). Two independent commits:

- **`utils.sanitize_floats`** — replaces three near-identical non-finite-float sanitizers (`screenspace_server._sanitize_floats`, `screenspace._sanitize_manifest_floats`, `data_export._scalar_safe`) with one. The robust numpy/`Integral`/`Real`-aware version is kept as canonical; event metadata is always scalar, so it's behaviour-equivalent at every call site.
- **`utils.resolve_timeline_segment`** — extracts the `timeline + global second → (sub_video_path, local_seconds)` step shared by `server.api_thumbnail` and `screenspace_server._map_participant_time`. Both keep their own timeline source (`api_thumbnail` builds fresh with its two distinct 404s; `_map_participant_time` keeps its `mtime`-keyed cache), so no behaviour or caching change.

Out of scope by design (verified false-positive / overstated in the review): task-media "triplication", `cut_global_range`/`_process_single_clip_segments`, `api_tasks_create`/`api_calibrate`. The `api_gallery` full-timeline-offset path is a different shape and left as-is.

## Test plan
- [x] Full suite → **1334 passed** (1332 + 2 new `resolve_timeline_segment` unit tests)
- [x] Existing `test_sanitize_floats_handles_numpy_scalars` repointed to `utils.sanitize_floats` and passing
- [x] `/check` green — ruff format, ruff check, ty all pass
- No `build/VERSION` bump (`refactor:`)