### PR TITLE
fix: address code-review findings across transcripts, screenspace, studio

### DIFF
--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -6250,11 +6250,20 @@
 
   // ---- SSE (Server-Sent Events) with polling fallback ----
 
+  // Heatmap PNG/GIF filenames are attached after a task is marked completed
+  // (they're generated outside the worker lock), so a task can surface as
+  // "completed" before they exist. Signature lets us detect their late arrival.
+  function _heatmapSig(t) {
+    if (!t) return "";
+    return (t.heatmap || "") + "|" + (t.heatmap_gif || "") + "|" + (t.heatmap_rolling_gif || "");
+  }
+
   function handleTaskData(data) {
     if (!data.ok) return;
     var oldSelected = state.selectedTaskId;
     var oldTask = oldSelected ? findTask(oldSelected) : null;
     var wasRunning = oldTask && (oldTask.status === "queued" || oldTask.status === "running");
+    var oldHeatmapSig = _heatmapSig(oldTask);
     state.tasks = data.tasks;
     // Only rebuild the pause/play icon when the queue state actually flips —
     // handleTaskData runs on every SSE push (≈2/s while a task streams
@@ -6263,8 +6272,10 @@
       state.queuePaused = data.paused;
       updatePauseButton();
     }
+    // Heatmap fields are part of the fingerprint so a push that only attaches
+    // them (status/progress unchanged at completed:1) still refreshes the list.
     var fp = JSON.stringify(data.tasks.map(function (t) {
-      return t.id + ":" + t.status + ":" + t.progress;
+      return t.id + ":" + t.status + ":" + t.progress + ":" + _heatmapSig(t);
     }));
     var changed = fp !== _lastPollFingerprint;
     _lastPollFingerprint = fp;
@@ -6285,6 +6296,14 @@
       var newTask = findTask(oldSelected);
       if (newTask && newTask.status === "completed") {
         loadAndShowResults(oldSelected);
+      }
+    } else if (oldSelected) {
+      // Late heatmap arrival on an already-completed selected task: re-render
+      // so the heatmap section appears without a page reload.
+      var curTask = findTask(oldSelected);
+      if (curTask && curTask.status === "completed" && _heatmapSig(curTask) !== oldHeatmapSig) {
+        if (state.selectedTaskResults) renderResults();
+        else loadAndShowResults(oldSelected);
       }
     }
     ensureEtaTicker();

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -788,6 +788,11 @@
       if (ver !== _participantReqVer) return;
       if (data.ok && data.summary) {
         _stopSummaryPoll();
+        // Clear any citation state carried over from a previous participant
+        // before rendering — renderSummary() reapplies state.summaryCitations,
+        // so stale superscripts would otherwise leak onto this summary.
+        state.summaryCitations = null;
+        state.citationsGenerating = false;
         renderSummary(data.summary);
         // Handle citations
         if (data.citations && data.citations.length > 0) {
@@ -829,6 +834,9 @@
         if (ver !== _participantReqVer) return;
         if (data.ok && data.summary) {
           _stopSummaryPoll();
+          // Clear stale citation state before render (see loadSummary).
+          state.summaryCitations = null;
+          state.citationsGenerating = false;
           renderSummary(data.summary);
           // Summary just arrived — check citation status
           if (data.citations && data.citations.length > 0) {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -4292,20 +4292,52 @@
   }
 
   function transcribeParticipants(pids, force, overrides) {
-    ensureWhisperModelsForPids(pids, overrides).then(function (ok) {
-      if (!ok) return;
-      var body = { participants: pids, force: force };
-      if (overrides && Object.keys(overrides).length > 0) body.overrides = overrides;
-      apiPost("api/transcribe", body).then(function (data) {
-        if (!data.ok) {
-          showToast("Failed to enqueue transcription");
+    _postTranscribe(pids, force, overrides, false);
+  }
+
+  // POST to the transcribe endpoint. The server is the authority on whether a
+  // Whisper model is cached: when it rejects with reason "model_not_cached", we
+  // confirm each uncached download with the user and retry with allow_download.
+  function _postTranscribe(pids, force, overrides, allowDownload) {
+    var body = { participants: pids, force: force };
+    if (overrides && Object.keys(overrides).length > 0) body.overrides = overrides;
+    if (allowDownload) body.allow_download = true;
+    apiPost("api/transcribe", body).then(function (data) {
+      if (!data.ok) {
+        if (data.reason === "model_not_cached" && data.uncached && data.uncached.length) {
+          _confirmUncachedWhisperModels(data.uncached).then(function (ok) {
+            if (ok) _postTranscribe(pids, force, overrides, true);
+          });
           return;
         }
-        showToast("Enqueued " + clipgenPluralUnit(data.tasks.length, "transcription", "transcriptions"));
-        startPolling();
-        pollTaskStatus();
-      });
+        showToast("Failed to enqueue transcription");
+        return;
+      }
+      showToast("Enqueued " + clipgenPluralUnit(data.tasks.length, "transcription", "transcriptions"));
+      startPolling();
+      pollTaskStatus();
     });
+  }
+
+  // Confirm each distinct non-cached Whisper model in turn; any cancel aborts.
+  function _confirmUncachedWhisperModels(uncached) {
+    return uncached.reduce(function (chain, m) {
+      return chain.then(function (okSoFar) {
+        if (!okSoFar) return false;
+        return confirmModelInstall({
+          kind: "whisper",
+          model: m.model,
+          sizeMb: m.size_mb,
+        }).then(function (ok) {
+          if (ok) {
+            _whisperDownloadConfirmed[m.model] = true;
+            _trModelsCache = null;
+            _trModelsCachePromise = null;
+          }
+          return ok;
+        });
+      });
+    }, Promise.resolve(true));
   }
 
   // ---- Task polling ----
@@ -4852,50 +4884,6 @@
       }
       if (!info || info.installed || !info.model) return true;
       return confirmModelInstall({ kind: "ollama", agentKey: agentKey, model: info.model });
-    }).catch(function () { return true; });
-  }
-
-  // Gate transcription on every resolved whisper model being downloaded.
-  // Resolves true to proceed, false if the user cancels any required download.
-  function ensureWhisperModelsForPids(pids, overrides) {
-    return _trFetchModels().then(function (data) {
-      var models = (data && data.whisper && data.whisper.models) || [];
-      if (!models.length) return true;
-      var byName = {};
-      var defaultName = "";
-      models.forEach(function (m) {
-        byName[m.name] = m;
-        if (m.selected) defaultName = m.name;
-      });
-      var needed = {};
-      (pids || []).forEach(function (pid) {
-        var ov = (overrides && overrides[pid]) || {};
-        var name = ov.model || defaultName;
-        var m = name && byName[name];
-        if (m && m.cached === false && !_whisperDownloadConfirmed[name]) needed[name] = m;
-      });
-      var names = Object.keys(needed);
-      if (!names.length) return true;
-      // Confirm each distinct non-cached model in turn; any cancel aborts.
-      return names.reduce(function (chain, name) {
-        return chain.then(function (okSoFar) {
-          if (!okSoFar) return false;
-          return confirmModelInstall({
-            kind: "whisper",
-            model: name,
-            sizeMb: needed[name].size_mb,
-          }).then(function (ok) {
-            // Remember the agreement so we don't re-prompt before the
-            // background download has finished (the cached flag lags).
-            if (ok) {
-              _whisperDownloadConfirmed[name] = true;
-              _trModelsCache = null;
-              _trModelsCachePromise = null;
-            }
-            return ok;
-          });
-        });
-      }, Promise.resolve(true));
     }).catch(function () { return true; });
   }
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1313,8 +1313,16 @@ def _build_reel_transcript(
     cards_enabled, titlecard_duration = _resolve_titlecard_options(
         titlecards_enabled, titlecard_duration_seconds
     )
+    # Each wrapped clip is titlecard + clip body + endcard (wrap_clip_with_cards),
+    # so the per-component span the next component starts after is
+    # titlecard + clip + endcard. The endcard is skipped only when ENDCARD_IMAGE
+    # is the "none" sentinel; mirror that decision via resolve_card_background.
+    endcard_duration = 0
     if not cards_enabled:
         titlecard_duration = 0
+    else:
+        _bg, _allow, skip_end, _color = titlecards.resolve_card_background("end")
+        endcard_duration = 0 if skip_end else titlecard_duration
 
     for comp in components:
         participant = comp.get("participant", "")
@@ -1349,7 +1357,7 @@ def _build_reel_transcript(
                 )
                 seg_counter += 1
 
-        cumulative_offset += comp_duration + titlecard_duration
+        cumulative_offset += comp_duration + titlecard_duration + endcard_duration
 
     return merged_segments
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1387,6 +1387,32 @@ def process_reel(
         Each reel record contains an ``id``, ``file``, ``study``, ``description``,
         and an ordered ``components`` list with per-segment metadata for regeneration.
     """
+    try:
+        return _process_reel(
+            clips_list,
+            output_file,
+            cancel_flag=cancel_flag,
+            progress_cb=progress_cb,
+            titlecards_enabled=titlecards_enabled,
+            titlecard_duration_seconds=titlecard_duration_seconds,
+        )
+    finally:
+        # Endcard temp files are cached per-process across every wrap call;
+        # purge them so per-request cards don't leak between reel builds. The
+        # CLI, interactive, and Studio /api/reel paths all route through here,
+        # mirroring the cleanup process_clips and /api/reel-direct already do.
+        titlecards.clear_endcard_cache()
+
+
+def _process_reel(
+    clips_list: list[ClipRecord],
+    output_file: str | None = None,
+    cancel_flag: Callable[[], bool] | None = None,
+    progress_cb: Callable[[dict[str, Any]], None] | None = None,
+    titlecards_enabled: bool | None = None,
+    titlecard_duration_seconds: int | None = None,
+) -> tuple[int, list[dict[str, Any]]]:
+    """Reel build implementation; see process_reel for the public contract."""
     if not clips_list:
         utils.warning_print(
             "No clips to process for reel. No timestamps were found or selected."

--- a/screenspace.py
+++ b/screenspace.py
@@ -74,8 +74,13 @@ from screenspace_ocr import (
     _score_text_readings,
     run_calibration_ocr,
 )
+
+# Re-exporting a name here only rebinds it on the facade — it does NOT propagate
+# to siblings that imported it (e.g. ``screenspace_scans._probe_video_meta``). To
+# stub a seam in a test, patch the owning module, not the facade.
 from screenspace_frames import (
     _ffmpeg_pipe_frames,
+    _probe_video_meta,
     _scan_via_ffmpeg_pipe,
     build_timelapse_command,
     scan_video_frames,

--- a/screenspace_heatmap.py
+++ b/screenspace_heatmap.py
@@ -155,6 +155,20 @@ def _heatmap_frame_image(
     return Image.fromarray(rgb)
 
 
+def _frame_bucket_bounds(
+    frame_idx: int, total: int, num_frames: int
+) -> tuple[int, int]:
+    """Return the ``[start, end)`` result indices for one GIF frame.
+
+    Proportional split (``floor(i*total/n) .. floor((i+1)*total/n)``) so results
+    spread evenly across frames — adjacent bucket sizes differ by at most one.
+    Floor division of ``total // num_frames`` instead piles every remainder onto
+    the final frame (e.g. 47 results / 24 frames → 23 frames of 1, last of 24).
+    The last frame's end is exactly ``total``.
+    """
+    return (frame_idx * total) // num_frames, ((frame_idx + 1) * total) // num_frames
+
+
 def generate_heatmap_gif(
     results: list[dict[str, Any]],
     width: int,
@@ -191,15 +205,9 @@ def generate_heatmap_gif(
     # Second pass: build progressive frames
     accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
     frames: list[Image.Image] = []
-    bucket_size = max(1, len(results) // num_frames)
 
     for frame_idx in range(num_frames):
-        start_idx = frame_idx * bucket_size
-        end_idx = (
-            len(results)
-            if frame_idx == num_frames - 1
-            else min((frame_idx + 1) * bucket_size, len(results))
-        )
+        start_idx, end_idx = _frame_bucket_bounds(frame_idx, len(results), num_frames)
         for r_idx in range(start_idx, end_idx):
             _accumulate_heatmap_result(accumulator, results[r_idx], heatmap_type)
 
@@ -248,18 +256,12 @@ def generate_rolling_heatmap_gif(
     acc_h, acc_w = height, width
     if heatmap_type in ("flow", "change"):
         acc_h = acc_w = 256
-    bucket_size = max(1, len(results) // num_frames)
 
     def _accumulate_window(frame_idx: int) -> np.ndarray:
         acc = np.zeros((acc_h, acc_w), dtype=np.float32)
         win_start = max(0, frame_idx - window_frames + 1)
         for bucket in range(win_start, frame_idx + 1):
-            start_idx = bucket * bucket_size
-            end_idx = (
-                len(results)
-                if bucket == num_frames - 1
-                else min((bucket + 1) * bucket_size, len(results))
-            )
+            start_idx, end_idx = _frame_bucket_bounds(bucket, len(results), num_frames)
             for r_idx in range(start_idx, end_idx):
                 _accumulate_heatmap_result(acc, results[r_idx], heatmap_type)
         return acc

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -566,6 +566,13 @@ class ScreenspaceWorker:
                     t = self._tasks.get(task_id)
                     if t is not None:
                         t.update(attachments)
+                # The task was already marked completed before these heatmap
+                # filenames were attached, so emit an SSE update now — otherwise
+                # the frontend (which may already have seen the completed task via
+                # another worker's progress push) never re-renders the heatmap
+                # section until a page reload.
+                if attachments and self.on_progress_update:
+                    self.on_progress_update()
         except Exception as exc:
             with self._lock:
                 t = self._tasks.get(task_id)

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -287,17 +287,20 @@ class ScreenspaceWorker:
 
     def _write_heatmap_gifs(
         self,
-        task: dict[str, Any],
+        task_id: str,
         results: list[dict[str, Any]],
         width: int,
         height: int,
         heatmap_type: str,
         *,
         rolling: bool,
-    ) -> None:
-        """Write the cumulative (and optionally rolling-window) heatmap GIFs."""
+    ) -> dict[str, str]:
+        """Write the cumulative (and optionally rolling-window) heatmap GIFs.
+
+        Returns the generated GIF filenames keyed by attachment name.
+        """
         out_dir = Path(utils.get_effective_output_dir())
-        task_id = task["id"]
+        attachments: dict[str, str] = {}
         gp = generate_heatmap_gif(
             results,
             width,
@@ -306,7 +309,7 @@ class ScreenspaceWorker:
             heatmap_type=heatmap_type,
         )
         if gp:
-            task["heatmap_gif"] = Path(gp).name
+            attachments["heatmap_gif"] = Path(gp).name
         if rolling:
             rp = generate_rolling_heatmap_gif(
                 results,
@@ -317,49 +320,63 @@ class ScreenspaceWorker:
                 window_frames=config.SCREENSPACE_HEATMAP_ROLLING_WINDOW,
             )
             if rp:
-                task["heatmap_rolling_gif"] = Path(rp).name
+                attachments["heatmap_rolling_gif"] = Path(rp).name
+        return attachments
 
     def _generate_heatmap(
-        self, task: dict[str, Any], results: list[dict[str, Any]]
-    ) -> None:
+        self,
+        task_type: str,
+        task_id: str,
+        video_paths: list[str],
+        region_coords: dict[str, Any],
+        results: list[dict[str, Any]],
+    ) -> dict[str, str]:
         """Generate heatmap artifacts for template, flow, or change tasks.
 
-        Honors the per-tool ``SCREENSPACE_GENERATE_*_HEATMAP`` settings: when a
-        tool's heatmaps are disabled, nothing is generated for that task.
+        Pure compute + file I/O — takes primitives instead of the task dict and
+        returns the generated filenames keyed by attachment name, so it can run
+        *outside* the worker lock (it touches no shared task state). Honors the
+        per-tool ``SCREENSPACE_GENERATE_*_HEATMAP`` settings: when a tool's
+        heatmaps are disabled, returns ``{}``.
         """
-        task_type = task.get("type", "")
         heatmap_enabled = {
             "template": config.SCREENSPACE_GENERATE_TEMPLATE_HEATMAP,
             "flow": config.SCREENSPACE_GENERATE_FLOW_HEATMAP,
             "change": config.SCREENSPACE_GENERATE_CHANGE_HEATMAP,
         }
         if not heatmap_enabled.get(task_type, False):
-            return
-        task_id = task["id"]
+            return {}
+        attachments: dict[str, str] = {}
         heatmap_path = str(
             Path(utils.get_effective_output_dir()) / f"heatmap_{task_id}.png"
         )
         if task_type == "template":
-            props = video.probe_video_properties(task["video_paths"][0])
+            props = video.probe_video_properties(video_paths[0])
             fw = props.get("width", 1920) if props else 1920
             fh = props.get("height", 1080) if props else 1080
             hp = generate_template_heatmap(results, fw, fh, heatmap_path)
             if hp:
-                task["heatmap"] = Path(hp).name
-            self._write_heatmap_gifs(task, results, fw, fh, "template", rolling=True)
+                attachments["heatmap"] = Path(hp).name
+            attachments.update(
+                self._write_heatmap_gifs(
+                    task_id, results, fw, fh, "template", rolling=True
+                )
+            )
         elif task_type in ("flow", "change"):
-            rc = task.get("region_coords", {})
-            rw = rc.get("w", 256)
-            rh = rc.get("h", 256)
+            rw = region_coords.get("w", 256)
+            rh = region_coords.get("h", 256)
             if task_type == "flow":
                 hp = generate_flow_heatmap(results, rw, rh, heatmap_path)
             else:
                 hp = generate_change_heatmap(results, rw, rh, heatmap_path)
             if hp:
-                task["heatmap"] = Path(hp).name
-            self._write_heatmap_gifs(
-                task, results, rw, rh, task_type, rolling=task_type == "change"
+                attachments["heatmap"] = Path(hp).name
+            attachments.update(
+                self._write_heatmap_gifs(
+                    task_id, results, rw, rh, task_type, rolling=task_type == "change"
+                )
             )
+        return attachments
 
     def _run(self) -> None:
         """Worker loop with concurrent task execution via ThreadPoolExecutor."""
@@ -492,6 +509,9 @@ class ScreenspaceWorker:
 
         try:
             result = self._dispatch(task, _on_progress, _cancel_flag, _on_result)
+            # Inputs for deferred (lock-free) heatmap generation, captured under
+            # the lock and consumed after it's released.
+            heatmap_inputs: tuple[str, list[str], dict[str, Any]] | None = None
             with self._lock:
                 t = self._tasks.get(task_id)
                 if t:
@@ -517,14 +537,35 @@ class ScreenspaceWorker:
                             t, raw
                         )
                         if isinstance(result, list) and result:
-                            self._generate_heatmap(t, result)
-                            # change_grid is consumed only by heatmap generation;
-                            # drop it so completed tasks don't retain per-frame
-                            # grids in memory until dismissal.
-                            for r in result:
-                                if isinstance(r, dict):
-                                    r.pop("change_grid", None)
+                            # Defer heatmap/GIF generation to outside the lock —
+                            # it's heavy I/O (PNG + cumulative/rolling GIFs) that
+                            # would otherwise block status reads, cancellation,
+                            # dismissal, and SSE snapshots after scan completion.
+                            heatmap_inputs = (
+                                t.get("type", ""),
+                                list(t.get("video_paths", [])),
+                                dict(t.get("region_coords", {})),
+                            )
                     t["completed_at"] = datetime.now(timezone.utc).isoformat()
+
+            # Generate heatmaps without holding the lock, then briefly reacquire
+            # it to attach the filenames. Safe because the scan has finished
+            # (no more _on_result appends) and nothing else mutates `result`.
+            if heatmap_inputs is not None and isinstance(result, list) and result:
+                task_type, video_paths, region_coords = heatmap_inputs
+                attachments = self._generate_heatmap(
+                    task_type, task_id, video_paths, region_coords, result
+                )
+                # change_grid is consumed only by heatmap generation; drop it so
+                # completed tasks don't retain per-frame grids in memory until
+                # dismissal.
+                for r in result:
+                    if isinstance(r, dict):
+                        r.pop("change_grid", None)
+                with self._lock:
+                    t = self._tasks.get(task_id)
+                    if t is not None:
+                        t.update(attachments)
         except Exception as exc:
             with self._lock:
                 t = self._tasks.get(task_id)

--- a/server.py
+++ b/server.py
@@ -178,6 +178,25 @@ _HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 _MARK_KEY_RE = re.compile(r"^[a-z0-9_]+$")
 
 
+def _validate_card_image(value: str) -> str | None:
+    """Return a safe card-image setting value, or None to reject it.
+
+    Card image settings become path components under the titlecard_images
+    upload dir (see titlecards.resolve_card_background), so only accept the
+    known sentinels (default/empty, solid color, no-endcard) or a bare uploaded
+    filename with an allowed image extension — never a value that could traverse
+    out of the upload pool (e.g. ``../secret.png``). ``_ALLOWED_CARD_EXTS`` is
+    the same allowlist the upload route enforces.
+    """
+    if value in ("", config.CARD_IMAGE_COLOR, config.CARD_IMAGE_NONE):
+        return value
+    if Path(value).name != value:  # rejects separators, traversal, absolute paths
+        return None
+    if Path(value).suffix.lower() not in _ALLOWED_CARD_EXTS:
+        return None
+    return value
+
+
 def _coerce_mark_categories(value: Any) -> dict[str, dict[str, str]] | None:
     """Validate and normalize a mark_categories payload.
 
@@ -1039,6 +1058,20 @@ def _load_studio_settings() -> dict[str, Any]:
                 continue
             setattr(config, name, cleaned)
             applied[name] = cleaned
+            continue
+        if meta.get("type") == "card_picker":
+            validated = _validate_card_image(str(value))
+            if validated is None:
+                continue  # ignore a tampered/invalid value, keep the default
+            setattr(config, name, validated)
+            applied[name] = validated
+            continue
+        if name in ("TITLECARD_COLOR", "ENDCARD_COLOR"):
+            color = str(value)
+            if not _HEX_COLOR_RE.match(color):
+                continue
+            setattr(config, name, color)
+            applied[name] = color
             continue
         expected_type = type(default) if default is not None else str
         try:
@@ -2198,6 +2231,20 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
                 return {}, f"Invalid {name} payload"
             setattr(config, name, cleaned)
             applied[name] = cleaned
+            continue
+        if meta.get("type") == "card_picker":
+            validated = _validate_card_image(str(value))
+            if validated is None:
+                return {}, f"Invalid {name}: not an uploaded card image or preset"
+            setattr(config, name, validated)
+            applied[name] = validated
+            continue
+        if name in ("TITLECARD_COLOR", "ENDCARD_COLOR"):
+            color = str(value)
+            if not _HEX_COLOR_RE.match(color):
+                return {}, f"Invalid {name}: expected a #rrggbb hex color"
+            setattr(config, name, color)
+            applied[name] = color
             continue
         expected_type = type(default) if default is not None else str
         try:

--- a/server.py
+++ b/server.py
@@ -2218,7 +2218,13 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
         setattr(config, name, coerced)
         applied[name] = coerced
 
-    _save_studio_settings(applied)
+    # Persist the full current settings state, not just the submitted keys: a
+    # partial PUT (e.g. only the inline titlecard toggle) must not drop other
+    # non-default settings already on disk. Every submitted key is now on
+    # config, so snapshot all of STUDIO_SETTINGS and let _save_studio_settings
+    # drop the ones equal to their default. Mirrors the reset path above.
+    merged = {name: getattr(config, name) for name in config.STUDIO_SETTINGS}
+    _save_studio_settings(merged)
     return applied, None
 
 

--- a/tests/screenspace/test_change_similarity.py
+++ b/tests/screenspace/test_change_similarity.py
@@ -231,22 +231,27 @@ class TestHeatmapDisableSetting:
             for i in range(n)
         ]
 
+    def _run_generate(self, worker, task):
+        return worker._generate_heatmap(
+            task["type"],
+            task["id"],
+            task["video_paths"],
+            task["region_coords"],
+            self._change_results(),
+        )
+
     def test_skipped_when_disabled(self, monkeypatch):
         monkeypatch.setattr(config, "SCREENSPACE_GENERATE_CHANGE_HEATMAP", False)
         worker = screenspace.ScreenspaceWorker()
-        task = self._change_task()
-        worker._generate_heatmap(task, self._change_results())
-        assert "heatmap" not in task
-        assert "heatmap_gif" not in task
-        assert "heatmap_rolling_gif" not in task
+        attachments = self._run_generate(worker, self._change_task())
+        assert attachments == {}
 
     def test_generated_when_enabled(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         monkeypatch.setattr(config, "SCREENSPACE_GENERATE_CHANGE_HEATMAP", True)
         worker = screenspace.ScreenspaceWorker()
-        task = self._change_task()
-        worker._generate_heatmap(task, self._change_results())
-        assert "heatmap" in task
+        attachments = self._run_generate(worker, self._change_task())
+        assert "heatmap" in attachments
 
     def test_settings_present_and_default_true(self):
         for name in (

--- a/tests/screenspace/test_scan_pipeline.py
+++ b/tests/screenspace/test_scan_pipeline.py
@@ -591,6 +591,16 @@ class TestScanVideoFramesFfmpegIntegration:
         assert "ffmpeg" in warnings[0].lower()
 
 
+class TestFacadeReExports:
+    """The screenspace facade must keep exposing former god-file seams."""
+
+    def test_probe_video_meta_reexported(self):
+        import screenspace_frames
+
+        assert hasattr(screenspace, "_probe_video_meta")
+        assert screenspace._probe_video_meta is screenspace_frames._probe_video_meta
+
+
 # ---------------------------------------------------------------------------
 # 2F: Parallel worker
 # ---------------------------------------------------------------------------

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import config
 import screenspace
+import screenspace_heatmap
 import screenspace_scans
 from _ss_helpers import _make_icon, _make_icon_frame
 
@@ -222,6 +223,43 @@ class TestGenerateRollingHeatmapGif:
         )
         assert path == out
         assert (tmp_path / "rolling_change.gif").stat().st_size > 0
+
+    def test_large_count_rolling_gif(self, tmp_path):
+        # 47 results / 24 frames: the old floor-division bucketing dumped the
+        # remainder onto the final frame; this just guards it still renders.
+        out = str(tmp_path / "rolling_large.gif")
+        path = screenspace.generate_rolling_heatmap_gif(
+            self._matches(47), 200, 200, out
+        )
+        assert path == out
+        assert (tmp_path / "rolling_large.gif").stat().st_size > 0
+
+
+class TestFrameBucketBounds:
+    """_frame_bucket_bounds spreads results evenly, no remainder on the last frame."""
+
+    def _buckets(self, total, num_frames):
+        return [
+            screenspace_heatmap._frame_bucket_bounds(i, total, num_frames)
+            for i in range(num_frames)
+        ]
+
+    def test_exact_multiple(self):
+        buckets = self._buckets(48, 24)
+        assert all(end - start == 2 for start, end in buckets)
+
+    def test_non_multiple_counts_are_even(self):
+        for total in (25, 47, 100):
+            num_frames = 24
+            buckets = self._buckets(total, num_frames)
+            sizes = [end - start for start, end in buckets]
+            # Contiguous, fully covering [0, total), adjacent sizes differ by ≤ 1.
+            assert buckets[0][0] == 0
+            assert buckets[-1][1] == total
+            for i in range(num_frames - 1):
+                assert buckets[i][1] == buckets[i + 1][0]
+            assert max(sizes) - min(sizes) <= 1
+            assert sum(sizes) == total
 
 
 class TestHeatmapConfigConstants:

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -592,6 +592,22 @@ def test_build_reel_transcript_skips_endcard_when_none(monkeypatch):
     assert merged[1]["end"] == 26.0
 
 
+def test_process_reel_clears_endcard_cache():
+    """process_reel purges the shared per-process endcard temp cache on exit.
+
+    Covers the CLI, interactive, and Studio /api/reel paths, which all route
+    through process_reel; previously only process_clips and /api/reel-direct
+    cleared it, so sheet/CLI reels leaked cached endcards.
+    """
+    pipeline.titlecards._endcard_cache["k"] = "/tmp/nonexistent_endcard.mp4"
+    try:
+        # An empty clip list returns early but still runs the wrapper's finally.
+        assert pipeline.process_reel([]) == (0, [])
+        assert pipeline.titlecards._endcard_cache == {}
+    finally:
+        pipeline.titlecards._endcard_cache.clear()
+
+
 def test_process_single_clip_segments_releases_reservation_on_ffmpeg_failure(
     monkeypatch, make_clip, tmp_path
 ):

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -515,6 +515,83 @@ def test_build_reel_transcript_uses_request_titlecard_duration(monkeypatch):
     assert merged[0]["end"] == 9.0
 
 
+def _mock_two_component_transcript(monkeypatch):
+    """Two participants, one segment each at local 1.0–2.0; passthrough filters."""
+    monkeypatch.setattr(
+        pipeline.transcripts,
+        "load_transcripts_manifest",
+        lambda: {
+            "source_transcripts": {
+                "P01": {"segments": [{"start": 1.0, "end": 2.0, "text": "a"}]},
+                "P02": {"segments": [{"start": 1.0, "end": 2.0, "text": "b"}]},
+            },
+            "corrections": [],
+        },
+    )
+    monkeypatch.setattr(
+        pipeline.transcripts,
+        "apply_corrections",
+        lambda segments, _corrections: segments,
+    )
+    monkeypatch.setattr(
+        pipeline.transcripts,
+        "filter_segments",
+        lambda full, start, end, offset_to_zero=True: {
+            "segments": [{"start": 1.0, "end": 2.0, "text": "seg"}]
+        },
+    )
+
+
+def test_build_reel_transcript_advances_offset_by_endcard(monkeypatch):
+    """The second component starts after clip + titlecard + endcard of the first."""
+    _mock_two_component_transcript(monkeypatch)
+    # Endcard renders (skip=False) → cumulative offset includes its duration.
+    monkeypatch.setattr(
+        pipeline.titlecards,
+        "resolve_card_background",
+        lambda kind: (None, True, False, "black"),
+    )
+    components = [
+        {"participant": "P01", "start": 0.0, "end": 10.0},
+        {"participant": "P02", "start": 0.0, "end": 8.0},
+    ]
+
+    merged = pipeline._build_reel_transcript(
+        components, titlecards_enabled=True, titlecard_duration_seconds=7
+    )
+
+    # comp1 segment: 1.0 + offset(0) + titlecard(7)
+    assert merged[0]["start"] == 8.0
+    # offset after comp1 = clip(10) + titlecard(7) + endcard(7) = 24
+    # comp2 segment: 1.0 + offset(24) + titlecard(7) = 32
+    assert merged[1]["start"] == 32.0
+    assert merged[1]["end"] == 33.0
+
+
+def test_build_reel_transcript_skips_endcard_when_none(monkeypatch):
+    """A 'none' endcard adds no outro duration to the cumulative offset."""
+    _mock_two_component_transcript(monkeypatch)
+    # Endcard skipped (skip=True) → cumulative offset omits its duration.
+    monkeypatch.setattr(
+        pipeline.titlecards,
+        "resolve_card_background",
+        lambda kind: (None, False, True, "black"),
+    )
+    components = [
+        {"participant": "P01", "start": 0.0, "end": 10.0},
+        {"participant": "P02", "start": 0.0, "end": 8.0},
+    ]
+
+    merged = pipeline._build_reel_transcript(
+        components, titlecards_enabled=True, titlecard_duration_seconds=7
+    )
+
+    # offset after comp1 = clip(10) + titlecard(7) + endcard(0) = 17
+    # comp2 segment: 1.0 + offset(17) + titlecard(7) = 25
+    assert merged[1]["start"] == 25.0
+    assert merged[1]["end"] == 26.0
+
+
 def test_process_single_clip_segments_releases_reservation_on_ffmpeg_failure(
     monkeypatch, make_clip, tmp_path
 ):

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -233,6 +233,56 @@ def test_settings_partial_put_preserves_other_settings(client, tmp_path, monkeyp
     assert saved.get("TITLECARD_DURATION_SECONDS") == 5
 
 
+def test_settings_rejects_card_image_path_traversal(client, tmp_path, monkeypatch):
+    """A crafted card image name that escapes the upload dir is rejected."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+    resp = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_IMAGE": "../secret.png"}},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+    assert server.config.TITLECARD_IMAGE == ""  # unchanged
+
+
+def test_settings_rejects_non_hex_card_color(client, tmp_path, monkeypatch):
+    """Card colors feed ffmpeg's lavfi color input — only #rrggbb is accepted."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_COLOR", "#000000")
+    resp = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_COLOR": "red; drawbox"}},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+    assert server.config.TITLECARD_COLOR == "#000000"  # unchanged
+
+
+def test_settings_accepts_valid_card_image(client, tmp_path, monkeypatch):
+    """A bare uploaded filename with an allowed extension is accepted."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+    resp = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_IMAGE": "card.png"}},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+    assert server.config.TITLECARD_IMAGE == "card.png"
+
+
+def test_load_studio_settings_drops_tampered_card_image(client, tmp_path, monkeypatch):
+    """A tampered settings file with a traversal card image is ignored on load."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "")
+    (tmp_path / server.config.STUDIO_SETTINGS_FILENAME).write_text(
+        json.dumps({"TITLECARD_IMAGE": "../../evil.png"})
+    )
+    server._load_studio_settings()
+    assert server.config.TITLECARD_IMAGE == ""  # kept default, not the tampered value
+
+
 def test_api_sheet_baseline_returns_empty_when_no_sheet(client):
     resp = client.get("/studio/api/sheet/baseline")
     assert resp.status_code == 200

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -211,6 +211,28 @@ def test_settings_put_persists_card_color(client, tmp_path, monkeypatch):
     assert server.config.TITLECARD_COLOR == "#ff8800"
 
 
+def test_settings_partial_put_preserves_other_settings(client, tmp_path, monkeypatch):
+    """A partial PUT must not drop unrelated non-default settings already saved."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    # A previously-selected card image (non-default) is live on config.
+    monkeypatch.setattr(server.config, "TITLECARD_IMAGE", "card.png")
+
+    # Submit only an inline titlecard key (mirrors the studio.js partial PUT;
+    # duration has no ffmpeg-support gate so the test stays dependency-free).
+    resp = client.put(
+        "/studio/api/settings",
+        json={"settings": {"TITLECARD_DURATION_SECONDS": 5}},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+    saved = server.utils.load_json_manifest(
+        server.config.STUDIO_SETTINGS_FILENAME, default={}
+    )
+    assert saved.get("TITLECARD_IMAGE") == "card.png"  # preserved, not dropped
+    assert saved.get("TITLECARD_DURATION_SECONDS") == 5
+
+
 def test_api_sheet_baseline_returns_empty_when_no_sheet(client):
     resp = client.get("/studio/api/sheet/baseline")
     assert resp.status_code == 200

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -220,6 +220,7 @@ def test_transcribe_applies_per_participant_overrides(tr_client, monkeypatch):
         {"id": "P01", "video_paths": ["/tmp/P01.mp4"], "has_video": True}
     ]
     transcripts_server._worker = cast("transcripts.TranscriptWorker", _StubWorker())
+    monkeypatch.setattr(transcripts, "is_whisper_model_cached", lambda n=None: True)
 
     resp = tr_client.post(
         "/transcripts/api/transcribe",
@@ -237,7 +238,7 @@ def test_transcribe_applies_per_participant_overrides(tr_client, monkeypatch):
     assert captured[0]["language"] == "sv"
 
 
-def test_transcribe_without_overrides_defaults_to_none(tr_client):
+def test_transcribe_without_overrides_defaults_to_none(tr_client, monkeypatch):
     """Missing overrides → task uses None (worker falls back to config defaults)."""
 
     captured: list[dict] = []
@@ -250,6 +251,7 @@ def test_transcribe_without_overrides_defaults_to_none(tr_client):
         {"id": "P01", "video_paths": ["/tmp/P01.mp4"], "has_video": True}
     ]
     transcripts_server._worker = cast("transcripts.TranscriptWorker", _StubWorker())
+    monkeypatch.setattr(transcripts, "is_whisper_model_cached", lambda n=None: True)
 
     resp = tr_client.post(
         "/transcripts/api/transcribe",
@@ -259,6 +261,68 @@ def test_transcribe_without_overrides_defaults_to_none(tr_client):
     assert len(captured) == 1
     assert captured[0]["model"] is None
     assert captured[0]["language"] is None
+
+
+def test_transcribe_rejects_uncached_model(tr_client, monkeypatch):
+    """An uncached Whisper model is gated: no enqueue, model_not_cached reason."""
+
+    captured: list[dict] = []
+
+    class _StubWorker:
+        def enqueue(self, task):
+            captured.append(task)
+
+    transcripts_server._participants = [
+        {"id": "P01", "video_paths": ["/tmp/P01.mp4"], "has_video": True}
+    ]
+    transcripts_server._worker = cast("transcripts.TranscriptWorker", _StubWorker())
+    monkeypatch.setattr(transcripts, "is_whisper_model_cached", lambda n=None: False)
+
+    resp = tr_client.post(
+        "/transcripts/api/transcribe",
+        json={
+            "participants": ["P01"],
+            "force": True,
+            "overrides": {"P01": {"model": "large-v3"}},
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert data["reason"] == "model_not_cached"
+    assert [u["model"] for u in data["uncached"]] == ["large-v3"]
+    assert captured == []  # nothing enqueued
+
+
+def test_transcribe_allows_uncached_with_allow_download(tr_client, monkeypatch):
+    """allow_download bypasses the cache gate and enqueues normally."""
+
+    captured: list[dict] = []
+
+    class _StubWorker:
+        def enqueue(self, task):
+            captured.append(task)
+
+    transcripts_server._participants = [
+        {"id": "P01", "video_paths": ["/tmp/P01.mp4"], "has_video": True}
+    ]
+    transcripts_server._worker = cast("transcripts.TranscriptWorker", _StubWorker())
+    monkeypatch.setattr(transcripts, "is_whisper_model_cached", lambda n=None: False)
+
+    resp = tr_client.post(
+        "/transcripts/api/transcribe",
+        json={
+            "participants": ["P01"],
+            "force": True,
+            "overrides": {"P01": {"model": "large-v3"}},
+            "allow_download": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(captured) == 1
+    assert captured[0]["model"] == "large-v3"
 
 
 # ---- Thinking-agent stop endpoints ----

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1135,6 +1135,14 @@ def api_search() -> FlaskResponse:
 # ---- Transcription queue ----
 
 
+def _whisper_model_size_mb(model: str) -> int | None:
+    """Download size (MB) for a Whisper model name, or None if unknown."""
+    return next(
+        (m["size_mb"] for m in transcripts.WHISPER_MODELS if m["name"] == model),
+        None,
+    )
+
+
 @transcripts_bp.route("/api/transcribe/warmup", methods=["POST"])
 def api_transcribe_warmup() -> FlaskResponse:
     """Background-load the Whisper model when automatic prewarm is not ``off``.
@@ -1163,17 +1171,13 @@ def api_transcribe_warmup() -> FlaskResponse:
     force = bool(data.get("force"))
     model = config.TRANSCRIBE_MODEL
     if not force and not transcripts.is_whisper_model_cached(model):
-        size_mb = next(
-            (m["size_mb"] for m in transcripts.WHISPER_MODELS if m["name"] == model),
-            None,
-        )
         return jsonify(
             {
                 "ok": True,
                 "skipped": True,
                 "reason": "model_not_cached",
                 "model": model,
-                "size_mb": size_mb,
+                "size_mb": _whisper_model_size_mb(model),
             }
         )
 
@@ -1301,6 +1305,7 @@ def api_transcribe() -> FlaskResponse:
     participant_ids = data.get("participants", [])
     force = data.get("force", False)
     overrides = data.get("overrides") or {}
+    allow_download = bool(data.get("allow_download"))
 
     if not participant_ids:
         return jsonify({"ok": False, "error": "No participants specified"}), 400
@@ -1311,6 +1316,10 @@ def api_transcribe() -> FlaskResponse:
 
     with _manifest_lock:
         src = _manifest.get("source_transcripts", {})
+
+        # Resolve the participants that would actually be enqueued, with the
+        # effective Whisper model for each (per-participant override → default).
+        eligible: list[tuple[dict[str, Any], str | None, str | None, str]] = []
         for pid in participant_ids:
             p = available.get(pid)
             if not p or not p.get("has_video"):
@@ -1323,8 +1332,35 @@ def api_transcribe() -> FlaskResponse:
             o = overrides.get(pid) or {}
             model_override = o.get("model") or None
             language_override = o.get("language") or None
+            effective_model = model_override or config.TRANSCRIBE_MODEL
+            eligible.append((p, model_override, language_override, effective_model))
+
+        # Authoritative download gate: never let a worker silently pull an
+        # uncached faster-whisper model. The browser confirmation is advisory;
+        # this enforces it for direct API calls and the /api/models fallback.
+        if not allow_download:
+            uncached: list[str] = []
+            for _p, _mo, _lo, effective_model in eligible:
+                if (
+                    effective_model not in uncached
+                    and not transcripts.is_whisper_model_cached(effective_model)
+                ):
+                    uncached.append(effective_model)
+            if uncached:
+                return jsonify(
+                    {
+                        "ok": False,
+                        "reason": "model_not_cached",
+                        "uncached": [
+                            {"model": m, "size_mb": _whisper_model_size_mb(m)}
+                            for m in uncached
+                        ],
+                    }
+                )
+
+        for p, model_override, language_override, _effective_model in eligible:
             task = transcripts.create_transcript_task(
-                pid,
+                p["id"],
                 p["video_paths"],
                 model=model_override,
                 language=language_override,
@@ -1334,7 +1370,7 @@ def api_transcribe() -> FlaskResponse:
             enqueued.append(
                 {
                     "id": task["id"],
-                    "participant": pid,
+                    "participant": p["id"],
                     "status": task["status"],
                 }
             )


### PR DESCRIPTION
## Summary

Nine independent fixes from a review of the recent screenspace/studio/transcripts work, one per commit:

- **`fix(transcripts)`** — gate uncached Whisper downloads server-side: `/api/transcribe` now rejects uncached models with `reason:"model_not_cached"` unless the request carries `allow_download:true`; the frontend confirms and retries. Closes the direct-API and `/api/models`-failure bypass of the browser gate.
- **`fix(transcripts)`** — clear stale citations on participant switch: reset `state.summaryCitations`/`citationsGenerating` before `renderSummary()` so superscripts don't leak across participants.
- **`fix(screenspace)`** — generate heatmaps outside the worker lock: heatmap PNG/GIF I/O no longer blocks status reads, cancellation, dismissal, and SSE snapshots.
- **`fix(screenspace)`** — re-export `_probe_video_meta` from the `screenspace.py` facade.
- **`fix(screenspace)`** — even heatmap GIF frame bucketing: proportional buckets via `_frame_bucket_bounds` instead of dumping the remainder onto the final frame.
- **`fix(studio)`** — preserve all settings on partial PUT: snapshot the full `STUDIO_SETTINGS` state before saving so a partial PUT no longer drops other non-default settings (e.g. card selections).
- **`fix(studio)`** — validate card image/color settings: path-traversal-safe `_validate_card_image` + `_HEX_COLOR_RE` in both `_apply_settings_payload` and `_load_studio_settings`.
- **`fix(titlecards)`** — account for the endcard in `_build_reel_transcript` cumulative offsets.
- **`fix(titlecards)`** — clear the shared endcard temp cache after `process_reel` (CLI/interactive/Studio paths).

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` all clean
- [x] Full suite green: `uv run --extra dev pytest -c tests/pytest.ini`
- [x] `node --check assets/web/transcripts.js`
- [x] New/updated tests: transcribe cache gate (reject + allow_download), facade re-export, `_frame_bucket_bounds` distribution (25/47/100), partial-PUT preservation, card image/color validation, two-component reel endcard offsets, endcard cache cleared after `process_reel`
- [ ] ⚠️ Browser-only, not agent-verified: citation-leak fix and card-picker UI — switch between a participant with citations and one without, and confirm card selections survive a settings save