### PR TITLE
docs: refresh & re-prioritize frontend refactor plan

### DIFF
--- a/plans/FRONTEND-REFACTOR-PLAN.md
+++ b/plans/FRONTEND-REFACTOR-PLAN.md
@@ -2,35 +2,36 @@
 
 Planning doc. No implementation in this file. Scope is `assets/web/` and how Flask / `viewer.py` deliver it.
 
-**Context:** The May 2026 redesign ([REDESIGN-PLAN.md](../REDESIGN-PLAN.md)) shipped tokens, TopNav, start overlay, settings, and Studio primitives. Remaining maintenance cost concentrates in three page monoliths and repeated cross-page patterns.
+**Context:** The May 2026 redesign ([REDESIGN-PLAN.md](archive/REDESIGN-PLAN.md), now archived) shipped tokens, TopNav, start overlay, settings, and Studio primitives. Remaining maintenance cost concentrates in three page monoliths and repeated cross-page patterns.
 
 **Related plans:**
 
-- [PERFORMANCE-PLAN.md](PERFORMANCE-PLAN.md) — Phase 4 (Studio grid, NDJSON intake) overlaps structural/perf work here
 - [MULTIPLAYER-PLAN.md](MULTIPLAYER-PLAN.md) — future presence layer; plan module boundaries before adding shared state
-- [FRONTEND-PLAN.md](FRONTEND-PLAN.md) — superseded preparatory research (pre-redesign); kept for history
+- [archive/PERFORMANCE-PLAN.md](archive/PERFORMANCE-PLAN.md) + [archive/PERFORMANCE-PLAN-2.md](archive/PERFORMANCE-PLAN-2.md) — Studio grid / NDJSON intake overlaps structural/perf work here (**archived** — verify what shipped before treating C2/C3 as pending)
+- [archive/FRONTEND-PLAN.md](archive/FRONTEND-PLAN.md) — superseded preparatory research (pre-redesign); **archived** for history
 
 ---
 
 ## Summary
 
-The frontend is a **vanilla JS/CSS stack** (~35k lines in 34 files under `assets/web/`) with a clear shared foundation (`tokens.css`, `utils.js`, TopNav, start overlay, settings). **Three page bundles** (`screenspace.js`, `studio.js`, `transcripts.js`) hold ~60% of all JavaScript (~13,900 lines) and drive most refactor value.
+The frontend is a **vanilla JS/CSS stack** (~50k lines in 43 files under `assets/web/`: 22 JS / 14 CSS / 7 HTML) with a clear shared foundation (`tokens.css`, `utils.js`, TopNav, start overlay, settings). **Three page bundles** (`screenspace.js`, `studio.js`, `transcripts.js`) hold ~57% of all JavaScript (~18,500 lines) and drive most refactor value.
 
 **Already working well:**
 
 - Thin server / thick client for rendering
 - `utils.get_frontend_config()` → `"config"` in API responses; `tests/test_shared_constants.py`
 - ES5 + `.then()` everywhere (no `async/await`)
-- Shared chrome: `ClipgenTopNav`, `ClipgenStartOverlay`, `openSettingsModal`
-- Studio sub-tabs split (`metadata.js`, `convergence.js`) but coupled via `window._studioState`
+- Shared chrome: `ClipgenTopNav`, `ClipgenStartOverlay`, `openSettingsModal` (now `settings-modal.js`)
+- **Wave 1–3 DRY shipped:** `export-actions.js`, `video-controls.js`, `intake-cluster.js` (`_studioCluster*` globals gone), shared toast (`topnav.css`), `getCanvasThemeColors`, unified icon-mask helpers in `utils.js`
+- Studio sub-tabs split (`metadata.js`, `convergence.js`, each now with its own CSS) but coupled via `window._studioState`
 
-**Main pain points:**
+**Main pain points (still open):**
 
-1. Copy-pasted **export quick action**, **toast**, **video speed controls**, **polling**, and **timeline rendering** across pages
-2. **Four separate `renderTimeline()` implementations** (only amplitude bands shared)
-3. **Convention debt:** inline SVG in HTML, raw `px`/`rem` in page CSS, dual button systems (`.cg-btn` vs `.btn`)
-4. **Implicit globals** between Studio and sub-tabs (`window._studioCluster*`)
-5. **Dead / partial assets:** `card-scrubber.js` parked; `primitives.css` on Screenspace/Transcripts without `primitives.js`
+1. **Four separate `renderTimeline()` implementations** (screenspace / transcripts / viewer / convergence; only amplitude bands shared)
+2. **Polling only half-unified:** `createPoller` adopted in Studio, but Screenspace + Transcripts still run ~8 raw `setInterval` pollers
+3. **Convention debt:** inline SVG in HTML/JS (Screenspace toolbar done, rest pending), ~770 raw `px` in the three page CSS files, dual button systems (`.cg-btn` vs `.btn`)
+4. **Page monoliths persist:** `screenspace.js` 7.5k (partially carved), `studio.js` 5.8k (state hub), `transcripts.js` 5.2k (untouched, no satellites)
+5. **Dead / partial assets:** `card-scrubber.js` parked **and** duplicated inline in `viewer.js`; `<head>` favicon/fonts copy-pasted across 7 HTML files
 
 **Stack constraints (do not violate):**
 
@@ -42,32 +43,51 @@ The frontend is a **vanilla JS/CSS stack** (~35k lines in 34 files under `assets
 
 ## Inventory
 
-### JavaScript (approx. lines)
+### JavaScript (approx. lines, 22 files)
 
 | File | Lines | Role |
 |------|------:|------|
-| `screenspace.js` | 6,173 | Canvas, tasks, timeline, regions |
-| `studio.js` | 4,392 | Sheet, queues, intake |
-| `transcripts.js` | 3,317 | Editor, search, video, agents |
-| `viewer.js` | 1,890 | Exported timeline viewer |
-| `metadata.js` | 1,542 | Studio Metadata tab |
-| `start-overlay.js` | 1,102 | Folder / spreadsheet picker |
-| `convergence.js` | 1,020 | Studio Convergence tab |
-| `utils.js` | 965 | Shared globals |
-| `primitives.js` | 754 | DOM factories (Studio only) |
-| Other chrome / parked | ~1,000 | topnav, settings, card-scrubber, gallery |
+| `screenspace.js` | 7,498 | Hub: canvas, tasks, timeline, regions (+ satellites below) |
+| `studio.js` | 5,813 | Sheet, queues, intake; state hub (`window._studioState`) for sub-tabs |
+| `transcripts.js` | 5,156 | Editor, search, video, agents — **monolith, no satellites** |
+| `viewer.js` | 2,142 | Exported timeline viewer (+ inline card-scrubber dup) |
+| `convergence.js` | 1,754 | Studio Convergence tab |
+| `metadata.js` | 1,714 | Studio Metadata tab |
+| `utils.js` | 1,499 | Shared globals + helpers (poller, icon masks, canvas colors) |
+| `start-overlay.js` | 1,211 | Folder / spreadsheet picker |
+| `settings-modal.js` | 966 | Shared tabbed settings modal (`openSettingsModal`) |
+| `screenspace-multitool-params.js` | 882 | Screenspace satellite: multitool step/param UI |
+| `primitives.js` | 763 | DOM factories (Studio only) |
+| `dev-token-tweak.js` | 748 | Dev-only live token-tweak widget (gated; stripped from exports) |
+| `screenspace-calibration.js` | 688 | Screenspace satellite: calibration strip |
+| `topnav.js` | 343 | Shared top nav |
+| `card-scrubber.js` | 298 | **Parked** (unloaded; dup'd inline in `viewer.js`) |
+| `color-picker.js` | 266 | Reusable popover color picker (titlecards) |
+| `gallery.js` | 214 | Gallery viewer |
+| `screenspace-color.js` | 179 | Screenspace satellite: HSV color picker |
+| `intake-cluster.js` | 106 | `window.ClipgenIntakeCluster` — Studio intake clustering |
+| `screenspace-utils.js` | 100 | Screenspace satellite: pure, state-free helpers |
+| `export-actions.js` | 63 | `window.ClipgenExportActions` — shared export quick action |
+| `video-controls.js` | 36 | `window.ClipgenVideoControls` — shared speed cycle |
 
-### CSS (approx. lines)
+### CSS (approx. lines, 14 files)
 
 | File | Lines | Notes |
 |------|------:|-------|
-| `screenspace.css` | 2,750 | Many raw px/rem |
-| `studio.css` | 2,408 | Many raw px/rem |
-| `transcripts.css` | 1,385 | |
-| `start-overlay.css` | 1,346 | |
-| `viewer.css` | 1,230 | |
-| `tokens.css` | 576 | Canonical tokens |
-| `primitives.css` | 669 | Some raw values despite token header |
+| `screenspace.css` | 4,004 | ~273 raw px |
+| `studio.css` | 2,969 | ~327 raw px |
+| `transcripts.css` | 1,926 | ~170 raw px |
+| `start-overlay.css` | 1,560 | |
+| `viewer.css` | 1,450 | Inline data-URI SVG masks (intentional — exported/offline) |
+| `metadata.css` | 718 | Studio Metadata tab |
+| `tokens.css` | 657 | Canonical tokens |
+| `primitives.css` | 613 | DOM-factory styles — **now linked by `studio.html` only** |
+| `convergence.css` | 599 | Studio Convergence tab |
+| `settings-modal.css` | 553 | Shared settings modal |
+| `topnav.css` | 327 | Top nav + **shared toast** |
+| `gallery.css` | 304 | |
+| `color-picker.css` | 118 | |
+| `card-scrubber.css` | 24 | Parked (unloaded) |
 
 ### Delivery paths
 
@@ -75,27 +95,29 @@ The frontend is a **vanilla JS/CSS stack** (~35k lines in 34 files under `assets
 |------|-----------|
 | Live Studio / Screenspace / Transcripts | `register_static_routes()` + ordered `<script>` tags |
 | Exported viewer / gallery | `viewer.py` inlines CSS/JS + `window.CLIPGEN_DATA` |
+| Multi-participant export | `timeline-viewer.html` — swimlane variant of `viewer.html`, reuses `viewer.js`/`viewer.css` |
 
 ---
 
 ## Duplication map
 
-| Pattern | Locations | Notes |
-|---------|-----------|--------|
-| Export quick action | `studio.js`, `screenspace.js`, `transcripts.js` | ~40 lines × 3; raw `fetch` not `apiPost` |
-| Toast markup + CSS | All three page HTML + CSS | Screenspace: opacity; others: `display: none` |
-| Video speed cycle | `screenspace.js`, `transcripts.js` | Same handler; speeds differ by design |
-| `renderTimeline()` | screenspace, transcripts, viewer, convergence | Four implementations |
-| Icon masks | `maskIconStyle`, `svgMask`, page `iconHTML` | Same technique, three APIs |
-| Canvas theme colors | `refreshThemeColors()` vs inline `getCSSVar` | Unify read/cache |
-| Polling | Studio intake, Transcripts agents, Screenspace tasks | `POLL_INTERVAL` in utils underused |
-| Card scrubber | `card-scrubber.js` + inline in `viewer.js` | Parked per ARCHITECTURE.md |
-| HTML `<head>` | 7 HTML files | Favicon + fonts repeated |
+| Pattern | Status | Notes |
+|---------|--------|-------|
+| Export quick action | ✅ RESOLVED | `export-actions.js` (`window.ClipgenExportActions`), used by all three pages |
+| Toast markup + CSS | ✅ RESOLVED | Shared in `topnav.css`; all three pages aligned |
+| Video speed cycle | ✅ RESOLVED | `video-controls.js` (`nextSpeed`/`applyPlaybackRate`) |
+| Icon masks | ✅ RESOLVED | Unified `iconMask*` helpers in `utils.js`; old APIs collapsed onto them |
+| Canvas theme colors | ✅ RESOLVED | `getCanvasThemeColors()` in `utils.js`; Screenspace + Transcripts |
+| Intake clustering | ✅ RESOLVED | `intake-cluster.js` (`window.ClipgenIntakeCluster`); `_studioCluster*` gone |
+| Polling | ◐ PARTIAL | `createPoller` adopted in Studio; Screenspace (1) + Transcripts (~7) still raw `setInterval` |
+| `renderTimeline()` | ❌ STILL PRESENT | Four implementations: screenspace, transcripts, viewer, convergence |
+| Card scrubber | ❌ STILL PRESENT | `card-scrubber.js` parked (unloaded) **and** dup'd inline in `viewer.js` |
+| HTML `<head>` | ❌ STILL PRESENT | Favicon + fonts copy-pasted across 7 HTML files; no shared/injected partial |
 
 ### Studio coupling
 
-- `window._studioState` — contract for `metadata.js` / `convergence.js`
-- `window._studioClusterIntakeEvents` etc. — clustering should move to shared module
+- `window._studioState` — **still the contract** for `metadata.js` / `convergence.js` (lazy-read on activation)
+- `window._studioCluster*` — ✅ gone; clustering now lives in `intake-cluster.js`
 
 ---
 
@@ -103,10 +125,10 @@ The frontend is a **vanilla JS/CSS stack** (~35k lines in 34 files under `assets
 
 | Rule | Gap |
 |------|-----|
-| Icons via `mask-image` from `assets/icons/` | Inline `<svg>` in several HTML files; data-URI SVG in `viewer.css` |
-| Tokens for spacing/type in new/touched CSS | Hundreds of raw values in page stylesheets |
+| Icons via `mask-image` from `assets/icons/` | Screenspace toolbar converted (PR #388); inline `<svg>` still in `studio.js`/`studio.html`/`start-overlay.html`; data-URI SVG in `viewer.css` is **intentional** (exported/offline) |
+| Tokens for spacing/type in new/touched CSS | ~770 raw `px` across `screenspace.css`/`studio.css`/`transcripts.css` (plus new `metadata.css`/`convergence.css`) |
 | No duplicate Python/JS constants | Intentional mirrors in `utils.js` + tests — maintenance surface only |
-| `primitives.js` only where factories needed | Screenspace/Transcripts load `primitives.css` without JS |
+| `primitives.js` only where factories needed | ✅ Resolved: `primitives.css` now linked by `studio.html` only (dropped from Screenspace/Transcripts) |
 
 Decorative SVG in `start-overlay.html` may remain an explicit exception after icon pass.
 
@@ -142,30 +164,62 @@ Decorative SVG in `start-overlay.html` may remain an explicit exception after ic
 | ID | Work | Impact |
 |----|------|--------|
 | C1 | Split page monoliths into feature scripts (ordered tags, no bundler) | Maintainability |
-| C2 | Studio grid perf ([PERFORMANCE-PLAN.md](PERFORMANCE-PLAN.md) §4.1) | Large-sheet UX — **profile first** |
-| C3 | NDJSON intake streaming (PERFORMANCE-PLAN §4.2) | Per-item progress |
+| C2 | Studio grid perf ([archive/PERFORMANCE-PLAN.md](archive/PERFORMANCE-PLAN.md) §4.1) | Large-sheet UX — **profile first** |
+| C3 | NDJSON intake streaming (archive/PERFORMANCE-PLAN §4.2) | Per-item progress |
 | C4 | Inline SVG → mask-image (viewer + Screenspace toolbars first) | Convention compliance |
 | C5 | Token migration on touched CSS files | Incremental, not big-bang |
 | C6 | Flask-injected HTML head partial | DRY favicon/fonts |
 
-#### Suggested split order for C1
+#### Split order for C1 — follow the established hub+satellite pattern
 
-1. **`screenspace.js`** (largest) → `state.js`, `canvas.js`, `timeline.js`, `tasks.js`, `workflow.js`
-2. **`studio.js`** → sheet, queues, intake
-3. **`transcripts.js`** → segments, search, agents
+The earlier proposal (`state/canvas/timeline/tasks/workflow`) is **OBE**. The codebase has
+since settled on a **hub + feature-satellite** convention (documented in AGENTS.md): a hub
+file keeps shared mutable state under a `window.Clipgen*` namespace (aliased e.g. `SS`), and
+satellites are carved by **feature/UI surface**, loaded as ordered `<script>` tags after the
+hub. New C1 work should match this, not invent a new axis.
 
-Globals stay on `window`; script order in HTML documents dependencies.
+Current state and next targets:
+
+1. **`transcripts.js`** (5.2k, **untouched, no satellites — cleanest target**) → carve
+   feature satellites (e.g. segments/editor, search, thinking-agents panel) behind a
+   `window.ClipgenTranscripts` namespace.
+2. **`screenspace.js`** (7.5k hub; satellites `multitool-params`/`calibration`/`color`/`utils`
+   already carved via `window.ClipgenScreenspace`/`SS`) → continue extracting cohesive feature
+   surfaces (tasks/queue UI, timeline, region CRUD) off the hub. Audit hub refs to satellite
+   `var`s when carving (see AGENTS.md gotcha — `node --check` won't catch `ReferenceError`s).
+3. **`studio.js`** (5.8k state hub) → `intake-cluster.js` + `metadata.js`/`convergence.js`
+   already split out; remaining win is reducing the `window._studioState` surface, not more
+   file splits.
+
+Globals stay on `window` namespaces; script order in HTML documents dependencies.
 
 ---
 
-## Recommended waves
+## Waves — status
 
-| Wave | Items | Outcome |
-|------|-------|---------|
-| **1** | A1, A2, A3, A4 | Chrome DRY, no feature change |
-| **2** | A5, A6, B1, B2 | Small modules, clearer boundaries |
-| **3** | B3, C4 (incremental), C5 (opportunistic) | Convention cleanup |
-| **4** | C1 (screenspace first), C2 after profiling | Structural + perf |
+| Wave | Items | Status |
+|------|-------|--------|
+| **1** | A1, A2, A3, A4 | ✅ Shipped (PR #366) — except A3 polling adoption (Studio only) |
+| **2** | A5, A6, B1, B2 | ✅ Shipped (PR #385) — except A6 card-scrubber (still parked) |
+| **3** | B3, C4 (incremental), C5 (opportunistic) | ✅ B3 shipped (PR #388); C4/C5 partial |
+| **4** | C1, C2, C3 | ⬜ Not started (Screenspace partially carved on a different axis) |
+
+## Remaining work — re-prioritized (as of 2026-06-23)
+
+1. **Finish half-done (now, low risk):**
+   - **A3** — adopt `createPoller` in Screenspace (1 poller) + Transcripts (~7 pollers); retires ~8 raw `setInterval` bug surfaces.
+   - **C6** — server-injected `<head>` partial (favicon + fonts) for the three live pages; leave exported viewers self-contained.
+2. **Decide & close:**
+   - **A6** — card-scrubber: **delete** the parked module + the inline `viewer.js` dup, or keep parked with a one-line pointer. Parked across two ARCHITECTURE.md notes — make the call.
+3. **Opportunistic (touched files only):**
+   - **C4** — remaining inline SVG → `mask-image` (`studio.js`/`studio.html`/`start-overlay.html`; keep `viewer.css` data-URIs).
+   - **C5** — token sweep on touched CSS (now also `metadata.css`/`convergence.css`).
+   - **B5** — `.btn` vs `.cg-btn`: reconcile or document the dual system (still **defer** unless touched).
+4. **Structural (largest remaining value, when there's appetite):**
+   - **C1** — per the split-order section above: **Transcripts first**, then continue Screenspace/Studio carve-outs on the hub+satellite axis.
+   - **B4** — shared timeline core: still **deferred** unless timeline bugs force it (four impls remain).
+5. **Verify / relink before scheduling:**
+   - **C2 / C3** — reconcile against `archive/PERFORMANCE-PLAN.md` + `archive/PERFORMANCE-PLAN-2.md`; confirm what perf work already shipped before treating Studio-grid / NDJSON-intake as pending.
 
 ---
 
@@ -176,7 +230,7 @@ Globals stay on `window`; script order in HTML documents dependencies.
 - Headless browser CI
 - Merging Quick Actions with Studio sub-header (gallery drawer flow — see REDESIGN-PLAN session 1)
 - Screenspace flat-scroll, Transcripts sticky PiP (redesign deferred)
-- SSE task progress ([PERFORMANCE-PLAN.md](PERFORMANCE-PLAN.md) dropped for now)
+- SSE task progress ([archive/PERFORMANCE-PLAN.md](archive/PERFORMANCE-PLAN.md) dropped for now)
 - Full timeline abstraction (B4) unless timeline bugs force it
 
 ---
@@ -203,7 +257,7 @@ Use this when executing waves; check items in PR descriptions.
 
 - [x] A1 `export-actions.js` + TopNav wiring on all three surfaces
 - [x] A2 Shared toast CSS + consistent hide behavior
-- [x] A3 `createPoller` in `utils.js`; adopt in hot paths
+- [~] A3 `createPoller` in `utils.js` — **PARTIAL**: adopted in Studio only; Screenspace (1) + Transcripts (~7) still raw `setInterval` (see Remaining work §1)
 - [x] A4 `getCanvasThemeColors` in `utils.js`; Screenspace + Transcripts canvases
 
 ### Wave 2
@@ -219,13 +273,19 @@ Use this when executing waves; check items in PR descriptions.
 - [~] C4 SVG → mask — **Screenspace toolbar done** (11 `.wf-tab` + info + Run now reuse the `.ss-task-icon` family); **viewer deferred** (exported viewer's inline SVG / data-URI are intentional offline fallbacks — no `/icons/` route in exports)
 - [~] C5 Token sweep — opportunistic on touched file only: `.wf-tab` icon size `12px` → `var(--icon-size-xs)` in `screenspace.css`
 
-### Wave 4
+### Remaining (re-prioritized)
 
-- [ ] C1 `screenspace.js` module split
-- [ ] C1 `studio.js` module split
-- [ ] C1 `transcripts.js` module split
-- [ ] C2 Studio grid: profile → incremental filter → chunk render → virtualize only if needed
-- [ ] C3 NDJSON intake (coordinate with server.py)
+- [ ] A3 finish — adopt `createPoller` in Screenspace + Transcripts pollers
+- [ ] C6 server-injected `<head>` partial (live pages; exports stay self-contained)
+- [ ] A6 card-scrubber — delete (module + inline `viewer.js` dup) **or** keep parked with pointer
+- [~] C4 SVG → mask — Screenspace toolbar done; remaining: `studio.js`/`studio.html`/`start-overlay.html` (opportunistic)
+- [~] C5 token sweep — opportunistic on touched CSS (incl. `metadata.css`/`convergence.css`)
+- [ ] B5 `.btn` vs `.cg-btn` — reconcile or document (defer unless touched)
+- [ ] C1 `transcripts.js` split first (untouched monolith, no satellites) — hub+satellite axis
+- [ ] C1 `screenspace.js` — continue hub carve-outs (satellites already on `window.ClipgenScreenspace`)
+- [ ] C1 `studio.js` — shrink `window._studioState` surface (intake/metadata/convergence already split)
+- [ ] B4 shared timeline core — deferred unless timeline bugs force it (four impls remain)
+- [ ] C2 / C3 — **first** reconcile against `archive/PERFORMANCE-PLAN*.md` (confirm what shipped), then Studio grid profile + NDJSON intake if still pending
 
 ---
 
@@ -234,3 +294,4 @@ Use this when executing waves; check items in PR descriptions.
 | Date | Change |
 |------|--------|
 | 2026-05-19 | Initial plan from frontend refactor investigation (plan-only session) |
+| 2026-06-23 | Refreshed inventory/counts to current reality (43 files); repointed archived cross-links; reconciled Screenspace C1 to the actual hub+satellite axis; marked Waves 1–3 shipped + A3 partial; re-prioritized remaining work (Transcripts split first) |


### PR DESCRIPTION
## Summary

Brings `plans/FRONTEND-REFACTOR-PLAN.md` in line with the codebase, which moved on after Waves 1–3 shipped (PRs #366/#385/#388) and several files landed. Refreshes the inventory (34 → 43 files, all line counts, new modules), repoints dead cross-links to `plans/archive/`, annotates the duplication map (resolved vs still-open) and flags A3 polling as partial, reconciles C1 to the actual hub+satellite split axis (the proposed `state/canvas/timeline/tasks/workflow` names were OBE), and re-prioritizes the remaining work (Transcripts split first).

## Test plan

- [x] Verified every refreshed line count against `wc -l assets/web/*`
- [x] Confirmed all Markdown links resolve (`archive/{REDESIGN,PERFORMANCE,PERFORMANCE-2,FRONTEND}-PLAN.md`, `MULTIPLAYER-PLAN.md`)
- Docs-only — no code touched, no `build/VERSION` bump