### PR TITLE
fix(web): floor tooltip top position so tall tooltips don't clip off-screen

### DIFF
--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -1163,7 +1163,7 @@
     var y = clientY - tipRect.height - 12;
     if (x + tipRect.width > window.innerWidth - 8) x = window.innerWidth - tipRect.width - 8;
     if (y < 8) y = clientY + 16;
-    if (y + tipRect.height > window.innerHeight - 8) y = window.innerHeight - tipRect.height - 8;
+    if (y + tipRect.height > window.innerHeight - 8) y = Math.max(8, window.innerHeight - tipRect.height - 8);
     tip.style.left = x + "px";
     tip.style.top = y + "px";
     state.frictionTooltipShown = true;

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -345,7 +345,7 @@
     var y = clientY - tipRect.height - 12;
     if (x + tipRect.width > window.innerWidth - 8) x = window.innerWidth - tipRect.width - 8;
     if (y < 8) y = clientY + 16;
-    if (y + tipRect.height > window.innerHeight - 8) y = window.innerHeight - tipRect.height - 8;
+    if (y + tipRect.height > window.innerHeight - 8) y = Math.max(8, window.innerHeight - tipRect.height - 8);
     tip.style.left = x + "px";
     tip.style.top = y + "px";
   }


### PR DESCRIPTION
The bottom-edge clamp added in #458 had no lower bound, so a tooltip taller
than the available vertical space (friction tooltips can stack badges + up to
5 markers + a score line on a short viewport) got positioned at a negative
top and clipped off the top of the window. Floor the clamped value at 8px.

Applies to the friction-marker tooltip (transcripts-agents.js) and the video
timeline-mark tooltip (transcripts-video.js).