### PR TITLE
fix(workflows): show node tooltips via data-tooltip singleton

### DIFF
--- a/assets/web/workflows-nodes.js
+++ b/assets/web/workflows-nodes.js
@@ -309,12 +309,13 @@
     }
 
     // Colour-coded title bar (domain background via CSS data-domain): the label
-    // plus a `?` help glyph whose native tooltip carries the catalog description.
+    // plus a `?` help glyph whose tooltip carries the catalog description. Uses
+    // the [data-tooltip] singleton (styled/in-viewport), not native title.
     var titleBar = el("div", "wf-node-title");
     titleBar.appendChild(el("span", "wf-node-title-text", type.label || node.type));
     if (type.description) {
       var help = el("span", "wf-node-help");
-      help.title = type.description;
+      help.setAttribute("data-tooltip", type.description);
       titleBar.appendChild(help);
     }
     card.appendChild(titleBar);

--- a/assets/web/workflows.js
+++ b/assets/web/workflows.js
@@ -99,7 +99,9 @@
     var item = el("div", "wf-palette-item", node.label);
     item.setAttribute("data-domain", node.domain || "");
     // Brief description tooltip for every palette row (mirrors the on-card `?`).
-    if (node.description) item.title = node.description;
+    // Use the [data-tooltip] singleton, not native title — title doesn't render
+    // on draggable=true rows, and the singleton is styled/positioned in-viewport.
+    if (node.description) item.setAttribute("data-tooltip", node.description);
     if (nodeContextMet(node)) {
       item.draggable = true;
       item.dataset.nodeType = node.id;
@@ -116,7 +118,10 @@
       item.classList.add("disabled");
       // Disabled rows still show the description, plus what context they need.
       var req = "Requires " + ((node.requires || []).join(", ") || "context");
-      item.title = node.description ? node.description + " — " + req : req;
+      item.setAttribute(
+        "data-tooltip",
+        node.description ? node.description + " — " + req : req,
+      );
     }
     return item;
   }

--- a/tests/test_workflows_frontend_source.py
+++ b/tests/test_workflows_frontend_source.py
@@ -310,6 +310,21 @@ def test_universal_control_port_for_gate_wiring():
     assert '"control"' in src or "'control'" in src
 
 
+def test_node_descriptions_use_data_tooltip_singleton():
+    """Palette rows and the on-card `?` glyph surface the catalog description
+    through the [data-tooltip] singleton (utils.clipgenInitDataTooltips), not
+    native `title` — native tooltips don't render on draggable=true palette
+    rows and are unstyled. Guards against regressing to `.title =`."""
+    src = _workflows_js()
+    # Palette row + help glyph both wire description via data-tooltip.
+    assert 'setAttribute("data-tooltip", node.description)' in src
+    assert 'setAttribute("data-tooltip", type.description)' in src
+    # The help glyph itself ships (mask-icon span carrying the tooltip).
+    assert "wf-node-help" in src
+    css = WORKFLOWS_CSS.read_text(encoding="utf-8")
+    assert ".wf-node-help" in css
+
+
 def test_css_defines_run_panel_and_node_status_styles():
     css = WORKFLOWS_CSS.read_text(encoding="utf-8")
     assert ".wf-run-card" in css


### PR DESCRIPTION
## Summary

Node description tooltips (palette rows + the on-card `?` help glyph) didn't appear because they used native `title`, which the browser suppresses on `draggable=true` palette rows and renders unstyled/slowly elsewhere. They now use the project's `[data-tooltip]` singleton (`clipgenInitDataTooltips`, styled by `.cg-tooltip`), which is already loaded on the Workflows page.

## Test plan

- [x] `/check` green — ruff format + lint, ty, full pytest, plus a new source-test guarding against regressing to `.title =`.
- [ ] ⚠️ UI not browser-checked (no-headless rule): confirm hovering a palette row and a card's `?` shows the styled description tooltip.
