### PR TITLE
refactor(web): inject shared <head> partial into live pages

### DIFF
--- a/assets/web/_head.html
+++ b/assets/web/_head.html
@@ -1,0 +1,11 @@
+<link rel="icon" type="image/svg+xml" href="logos/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="logos/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="logos/favicon-192.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="logos/apple-touch-icon-180.png">
+  <link rel="apple-touch-icon" sizes="167x167" href="logos/apple-touch-icon-167.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="logos/apple-touch-icon-152.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="logos/apple-touch-icon-120.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -4,17 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>clipgen Screenspace</title>
-  <link rel="icon" type="image/svg+xml" href="logos/favicon.svg">
-  <link rel="icon" type="image/png" sizes="32x32" href="logos/favicon-32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="logos/favicon-192.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="logos/apple-touch-icon-180.png">
-  <link rel="apple-touch-icon" sizes="167x167" href="logos/apple-touch-icon-167.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="logos/apple-touch-icon-152.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="logos/apple-touch-icon-120.png">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <!-- CLIPGEN_HEAD_HERE -->
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="topnav.css">
   <link rel="stylesheet" href="screenspace.css">

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -4,17 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>clipgen Studio</title>
-  <link rel="icon" type="image/svg+xml" href="logos/favicon.svg">
-  <link rel="icon" type="image/png" sizes="32x32" href="logos/favicon-32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="logos/favicon-192.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="logos/apple-touch-icon-180.png">
-  <link rel="apple-touch-icon" sizes="167x167" href="logos/apple-touch-icon-167.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="logos/apple-touch-icon-152.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="logos/apple-touch-icon-120.png">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <!-- CLIPGEN_HEAD_HERE -->
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="topnav.css">
   <link rel="stylesheet" href="primitives.css">

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -4,17 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>clipgen Transcripts</title>
-  <link rel="icon" type="image/svg+xml" href="logos/favicon.svg">
-  <link rel="icon" type="image/png" sizes="32x32" href="logos/favicon-32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="logos/favicon-192.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="logos/apple-touch-icon-180.png">
-  <link rel="apple-touch-icon" sizes="167x167" href="logos/apple-touch-icon-167.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="logos/apple-touch-icon-152.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="logos/apple-touch-icon-120.png">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <!-- CLIPGEN_HEAD_HERE -->
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="topnav.css">
   <link rel="stylesheet" href="transcripts.css">

--- a/plans/FRONTEND-REFACTOR-PLAN.md
+++ b/plans/FRONTEND-REFACTOR-PLAN.md
@@ -31,7 +31,7 @@ The frontend is a **vanilla JS/CSS stack** (~50k lines in 43 files under `assets
 2. ~~**Polling only half-unified**~~ ✅ Resolved: `createPoller` now drives every periodic poller (Studio, Screenspace, Transcripts); only the Ollama model-pull loop (Promise-based, custom cancel/miss-count) stays a raw `setInterval`
 3. **Convention debt:** inline SVG ✅ closed (documented intentional exceptions) and raw `px` ✅ swept to tokens (2026-06-23) — remaining only the dual button systems (`.cg-btn` vs `.btn`, B5, deferred)
 4. **Page monoliths persist:** `screenspace.js` 7.5k (partially carved), `studio.js` 5.8k (state hub), `transcripts.js` 5.2k (untouched, no satellites)
-5. **Dead / partial assets:** `card-scrubber.js` parked **and** duplicated inline in `viewer.js`; `<head>` favicon/fonts copy-pasted across 7 HTML files
+5. **Dead / partial assets:** `card-scrubber.js` parked **and** duplicated inline in `viewer.js` (~~`<head>` favicon/fonts copy-paste~~ ✅ resolved 2026-06-23 — live pages now inject a shared `_head.html` partial)
 
 **Stack constraints (do not violate):**
 
@@ -112,7 +112,7 @@ The frontend is a **vanilla JS/CSS stack** (~50k lines in 43 files under `assets
 | Polling | ✅ RESOLVED | `createPoller` adopted across Studio, Screenspace, Transcripts (8 pollers converted 2026-06-23); only the Ollama model-pull loop stays a raw `setInterval` (Promise-based, custom cancel/miss-count) |
 | `renderTimeline()` | ❌ STILL PRESENT | Four implementations: screenspace, transcripts, viewer, convergence |
 | Card scrubber | ❌ STILL PRESENT | `card-scrubber.js` parked (unloaded) **and** dup'd inline in `viewer.js` |
-| HTML `<head>` | ❌ STILL PRESENT | Favicon + fonts copy-pasted across 7 HTML files; no shared/injected partial |
+| HTML `<head>` | ✅ RESOLVED | Live pages (Studio/Screenspace/Transcripts) embed `<!-- CLIPGEN_HEAD_HERE -->`, expanded server-side from `assets/web/_head.html` by `utils.render_index_html()`. Exported viewers keep their self-contained inline `data:` favicons. |
 
 ### Studio coupling
 
@@ -206,9 +206,9 @@ Globals stay on `window` namespaces; script order in HTML documents dependencies
 
 ## Remaining work — re-prioritized (as of 2026-06-23)
 
-1. **Finish half-done (now, low risk):**
+1. **Finish half-done (now, low risk):** ✅ Cleared
    - ~~**A3** — adopt `createPoller` in Screenspace + Transcripts~~ ✅ Done (2026-06-23): 8 pollers converted (Screenspace ×1, Transcripts ×6, Studio job-status ×1); Ollama model-pull loop left as a raw `setInterval` (Promise-based, custom cancel/miss-count).
-   - **C6** — server-injected `<head>` partial (favicon + fonts) for the three live pages; leave exported viewers self-contained.
+   - ~~**C6** — server-injected `<head>` partial (favicon + fonts) for the three live pages~~ ✅ Done (2026-06-23): shared `assets/web/_head.html` expanded into live index pages by `utils.render_index_html()`; exported viewers left self-contained.
 2. **Decide & close:**
    - **A6** — card-scrubber: **delete** the parked module + the inline `viewer.js` dup, or keep parked with a one-line pointer. Parked across two ARCHITECTURE.md notes — make the call.
 3. **Opportunistic (touched files only):**
@@ -276,7 +276,7 @@ Use this when executing waves; check items in PR descriptions.
 ### Remaining (re-prioritized)
 
 - [x] A3 finish — `createPoller` adopted in Screenspace + Transcripts (and Studio job-status); only the Ollama model-pull loop stays raw `setInterval`
-- [ ] C6 server-injected `<head>` partial (live pages; exports stay self-contained)
+- [x] C6 server-injected `<head>` partial — `assets/web/_head.html` expanded into the three live index pages via `<!-- CLIPGEN_HEAD_HERE -->` + `utils.render_index_html()`; exported viewers stay self-contained
 - [x] A6 card-scrubber — **integrated** (opt-in, default off) on Studio + the timeline viewer; the viewer keeps its `<video>`-seek visual scrub and adds the module's audio + waveform. Note: the inline `viewer.js` scrubber and `card-scrubber.js` were never true duplicates (video-seek vs sprite-sheet), so the viewer-dup line in the duplication map is moot
 - [x] C4 SVG → mask — closed: `studio.js`/`studio.html`/`start-overlay.html` audited; remaining inline `<svg>` are documented intentional exceptions (animations, brand/file-type glyphs, decorative artworks), `viewer.css` data-URIs kept
 - [x] C5 token sweep — done: full pass across all five page CSS files; 4 new tokens (`--text-2xs`, `--radius-xs`, `--space-1-5`, `--space-2-5`)
@@ -296,3 +296,4 @@ Use this when executing waves; check items in PR descriptions.
 | 2026-05-19 | Initial plan from frontend refactor investigation (plan-only session) |
 | 2026-06-23 | Refreshed inventory/counts to current reality (43 files); repointed archived cross-links; reconciled Screenspace C1 to the actual hub+satellite axis; marked Waves 1–3 shipped + A3 partial; re-prioritized remaining work (Transcripts split first) |
 | 2026-06-23 | Closed C4 (icon gap — documented intentional inline-SVG exceptions), C5 (full 181-`px`→token sweep + 4 new tokens), and A3 (`createPoller` across all 8 remaining pollers). Verified A1/A2/A4/A5 already shipped. |
+| 2026-06-23 | Closed C6: shared `assets/web/_head.html` favicon/fonts partial injected into the three live index pages via `<!-- CLIPGEN_HEAD_HERE -->` + `utils.render_index_html()`; exported viewers left self-contained. "Finish half-done" bucket now empty — next up is C1 (Transcripts split). |

--- a/tests/test_head_partial.py
+++ b/tests/test_head_partial.py
@@ -1,0 +1,56 @@
+"""Regression checks for the shared server-injected ``<head>`` partial (C6).
+
+The three live pages embed ``<!-- CLIPGEN_HEAD_HERE -->`` where the shared
+favicon + Google-fonts block belongs; ``utils.render_index_html`` expands it
+from ``assets/web/_head.html``. Exported viewers stay self-contained and must
+not gain the marker.
+"""
+
+from pathlib import Path
+
+import utils
+
+WEB = Path(__file__).resolve().parent.parent / "assets" / "web"
+HEAD_MARKER = "<!-- CLIPGEN_HEAD_HERE -->"
+LIVE_PAGES = ("studio.html", "screenspace.html", "transcripts.html")
+EXPORT_PAGES = ("viewer.html", "gallery.html", "timeline-viewer.html")
+FAVICON_LINK = '<link rel="icon" type="image/svg+xml" href="logos/favicon.svg">'
+FONTS_LINK = "https://fonts.googleapis.com/css2?family=Inter"
+
+
+def test_head_partial_holds_shared_block():
+    head = (WEB / "_head.html").read_text(encoding="utf-8")
+    assert FAVICON_LINK in head
+    assert FONTS_LINK in head
+    # All seven favicon/apple-touch links plus preconnect/preload/stylesheet.
+    assert head.count("<link") == 11
+
+
+def test_live_pages_use_marker_not_inline_block():
+    for page in LIVE_PAGES:
+        src = (WEB / page).read_text(encoding="utf-8")
+        assert HEAD_MARKER in src, page
+        # The duplicated block must be gone so it can only be edited in one place.
+        assert FAVICON_LINK not in src, page
+        assert FONTS_LINK not in src, page
+
+
+def test_export_pages_stay_self_contained():
+    for page in EXPORT_PAGES:
+        src = (WEB / page).read_text(encoding="utf-8")
+        assert HEAD_MARKER not in src, page
+
+
+def test_render_index_expands_marker():
+    rendered = utils.render_index_html(WEB, "transcripts.html")
+    assert HEAD_MARKER not in rendered
+    assert FAVICON_LINK in rendered
+    assert FONTS_LINK in rendered
+    # No empty line left where the marker stood (the partial is rstripped).
+    assert '\n\n  <link rel="stylesheet" href="tokens.css">' not in rendered
+
+
+def test_render_index_passthrough_without_marker():
+    # Export templates have no marker -> returned unchanged.
+    src = (WEB / "gallery.html").read_text(encoding="utf-8")
+    assert utils.render_index_html(WEB, "gallery.html") == src

--- a/utils.py
+++ b/utils.py
@@ -1843,6 +1843,24 @@ def discover_participant_videos(study_name: str = "") -> list[dict[str, Any]]:
 
 # ---- Flask blueprint helpers ----
 
+# Live index pages embed this marker where the shared favicon + Google-fonts
+# block belongs; render_index_html() expands it from assets/web/_head.html so
+# the block lives in one place. Exported viewers don't use it (self-contained).
+_HEAD_MARKER = "<!-- CLIPGEN_HEAD_HERE -->"
+
+
+def render_index_html(assets_dir: Path, index_html: str) -> str:
+    """Read an index page, expanding the shared ``<head>`` marker if present.
+
+    Pages without the marker are returned unchanged, so this stays safe for any
+    current or future index page.
+    """
+    html = (assets_dir / index_html).read_text(encoding="utf-8")
+    if _HEAD_MARKER in html:
+        head = (assets_dir / "_head.html").read_text(encoding="utf-8").rstrip("\n")
+        html = html.replace(_HEAD_MARKER, head)
+    return html
+
 
 def register_static_routes(
     bp: Any,
@@ -1876,7 +1894,7 @@ def register_static_routes(
 
     @bp.route("/")
     def serve_index() -> Response:
-        return send_from_directory(assets_dir, index_html)
+        return Response(render_index_html(assets_dir, index_html), mimetype="text/html")
 
     @bp.route("/<path:filename>")
     def serve_static(filename: str) -> Response:


### PR DESCRIPTION
## Summary

The three live pages (Studio/Screenspace/Transcripts) each carried an identical 11-line favicon + Google-fonts `<head>` block; this hoists it into a single `assets/web/_head.html`, expanded server-side where each page now has a `<!-- CLIPGEN_HEAD_HERE -->` marker via the new `utils.render_index_html()` (pages without the marker pass through unchanged). Exported viewers (`viewer`/`gallery`/`timeline-viewer`) are untouched and keep their self-contained inline `data:` favicons. Closes **C6** in `plans/FRONTEND-REFACTOR-PLAN.md`.

## Test plan

- [x] `/check` green — ruff format + lint, `ty`, full suite (**1476 passed**) including the new `tests/test_head_partial.py` (marker present / inline block gone on live pages, partial holds all 11 links, exports stay marker-free, render expands cleanly)
- [x] Browser-verified (no headless per project rules) — confirmed tab favicon + Inter/JetBrains fonts render on `/studio/`, `/screenspace/`, `/transcripts/`