### PR TITLE
fix(titlecards): address four code-review findings

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -535,14 +535,6 @@ def _process_single_clip_segments(
     # path (unchanged behavior, no probing).
     timeline = clip.get("source_timeline")
 
-    # Probe the source video once so wrap_clip_with_cards doesn't need to re-probe
-    # each generated output; stream-copy cuts preserve source resolution.
-    source_resolution: str | None = None
-    if output_format == "clip" and cards_enabled:
-        props = video.probe_video_properties(base_video)
-        if props:
-            source_resolution = f"{props['width']}x{props['height']}"
-
     for time_idx, (start_time, end_time) in enumerate(clip["times"]):
         if cancel_flag and cancel_flag():
             break
@@ -598,10 +590,13 @@ def _process_single_clip_segments(
                     cancel_flag=cancel_flag,
                 )
             if ok and cards_enabled:
+                # Wrap at the generated clip's own resolution (probed inside
+                # wrap_clip_with_cards). For multi-video participants a clip may
+                # be cut from a later part whose resolution differs from the
+                # first source, so trusting the clip avoids a concat mismatch.
                 ok = titlecards.wrap_clip_with_cards(
                     clip,
                     out_name,
-                    resolution=source_resolution,
                     cancel_flag=cancel_flag,
                     titlecards_enabled=cards_enabled,
                     titlecard_duration_seconds=card_duration,

--- a/server.py
+++ b/server.py
@@ -2593,9 +2593,6 @@ def api_reel_direct() -> FlaskResponse:
             output_dir = Path(utils.get_effective_output_dir())
             clip_paths: list[str] = []
             temp_clips: list[str] = []
-            # Cache (w x h) per source video so wrap_clip_with_cards doesn't
-            # re-probe per segment. Same source can appear many times.
-            resolution_cache: dict[str, str | None] = {}
             # Throttle concat progress emissions to ~5 Hz, same as before.
             concat_last_emit = [0.0]
 
@@ -2674,21 +2671,16 @@ def api_reel_direct() -> FlaskResponse:
                         is not None
                     )
                     if ok and cards_enabled:
-                        res_key = video_paths[0]
-                        if res_key not in resolution_cache:
-                            probed = video.probe_video_properties(res_key)
-                            resolution_cache[res_key] = (
-                                f"{probed['width']}x{probed['height']}"
-                                if probed
-                                else None
-                            )
+                        # Wrap at the cut clip's own resolution (probed inside
+                        # wrap_clip_with_cards). A global span may be cut from a
+                        # later source part whose resolution differs from the
+                        # first; trusting the clip avoids a concat mismatch.
                         wrap_clip: utils.ClipRecord = {
                             "desc": seg.get("event_type") or seg.get("desc") or "",
                         }
                         ok = titlecards.wrap_clip_with_cards(
                             wrap_clip,
                             tmp_path,
-                            resolution=resolution_cache[res_key],
                             cancel_flag=_reel_cancel_event.is_set,
                             titlecards_enabled=cards_enabled,
                             titlecard_duration_seconds=card_duration,

--- a/server.py
+++ b/server.py
@@ -2246,6 +2246,12 @@ def api_settings_put() -> FlaskResponse:
 # ── Titlecard / endcard background picker ────────────────────────────────
 _ALLOWED_CARD_EXTS: set[str] = {".png", ".jpg", ".jpeg", ".webp"}
 _MAX_CARD_UPLOAD_BYTES: int = 10 * 1024 * 1024  # 10 MB
+# URL-reserved / unsafe ASCII characters that sanitize_filename leaves intact.
+# Card images are served at /api/titlecards/image/<name>, so a stem containing
+# e.g. '#' would have its tail dropped by the browser as a URL fragment. These
+# are replaced with '_' at upload time; unicode is preserved (only these ASCII
+# characters are touched, matching sanitize_filename's unicode policy).
+_URL_UNSAFE_CARD_CHARS: str = "#%&+=;@$,!*()[]{}^~` "
 
 
 def _titlecard_images_dir() -> Path:
@@ -2392,8 +2398,12 @@ def api_titlecard_upload() -> FlaskResponse:
     if size > _MAX_CARD_UPLOAD_BYTES:
         return jsonify({"ok": False, "error": "File too large (max 10 MB)."}), 400
 
-    # sanitize_filename strips the dot from extensions, so clean the stem only.
-    stem = utils.sanitize_filename(Path(filename).stem).strip() or "titlecard"
+    # sanitize_filename strips the dot from extensions, so clean the stem only,
+    # then replace URL-reserved chars so the served image URL isn't truncated.
+    stem = utils.sanitize_filename(Path(filename).stem).strip()
+    for ch in _URL_UNSAFE_CARD_CHARS:
+        stem = stem.replace(ch, "_")
+    stem = stem.strip("_") or "titlecard"
     images_dir = _titlecard_images_dir()
     images_dir.mkdir(parents=True, exist_ok=True)
     candidate = f"{stem}{ext}"

--- a/server.py
+++ b/server.py
@@ -1871,14 +1871,21 @@ def api_gallery() -> FlaskResponse:
             source_name = sources[0].name
         else:
             artifacts = []
-            for part_path, _dur, cumulative in timeline:
+            for part_path, dur, cumulative in timeline:
                 if _gallery_cancel_event.is_set():
                     break
+                # Align each part's local grid to the global interval so spacing
+                # stays even across part boundaries; a part whose duration isn't
+                # a multiple of the interval would otherwise shift the next
+                # part's grid off the global cadence.
+                first = (interval - cumulative % interval) % interval
+                local_ts = list(range(first, dur, interval))
                 part_artifacts = video.generate_interval_captures(
                     part_path,
                     interval_seconds=interval,
                     output_format=output_format,
                     gif_duration_seconds=config.GALLERY_GIF_DURATION_SECONDS,
+                    timestamps=local_ts,
                     cancel_flag=_gallery_cancel_event.is_set,
                 )
                 for a in part_artifacts:

--- a/server.py
+++ b/server.py
@@ -1040,6 +1040,16 @@ def _load_studio_settings() -> dict[str, Any]:
             setattr(config, name, cleaned)
             applied[name] = cleaned
             continue
+        if meta.get("type") == "card_picker":
+            # Validate persisted selections too, so a stale studio_settings.json
+            # (traversal, a deleted upload, or __none__ on a titlecard) doesn't
+            # apply a value the PUT path would reject; leave config at its default.
+            cleaned = _coerce_card_image(value, str(meta.get("kind", "title")))
+            if cleaned is None:
+                continue
+            setattr(config, name, cleaned)
+            applied[name] = cleaned
+            continue
         expected_type = type(default) if default is not None else str
         try:
             if expected_type is bool:

--- a/server.py
+++ b/server.py
@@ -2199,6 +2199,13 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
             setattr(config, name, cleaned)
             applied[name] = cleaned
             continue
+        if meta.get("type") == "card_picker":
+            cleaned = _coerce_card_image(value, str(meta.get("kind", "title")))
+            if cleaned is None:
+                return {}, f"Invalid {name} payload"
+            setattr(config, name, cleaned)
+            applied[name] = cleaned
+            continue
         expected_type = type(default) if default is not None else str
         try:
             if expected_type is bool:
@@ -2257,6 +2264,32 @@ def _list_uploaded_titlecards() -> list[str]:
         if p.is_file() and p.suffix.lower() in _ALLOWED_CARD_EXTS
     ]
     return sorted(names, key=str.lower)
+
+
+def _coerce_card_image(value: Any, kind: str) -> str | None:
+    """Validate a card-picker selection against the upload pool.
+
+    Returns the cleaned selection id, or None when the value is invalid. Accepts
+    the sentinel ids (empty = bundled default, CARD_IMAGE_COLOR = solid color,
+    and — for endcards only — CARD_IMAGE_NONE) or the basename of an existing
+    uploaded image. Rejects path separators / traversal so a setting can never
+    point outside the titlecard_images pool (see titlecards.resolve_card_background).
+    """
+    if not isinstance(value, str):
+        return None
+    if value in ("", config.CARD_IMAGE_COLOR):
+        return value
+    if kind == "end" and value == config.CARD_IMAGE_NONE:
+        return value
+    # Otherwise it must be a real uploaded file inside the pool: a bare basename
+    # with an allowed extension that exists on disk.
+    if Path(value).name != value:
+        return None
+    if Path(value).suffix.lower() not in _ALLOWED_CARD_EXTS:
+        return None
+    if not (_titlecard_images_dir() / value).is_file():
+        return None
+    return value
 
 
 def _card_picker_payload(kind: str) -> dict[str, Any]:

--- a/tests/test_multi_video.py
+++ b/tests/test_multi_video.py
@@ -263,6 +263,46 @@ def test_multi_video_clip_maps_into_second_video(monkeypatch, make_clip):
     assert kwargs["end_pos"] == "0:00:50"
 
 
+def test_multi_video_titlecard_wraps_at_clip_resolution(monkeypatch, make_clip):
+    """A clip cut from a later part must not be wrapped at the first part's resolution.
+
+    The pipeline passes no resolution to wrap_clip_with_cards, which probes the
+    generated clip itself — so a video2 cut whose resolution differs from video1
+    still gets titlecards instead of a silently-skipped concat mismatch.
+    """
+    clip = _multi_clip(make_clip, [("2:04", "2:10")])  # global 124-130 -> video2 @44s
+
+    monkeypatch.setattr(pipeline.config, "TITLECARDS_ENABLED", True)
+    monkeypatch.setattr(pipeline.config, "REENCODING", False)
+    monkeypatch.setattr(pipeline.config, "DEBUGGING", False)
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", lambda **_k: True)
+    monkeypatch.setattr(
+        pipeline.files, "get_unique_filename", lambda *a, **k: "out.mp4"
+    )
+
+    # The pipeline must not probe a source video to force a resolution onto wrap.
+    def fail_probe(_path):
+        raise AssertionError("pipeline should not probe a source video for wrap")
+
+    monkeypatch.setattr(pipeline.video, "probe_video_properties", fail_probe)
+
+    wrap_calls = []
+
+    def fake_wrap(_clip, out_name, resolution=None, **_kwargs):
+        wrap_calls.append((out_name, resolution))
+        return True
+
+    monkeypatch.setattr(pipeline.titlecards, "wrap_clip_with_cards", fake_wrap)
+
+    generated, _ = pipeline._process_single_clip_segments(
+        clip, "video1.mp4", set(), output_format="clip", collect_paths=True
+    )
+
+    assert generated == 1
+    # Wrap receives no forced resolution -> it self-probes the actual clip.
+    assert wrap_calls == [("out.mp4", None)]
+
+
 def test_multi_video_clip_stitches_across_boundary(monkeypatch, make_clip):
     clip = _multi_clip(make_clip, [("1:00", "1:30")])  # global 60-90 spans boundary
     run_ffmpeg = Mock(return_value=True)

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1635,6 +1635,69 @@ def test_api_gallery_multi_video_captures_all_parts_with_global_times(
     assert captured["duration"] == 200  # total timeline duration
 
 
+def test_api_gallery_multi_video_intervals_globally_aligned(
+    client, monkeypatch, tmp_path
+):
+    """A part boundary keeps the global capture grid evenly spaced.
+
+    A first part whose duration isn't a multiple of the interval must not push
+    the next part's grid off the global cadence (the pre-fix behavior restarted
+    each part's timestamps at 0 then shifted by the cumulative start).
+    """
+    import video
+    import viewer
+
+    a = tmp_path / "a.mp4"
+    b = tmp_path / "b.mp4"
+    a.write_bytes(b"x")
+    b.write_bytes(b"x")
+    monkeypatch.setattr(server, "_sheet_context", object())
+    monkeypatch.setattr(server, "_resolve_participant_sources", lambda p: [a, b])
+    # Part 1 is 95s (not a multiple of the 10s interval); part 2 starts at 95.
+    monkeypatch.setattr(
+        video,
+        "timeline_or_none",
+        lambda paths: [(str(a), 95, 0), (str(b), 120, 95)],
+    )
+
+    requested: dict[str, list[int]] = {}
+
+    def fake_captures(path, *, timestamps=None, **kw):
+        requested[path] = list(timestamps or [])
+        return [
+            {"file": f"{path}-{ts}.png", "timestamp": float(ts), "type": "screen"}
+            for ts in (timestamps or [])
+        ]
+
+    monkeypatch.setattr(video, "generate_interval_captures", fake_captures)
+
+    captured = {}
+
+    def fake_finalize(artifacts, **kw):
+        captured["artifacts"] = artifacts
+        return {"meta": {}}
+
+    monkeypatch.setattr(viewer, "finalize_gallery_data", fake_finalize)
+    monkeypatch.setattr(
+        viewer, "generate_gallery_viewer", lambda *a, **kw: "/out/gallery.html"
+    )
+
+    server._gallery_cancel_event.clear()
+    resp = client.post(
+        "/studio/api/gallery",
+        json={"participant": "P01", "format": "screen", "interval": 10},
+    )
+
+    assert resp.status_code == 200
+    # Each part is asked for an interval-aligned local grid.
+    assert requested[str(a)] == list(range(0, 95, 10))  # 0,10,...,90
+    assert requested[str(b)] == list(range(5, 120, 10))  # 5,15,...,115
+    # Global timestamps are evenly spaced by the interval across the boundary.
+    globals_ = sorted(art["timestamp"] for art in captured["artifacts"])
+    diffs = {round(hi - lo, 6) for lo, hi in zip(globals_, globals_[1:])}
+    assert diffs == {10.0}
+
+
 def test_api_timeline_viewer_returns_409_when_busy(client, monkeypatch):
     """A second timeline-viewer build is rejected while one holds the slot, so
     the two builds can't clobber the shared cancel event."""

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -211,6 +211,66 @@ def test_settings_put_persists_card_color(client, tmp_path, monkeypatch):
     assert server.config.TITLECARD_COLOR == "#ff8800"
 
 
+def test_settings_put_rejects_card_image_traversal(client, tmp_path, monkeypatch):
+    """A card image setting that escapes the upload pool is rejected, not stored."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+    resp = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_IMAGE": "../secret.png"}},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+    assert server.config.TITLECARD_IMAGE == ""
+
+
+def test_settings_put_endcard_accepts_none_title_rejects_none(
+    client, tmp_path, monkeypatch
+):
+    """`__none__` is valid only for endcards; titlecards always render."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "ENDCARD_IMAGE", "")
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+
+    ok = client.put(
+        "/studio/api/settings",
+        json={"settings": {"ENDCARD_IMAGE": server.config.CARD_IMAGE_NONE}},
+    )
+    assert ok.status_code == 200
+    assert server.config.ENDCARD_IMAGE == server.config.CARD_IMAGE_NONE
+
+    bad = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_IMAGE": server.config.CARD_IMAGE_NONE}},
+    )
+    assert bad.status_code == 400
+    assert server.config.TITLECARD_IMAGE == ""
+
+
+def test_settings_put_card_image_validates_against_pool(client, tmp_path, monkeypatch):
+    """An existing uploaded basename is accepted; a missing one is rejected."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+    images = tmp_path / server.config.TITLECARD_IMAGES_DIRNAME
+    images.mkdir()
+    (images / "card.png").write_bytes(b"x")
+
+    ok = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_IMAGE": "card.png"}},
+    )
+    assert ok.status_code == 200
+    assert server.config.TITLECARD_IMAGE == "card.png"
+
+    missing = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_IMAGE": "ghost.png"}},
+    )
+    assert missing.status_code == 400
+    # A rejected value must not overwrite the prior good selection.
+    assert server.config.TITLECARD_IMAGE == "card.png"
+
+
 def test_api_sheet_baseline_returns_empty_when_no_sheet(client):
     resp = client.get("/studio/api/sheet/baseline")
     assert resp.status_code == 200

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -3693,10 +3693,6 @@ def test_api_reel_direct_wraps_segments_when_titlecards_enabled(
     monkeypatch.setattr(
         "files.get_unique_filename", lambda name, file_format=None: name
     )
-    monkeypatch.setattr(
-        "video.probe_video_properties",
-        lambda path: {"width": 1280, "height": 720, "audio_codec": "aac"},
-    )
 
     wrap_calls: list[dict] = []
 
@@ -3740,7 +3736,9 @@ def test_api_reel_direct_wraps_segments_when_titlecards_enabled(
     assert len(wrap_calls) == 2
     assert wrap_calls[0]["duration"] == 3
     assert wrap_calls[0]["enabled"] is True
-    assert wrap_calls[0]["resolution"] == "1280x720"
+    # No forced resolution: wrap_clip_with_cards probes the cut clip itself, so a
+    # span cut from a later source part is wrapped at that part's resolution.
+    assert wrap_calls[0]["resolution"] is None
     assert wrap_calls[0]["desc"] == "first"
     assert wrap_calls[1]["desc"] == "second"
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -2530,6 +2530,34 @@ def test_load_studio_settings_missing_file(monkeypatch, tmp_path):
     assert applied == {}
 
 
+def test_load_studio_settings_skips_invalid_card_image(monkeypatch, tmp_path):
+    """A persisted card image that PUT would reject is not applied on load."""
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+    monkeypatch.setattr(server.config, "ENDCARD_IMAGE", "")
+
+    images = tmp_path / server.config.TITLECARD_IMAGES_DIRNAME
+    images.mkdir()
+    (images / "good.png").write_bytes(b"x")
+
+    settings_file = tmp_path / server.config.STUDIO_SETTINGS_FILENAME
+    settings_file.write_text(
+        json.dumps(
+            {
+                "TITLECARD_IMAGE": "../escape.png",  # traversal → rejected
+                "ENDCARD_IMAGE": "good.png",  # real upload → applied
+            }
+        )
+    )
+
+    applied = server._load_studio_settings()
+    # The bad value is skipped (config stays at default); the good one applies.
+    assert "TITLECARD_IMAGE" not in applied
+    assert server.config.TITLECARD_IMAGE == ""
+    assert applied["ENDCARD_IMAGE"] == "good.png"
+    assert server.config.ENDCARD_IMAGE == "good.png"
+
+
 def test_save_studio_settings_non_defaults_only(monkeypatch, tmp_path):
     """Only non-default values are written; all-defaults deletes the file."""
     import config

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -127,6 +127,28 @@ def test_api_titlecard_upload_list_and_serve(client, tmp_path, monkeypatch):
     assert served.data == b"\x89PNG fake"
 
 
+def test_api_titlecard_upload_makes_filename_url_safe(client, tmp_path, monkeypatch):
+    """A filename with URL-reserved chars is sanitized so its served URL works."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    resp = client.post(
+        "/studio/api/titlecards/upload",
+        data={"file": (io.BytesIO(b"\x89PNG fake"), "my #1.png")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    item = resp.get_json()["item"]
+    name = item["id"]
+    # No URL-reserved character survives into the stored name, id, or URL.
+    for bad in ("#", " ", "%", "&"):
+        assert bad not in name
+        assert bad not in item["url"]
+    assert item["url"] == "/api/titlecards/image/" + name
+
+    served = client.get("/studio/api/titlecards/image/" + name)
+    assert served.status_code == 200
+    assert served.data == b"\x89PNG fake"
+
+
 def test_api_titlecard_delete_resets_selection(client, tmp_path, monkeypatch):
     monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
     images = tmp_path / server.config.TITLECARD_IMAGES_DIRNAME

--- a/tests/test_titlecards.py
+++ b/tests/test_titlecards.py
@@ -547,8 +547,14 @@ def test_wrap_reencode_uses_fast_preset(monkeypatch, make_clip):
     assert "-c:a aac" in joined
 
 
-def test_pipeline_skips_per_output_probe(monkeypatch, make_clip):
-    """Regression: pipeline should probe the source video, not each generated output."""
+def test_pipeline_wraps_clip_without_forcing_source_resolution(monkeypatch, make_clip):
+    """Pipeline lets wrap_clip_with_cards probe each generated clip itself.
+
+    Previously the pipeline probed the first source video once and forced that
+    resolution onto every wrap, which broke multi-video clips cut from a part
+    with a different resolution. Now the pipeline does no source probe and wrap
+    is called with resolution unset so it uses the actual clip's dimensions.
+    """
     import pipeline
 
     clip = make_clip(value="00:10-00:20")
@@ -594,9 +600,10 @@ def test_pipeline_skips_per_output_probe(monkeypatch, make_clip):
     )
 
     assert generated == 2
-    # Source is probed once for two segments; outputs are not probed separately.
-    assert probe_calls == ["source.mp4"]
+    # The pipeline no longer probes the source; each clip's resolution is
+    # determined by wrap_clip_with_cards itself (resolution left as None).
+    assert probe_calls == []
     assert wrap_calls == [
-        ("out1.mp4", "1280x720"),
-        ("out2.mp4", "1280x720"),
+        ("out1.mp4", None),
+        ("out2.mp4", None),
     ]

--- a/tests/test_titlecards.py
+++ b/tests/test_titlecards.py
@@ -338,6 +338,17 @@ def test_resolve_card_background_upload_missing_falls_back(monkeypatch, tmp_path
     assert skip is False
 
 
+def test_resolve_card_background_rejects_traversal(monkeypatch, tmp_path):
+    """A '../' value must fall back to the default, not resolve outside the pool."""
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    # Plant a real file one level above the pool that a traversal value targets.
+    (tmp_path / "outside.png").write_bytes(b"x")
+    monkeypatch.setattr(config, "TITLECARD_IMAGE", "../outside.png")
+    path, _allow_color, skip, _fill = titlecards.resolve_card_background("title")
+    assert path == utils.get_bundled_assets_root() / "assets" / "titlecard.png"
+    assert skip is False
+
+
 def test_build_titlecard_frame_uses_configured_solid_color(monkeypatch, make_clip):
     """An explicit solid-color titlecard fills with the configured color."""
     clip = make_clip(desc="Colored")

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1073,3 +1073,24 @@ def test_mux_subtitles_missing_input_returns_false(tmp_path):
         str(tmp_path / "missing.mp4"), str(srt), str(tmp_path / "out.mp4")
     )
     assert ok is False
+
+
+def test_batch_extract_screenshots_seeks_only_for_offset_grid(monkeypatch):
+    """An offset (interval-aligned) grid seeks the input; a zero grid does not."""
+    captured = {}
+
+    def fake_run(command, **_kwargs):
+        captured["cmd"] = command
+        return None  # short-circuit fallback; we only inspect the built command
+
+    monkeypatch.setattr(video.config, "SCREENSHOT_FORMAT", ".png")
+    monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)
+
+    # Multi-video part aligned to the global grid -> first capture at 5s.
+    video._batch_extract_screenshots("in.mp4", [5, 15], 10)
+    assert "-ss" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("-ss") + 1] == "5"
+
+    # Zero-aligned grid -> no input seek (unchanged behavior).
+    video._batch_extract_screenshots("in.mp4", [0, 10], 10)
+    assert "-ss" not in captured["cmd"]

--- a/titlecards.py
+++ b/titlecards.py
@@ -246,6 +246,13 @@ def resolve_card_background(kind: str) -> tuple[Path | None, bool, bool, str]:
     if not value:
         return (default_path, default_allow_color, False, "black")
 
+    # Only a bare filename inside the upload pool is a valid selection. Reject
+    # path separators / traversal so a stray config value can't resolve outside
+    # TITLECARD_IMAGES_DIRNAME. The Studio settings route validates this already;
+    # this guards the CLI / persisted-settings path too.
+    if Path(value).name != value:
+        return (default_path, default_allow_color, False, "black")
+
     upload_path = (
         utils.get_effective_output_dir() / config.TITLECARD_IMAGES_DIRNAME / value
     )

--- a/video.py
+++ b/video.py
@@ -1914,11 +1914,17 @@ def _batch_extract_screenshots(
         return None
     tmpdir = tempfile.mkdtemp(prefix="clipgen_gallery_")
     try:
+        # The fps filter samples from t=0, so for an offset grid (a multi-video
+        # part aligned to the global interval) seek the input first; frame index
+        # i then still maps to timestamps[i] because the grid is evenly spaced.
+        start_offset = timestamps[0] if timestamps else 0
+        seek_args = ["-ss", str(start_offset)] if start_offset > 0 else []
         ffmpeg_command = [
             "ffmpeg",
             "-y",
             "-loglevel",
             config.FFMPEG_LOGLEVEL,
+            *seek_args,
             "-i",
             input_file,
             "-vf",
@@ -2050,6 +2056,7 @@ def generate_interval_captures(
     interval_seconds: int = 10,
     output_format: str = "screen",
     gif_duration_seconds: int = 3,
+    timestamps: list[int] | None = None,
     cancel_flag: Callable[[], bool] | None = None,
 ) -> list[dict[str, Any]]:
     """Generate screenshots or GIFs at regular intervals throughout a video.
@@ -2059,6 +2066,11 @@ def generate_interval_captures(
         interval_seconds: Seconds between each capture
         output_format: 'screen' for PNG screenshots or 'gif' for animated GIFs
         gif_duration_seconds: Duration of each GIF in seconds (ignored for screenshots)
+        timestamps: Explicit (local) capture times in seconds. When omitted,
+            defaults to ``range(0, duration, interval_seconds)``. Multi-video
+            galleries pass a grid aligned to the global interval so spacing stays
+            even across part boundaries; values must still be evenly spaced by
+            ``interval_seconds`` (the batch screenshot path relies on it).
         cancel_flag: Optional callable; when it returns True the build stops and
             the in-flight ffmpeg encode is terminated (used by Studio's gallery
             Cancel button).
@@ -2083,7 +2095,8 @@ def generate_interval_captures(
         return []
 
     ext = config.SCREENSHOT_FORMAT if output_format == "screen" else config.GIF_FORMAT
-    timestamps = list(range(0, duration, interval_seconds))
+    if timestamps is None:
+        timestamps = list(range(0, duration, interval_seconds))
     total = len(timestamps)
     artifacts: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary

Four independent fixes from a code review of the recent titlecard work (PRs #439–#441), one per commit:

- **`fix(server): validate card image settings against the upload pool`** — `PUT /api/settings` accepted arbitrary strings for `TITLECARD_IMAGE`/`ENDCARD_IMAGE`, which `resolve_card_background` later joined under the output dir, so `../foo.png` escaped the `titlecard_images` pool. A new `_coerce_card_image` + `card_picker` validation branch accepts only the sentinel ids (`""`, `__color__`, and `__none__` for endcards) or an existing basename in the pool; `resolve_card_background` also gains a basename guard for the CLI/persisted-settings path.
- **`fix(titlecards): probe the generated clip for wrap resolution`** — multi-video clips cut from a later part were wrapped at the *first* source's resolution, so a mismatch failed the card concat and silently kept the unwrapped clip. `wrap_clip_with_cards` already probes the generated clip, so the forced resolution never saved a probe — it only substituted the wrong value. Dropped the first-source probe (`pipeline.py`) and the `resolution_cache` (direct-intake reel) and let wrap use the clip's own resolution.
- **`fix(server): sanitize uploaded card filenames for URL safety`** — `sanitize_filename` left URL-reserved chars (`#`, `%`, `&`, space, …) intact, so an upload like `my #1.png` served at `/api/titlecards/image/...` lost its `#…` fragment. Those characters are now replaced with `_` at upload time (unicode preserved).
- **`fix(server): keep gallery interval captures globally aligned across parts`** — multi-video galleries captured each part from t=0 then shifted by the cumulative start, so a part whose duration wasn't a multiple of the interval left uneven spacing at boundaries. `generate_interval_captures` gains an optional `timestamps` arg; the route now passes an interval-aligned local grid, and the batch screenshot path seeks the input by the grid's first offset.

No `build/VERSION` bump (all `fix:`).

## Test plan

- [x] `ruff format --check` + `ruff check` clean
- [x] `ty check` clean
- [x] Full `pytest` suite green, including new tests:
  - settings validation rejects traversal / `__none__` on titlecards / missing uploads; `resolve_card_background` rejects traversal
  - pipeline + direct-intake reel wrap with no forced resolution; multi-video clip from part 2 wrapped at its own resolution
  - uploaded `my #1.png` is URL-safe and serves correctly
  - multi-video gallery grid stays evenly spaced across an indivisible part boundary; batch screenshot seeks only for an offset grid
- [x] Studio UI not browser-checked — recommend confirming the card picker, an upload with `#` in the name, and a multi-video gallery in the browser.