### PR TITLE
fix(transcripts): keep thinking-agent elapsed timers across navigation

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -51,6 +51,9 @@
     frictionData: null,
     frictionBySegId: {},
     frictionGenerating: false,
+    // Server-recorded friction run start (epoch ms) so the elapsed clock
+    // survives page navigation; null while idle or for a just-clicked run.
+    frictionStartedAt: null,
     frictionHeatmapEnabled: false,
     frictionThreshold: 0.5,
     frictionCategoryFilter: null,
@@ -701,12 +704,14 @@
         } else if (data.citations_generating) {
           state.summaryCitations = null;
           state.citationsGenerating = true;
-          renderCitationsStatus();
+          renderCitationsStatus(
+            data.citations_started_at ? data.citations_started_at * 1000 : undefined
+          );
           _startCitationsPoll(pid);
           _refreshAgentStateNow();
         }
       } else if (data.generating) {
-        renderSummaryGenerating();
+        renderSummaryGenerating(data.started_at ? data.started_at * 1000 : undefined);
         _startSummaryPoll(pid);
         _refreshAgentStateNow();
       } else {
@@ -740,7 +745,9 @@
           } else if (data.citations_generating) {
             state.summaryCitations = null;
             state.citationsGenerating = true;
-            renderCitationsStatus();
+            renderCitationsStatus(
+              data.citations_started_at ? data.citations_started_at * 1000 : undefined
+            );
             _startCitationsPoll(pid);
           }
         } else if (!data.generating) {
@@ -763,7 +770,10 @@
     }
   }
 
-  function renderSummaryGenerating() {
+  // startedAtMs (optional): server-recorded run start in epoch ms. Seeds the
+  // elapsed clock so navigating away and back resumes from the true elapsed
+  // time instead of zero; omit it for a just-clicked manual run (starts now).
+  function renderSummaryGenerating(startedAtMs) {
     var content = qs("#summaryContent");
     content.innerHTML =
       '<p class="summary-generating">Generating summary\u2026' +
@@ -773,7 +783,7 @@
     qs("#summaryActions").classList.add("hidden");
     state.summaryEditing = false;
     state.summaryText = "";
-    _summaryEtaTracker.start();
+    _summaryEtaTracker.start(startedAtMs || undefined);
     _updateAgentElapsed("summaryElapsed", _summaryEtaTracker);
     _txEtaTicker.ensure();
   }
@@ -949,7 +959,9 @@
     }
   }
 
-  function renderCitationsStatus() {
+  // startedAtMs (optional): server-recorded run start in epoch ms \u2014 seeds the
+  // elapsed clock so it survives navigation; omit for a just-clicked manual run.
+  function renderCitationsStatus(startedAtMs) {
     // Remove any existing status
     var existing = qs("#summaryContent .citations-status");
     if (existing) existing.remove();
@@ -962,7 +974,12 @@
     sp.id = "citationsElapsed";
     p.appendChild(sp);
     qs("#summaryContent").appendChild(p);
-    _citationsEtaTracker.start();
+    // Reset before seeding so a re-run adopts the new (server) start instead of
+    // the idempotent tracker clinging to a prior run's start. Teardown
+    // (_stopCitationsPoll) is timer-only — mirroring summary/friction — so the
+    // _startCitationsPoll() that follows this call can't wipe this seed.
+    _citationsEtaTracker.reset();
+    _citationsEtaTracker.start(startedAtMs || undefined);
     _updateAgentElapsed("citationsElapsed", _citationsEtaTracker);
     _txEtaTicker.ensure();
   }
@@ -1012,8 +1029,10 @@
     }, 3000);
   }
 
+  // Timer teardown only — does NOT reset _citationsEtaTracker (renderCitationsStatus
+  // resets-then-seeds), mirroring _stopSummaryPoll / _stopFrictionPoll. Resetting
+  // here would wipe the seed when _startCitationsPoll restarts the poll timer.
   function _stopCitationsPoll() {
-    _citationsEtaTracker.reset();
     if (_citationsPollTimer) {
       clearInterval(_citationsPollTimer);
       _citationsPollTimer = null;
@@ -1185,6 +1204,7 @@
         _setFrictionData(data.friction);
       } else if (data.generating) {
         state.frictionGenerating = true;
+        state.frictionStartedAt = data.started_at ? data.started_at * 1000 : null;
         renderFrictionGenerating();
         _startFrictionPoll(pid);
         _refreshAgentStateNow();
@@ -1242,7 +1262,7 @@
       statusEl.classList.remove("friction-status--stale");
       rerun.classList.add("hidden");
       cancel.classList.remove("hidden");
-      _frictionEtaTracker.start();
+      _frictionEtaTracker.start(state.frictionStartedAt || undefined);
       _updateAgentElapsed("frictionElapsed", _frictionEtaTracker);
       _txEtaTicker.ensure();
       return;
@@ -1369,6 +1389,7 @@
     var pid = state.selectedParticipant;
     if (!pid || !_frictionDepMet()) return;
     state.frictionGenerating = true;
+    state.frictionStartedAt = null;
     renderFrictionGenerating();
     apiPost("api/friction/" + pid + "/regenerate", {}).then(function (data) {
       if (data.ok && data.generating) {

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -233,6 +233,8 @@ def _agent_state_clean():
             transcripts_server._orchestrator._in_flight[key].clear()
         for key in transcripts_server._orchestrator._cancel_events:
             transcripts_server._orchestrator._cancel_events[key].clear()
+        for key in transcripts_server._orchestrator._started_at:
+            transcripts_server._orchestrator._started_at[key].clear()
         with transcripts_server._pending_model_unloads_lock:
             for timer in transcripts_server._pending_model_unloads.values():
                 timer.cancel()
@@ -641,6 +643,60 @@ def test_friction_get_generating_when_in_flight(tr_client, _agent_state_clean):
     resp = tr_client.get("/transcripts/api/friction/P01")
     assert resp.status_code == 200
     assert resp.get_json()["generating"] is True
+
+
+def _claim_slot(agent_key: str, pid: str, started_at: float) -> None:
+    """Mark *agent_key* in flight for *pid* with a known start time, mirroring
+    what run_agent stamps when it claims the slot."""
+    transcripts_server._orchestrator._in_flight[agent_key].add(pid)
+    transcripts_server._orchestrator._started_at[agent_key][pid] = started_at
+
+
+def test_summary_get_generating_includes_started_at(tr_client, _agent_state_clean):
+    """A generating summary must surface its server start time so the frontend
+    elapsed clock survives page navigation instead of resetting to zero."""
+    transcripts_server._manifest["source_transcripts"]["P01"] = {
+        "segments": [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "x"}],
+    }
+    _claim_slot("summary", "P01", 1000.0)
+    resp = tr_client.get("/transcripts/api/summary/P01")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["generating"] is True
+    assert data["started_at"] == 1000.0
+
+
+def test_citations_get_generating_includes_started_at(tr_client, _agent_state_clean):
+    _seed_friction_entry()  # summary present, no citations yet
+    _claim_slot("citations", "P01", 2000.0)
+    resp = tr_client.get("/transcripts/api/citations/P01")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["generating"] is True
+    assert data["started_at"] == 2000.0
+
+
+def test_summary_get_includes_citations_started_at(tr_client, _agent_state_clean):
+    """On a fresh load with the summary done but citations still running, the
+    citations start rides on the summary response (the only call the UI makes)."""
+    _seed_friction_entry()  # summary present, no citations yet
+    _claim_slot("citations", "P01", 3000.0)
+    resp = tr_client.get("/transcripts/api/summary/P01")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["citations_generating"] is True
+    assert data["citations_started_at"] == 3000.0
+
+
+def test_friction_get_generating_includes_started_at(tr_client, _agent_state_clean):
+    _seed_friction_entry()
+    _claim_slot("friction", "P01", 4000.0)
+    resp = tr_client.get("/transcripts/api/friction/P01")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["generating"] is True
+    assert data["started_at"] == 4000.0
 
 
 def test_friction_regenerate_404_without_summary(tr_client, _agent_state_clean):

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -564,7 +564,13 @@ def api_summary(participant: str) -> FlaskResponse:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry or not entry.get("summary"):
             if _orchestrator.is_generating(participant, "summary"):
-                return jsonify({"ok": False, "generating": True})
+                return jsonify(
+                    {
+                        "ok": False,
+                        "generating": True,
+                        "started_at": _orchestrator.started_at(participant, "summary"),
+                    }
+                )
             return jsonify({"ok": False}), 404
         summary = entry["summary"]
         citations = entry.get("citations")
@@ -572,6 +578,10 @@ def api_summary(participant: str) -> FlaskResponse:
     if citations:
         resp["citations"] = citations
     resp["citations_generating"] = _orchestrator.is_generating(participant, "citations")
+    if resp["citations_generating"]:
+        resp["citations_started_at"] = _orchestrator.started_at(
+            participant, "citations"
+        )
     return jsonify(resp)
 
 
@@ -643,7 +653,13 @@ def api_citations(participant: str) -> FlaskResponse:
     if citations:
         return jsonify({"ok": True, "citations": citations})
     if _orchestrator.is_generating(participant, "citations"):
-        return jsonify({"ok": False, "generating": True})
+        return jsonify(
+            {
+                "ok": False,
+                "generating": True,
+                "started_at": _orchestrator.started_at(participant, "citations"),
+            }
+        )
     return jsonify({"ok": False}), 404
 
 
@@ -701,7 +717,13 @@ def api_friction(participant: str) -> FlaskResponse:
     if friction_data:
         return jsonify({"ok": True, "friction": friction_data})
     if _orchestrator.is_generating(participant, "friction"):
-        return jsonify({"ok": False, "generating": True})
+        return jsonify(
+            {
+                "ok": False,
+                "generating": True,
+                "started_at": _orchestrator.started_at(participant, "friction"),
+            }
+        )
     return jsonify({"ok": False}), 404
 
 
@@ -1379,6 +1401,14 @@ class AgentOrchestrator:
         self._cancel_events: dict[str, dict[str, threading.Event]] = {
             a["key"]: {} for a in thinking_agents.AGENTS
         }
+        # Wall-clock epoch (seconds) stamped when each run claims its in-flight
+        # slot, so a UI reattach after page navigation can show accurate elapsed
+        # time instead of restarting from zero. Maintained in lockstep with
+        # _in_flight / _cancel_events (claimed, released, and ownership-guarded
+        # at the same points).
+        self._started_at: dict[str, dict[str, float]] = {
+            a["key"]: {} for a in thinking_agents.AGENTS
+        }
         self._threads: dict[str, set[threading.Thread]] = {
             a["key"]: set() for a in thinking_agents.AGENTS
         }
@@ -1386,6 +1416,14 @@ class AgentOrchestrator:
     def is_generating(self, participant: str, agent_key: str) -> bool:
         """Return True if *agent_key* is currently running for *participant*."""
         return participant in self._in_flight.get(agent_key, set())
+
+    def started_at(self, participant: str, agent_key: str) -> float | None:
+        """Epoch seconds when *agent_key* started running for *participant*.
+
+        ``None`` when no run is in flight. Lets the frontend seed its elapsed
+        clock from the true start so navigating away and back doesn't reset it.
+        """
+        return self._started_at.get(agent_key, {}).get(participant)
 
     def stop(self, agent_key: str, participant: str) -> bool:
         """Abort an in-flight run. Returns True iff a run was actually stopped.
@@ -1399,6 +1437,7 @@ class AgentOrchestrator:
                 return False
             event = self._cancel_events.get(agent_key, {}).get(participant)
             self._in_flight[agent_key].discard(participant)
+            self._started_at.get(agent_key, {}).pop(participant, None)
         if event is not None:
             event.set()
         return True
@@ -1453,6 +1492,9 @@ class AgentOrchestrator:
                 return
             self._in_flight[agent_key].add(participant)
             self._cancel_events[agent_key][participant] = cancel_event
+            self._started_at[agent_key][participant] = datetime.now(
+                timezone.utc
+            ).timestamp()
 
         # If a Stop just scheduled an unload for this model, cancel it — the
         # next request would only force a reload.
@@ -1514,6 +1556,7 @@ class AgentOrchestrator:
                     if slot is cancel_event:
                         self._in_flight[agent_key].discard(participant)
                         self._cancel_events[agent_key].pop(participant, None)
+                        self._started_at[agent_key].pop(participant, None)
                     self._threads[agent_key].discard(t)
 
         t = threading.Thread(


### PR DESCRIPTION
## Summary

The Summary/Citations/Friction elapsed clocks reset to `0:00` when navigating away from Transcripts and back, because each tracker seeded from `Date.now()` at render time rather than the run's true start. The orchestrator now records a per-agent start time (in lockstep with `_in_flight`/`_cancel_events`) and exposes it as `started_at` — plus `citations_started_at` on the summary response — from the agent GET endpoints, and the frontend seeds its elapsed trackers from it so the clocks resume the true elapsed time. Also made `_stopCitationsPoll` timer-only (reset moved into `renderCitationsStatus`), mirroring summary/friction, so the poll restart no longer wipes the freshly seeded citations start.

## Test plan

- [x] `/check` green — ruff format + lint, `ty`, full suite; added `tests/test_transcripts_api.py` coverage that the summary/citations/friction GET endpoints return `started_at` (and the summary response `citations_started_at`) when generating.
- [x] ⚠️ Not browser-verified: start a Summary/Citations/Friction run, switch to Studio (or reload), return and re-select the participant → the clock resumes at the true elapsed time, not `0:00`; a freshly-clicked manual run still starts at `0:00`.