### PR TITLE
refactor(workflows): tidy deleteBlueprint autosave/race handling

### DIFF
--- a/assets/web/workflows.js
+++ b/assets/web/workflows.js
@@ -187,16 +187,14 @@
   function deleteBlueprint(id) {
     if (!id) return;
     cancelSave(); // don't resurrect the row we're about to delete
+    // Clear the active id up front so any autosave PUT already in flight for it
+    // is a no-op (flushSave bails on a falsy id), not after the DELETE resolves.
+    state.activeBlueprintId = null;
     apiDelete("api/blueprints/" + encodeURIComponent(id))
-      .then(function (res) {
-        if (!res || !res.ok) {
-          showToast("Failed to delete blueprint");
-          return;
-        }
+      .then(function () {
         state.blueprints = state.blueprints.filter(function (b) {
           return b.id !== id;
         });
-        state.activeBlueprintId = null; // so the next open's flushSave is a no-op
         if (state.blueprints.length) {
           populateSelect();
           openBlueprint(state.blueprints[0]);


### PR DESCRIPTION
Two small cleanups to the blueprint delete path in workflows.js:

- Null state.activeBlueprintId before the DELETE (not inside the success
  handler) so an autosave PUT already in flight for that id becomes a
  client-side no-op via flushSave's falsy-id guard — drops the only path
  to a spurious "Failed to save" toast on delete.
- Remove the unreachable !res.ok branch in the .then: apiDelete throws on
  non-OK, so the .catch is the real error handler.

No behavior change beyond suppressing the stray toast; server-side delete
was already safe (PUT 404s for a missing id, no upsert).