### PR TITLE
fix: stop web modes and tests from leaving empty artifacts in the CWD

### DIFF
--- a/config.py
+++ b/config.py
@@ -146,6 +146,10 @@ STUDIO_SETTINGS_FILENAME: str = "studio_settings.json"
 WORKFLOWS_MANIFEST_FILENAME: str = (
     "workflows_manifest.json"  # node-canvas blueprints, stashes, run history
 )
+# Prefix for our own scratch temp-files written into the output dir (currently the
+# reel-builder's mkstemp clips). Lets sweep_stale_temp_artifacts() reclaim orphans
+# left by a hard kill without ever touching user files.
+TEMP_ARTIFACT_PREFIX: str = "clipgen_tmp_"
 # Watch-dir trigger (P6): poll interval for the daemon that auto-runs an armed
 # blueprint when a new participant video lands in the input dir. The partial-copy
 # stability window is 2x this (a file must stat identically across two polls).

--- a/screenspace_manifest.py
+++ b/screenspace_manifest.py
@@ -89,6 +89,19 @@ def load_screenspace_manifest() -> dict[str, Any]:
     )
 
 
+def _is_empty_screenspace_manifest(payload: dict[str, Any]) -> bool:
+    """True when no regions, tasks, events, stashes, per-participant data, or pins
+    exist — i.e. nothing worth writing into the output dir."""
+    return not (
+        payload.get("regions")
+        or payload.get("tasks")
+        or payload.get("events")
+        or payload.get("stashes")
+        or payload.get("per_participant")
+        or payload.get("pins")
+    )
+
+
 def save_screenspace_manifest(
     regions: dict[str, dict[str, Any]],
     tasks: list[dict[str, Any]],
@@ -147,6 +160,9 @@ def save_screenspace_manifest(
             "pins": pins_payload,
         }
     )
+    if _is_empty_screenspace_manifest(payload):
+        utils.remove_json_manifest(config.SCREENSPACE_MANIFEST_FILENAME)
+        return None
     return utils.save_json_manifest(
         config.SCREENSPACE_MANIFEST_FILENAME,
         payload,

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -2714,6 +2714,10 @@ def _init_screenspace_state(
     _worker.restore_tasks(_manifest.get("tasks", []))
     _worker.start()
 
+    # Reclaim a stale empty manifest left by a prior abandoned session: the
+    # guarded save removes the file when empty, idempotent rewrite otherwise.
+    _persist_manifest()
+
 
 def _discover_participant_videos(study_name: str) -> None:
     """Scan input directory for source video files and populate _participants."""

--- a/server.py
+++ b/server.py
@@ -1260,14 +1260,7 @@ def _save_studio_settings(overrides: dict[str, Any]) -> Path | None:
         if name in _settings_defaults and value != _settings_defaults[name]:
             to_save[name] = value
     if not to_save:
-        settings_path = (
-            Path(utils.get_effective_output_dir()) / config.STUDIO_SETTINGS_FILENAME
-        )
-        if settings_path.is_file():
-            try:
-                settings_path.unlink()
-            except OSError:
-                pass
+        utils.remove_json_manifest(config.STUDIO_SETTINGS_FILENAME)
         return None
     return utils.save_json_manifest(config.STUDIO_SETTINGS_FILENAME, to_save)
 
@@ -2870,7 +2863,9 @@ def api_reel_direct() -> FlaskResponse:
                     timeline = video.timeline_or_none(video_paths)
 
                     fd, tmp_path = tempfile.mkstemp(
-                        suffix=config.FILEFORMAT, dir=str(output_dir)
+                        prefix=config.TEMP_ARTIFACT_PREFIX,
+                        suffix=config.FILEFORMAT,
+                        dir=str(output_dir),
                     )
                     # Track for cleanup BEFORE os.close(fd) or any other call
                     # that could raise; otherwise the tmp file is on disk but
@@ -3870,6 +3865,10 @@ def start_combined_server(
     # ``input()`` — this previously hung Studio generate and watch-dir-triggered
     # workflow runs alike.
     utils.NO_INPUT_MODE = True
+
+    # Reclaim orphaned scratch files (atomic-write .tmp siblings, reel temp-clips)
+    # a prior hard kill may have left in the output dir, before workers spin up.
+    utils.sweep_stale_temp_artifacts()
 
     combined = build_combined_app(
         worksheet=worksheet,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,21 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
+@pytest.fixture(autouse=True)
+def _sandbox_cwd(tmp_path, monkeypatch):
+    """Run every test from a throwaway working directory.
+
+    Many code paths fall back to ``Path.cwd()`` when ``config.OUTPUT_DIR`` is
+    unset — notably ``files.get_unique_filename`` reserving a 0-byte placeholder.
+    A test that exercises those without sandboxing the output dir would otherwise
+    drop artifacts into the repo root (``.mp4`` is gitignored, so they accumulate
+    invisibly). Chdir-ing into ``tmp_path`` keeps any such fallback inside
+    pytest's auto-cleaned tmp tree. Tests that set ``config.OUTPUT_DIR``
+    explicitly are unaffected; this is purely a safety net for the rest.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture
 def make_clip():
     def _make_clip(

--- a/tests/screenspace/test_manifest_events.py
+++ b/tests/screenspace/test_manifest_events.py
@@ -152,6 +152,33 @@ class TestManifest:
         assert screenspace.load_screenspace_manifest()["pins"] == {}
 
 
+class TestEmptyManifestGuard:
+    """An empty screenspace manifest is never written (and an existing one is
+    removed) so a zero-interaction / abandoned launch leaves no CWD junk."""
+
+    def test_empty_save_writes_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        path = screenspace.save_screenspace_manifest({}, [])
+        assert path is None
+        assert not (tmp_path / config.SCREENSPACE_MANIFEST_FILENAME).exists()
+
+    def test_nonempty_save_writes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        path = screenspace.save_screenspace_manifest({"hud": {"x": 0}}, [])
+        assert path is not None and path.is_file()
+
+    def test_emptying_existing_manifest_removes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        manifest = tmp_path / config.SCREENSPACE_MANIFEST_FILENAME
+        screenspace.save_screenspace_manifest({"hud": {"x": 0}}, [])
+        assert manifest.is_file()
+        # A stale .tmp from a prior crashed write must also be reclaimed.
+        (tmp_path / (config.SCREENSPACE_MANIFEST_FILENAME + ".tmp")).write_text("x")
+        screenspace.save_screenspace_manifest({}, [])
+        assert not manifest.exists()
+        assert not (tmp_path / (config.SCREENSPACE_MANIFEST_FILENAME + ".tmp")).exists()
+
+
 # ---------------------------------------------------------------------------
 # Events
 # ---------------------------------------------------------------------------

--- a/tests/test_artifact_cleanup.py
+++ b/tests/test_artifact_cleanup.py
@@ -1,0 +1,81 @@
+"""Tests for output-dir hygiene: empty-manifest removal and stale-temp sweeping.
+
+Covers ``utils.remove_json_manifest`` / ``utils.sweep_stale_temp_artifacts`` and
+the Workflows launch-time cleanup that reclaims a stale empty manifest left by a
+prior abandoned session.
+"""
+
+import config
+import utils
+import workflows
+import workflows_server
+
+
+class TestRemoveJsonManifest:
+    def test_deletes_file_and_tmp_sibling(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        (tmp_path / "thing.json").write_text("{}")
+        (tmp_path / "thing.json.tmp").write_text("partial")
+        utils.remove_json_manifest("thing.json")
+        assert not (tmp_path / "thing.json").exists()
+        assert not (tmp_path / "thing.json.tmp").exists()
+
+    def test_missing_file_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        # Must not raise when nothing is on disk.
+        utils.remove_json_manifest("absent.json")
+
+
+class TestSweepStaleTempArtifacts:
+    def test_sweeps_only_our_orphans(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        # Our orphans: an atomic-write tmp sibling and a reel temp-clip.
+        (tmp_path / "screenspace_manifest.json.tmp").write_text("partial")
+        (tmp_path / (config.TEMP_ARTIFACT_PREFIX + "ab12.mp4")).write_bytes(b"")
+        # User files that must survive.
+        (tmp_path / "keep.json").write_text("{}")
+        (tmp_path / "keep.mp4").write_bytes(b"data")
+
+        utils.sweep_stale_temp_artifacts()
+
+        assert not (tmp_path / "screenspace_manifest.json.tmp").exists()
+        assert not (tmp_path / (config.TEMP_ARTIFACT_PREFIX + "ab12.mp4")).exists()
+        assert (tmp_path / "keep.json").exists()
+        assert (tmp_path / "keep.mp4").exists()
+
+    def test_missing_output_dir_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path / "nope"))
+        # Must not raise when the output dir does not exist.
+        utils.sweep_stale_temp_artifacts()
+
+
+class TestWorkflowsLaunchCleanup:
+    def test_init_removes_stale_empty_manifest(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        # Keep the launch hermetic — no watch daemon / disk discovery.
+        monkeypatch.setattr(workflows_server, "_start_watch_thread", lambda: None)
+        monkeypatch.setattr(workflows_server, "_seed_watch_seen", lambda: None)
+
+        manifest = tmp_path / config.WORKFLOWS_MANIFEST_FILENAME
+        manifest.write_text('{"blueprints": [], "stashes": [], "runs": []}')
+        (tmp_path / (config.WORKFLOWS_MANIFEST_FILENAME + ".tmp")).write_text("partial")
+
+        workflows_server._init_workflows_state()
+
+        assert not manifest.exists()
+        assert not (tmp_path / (config.WORKFLOWS_MANIFEST_FILENAME + ".tmp")).exists()
+
+    def test_init_keeps_nonempty_manifest(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        monkeypatch.setattr(workflows_server, "_start_watch_thread", lambda: None)
+        monkeypatch.setattr(workflows_server, "_seed_watch_seen", lambda: None)
+
+        workflows.save_workflows_manifest(
+            [{"id": "bp1", "name": "Real", "nodes": [{"id": "n1"}], "edges": []}]
+        )
+        manifest = tmp_path / config.WORKFLOWS_MANIFEST_FILENAME
+        assert manifest.is_file()
+
+        workflows_server._init_workflows_state()
+
+        assert manifest.is_file()

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -529,6 +529,23 @@ class TestTranscriptsManifest:
         loaded = transcripts.load_transcripts_manifest()
         assert loaded["corrections"] == corrections
 
+    def test_empty_save_writes_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        path = transcripts.save_transcripts_manifest({}, [])
+        assert path is None
+        assert not (tmp_path / config.TRANSCRIPTS_MANIFEST_FILENAME).exists()
+
+    def test_emptying_existing_manifest_removes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+        manifest = tmp_path / config.TRANSCRIPTS_MANIFEST_FILENAME
+        transcripts.save_transcripts_manifest(
+            {}, [{"id": "c1", "from": "a", "to": "b", "created": "2025-01-01T00:00:00"}]
+        )
+        assert manifest.is_file()
+        # Pass marks=[] explicitly to defeat the marks-from-disk preservation.
+        transcripts.save_transcripts_manifest({}, [], marks=[])
+        assert not manifest.exists()
+
     def test_load_corrupt_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
         (tmp_path / config.TRANSCRIPTS_MANIFEST_FILENAME).write_text("not json")

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -297,6 +297,28 @@ def test_blueprint_create_returns_id_and_defaults(wf_client):
     assert any(b["id"] == bp["id"] for b in listed)
 
 
+def test_zero_interaction_launch_writes_no_manifest(wf_client, tmp_path):
+    # The frontend auto-creates a bare "Untitled" blueprint on first load; that
+    # node-less blueprint must not drop a manifest file in the output dir.
+    resp = wf_client.post("/workflows/api/blueprints", json={})
+    assert resp.status_code == 200
+    assert not (tmp_path / config.WORKFLOWS_MANIFEST_FILENAME).exists()
+
+
+def test_blueprint_with_node_persists_manifest(wf_client, tmp_path):
+    _make_blueprint(wf_client, nodes=[{"id": "n1", "type": "video_source"}])
+    assert (tmp_path / config.WORKFLOWS_MANIFEST_FILENAME).is_file()
+
+
+def test_emptying_blueprint_removes_manifest(wf_client, tmp_path):
+    bp_id = _make_blueprint(wf_client, nodes=[{"id": "n1", "type": "video_source"}])
+    manifest = tmp_path / config.WORKFLOWS_MANIFEST_FILENAME
+    assert manifest.is_file()
+    # Clear the graph back to empty (the autosave PUT shape) → file reclaimed.
+    wf_client.put(f"/workflows/api/blueprints/{bp_id}", json={"nodes": [], "edges": []})
+    assert not manifest.exists()
+
+
 def test_blueprint_update_round_trips_nodes_and_viewport(wf_client):
     bp = wf_client.post("/workflows/api/blueprints", json={}).get_json()["blueprint"]
     payload = {

--- a/transcripts.py
+++ b/transcripts.py
@@ -409,6 +409,13 @@ def _empty_transcripts_manifest() -> dict[str, Any]:
     return {"source_transcripts": {}, "corrections": [], "marks": []}
 
 
+def _is_empty_transcripts_manifest(data: dict[str, Any]) -> bool:
+    """True when no transcripts, corrections, or marks exist — nothing to persist."""
+    return not (
+        data.get("source_transcripts") or data.get("corrections") or data.get("marks")
+    )
+
+
 def load_transcripts_manifest() -> dict[str, Any]:
     """Load the transcripts manifest from the output directory.
 
@@ -452,6 +459,9 @@ def save_transcripts_manifest(
         "corrections": corrections,
         "marks": marks,
     }
+    if _is_empty_transcripts_manifest(data):
+        utils.remove_json_manifest(config.TRANSCRIPTS_MANIFEST_FILENAME)
+        return None
     return utils.save_json_manifest(
         config.TRANSCRIPTS_MANIFEST_FILENAME,
         data,

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1924,3 +1924,7 @@ def _init_transcripts_state(
         if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get("result"):
             _merged_task_ids.add(task["id"])
     _worker.start()
+
+    # Reclaim a stale empty manifest left by a prior abandoned session: the
+    # guarded save removes the file when empty, idempotent rewrite otherwise.
+    _persist_manifest()

--- a/utils.py
+++ b/utils.py
@@ -562,6 +562,40 @@ def save_json_manifest(
         return None
 
 
+def remove_json_manifest(filename: str) -> None:
+    """Delete a manifest and any stale ``.tmp`` sibling from the output dir.
+
+    Used by the save wrappers when a manifest is semantically empty: rather than
+    writing an empty artifact into the user's CWD, remove the file so a
+    zero-interaction launch leaves no junk. No-op when nothing is on disk.
+    """
+    path = Path(get_effective_output_dir()) / filename
+    for candidate in (path, path.with_suffix(path.suffix + ".tmp")):
+        try:
+            candidate.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def sweep_stale_temp_artifacts() -> None:
+    """Remove orphaned atomic-write tmps and reel temp-clips from the output dir.
+
+    Targets only our own artifacts — ``*.json.tmp`` siblings (manifest atomic
+    writes) and ``{TEMP_ARTIFACT_PREFIX}*`` reel temp-clips — so user files are
+    never touched. Meant to run once at server startup, before any worker thread,
+    to reclaim leftovers from a prior hard kill.
+    """
+    base = Path(get_effective_output_dir())
+    if not base.is_dir():
+        return
+    for pattern in ("*.json.tmp", config.TEMP_ARTIFACT_PREFIX + "*"):
+        for stale in base.glob(pattern):
+            try:
+                stale.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
 def get_bundled_assets_root() -> Path:
     """Return the base directory for bundled project assets.
 

--- a/workflows.py
+++ b/workflows.py
@@ -77,17 +77,40 @@ def load_workflows_manifest() -> dict[str, Any]:
     return base
 
 
+def _is_empty_workflows_manifest(payload: dict[str, Any]) -> bool:
+    """True when nothing worth persisting exists.
+
+    A blueprint counts only if it carries graph content (nodes or edges); a bare
+    auto-created "Untitled" with empty nodes/edges is treated as empty even when
+    renamed, so a zero-interaction Workflows launch writes no file. Any stash or
+    run is user-meaningful and keeps the manifest.
+    """
+    if payload.get("stashes") or payload.get("runs"):
+        return False
+    for blueprint in payload.get("blueprints", []):
+        if blueprint.get("nodes") or blueprint.get("edges"):
+            return False
+    return True
+
+
 def save_workflows_manifest(
     blueprints: list[dict[str, Any]],
     stashes: list[dict[str, Any]] | None = None,
     runs: list[dict[str, Any]] | None = None,
 ) -> Path | None:
-    """Persist the workflows manifest atomically; returns the path or ``None``."""
+    """Persist the workflows manifest atomically; returns the path or ``None``.
+
+    Skips the write (and removes any stale file) when the manifest is empty, so
+    an unused canvas leaves no junk in the output dir.
+    """
     payload = {
         "blueprints": blueprints,
         "stashes": stashes or [],
         "runs": runs or [],
     }
+    if _is_empty_workflows_manifest(payload):
+        utils.remove_json_manifest(config.WORKFLOWS_MANIFEST_FILENAME)
+        return None
     return utils.save_json_manifest(
         config.WORKFLOWS_MANIFEST_FILENAME,
         payload,

--- a/workflows_server.py
+++ b/workflows_server.py
@@ -1131,5 +1131,10 @@ def _init_workflows_state(
     _sheet_context = sheet_context
     _worksheet = worksheet
     _manifest = workflows.load_workflows_manifest()
+    # Reclaim a stale empty manifest (e.g. an abandoned auto-created "Untitled"
+    # blueprint) left by a prior session: the guarded save removes the file when
+    # empty and is an idempotent rewrite otherwise.
+    with _manifest_lock:
+        _persist_locked()
     _seed_watch_seen()
     _start_watch_thread()


### PR DESCRIPTION
## Summary

Web modes default their output dir to the launch CWD, so empty/throwaway state accumulated there. This change persists only real content and reclaims leftovers.

- **Empty-manifest guards** — the workflows/screenspace/transcripts save wrappers now skip the write and remove any existing file when the manifest is semantically empty (new `utils.remove_json_manifest`, generalizing `_save_studio_settings`'s idiom). A node-less Workflows blueprint counts as empty, so the frontend's zero-interaction auto-created "Untitled" no longer drops a `workflows_manifest.json`.
- **Startup temp sweep** — `start_combined_server` reclaims orphaned `*.json.tmp` siblings and prefixed reel temp-clips (`clipgen_tmp_*`) left by a prior hard kill; each `_init_*_state` does one guarded persist on launch to clear a stale empty manifest.
- **Test hygiene** — an autouse `conftest` fixture chdirs every test into `tmp_path`, so any `Path.cwd()` fallback (e.g. `get_unique_filename`'s 0-byte placeholder under mocked ffmpeg) lands in pytest's tmp tree instead of the repo root, where two tests had been silently leaking gitignored `.mp4`s.

## Test plan

- [x] `/check` green — ruff format + lint, ty, pytest **1722 passed**
- [x] Full suite run leaves the repo root clean (no new `.mp4`/`.json`); pre-existing orphans removed
- [ ] ⚠️ Manual browser check pending: launch `--workflows` in an empty dir, open the page, do nothing, quit → confirm no `workflows_manifest.json`; add a node → it appears; clear it → it's removed
