### PR TITLE
fix(studio): generate only remaining segments after card removal

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2841,10 +2841,13 @@
   }
 
   // Collect per-cell time overrides for spreadsheet clips the user trimmed on
-  // the duration badge. The backend replaces a cell's whole time list, so for
-  // any cell with at least one edited segment we send every queued segment
-  // (segIdx-ordered) as [startSec, endSec] pairs. Returns {} when nothing was
-  // edited. Intake items carry their own start/end and are skipped here.
+  // the duration badge or pruned from the queue. The backend replaces a cell's
+  // whole time list, so whenever a cell has an edited segment OR has had cards
+  // removed (fewer queued segments than its original segTotal) we send every
+  // remaining segment (segIdx-ordered) as [startSec, endSec] pairs — that
+  // becomes the cell's complete output. Returns {} when a cell is untouched
+  // (no edits, no removals) so artifact caching still applies. Intake items
+  // carry their own start/end and are skipped here.
   function buildCellOverrides(items) {
     var byCell = {};
     for (var i = 0; i < items.length; i++) {
@@ -2864,7 +2867,9 @@
           break;
         }
       }
-      if (!anyEdited) return;
+      var segTotal = segs[0].segTotal || segs.length;
+      var removed = segs.length < segTotal;
+      if (!anyEdited && !removed) return;
       segs.sort(function (a, b) {
         return (a.segIdx || 0) - (b.segIdx || 0);
       });


### PR DESCRIPTION
## Summary

In Studio, queuing a multi-timestamp cell expands it into one card per timestamp; removing all but one card and clicking Generate still produced a clip for **every** timestamp in the cell. `buildCellOverrides()` only sent a cell's segment overrides when a segment was *edited*, so a pure removal sent nothing and the backend re-parsed the whole cell. It now also emits the override when cards were *removed* (fewer queued segments than the cell's original `segTotal`), so the existing `segIdx`-ordered `[start, end]` list becomes the cell's complete output. Untouched cells still send nothing, preserving artifact caching, and both the Artifacts and Reel queues are fixed since both call `buildCellOverrides`.

## Test plan

- [x] `node --check assets/web/studio.js`
- [x] `/check` — ruff format + lint, ty, full suite (1379 passed)
- [ ] ⚠️ Browser (not headless-verified): queue a 3-timestamp cell, remove 2 cards → expect 1 clip; same on Reel queue; confirm untouched cell still generates all segments and an edited-but-not-removed cell generates all at edited bounds.