### PR TITLE
fix(video): stop get_duration silently dropping valid clip timestamps

### DIFF
--- a/config.py
+++ b/config.py
@@ -318,7 +318,6 @@ MAX_SKIPPED_TIMESTAMPS_TO_SHOW: int = (
 # ── Timestamps ───────────────────────────────────────────────────────
 SECONDS_PER_HOUR: int = 3600
 SECONDS_PER_MINUTE: int = 60
-MAX_MMSS_LENGTH: int = 5  # Max length of an MM:SS timestamp string
 
 # ── FFmpeg ────────────────────────────────────────────────────────────
 FFMPEG_LOGLEVEL: str = "16"  # ffmpeg -loglevel value (16 = error)

--- a/data_export.py
+++ b/data_export.py
@@ -111,9 +111,9 @@ def _flatten_value_for_csv(value: Any) -> Any:
                 "" if (safe := utils.sanitize_floats(item)) is None else str(safe)
                 for item in value
             )
-        return json.dumps(value, ensure_ascii=False)
+        return json.dumps(utils.sanitize_floats(value), ensure_ascii=False)
     if isinstance(value, dict):
-        return json.dumps(value, ensure_ascii=False)
+        return json.dumps(utils.sanitize_floats(value), ensure_ascii=False)
     return str(value)
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -325,9 +325,12 @@ def _prepare_and_check_clip(
 def _local_timestamp(seconds: float) -> str:
     """Format local *seconds* as ``H:MM:SS`` for ffmpeg.
 
-    Always emits the hours component so a clip's start/end can't end up in mixed
-    formats (``video.get_duration`` parses both ends with one format). These
-    strings feed ffmpeg, not the spreadsheet, so the explicit hours are harmless.
+    Always emits the hours component so every ffmpeg-bound timestamp shares one
+    uniform shape. This is a consistency/readability invariant, not a
+    correctness requirement: ``video.get_duration`` parses each end
+    independently (via ``utils.timestamp_to_seconds``) and tolerates mixed
+    ``M:SS`` / ``H:MM:SS`` pairs. These strings feed ffmpeg, not the
+    spreadsheet, so the explicit hours are harmless.
     """
     return utils.seconds_to_timestamp(int(round(seconds)), force_hours=True)
 
@@ -423,8 +426,8 @@ def cut_global_range(
         ok = video.run_ffmpeg(
             base_video,
             out_path,
-            utils.seconds_to_timestamp(int(round(start_seconds))),
-            utils.seconds_to_timestamp(int(round(end_seconds))),
+            _local_timestamp(start_seconds),
+            _local_timestamp(end_seconds),
             reencode,
             cancel_flag=cancel_flag,
         )

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 
+import utils
 import video
 
 _MATCHING_PROPS = {
@@ -405,6 +406,31 @@ def test_get_duration_valid_and_invalid_values(monkeypatch):
     assert video.get_duration("00:10", video.INVALID_END_TIMESTAMP) is None
     # Completely invalid format returns None
     assert video.get_duration("not-a-time", "also-bad") is None
+
+
+def test_get_duration_mixed_format_and_overflow_minutes():
+    """Pairs whose ends need different formats, and MM:SS with minutes >= 60,
+    must yield a real duration. The timestamp parser emits both shapes; a
+    shared-format strptime previously returned None and silently dropped the
+    clip in run_ffmpeg."""
+    # Mixed M:SS / H:MM:SS pair (a clip straddling the hour boundary).
+    assert video.get_duration("59:50", "1:00:10") == 20
+    # MM:SS with minutes >= 60 (a long session written without an hours field).
+    assert video.get_duration("75:00", "80:00") == 300
+    # Both ends carrying hours still work.
+    assert video.get_duration("1:00:10", "1:00:30") == 20
+
+
+def test_get_duration_accepts_every_pair_the_parser_emits():
+    """Tie the parser contract to the cutter: any (start, end) pair that
+    parse_timestamps produces must yield a duration, not None — including
+    single timestamps whose default-duration end crosses the hour."""
+    for cell in ("59:50", "75:00", "58:30", "0:10"):
+        start, end = utils.parse_timestamps(cell)[0]
+        assert video.get_duration(start, end) is not None, cell
+    # Explicit range cell with overflow minutes.
+    start, end = utils.parse_timestamps("75:00-80:00")[0]
+    assert video.get_duration(start, end) == 300
 
 
 def test_calculate_target_bitrate_typical_and_min_floor():

--- a/video.py
+++ b/video.py
@@ -11,7 +11,6 @@ import tempfile
 import threading
 from collections import Counter
 from collections.abc import Callable
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -1442,9 +1441,7 @@ def get_duration(start_time: str, end_time: str | None) -> int | None:
     """
     if config.DEBUGGING:
         ic(start_time, end_time)
-    utils.debug_print(
-        f"start_time is {start_time} with length {len(start_time)}, end_time is {end_time}"
-    )
+    utils.debug_print(f"start_time is {start_time}, end_time is {end_time}")
 
     if end_time is INVALID_END_TIMESTAMP:
         utils.error_print(
@@ -1453,31 +1450,29 @@ def get_duration(start_time: str, end_time: str | None) -> int | None:
         )
         return None
 
-    formats = (
-        ["%M:%S", "%H:%M:%S"]
-        if len(str(start_time)) <= config.MAX_MMSS_LENGTH
-        else ["%H:%M:%S", "%M:%S"]
-    )
+    # Parse each end independently with the canonical timestamp parser rather
+    # than picking one strptime format for both ends: the two ends can
+    # legitimately need different formats (a clip 59:50 -> 1:00:10 straddling
+    # the hour, or a single timestamp whose default-duration end crosses it),
+    # and MM:SS minutes may exceed 59 ("75:00", a long session written without
+    # an hours component). A shared-format strptime rejected all of those and
+    # silently dropped the clip.
+    start_seconds = utils.timestamp_to_seconds(start_time)
+    end_seconds = utils.timestamp_to_seconds(end_time)
+    if start_seconds is None or end_seconds is None:
+        utils.error_print(
+            "Timestamp formatting error in get_duration().",
+            [
+                f"Start time: '{start_time}', End time: '{end_time}'",
+                "Accepted formats: HH:MM:SS, MM:SS, or M:SS (e.g., 1:23:45, 12:34, 1:23)",
+            ],
+        )
+        return None
 
-    for time_format in formats:
-        try:
-            start_datetime = datetime.strptime(str(start_time), time_format)
-            end_datetime = datetime.strptime(str(end_time), time_format)
-            duration = int((end_datetime - start_datetime).total_seconds())
-            if config.DEBUGGING:
-                ic(duration)
-            return duration
-        except ValueError:
-            continue
-
-    utils.error_print(
-        "Timestamp formatting error in get_duration().",
-        [
-            f"Start time: '{start_time}', End time: '{end_time}'",
-            "Accepted formats: HH:MM:SS, MM:SS, or M:SS (e.g., 1:23:45, 12:34, 1:23)",
-        ],
-    )
-    return None
+    duration = int(end_seconds - start_seconds)
+    if config.DEBUGGING:
+        ic(duration)
+    return duration
 
 
 def calculate_target_bitrate(


### PR DESCRIPTION
## Summary

`get_duration` chose one `strptime` format from the start string and parsed both ends with it, so `run_ffmpeg` silently skipped clips for timestamp pairs the canonical parser already supports — mixed `M:SS`/`H:MM:SS` (a clip straddling the hour, e.g. a single timestamp whose default-duration end crosses it) and `MM:SS` with minutes ≥ 60 (e.g. `75:00`). It now parses each end independently via `utils.timestamp_to_seconds`; `cut_global_range`'s single-video branch forces hours so it stops emitting mixed pairs, and `data_export` sanitizes nested list/dict values before `json.dumps` so a non-finite float can't emit an invalid `NaN` token in a CSV cell.

## Test plan

- [x] New regression tests for mixed-format and overflow-minute durations (`tests/test_video_commands.py`)
- [x] `/check` green — ruff format + lint, ty, full suite (1724 passed)
- [ ] Not browser/clip-output verified end-to-end against a >80-min source video
