### PR TITLE
fix(web): tighten tooltip/hover edge cases and frontend consistency

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -1106,7 +1106,7 @@
       var cellValue = (rawRow.cells && rawRow.cells[event.participant])
         ? rawRow.cells[event.participant].value : "";
       var parts = event.id.split("_");
-      var segIdx = parseInt(parts[parts.length - 1]) || 0;
+      var segIdx = parseInt(parts[parts.length - 1], 10) || 0;
       var baselineOffset2 = (cvState.baselines && cvState.baselines[event.participant]) || 0;
       var segs = parseClipSegmentsForCell(cellValue, baselineOffset2, CLIPGEN_CONFIG.defaultDuration);
       item.row = rawRow.rowNum;

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -117,7 +117,7 @@
   }
 
   function reclusterIntake() {
-    var threshold = parseInt((qs("#intakeClusterThreshold") || {}).value) || 10;
+    var threshold = parseInt((qs("#intakeClusterThreshold") || {}).value, 10) || 10;
     state.intakeClusters = clusterIntakeEvents(intakeClusterSource(), threshold);
     renderIntake(false);
   }
@@ -167,7 +167,7 @@
           }
         });
         state.intakeEvents = events;
-        var threshold = parseInt((qs("#intakeClusterThreshold") || {}).value) || 10;
+        var threshold = parseInt((qs("#intakeClusterThreshold") || {}).value, 10) || 10;
         state.intakeClusters = clusterIntakeEvents(intakeClusterSource(), threshold);
         renderIntake(hasNew);
         checkConvergenceTabVisibility();
@@ -674,7 +674,7 @@
     cards.addEventListener("click", function (e) {
       var card = e.target.closest(cfg.cardSel);
       if (!card) return;
-      var cluster = cfg.filtered()[parseInt(card.dataset[cfg.idxAttr])];
+      var cluster = cfg.filtered()[parseInt(card.dataset[cfg.idxAttr], 10)];
       if (!cluster) return;
       if (e.shiftKey) cfg.toggleReel(cluster);
       else cfg.toggleArtifacts(cluster);
@@ -685,7 +685,7 @@
       var card = e.target.closest(cfg.cardSel);
       if (!card) return;
       e.preventDefault();
-      var cluster = cfg.filtered()[parseInt(card.dataset[cfg.idxAttr])];
+      var cluster = cfg.filtered()[parseInt(card.dataset[cfg.idxAttr], 10)];
       if (cluster) cfg.onDismiss(cluster);
     });
 
@@ -693,7 +693,7 @@
     cards.addEventListener("mouseover", function (e) {
       var card = e.target.closest(cfg.cardSel);
       if (!card) return;
-      var idx = parseInt(card.dataset[cfg.idxAttr]);
+      var idx = parseInt(card.dataset[cfg.idxAttr], 10);
       if (state[cfg.hoveredIdxKey] !== idx) {
         state[cfg.hoveredIdxKey] = idx;
         cfg.highlightCard(idx);
@@ -738,7 +738,7 @@
     var thresholdInput = qs(cfg.thresholdSel);
     if (thresholdInput) {
       thresholdInput.addEventListener("change", function () {
-        cfg.onThresholdChange(parseInt(this.value) || 5);
+        cfg.onThresholdChange(parseInt(this.value, 10) || 5);
       });
     }
 
@@ -788,7 +788,7 @@
     apiGet("../transcripts/api/marks")
       .then(function (data) {
         if (!data.ok) return;
-        var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value) || 10;
+        var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value, 10) || 10;
         if (!state.trIntakeShowAll) {
           var fp =
             String(threshold) +

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -388,13 +388,13 @@
     _txEtaTicker.ensure();
   }
 
-  // Hard cap on the citations poll. The previous 90 s value was shorter than
-  // some real Ollama runs on long transcripts, so the result would land in
-  // the manifest after we'd given up — and the UI only picked it up on a
-  // full page reload. Five minutes covers realistic completion times; the
-  // server-side `generating: false` signal stops the poll earlier when the
+  // Hard cap on agent polls (citations and friction). The previous 90 s value
+  // was shorter than some real Ollama runs on long transcripts, so the result
+  // would land in the manifest after we'd given up — and the UI only picked it
+  // up on a full page reload. Five minutes covers realistic completion times;
+  // the server-side `generating: false` signal stops the poll earlier when the
   // agent finishes (or fails) sooner.
-  var _CITATIONS_POLL_TIMEOUT = 300000;
+  var _AGENT_POLL_TIMEOUT = 300000;
 
   function _startCitationsPoll(pid) {
     _stopCitationsPoll();
@@ -404,7 +404,7 @@
     _citationsPoller = createPoller(function () {
       if (ver !== state.participantReqVer ||
           state.selectedParticipant !== pid ||
-          Date.now() - started > _CITATIONS_POLL_TIMEOUT) {
+          Date.now() - started > _AGENT_POLL_TIMEOUT) {
         _stopCitationsPoll();
         state.citationsGenerating = false;
         var status = qs("#summaryContent .citations-status");
@@ -811,7 +811,7 @@
     _frictionPoller = createPoller(function () {
       if (ver !== state.participantReqVer ||
           state.selectedParticipant !== pid ||
-          Date.now() - started > _CITATIONS_POLL_TIMEOUT) {
+          Date.now() - started > _AGENT_POLL_TIMEOUT) {
         _stopFrictionPoll();
         state.frictionGenerating = false;
         renderFriction();
@@ -1163,6 +1163,7 @@
     var y = clientY - tipRect.height - 12;
     if (x + tipRect.width > window.innerWidth - 8) x = window.innerWidth - tipRect.width - 8;
     if (y < 8) y = clientY + 16;
+    if (y + tipRect.height > window.innerHeight - 8) y = window.innerHeight - tipRect.height - 8;
     tip.style.left = x + "px";
     tip.style.top = y + "px";
     state.frictionTooltipShown = true;

--- a/assets/web/transcripts-search.js
+++ b/assets/web/transcripts-search.js
@@ -135,9 +135,9 @@
       markAllBtn.className = "btn btn-small";
       markAllBtn.textContent = "Mark All";
       countEl.parentNode.insertBefore(markAllBtn, countEl.nextSibling);
+      markAllBtn.addEventListener("click", function () { markAllSearchResults(); });
     }
     markAllBtn.classList.remove("hidden");
-    markAllBtn.onclick = function () { markAllSearchResults(); };
 
     // Group results by participant
     var groups = {};

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -345,6 +345,7 @@
     var y = clientY - tipRect.height - 12;
     if (x + tipRect.width > window.innerWidth - 8) x = window.innerWidth - tipRect.width - 8;
     if (y < 8) y = clientY + 16;
+    if (y + tipRect.height > window.innerHeight - 8) y = window.innerHeight - tipRect.height - 8;
     tip.style.left = x + "px";
     tip.style.top = y + "px";
   }

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1313,7 +1313,9 @@
         var card = document.querySelector(
           '#artifactList .artifact-card[data-id="' + _hoveredCardId + '"]'
         );
-        if (card && (!related || !card.contains(related))) {
+        // If the card is gone (list re-rendered mid-hover) or the pointer left
+        // it, drop the hover state so the tooltip can't get orphaned.
+        if (!card || !related || !card.contains(related)) {
           _hoveredCardId = null;
           hideTooltip();
         }


### PR DESCRIPTION
Code-quality review fixes (vanilla JS, no behavior change to happy paths):

- viewer: clear hover state and hide the artifact tooltip when the hovered
  card is removed mid-hover (list re-render), preventing an orphaned tooltip.
- transcripts: clamp the timeline and friction tooltips to the bottom viewport
  edge so they can't run off-screen when flipped below the cursor near the top.
- transcripts-agents: rename _CITATIONS_POLL_TIMEOUT to _AGENT_POLL_TIMEOUT
  since the friction poll shares it (clarity, no value change).
- transcripts-search: bind the "Mark All" click handler once at creation via
  addEventListener instead of reassigning .onclick on every render.
- studio-intake, convergence: add explicit radix 10 to parseInt calls for
  consistency with the rest of the codebase.