### PR TITLE
docs: add frontend refactors & carveouts plan

### DIFF
--- a/assets/web/convergence.css
+++ b/assets/web/convergence.css
@@ -314,7 +314,7 @@
   display: inline-block;
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 

--- a/assets/web/screenspace-overlay.js
+++ b/assets/web/screenspace-overlay.js
@@ -1,0 +1,251 @@
+/* clipgen Screenspace — overlay-render satellite.
+ *
+ * Carved out of screenspace.js (the hub) following the hub+satellite convention
+ * (see screenspace-tasks/results/...). renderOverlay paints the region editor's
+ * canvas chrome: saved/preview regions + labels + handles, the in-progress draw
+ * rect, the pending region, the draggable template preview, template/flow result
+ * overlays, the heatmap composite, and the model-view comparator.
+ *
+ * It is a pure read of the hub's shared `state` plus a handful of hub helpers,
+ * all reached through the window.ClipgenScreenspace (SS) namespace. hexToRgba
+ * and qs are ambient utils.js globals (scope chain). The hub keeps a same-named
+ * renderOverlay delegator for its ~33 call sites. Loaded by screenspace.html
+ * right after screenspace.js and BEFORE screenspace-tasks.js / -results.js,
+ * which destructure SS.renderOverlay at load time.
+ */
+
+(function () {
+  "use strict";
+
+  var SS = window.ClipgenScreenspace;
+  var state = SS.state;
+  // Hub helpers (published synchronously during the hub's load, before this
+  // file runs). hexToRgba / qs are ambient utils.js globals.
+  var regionToPixels = SS.regionToPixels,
+    regionColorForIndex = SS.regionColorForIndex,
+    computeLabelRect = SS.computeLabelRect,
+    getThemeColors = SS.getThemeColors,
+    templateOverlayBounds = SS.templateOverlayBounds,
+    taskTypeColor = SS.taskTypeColor,
+    _overlayEligibleForActiveTool = SS._overlayEligibleForActiveTool;
+
+  function renderOverlay() {
+    var canvas = qs("#overlayCanvas");
+    if (!canvas.width || !canvas.height) return;
+    var ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // Scale factor: canvas pixels per display pixel, so chrome looks
+    // the same physical size regardless of the underlying video resolution.
+    var displayW = canvas.getBoundingClientRect().width || canvas.width;
+    var s = canvas.width / displayW;
+
+    // Draw saved regions (or preview regions when hovering a stash)
+    var drawRegions = state.previewRegions || state.regions;
+    if (state.showRegionOverlays) {
+      var names = Object.keys(drawRegions);
+      names.forEach(function (name, i) {
+        var r = regionToPixels(drawRegions[name]);
+        var color = regionColorForIndex(i);
+        var isActive = (name === state.activeRegion);
+        var isHovered = state.hoveredRegion && state.hoveredRegion.name === name;
+        var showHandles = isActive || isHovered;
+        ctx.strokeStyle = color;
+        ctx.lineWidth = (isActive ? 2 : 1) * s;
+        ctx.setLineDash(isActive ? [] : [6 * s, 3 * s]);
+        ctx.strokeRect(r.x, r.y, r.w, r.h);
+        if (isActive) {
+          ctx.fillStyle = hexToRgba(color, 0.12);
+          ctx.fillRect(r.x, r.y, r.w, r.h);
+        }
+        ctx.setLineDash([]);
+
+        // Label with grip indicator
+        if (state.showRegionLabels) {
+          var lr = computeLabelRect(r, name, ctx, s);
+          ctx.fillStyle = hexToRgba(color, 0.85);
+          ctx.fillRect(lr.x, lr.y, lr.w, lr.h);
+          if (showHandles) {
+            ctx.fillStyle = "rgba(255,255,255,0.5)";
+            var dotR = Math.round(1 * s);
+            var gripColGap = Math.round(3 * s);
+            var gripRowGap = Math.round(3 * s);
+            var gx = lr.x + lr.gripPadL + dotR + Math.round(1 * s);
+            var gy = lr.y + Math.round(lr.h / 2) - gripRowGap;
+            for (var row = 0; row < 3; row++) {
+              for (var col = 0; col < 2; col++) {
+                ctx.beginPath();
+                ctx.arc(gx + col * gripColGap, gy + row * gripRowGap, dotR, 0, Math.PI * 2);
+                ctx.fill();
+              }
+            }
+          }
+          ctx.fillStyle = "#fff";
+          ctx.fillText(name, lr.x + lr.gripPadL + lr.gripW + lr.pad, r.y - Math.round(4 * s));
+        }
+
+        // Resize handle (bottom-right corner, 3-dot triangle)
+        if (showHandles) {
+          var dotRr = Math.round(1.5 * s);
+          var handlePad = Math.round(5 * s);
+          var dotSpacing = Math.round(4 * s);
+          var bx = r.x + r.w - handlePad;
+          var by = r.y + r.h - handlePad;
+          ctx.fillStyle = hexToRgba(color, 0.9);
+          ctx.beginPath(); ctx.arc(bx, by, dotRr, 0, Math.PI * 2); ctx.fill();
+          ctx.beginPath(); ctx.arc(bx - dotSpacing, by, dotRr, 0, Math.PI * 2); ctx.fill();
+          ctx.beginPath(); ctx.arc(bx, by - dotSpacing, dotRr, 0, Math.PI * 2); ctx.fill();
+        }
+      });
+    }
+
+    // Drawing in progress
+    if (state.drawingRegion) {
+      var d = state.drawingRegion;
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 1.5 * s;
+      ctx.setLineDash([4 * s, 3 * s]);
+      ctx.strokeRect(d.startX, d.startY, d.endX - d.startX, d.endY - d.startY);
+      ctx.setLineDash([]);
+      // Dimensions
+      var w = Math.abs(d.endX - d.startX);
+      var h = Math.abs(d.endY - d.startY);
+      if (w > 20 && h > 20) {
+        ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
+        ctx.fillStyle = "rgba(255,255,255,0.9)";
+        ctx.fillText(w + "\u00d7" + h, Math.min(d.startX, d.endX) + Math.round(4 * s), Math.max(d.startY, d.endY) + Math.round(14 * s));
+      }
+    }
+
+    // Pending (unsaved) region
+    if (state.pendingRegion) {
+      var p = state.pendingRegion;
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 1.5 * s;
+      ctx.setLineDash([]);
+      ctx.strokeRect(p.x, p.y, p.w, p.h);
+      ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
+      ctx.fillRect(p.x, p.y, p.w, p.h);
+      ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
+      ctx.fillStyle = "rgba(255,255,255,0.9)";
+      ctx.fillText(p.w + "\u00d7" + p.h + " px", p.x + Math.round(4 * s), p.y + p.h + Math.round(14 * s));
+    }
+
+    // Template preview: overlay the uploaded PNG at its effective in-video
+    // size (native PNG pixels * template_scale) so the user can see how
+    // large it will match. Canvas is sized in native video pixels, so the
+    // display-to-video ratio is applied automatically when the browser
+    // scales the canvas to fit the viewport. The overlay is draggable so
+    // the user can position it against specific elements in the frame.
+    var tBounds = templateOverlayBounds();
+    if (tBounds) {
+      var tImg = state.uploadedTemplateImg;
+      ctx.globalAlpha = state.draggingTemplate ? 0.9 : 0.75;
+      ctx.drawImage(tImg, tBounds.x, tBounds.y, tBounds.w, tBounds.h);
+      ctx.globalAlpha = 1.0;
+      ctx.strokeStyle = taskTypeColor("template");
+      ctx.lineWidth = (state.draggingTemplate ? 2 : 1.5) * s;
+      ctx.setLineDash([4 * s, 3 * s]);
+      ctx.strokeRect(tBounds.x, tBounds.y, tBounds.w, tBounds.h);
+      ctx.setLineDash([]);
+      ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
+      ctx.fillStyle = taskTypeColor("template");
+      ctx.fillText(tBounds.w + "\u00d7" + tBounds.h + " px",
+        tBounds.x + Math.round(4 * s),
+        tBounds.y + tBounds.h + Math.round(14 * s));
+    }
+
+    // Result overlay: template match bounding boxes / flow motion arrows
+    if (state.resultOverlay) {
+      ctx.setLineDash([]);
+      if (state.resultOverlay.type === "template") {
+        var matches = state.resultOverlay.data.matches || [];
+        matches.forEach(function (m) {
+          ctx.strokeStyle = taskTypeColor("template");
+          ctx.lineWidth = 2 * s;
+          ctx.strokeRect(m.x, m.y, m.w, m.h);
+          ctx.fillStyle = hexToRgba(taskTypeColor("template"), 0.15);
+          ctx.fillRect(m.x, m.y, m.w, m.h);
+          ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
+          ctx.fillStyle = taskTypeColor("template");
+          ctx.fillText((m.score * 100).toFixed(0) + "%", m.x + Math.round(3 * s), m.y - Math.round(4 * s));
+        });
+      } else if (state.resultOverlay.type === "flow") {
+        var grid = state.resultOverlay.data.flow_grid || [];
+        var fRegion = state.resultOverlay.region;
+        if (fRegion && fRegion.w && grid.length) {
+          var maxMag = 0;
+          grid.forEach(function (c) { if (c.mag > maxMag) maxMag = c.mag; });
+          if (maxMag > 0) {
+            grid.forEach(function (c) {
+              var px = fRegion.x + c.x * fRegion.w;
+              var py = fRegion.y + c.y * fRegion.h;
+              var norm = Math.min(c.mag / maxMag, 1);
+              var arrowLen = norm * 20 * s;
+              var rad = c.ang * Math.PI / 180;
+              var ex = px + Math.cos(rad) * arrowLen;
+              var ey = py + Math.sin(rad) * arrowLen;
+              var alpha = norm * 0.8 + 0.2;
+              ctx.strokeStyle = "rgba(99, 102, 241, " + alpha + ")";
+              ctx.lineWidth = 1.5 * s;
+              ctx.beginPath();
+              ctx.moveTo(px, py);
+              ctx.lineTo(ex, ey);
+              ctx.stroke();
+              var headLen = 4 * s;
+              ctx.beginPath();
+              ctx.moveTo(ex, ey);
+              ctx.lineTo(ex - headLen * Math.cos(rad - 0.4), ey - headLen * Math.sin(rad - 0.4));
+              ctx.moveTo(ex, ey);
+              ctx.lineTo(ex - headLen * Math.cos(rad + 0.4), ey - headLen * Math.sin(rad + 0.4));
+              ctx.stroke();
+            });
+          }
+        }
+      }
+    }
+
+    // Heatmap image overlay (semi-transparent composite)
+    if (state.heatmapOverlay && state.heatmapOverlay._img) {
+      var hm = state.heatmapOverlay;
+      ctx.globalAlpha = 0.5;
+      if (hm.type === "template") {
+        ctx.drawImage(hm._img, 0, 0, canvas.width, canvas.height);
+      } else if (hm.type === "flow" || hm.type === "change") {
+        var rPx = hm.region_coords;
+        if (rPx && rPx.w) {
+          ctx.drawImage(hm._img, rPx.x, rPx.y, rPx.w, rPx.h);
+        }
+      }
+      ctx.globalAlpha = 1.0;
+    }
+
+    // Model-view overlay (toggle or held-key blink comparator)
+    var overlayActive = (state.overlayEnabled || state.overlayBlinkActive)
+      && state.overlayImage
+      && _overlayEligibleForActiveTool();
+    if (overlayActive) {
+      ctx.globalAlpha = state.overlayBlinkActive ? 1.0 : 0.7;
+      var scope = state.overlayImageScope || "region";
+      if (scope === "frame") {
+        ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
+      } else {
+        var oRegion = state.pendingRegion
+          ? state.pendingRegion
+          : (state.activeRegion ? state.regions[state.activeRegion] : null);
+        if (oRegion) {
+          var oPx = regionToPixels(oRegion);
+          if (oPx && oPx.w && oPx.h) {
+            ctx.drawImage(state.overlayImage, oPx.x, oPx.y, oPx.w, oPx.h);
+          }
+        } else {
+          // No region active — overlay covers the whole frame.
+          ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
+        }
+      }
+      ctx.globalAlpha = 1.0;
+    }
+  }
+
+  SS.renderOverlay = renderOverlay;
+})();

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -184,40 +184,6 @@ body {
   outline-offset: 2px;
 }
 
-.theme-toggle-icon {
-  position: absolute;
-  width: var(--icon-size-md);
-  height: var(--icon-size-md);
-  border-radius: var(--radius-full);
-  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
-}
-
-.theme-icon-sun {
-  background: radial-gradient(circle at 30% 30%, #ffffff 0, #fde68a 40%, #fbbf24 70%, #f59e0b 100%);
-  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
-.theme-icon-moon {
-  background:
-    radial-gradient(circle at 30% 30%, #e5e7eb 0, #9ca3af 40%, #4b5563 100%),
-    radial-gradient(circle at 65% 35%, transparent 0, transparent 55%, rgba(15, 23, 42, 0.9) 56%, rgba(15, 23, 42, 0.9) 100%);
-  box-shadow: 0 0 10px rgba(148, 163, 184, 0.5);
-  opacity: 0;
-  transform: translateX(6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-sun {
-  opacity: 0;
-  transform: translateX(-6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-moon {
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
 /* Main content */
 
 #ssMain {
@@ -486,7 +452,7 @@ body {
   flex: 0 0 8px;
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   margin-top: 0.45em;
   background: var(--color-text-dim);
 }
@@ -765,7 +731,7 @@ body {
 .region-chip-dot {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 
@@ -1260,7 +1226,7 @@ body[data-frontend="screenspace"] {
 .legend-dot {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 
@@ -3002,7 +2968,7 @@ body.panel-dragging #bottomPanel {
 .rp-switcher-item-badge {
   width: 10px;
   height: 10px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 
@@ -3286,7 +3252,7 @@ body.panel-dragging #bottomPanel {
   height: 10px;
   border: 1.5px solid var(--color-border);
   border-top-color: var(--color-accent);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   animation: task-card-spin 0.7s linear infinite;
 }
 
@@ -3545,7 +3511,7 @@ body.panel-dragging #bottomPanel {
   appearance: none;
   width: 12px;
   height: 12px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-accent);
   border: none;
   cursor: pointer;
@@ -3557,7 +3523,7 @@ body.panel-dragging #bottomPanel {
 .scene-ref-thresh::-moz-range-thumb {
   width: 12px;
   height: 12px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-accent);
   border: none;
   cursor: pointer;
@@ -3823,7 +3789,7 @@ body.panel-dragging #bottomPanel {
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -331,6 +331,7 @@
   <script src="settings-modal.js"></script>
   <script src="video-controls.js"></script>
   <script src="screenspace.js"></script>
+  <script src="screenspace-overlay.js"></script>
   <script src="screenspace-tasks.js"></script>
   <script src="screenspace-multitool-params.js"></script>
   <script src="screenspace-calibration.js"></script>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -2760,222 +2760,10 @@
     return { x: x, y: y, w: w, h: h };
   }
 
+  // renderOverlay lives in screenspace-overlay.js; this hub delegator forwards
+  // its ~33 hub call sites to the satellite implementation.
   function renderOverlay() {
-    var canvas = qs("#overlayCanvas");
-    if (!canvas.width || !canvas.height) return;
-    var ctx = canvas.getContext("2d");
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    // Scale factor: canvas pixels per display pixel, so chrome looks
-    // the same physical size regardless of the underlying video resolution.
-    var displayW = canvas.getBoundingClientRect().width || canvas.width;
-    var s = canvas.width / displayW;
-
-    // Draw saved regions (or preview regions when hovering a stash)
-    var drawRegions = state.previewRegions || state.regions;
-    if (state.showRegionOverlays) {
-      var names = Object.keys(drawRegions);
-      names.forEach(function (name, i) {
-        var r = regionToPixels(drawRegions[name]);
-        var color = regionColorForIndex(i);
-        var isActive = (name === state.activeRegion);
-        var isHovered = state.hoveredRegion && state.hoveredRegion.name === name;
-        var showHandles = isActive || isHovered;
-        ctx.strokeStyle = color;
-        ctx.lineWidth = (isActive ? 2 : 1) * s;
-        ctx.setLineDash(isActive ? [] : [6 * s, 3 * s]);
-        ctx.strokeRect(r.x, r.y, r.w, r.h);
-        if (isActive) {
-          ctx.fillStyle = hexToRgba(color, 0.12);
-          ctx.fillRect(r.x, r.y, r.w, r.h);
-        }
-        ctx.setLineDash([]);
-
-        // Label with grip indicator
-        if (state.showRegionLabels) {
-          var lr = computeLabelRect(r, name, ctx, s);
-          ctx.fillStyle = hexToRgba(color, 0.85);
-          ctx.fillRect(lr.x, lr.y, lr.w, lr.h);
-          if (showHandles) {
-            ctx.fillStyle = "rgba(255,255,255,0.5)";
-            var dotR = Math.round(1 * s);
-            var gripColGap = Math.round(3 * s);
-            var gripRowGap = Math.round(3 * s);
-            var gx = lr.x + lr.gripPadL + dotR + Math.round(1 * s);
-            var gy = lr.y + Math.round(lr.h / 2) - gripRowGap;
-            for (var row = 0; row < 3; row++) {
-              for (var col = 0; col < 2; col++) {
-                ctx.beginPath();
-                ctx.arc(gx + col * gripColGap, gy + row * gripRowGap, dotR, 0, Math.PI * 2);
-                ctx.fill();
-              }
-            }
-          }
-          ctx.fillStyle = "#fff";
-          ctx.fillText(name, lr.x + lr.gripPadL + lr.gripW + lr.pad, r.y - Math.round(4 * s));
-        }
-
-        // Resize handle (bottom-right corner, 3-dot triangle)
-        if (showHandles) {
-          var dotRr = Math.round(1.5 * s);
-          var handlePad = Math.round(5 * s);
-          var dotSpacing = Math.round(4 * s);
-          var bx = r.x + r.w - handlePad;
-          var by = r.y + r.h - handlePad;
-          ctx.fillStyle = hexToRgba(color, 0.9);
-          ctx.beginPath(); ctx.arc(bx, by, dotRr, 0, Math.PI * 2); ctx.fill();
-          ctx.beginPath(); ctx.arc(bx - dotSpacing, by, dotRr, 0, Math.PI * 2); ctx.fill();
-          ctx.beginPath(); ctx.arc(bx, by - dotSpacing, dotRr, 0, Math.PI * 2); ctx.fill();
-        }
-      });
-    }
-
-    // Drawing in progress
-    if (state.drawingRegion) {
-      var d = state.drawingRegion;
-      ctx.strokeStyle = "#ffffff";
-      ctx.lineWidth = 1.5 * s;
-      ctx.setLineDash([4 * s, 3 * s]);
-      ctx.strokeRect(d.startX, d.startY, d.endX - d.startX, d.endY - d.startY);
-      ctx.setLineDash([]);
-      // Dimensions
-      var w = Math.abs(d.endX - d.startX);
-      var h = Math.abs(d.endY - d.startY);
-      if (w > 20 && h > 20) {
-        ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
-        ctx.fillStyle = "rgba(255,255,255,0.9)";
-        ctx.fillText(w + "\u00d7" + h, Math.min(d.startX, d.endX) + Math.round(4 * s), Math.max(d.startY, d.endY) + Math.round(14 * s));
-      }
-    }
-
-    // Pending (unsaved) region
-    if (state.pendingRegion) {
-      var p = state.pendingRegion;
-      ctx.strokeStyle = "#ffffff";
-      ctx.lineWidth = 1.5 * s;
-      ctx.setLineDash([]);
-      ctx.strokeRect(p.x, p.y, p.w, p.h);
-      ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
-      ctx.fillRect(p.x, p.y, p.w, p.h);
-      ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
-      ctx.fillStyle = "rgba(255,255,255,0.9)";
-      ctx.fillText(p.w + "\u00d7" + p.h + " px", p.x + Math.round(4 * s), p.y + p.h + Math.round(14 * s));
-    }
-
-    // Template preview: overlay the uploaded PNG at its effective in-video
-    // size (native PNG pixels * template_scale) so the user can see how
-    // large it will match. Canvas is sized in native video pixels, so the
-    // display-to-video ratio is applied automatically when the browser
-    // scales the canvas to fit the viewport. The overlay is draggable so
-    // the user can position it against specific elements in the frame.
-    var tBounds = templateOverlayBounds();
-    if (tBounds) {
-      var tImg = state.uploadedTemplateImg;
-      ctx.globalAlpha = state.draggingTemplate ? 0.9 : 0.75;
-      ctx.drawImage(tImg, tBounds.x, tBounds.y, tBounds.w, tBounds.h);
-      ctx.globalAlpha = 1.0;
-      ctx.strokeStyle = taskTypeColor("template");
-      ctx.lineWidth = (state.draggingTemplate ? 2 : 1.5) * s;
-      ctx.setLineDash([4 * s, 3 * s]);
-      ctx.strokeRect(tBounds.x, tBounds.y, tBounds.w, tBounds.h);
-      ctx.setLineDash([]);
-      ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
-      ctx.fillStyle = taskTypeColor("template");
-      ctx.fillText(tBounds.w + "\u00d7" + tBounds.h + " px",
-        tBounds.x + Math.round(4 * s),
-        tBounds.y + tBounds.h + Math.round(14 * s));
-    }
-
-    // Result overlay: template match bounding boxes / flow motion arrows
-    if (state.resultOverlay) {
-      ctx.setLineDash([]);
-      if (state.resultOverlay.type === "template") {
-        var matches = state.resultOverlay.data.matches || [];
-        matches.forEach(function (m) {
-          ctx.strokeStyle = taskTypeColor("template");
-          ctx.lineWidth = 2 * s;
-          ctx.strokeRect(m.x, m.y, m.w, m.h);
-          ctx.fillStyle = hexToRgba(taskTypeColor("template"), 0.15);
-          ctx.fillRect(m.x, m.y, m.w, m.h);
-          ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
-          ctx.fillStyle = taskTypeColor("template");
-          ctx.fillText((m.score * 100).toFixed(0) + "%", m.x + Math.round(3 * s), m.y - Math.round(4 * s));
-        });
-      } else if (state.resultOverlay.type === "flow") {
-        var grid = state.resultOverlay.data.flow_grid || [];
-        var fRegion = state.resultOverlay.region;
-        if (fRegion && fRegion.w && grid.length) {
-          var maxMag = 0;
-          grid.forEach(function (c) { if (c.mag > maxMag) maxMag = c.mag; });
-          if (maxMag > 0) {
-            grid.forEach(function (c) {
-              var px = fRegion.x + c.x * fRegion.w;
-              var py = fRegion.y + c.y * fRegion.h;
-              var norm = Math.min(c.mag / maxMag, 1);
-              var arrowLen = norm * 20 * s;
-              var rad = c.ang * Math.PI / 180;
-              var ex = px + Math.cos(rad) * arrowLen;
-              var ey = py + Math.sin(rad) * arrowLen;
-              var alpha = norm * 0.8 + 0.2;
-              ctx.strokeStyle = "rgba(99, 102, 241, " + alpha + ")";
-              ctx.lineWidth = 1.5 * s;
-              ctx.beginPath();
-              ctx.moveTo(px, py);
-              ctx.lineTo(ex, ey);
-              ctx.stroke();
-              var headLen = 4 * s;
-              ctx.beginPath();
-              ctx.moveTo(ex, ey);
-              ctx.lineTo(ex - headLen * Math.cos(rad - 0.4), ey - headLen * Math.sin(rad - 0.4));
-              ctx.moveTo(ex, ey);
-              ctx.lineTo(ex - headLen * Math.cos(rad + 0.4), ey - headLen * Math.sin(rad + 0.4));
-              ctx.stroke();
-            });
-          }
-        }
-      }
-    }
-
-    // Heatmap image overlay (semi-transparent composite)
-    if (state.heatmapOverlay && state.heatmapOverlay._img) {
-      var hm = state.heatmapOverlay;
-      ctx.globalAlpha = 0.5;
-      if (hm.type === "template") {
-        ctx.drawImage(hm._img, 0, 0, canvas.width, canvas.height);
-      } else if (hm.type === "flow" || hm.type === "change") {
-        var rPx = hm.region_coords;
-        if (rPx && rPx.w) {
-          ctx.drawImage(hm._img, rPx.x, rPx.y, rPx.w, rPx.h);
-        }
-      }
-      ctx.globalAlpha = 1.0;
-    }
-
-    // Model-view overlay (toggle or held-key blink comparator)
-    var overlayActive = (state.overlayEnabled || state.overlayBlinkActive)
-      && state.overlayImage
-      && _overlayEligibleForActiveTool();
-    if (overlayActive) {
-      ctx.globalAlpha = state.overlayBlinkActive ? 1.0 : 0.7;
-      var scope = state.overlayImageScope || "region";
-      if (scope === "frame") {
-        ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
-      } else {
-        var oRegion = state.pendingRegion
-          ? state.pendingRegion
-          : (state.activeRegion ? state.regions[state.activeRegion] : null);
-        if (oRegion) {
-          var oPx = regionToPixels(oRegion);
-          if (oPx && oPx.w && oPx.h) {
-            ctx.drawImage(state.overlayImage, oPx.x, oPx.y, oPx.w, oPx.h);
-          }
-        } else {
-          // No region active — overlay covers the whole frame.
-          ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
-        }
-      }
-      ctx.globalAlpha = 1.0;
-    }
+    return SS.renderOverlay && SS.renderOverlay.apply(null, arguments);
   }
 
   // ---- Timeline ----
@@ -5822,7 +5610,13 @@
   // thin hub delegators for the entry points the hub's own code calls.
   SS.applyColorMode = applyColorMode;
   SS.applyNormalizeMode = applyNormalizeMode;
-  SS.renderOverlay = renderOverlay;
+  // renderOverlay itself lives in screenspace-overlay.js and publishes SS.renderOverlay;
+  // these are the hub helpers that satellite reads (regionToPixels/taskTypeColor below).
+  SS.regionColorForIndex = regionColorForIndex;
+  SS.computeLabelRect = computeLabelRect;
+  SS.getThemeColors = getThemeColors;
+  SS.templateOverlayBounds = templateOverlayBounds;
+  SS._overlayEligibleForActiveTool = _overlayEligibleForActiveTool;
   SS.renderRegionChips = renderRegionChips;
   SS.renderRunRegionPicker = renderRunRegionPicker;
   SS.renderTimeline = renderTimeline;

--- a/assets/web/settings-modal.css
+++ b/assets/web/settings-modal.css
@@ -251,7 +251,7 @@
   width: 16px;
   height: 16px;
   background: var(--accent-fg);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   transition: transform var(--duration-normal);
 }
 

--- a/assets/web/start-overlay.css
+++ b/assets/web/start-overlay.css
@@ -1083,7 +1083,7 @@
 .start-overlay .tool-tile__dot {
   width: 7px;
   height: 7px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
 }
 
 .start-overlay .tool-tile__desc {

--- a/assets/web/studio-scrubber.js
+++ b/assets/web/studio-scrubber.js
@@ -1,0 +1,150 @@
+/* clipgen Studio — card-scrubber satellite (opt-in: STUDIO_CARD_SCRUBBER).
+ *
+ * Carved out of studio.js (the hub) following the hub+satellite convention used
+ * by studio-intake.js. Hover-to-scrub for queue/intake cards: sprite-sheet
+ * prefetch + warming and per-card wiring onto window.clipgenCardScrubber. The
+ * cluster is self-contained — its only cross-file dependency is the hub's
+ * mutable `state` (read for state.cardScrubberEnabled), reached through the
+ * window.ClipgenStudio (STUDIO) namespace; CLIPGEN_CONFIG and
+ * window.clipgenCardScrubber are ambient globals reached via the scope chain.
+ *
+ * The hub calls back in via same-named guarded delegators (attachQueueScrubbers,
+ * resetScrubberPrefetch). Loaded by studio.html after studio.js and BEFORE
+ * studio-intake.js, which destructures STUDIO.attachQueueScrubbers at load time.
+ */
+
+(function () {
+  "use strict";
+
+  var STUDIO = window.ClipgenStudio;
+  var state = STUDIO.state;
+
+  function scrubMediaUrl(kind, participant, start, end) {
+    return "api/" + kind + "/" + encodeURIComponent(participant) +
+      "?start=" + start + "&end=" + end;
+  }
+
+  // Background sprite-sheet warming so the first hover is instant (audio is
+  // cheap and loads on demand; the sprite is the slow part — many ffmpeg frame
+  // samples + tile). Throttled to a couple of passes at a time, and only fed
+  // cards whose thumbnail loaded, so large intake lists don't flood the server.
+  var _spritePrefetchQueue = [];
+  var _spritePrefetchActive = 0;
+  var SPRITE_PREFETCH_CONCURRENCY = 2;
+
+  function enqueueSpritePrefetch(thumb) {
+    if (thumb.dataset.scrubSpriteQueued) return;
+    thumb.dataset.scrubSpriteQueued = "1";
+    _spritePrefetchQueue.push(thumb);
+    processSpritePrefetch();
+  }
+
+  function processSpritePrefetch() {
+    while (_spritePrefetchActive < SPRITE_PREFETCH_CONCURRENCY && _spritePrefetchQueue.length) {
+      var thumb = _spritePrefetchQueue.shift();
+      if (!thumb.isConnected || thumb.dataset.scrubSpriteLoaded) continue;
+      _spritePrefetchActive++;
+      loadCardSprite(thumb, function () {
+        _spritePrefetchActive--;
+        processSpritePrefetch();
+      });
+    }
+  }
+
+  // Preload the sprite sheet and paint it as the thumb background; the
+  // .card-scrub-ready CSS rule reveals it under the resting <img> on hover.
+  // Idempotent — guards against duplicate in-flight or completed loads.
+  function loadCardSprite(thumb, done) {
+    if (thumb.dataset.scrubSpriteLoaded || thumb.dataset.scrubSpriteLoading) {
+      if (done) done();
+      return;
+    }
+    thumb.dataset.scrubSpriteLoading = "1";
+    var spriteUrl = scrubMediaUrl(
+      "sprite", thumb.dataset.participant, thumb.dataset.start, thumb.dataset.end,
+    );
+    var img = new Image();
+    img.onload = function () {
+      thumb.dataset.scrubSpriteLoading = "";
+      thumb.dataset.scrubSpriteLoaded = "1";
+      thumb.style.backgroundImage = 'url("' + spriteUrl + '")';
+      thumb.classList.add("card-scrub-ready");
+      if (done) done();
+    };
+    img.onerror = function () {
+      thumb.dataset.scrubSpriteLoading = "";
+      if (done) done();
+    };
+    img.src = spriteUrl;
+  }
+
+  // Wire one queue-card thumbnail for hover scrubbing, but only once its source
+  // frame is confirmed to exist. An invalid/out-of-range sheet timestamp still
+  // renders a card, yet its thumbnail 404s (→ queue-card-error, the <img> is
+  // removed); gating on the thumbnail's successful load keeps us from wiring it
+  // and firing sprite/audio requests that would only 404 too.
+  function wireCardScrubber(thumb, cols, rows, frameCount) {
+    var participant = thumb.dataset.participant;
+    var start = thumb.dataset.start;
+    var end = thumb.dataset.end;
+    if (!participant || start === undefined || end === undefined) return;
+    if (thumb.dataset.scrubWired) return;
+    var dur = Number(end) - Number(start);
+    if (!(dur > 0)) return;
+    var img = thumb.querySelector("img");
+    if (!img) return;
+
+    function activate() {
+      if (thumb.dataset.scrubWired) return;
+      thumb.dataset.scrubWired = "1";
+      var audioUrl = scrubMediaUrl("clip-audio", participant, start, end);
+      window.clipgenCardScrubber.attach(thumb, {
+        spriteData: {
+          cols: cols,
+          rows: rows,
+          frameCount: frameCount,
+          interval: dur / frameCount,
+        },
+        audioUrl: audioUrl,
+        audioFile: audioUrl, // cache key
+        audioBaseUrl: "",
+      });
+      // Hover loads immediately (jumps the prefetch queue); also warm in the
+      // background so a hover that lands before the queue reaches it is instant.
+      thumb.addEventListener("mouseenter", function () { loadCardSprite(thumb); });
+      enqueueSpritePrefetch(thumb);
+    }
+
+    // Activate when the thumbnail has a real frame. A thumbnail that errors is
+    // removed from the DOM, so its `load` never fires and the card stays unwired.
+    if (img.complete && img.naturalWidth > 0) {
+      activate();
+    } else {
+      img.addEventListener("load", function onLoad() {
+        img.removeEventListener("load", onLoad);
+        if (img.naturalWidth > 0) activate();
+      });
+    }
+  }
+
+  function attachQueueScrubbers(listEl) {
+    if (!state.cardScrubberEnabled || !window.clipgenCardScrubber || !listEl) return;
+    window.clipgenCardScrubber.detachStale();
+    var cols = CLIPGEN_CONFIG.cardScrubberSpriteCols;
+    var rows = CLIPGEN_CONFIG.cardScrubberSpriteRows;
+    var frameCount = cols * rows;
+    var thumbs = listEl.querySelectorAll(".queue-card-thumb");
+    for (var i = 0; i < thumbs.length; i++) {
+      wireCardScrubber(thumbs[i], cols, rows, frameCount);
+    }
+  }
+
+  // Hub resets the prefetch backlog when the scrubber toggle flips (settings
+  // apply) before re-rendering, so a stale queue can't re-warm shed cards.
+  function resetScrubberPrefetch() {
+    _spritePrefetchQueue = [];
+  }
+
+  STUDIO.attachQueueScrubbers = attachQueueScrubbers;
+  STUDIO.resetScrubberPrefetch = resetScrubberPrefetch;
+})();

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -100,40 +100,6 @@ body {
   outline-offset: 2px;
 }
 
-.theme-toggle-icon {
-  position: absolute;
-  width: var(--icon-size-md);
-  height: var(--icon-size-md);
-  border-radius: var(--radius-full);
-  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
-}
-
-.theme-icon-sun {
-  background: radial-gradient(circle at 30% 30%, #ffffff 0, #fde68a 40%, #fbbf24 70%, #f59e0b 100%);
-  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
-.theme-icon-moon {
-  background:
-    radial-gradient(circle at 30% 30%, #e5e7eb 0, #9ca3af 40%, #4b5563 100%),
-    radial-gradient(circle at 65% 35%, transparent 0, transparent 55%, rgba(15, 23, 42, 0.9) 56%, rgba(15, 23, 42, 0.9) 100%);
-  box-shadow: 0 0 10px rgba(148, 163, 184, 0.5);
-  opacity: 0;
-  transform: translateX(6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-sun {
-  opacity: 0;
-  transform: translateX(-6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-moon {
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
 #tooltipToggle {
   position: relative;
   width: 32px;
@@ -538,7 +504,7 @@ body[data-active-tab]:not([data-active-tab="sheet"]) #studioSidebar {
   display: inline-block;
   width: 7px;
   height: 7px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-pulse);
   margin-right: var(--space-1);
   vertical-align: middle;
@@ -932,7 +898,7 @@ body.bottom-animating #stashedArtifactsArea {
 .sev-pill-dot {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: currentColor;
   flex-shrink: 0;
 }
@@ -1632,7 +1598,7 @@ body.dragging #sheetMain {
   background: rgba(0, 0, 0, 0.5);
   color: var(--accent-fg);
   border: none;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   width: 18px;
   height: 18px;
   display: flex;
@@ -1909,7 +1875,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   background: var(--bg-active);
   color: var(--fg);
   border: 1px solid var(--border-strong);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   font-size: 10px;
   line-height: 14px;
   text-align: center;
@@ -2096,7 +2062,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   position: fixed;
   inset: 0;
   z-index: var(--z-modal);
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2244,7 +2210,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   left: 4px;
   width: 18px;
   height: 18px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2316,7 +2282,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   position: fixed;
   inset: 0;
   z-index: var(--z-dropdown);
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2422,7 +2388,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   position: fixed;
   inset: 0;
   z-index: var(--z-dropdown);
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2469,7 +2435,7 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   height: 2rem;
   border: 3px solid var(--color-border);
   border-top-color: var(--color-accent);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   animation: spin 0.7s linear infinite;
 }
 
@@ -2561,7 +2527,7 @@ html[data-theme="dark"] .stash-card-name-input {
 #logOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -302,6 +302,7 @@
   <script src="settings-modal.js"></script>
   <script src="intake-cluster.js"></script>
   <script src="studio.js"></script>
+  <script src="studio-scrubber.js"></script>
   <script src="studio-intake.js"></script>
   <script src="convergence.js"></script>
   <script src="metadata.js"></script>

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2273,126 +2273,13 @@
     return thumb;
   }
 
-  // ---- Card scrubber (opt-in: STUDIO_CARD_SCRUBBER) ----
-
-  function scrubMediaUrl(kind, participant, start, end) {
-    return "api/" + kind + "/" + encodeURIComponent(participant) +
-      "?start=" + start + "&end=" + end;
+  // ---- Card scrubber (opt-in: STUDIO_CARD_SCRUBBER) — studio-scrubber.js ----
+  // Hub delegators; the implementations live in studio-scrubber.js.
+  function attachQueueScrubbers() {
+    return STUDIO.attachQueueScrubbers && STUDIO.attachQueueScrubbers.apply(null, arguments);
   }
-
-  // Background sprite-sheet warming so the first hover is instant (audio is
-  // cheap and loads on demand; the sprite is the slow part — many ffmpeg frame
-  // samples + tile). Throttled to a couple of passes at a time, and only fed
-  // cards whose thumbnail loaded, so large intake lists don't flood the server.
-  var _spritePrefetchQueue = [];
-  var _spritePrefetchActive = 0;
-  var SPRITE_PREFETCH_CONCURRENCY = 2;
-
-  function enqueueSpritePrefetch(thumb) {
-    if (thumb.dataset.scrubSpriteQueued) return;
-    thumb.dataset.scrubSpriteQueued = "1";
-    _spritePrefetchQueue.push(thumb);
-    processSpritePrefetch();
-  }
-
-  function processSpritePrefetch() {
-    while (_spritePrefetchActive < SPRITE_PREFETCH_CONCURRENCY && _spritePrefetchQueue.length) {
-      var thumb = _spritePrefetchQueue.shift();
-      if (!thumb.isConnected || thumb.dataset.scrubSpriteLoaded) continue;
-      _spritePrefetchActive++;
-      loadCardSprite(thumb, function () {
-        _spritePrefetchActive--;
-        processSpritePrefetch();
-      });
-    }
-  }
-
-  // Preload the sprite sheet and paint it as the thumb background; the
-  // .card-scrub-ready CSS rule reveals it under the resting <img> on hover.
-  // Idempotent — guards against duplicate in-flight or completed loads.
-  function loadCardSprite(thumb, done) {
-    if (thumb.dataset.scrubSpriteLoaded || thumb.dataset.scrubSpriteLoading) {
-      if (done) done();
-      return;
-    }
-    thumb.dataset.scrubSpriteLoading = "1";
-    var spriteUrl = scrubMediaUrl(
-      "sprite", thumb.dataset.participant, thumb.dataset.start, thumb.dataset.end,
-    );
-    var img = new Image();
-    img.onload = function () {
-      thumb.dataset.scrubSpriteLoading = "";
-      thumb.dataset.scrubSpriteLoaded = "1";
-      thumb.style.backgroundImage = 'url("' + spriteUrl + '")';
-      thumb.classList.add("card-scrub-ready");
-      if (done) done();
-    };
-    img.onerror = function () {
-      thumb.dataset.scrubSpriteLoading = "";
-      if (done) done();
-    };
-    img.src = spriteUrl;
-  }
-
-  // Wire one queue-card thumbnail for hover scrubbing, but only once its source
-  // frame is confirmed to exist. An invalid/out-of-range sheet timestamp still
-  // renders a card, yet its thumbnail 404s (→ queue-card-error, the <img> is
-  // removed); gating on the thumbnail's successful load keeps us from wiring it
-  // and firing sprite/audio requests that would only 404 too.
-  function wireCardScrubber(thumb, cols, rows, frameCount) {
-    var participant = thumb.dataset.participant;
-    var start = thumb.dataset.start;
-    var end = thumb.dataset.end;
-    if (!participant || start === undefined || end === undefined) return;
-    if (thumb.dataset.scrubWired) return;
-    var dur = Number(end) - Number(start);
-    if (!(dur > 0)) return;
-    var img = thumb.querySelector("img");
-    if (!img) return;
-
-    function activate() {
-      if (thumb.dataset.scrubWired) return;
-      thumb.dataset.scrubWired = "1";
-      var audioUrl = scrubMediaUrl("clip-audio", participant, start, end);
-      window.clipgenCardScrubber.attach(thumb, {
-        spriteData: {
-          cols: cols,
-          rows: rows,
-          frameCount: frameCount,
-          interval: dur / frameCount,
-        },
-        audioUrl: audioUrl,
-        audioFile: audioUrl, // cache key
-        audioBaseUrl: "",
-      });
-      // Hover loads immediately (jumps the prefetch queue); also warm in the
-      // background so a hover that lands before the queue reaches it is instant.
-      thumb.addEventListener("mouseenter", function () { loadCardSprite(thumb); });
-      enqueueSpritePrefetch(thumb);
-    }
-
-    // Activate when the thumbnail has a real frame. A thumbnail that errors is
-    // removed from the DOM, so its `load` never fires and the card stays unwired.
-    if (img.complete && img.naturalWidth > 0) {
-      activate();
-    } else {
-      img.addEventListener("load", function onLoad() {
-        img.removeEventListener("load", onLoad);
-        if (img.naturalWidth > 0) activate();
-      });
-    }
-  }
-
-  function attachQueueScrubbers(listEl) {
-    if (!state.cardScrubberEnabled || !window.clipgenCardScrubber || !listEl) return;
-    window.clipgenCardScrubber.detachStale();
-    var cols = CLIPGEN_CONFIG.cardScrubberSpriteCols;
-    var rows = CLIPGEN_CONFIG.cardScrubberSpriteRows;
-    var frameCount = cols * rows;
-    var thumbs = listEl.querySelectorAll(".queue-card-thumb");
-    for (var i = 0; i < thumbs.length; i++) {
-      wireCardScrubber(thumbs[i], cols, rows, frameCount);
-    }
+  function resetScrubberPrefetch() {
+    return STUDIO.resetScrubberPrefetch && STUDIO.resetScrubberPrefetch.apply(null, arguments);
   }
 
   // Source-origin badge (Screenspace vs. Transcript) layered over an intake thumb.
@@ -4940,7 +4827,7 @@
         // Tear down current attachments, then re-render so cards (re)wire (or
         // shed) their scrubbers via attachQueueScrubbers.
         if (window.clipgenCardScrubber) window.clipgenCardScrubber.detachAll();
-        _spritePrefetchQueue = [];
+        resetScrubberPrefetch();
         renderArtifactQueue();
         renderReelQueue();
         renderIntake(false);
@@ -5262,7 +5149,6 @@
   // (Pure utils.js globals reach the satellite via the scope chain; only
   // hub-local functions need publishing here.)
   STUDIO.state = state;
-  STUDIO.attachQueueScrubbers = attachQueueScrubbers;
   STUDIO.buildQueueCardThumb = buildQueueCardThumb;
   STUDIO.buildXrefBadges = buildXrefBadges;
   STUDIO.checkConvergenceTabVisibility = checkConvergenceTabVisibility;

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -162,6 +162,7 @@
   --color-panel-bg:            rgba(20, 21, 24, 0.97);
   --color-panel-border:        var(--border);
   --color-panel-shadow:        rgba(0, 0, 0, 0.6);
+  --color-backdrop:            rgba(0, 0, 0, 0.4); /* dimming scrim behind modal overlays (both themes) */
 
   /* Shadows (depend on theme colors above) */
   --shadow-sm:    0 1px 3px var(--color-panel-shadow);

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -179,9 +179,11 @@ body.dragging .topnav {
   margin: 0 4px;
 }
 
-/* Theme toggle inherits #themeToggle styling from page CSS today; the redesign
- * adds an explicit appearance to keep it visually consistent inside the TopNav.
- * Page-level #themeToggle rules are scoped narrowly enough not to fight us. */
+/* The #themeToggle button base still comes from each page's CSS; this override
+ * gives it the compact TopNav appearance. The sun/moon icon visuals below are
+ * identical on every TopNav page, so they live here once (page-independent).
+ * Page-level #themeToggle rules are scoped narrowly enough not to fight us.
+ * (Standalone gallery/viewer don't load topnav.css and keep their own copies.) */
 .topnav-right #themeToggle {
   width: 30px;
   height: 30px;
@@ -199,6 +201,43 @@ body.dragging .topnav {
 .topnav-right #themeToggle:hover {
   background: var(--bg-hover);
   color: var(--fg);
+}
+
+/* Sun/moon icon visuals — shared by every TopNav page (consolidated from the
+ * per-page #themeToggle blocks). The crossfade is driven by #themeToggle's
+ * [data-theme] attribute, which topnav.js keeps in sync. */
+.theme-toggle-icon {
+  position: absolute;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
+  border-radius: var(--radius-full);
+  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
+}
+
+.theme-icon-sun {
+  background: radial-gradient(circle at 30% 30%, #ffffff 0, #fde68a 40%, #fbbf24 70%, #f59e0b 100%);
+  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
+  opacity: 1;
+  transform: translateX(0) scale(1);
+}
+
+.theme-icon-moon {
+  background:
+    radial-gradient(circle at 30% 30%, #e5e7eb 0, #9ca3af 40%, #4b5563 100%),
+    radial-gradient(circle at 65% 35%, transparent 0, transparent 55%, rgba(15, 23, 42, 0.9) 56%, rgba(15, 23, 42, 0.9) 100%);
+  box-shadow: 0 0 10px rgba(148, 163, 184, 0.5);
+  opacity: 0;
+  transform: translateX(6px) scale(0.85);
+}
+
+#themeToggle[data-theme="dark"] .theme-icon-sun {
+  opacity: 0;
+  transform: translateX(-6px) scale(0.85);
+}
+
+#themeToggle[data-theme="dark"] .theme-icon-moon {
+  opacity: 1;
+  transform: translateX(0) scale(1);
 }
 
 /* Version pill — small mono text */

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -80,7 +80,7 @@ body {
   display: inline-block;
   width: 10px;
   height: 10px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-text-dim);
   cursor: default;
   transition: background var(--duration-fast);
@@ -156,40 +156,6 @@ body {
 #themeToggle:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-.theme-toggle-icon {
-  position: absolute;
-  width: var(--icon-size-md);
-  height: var(--icon-size-md);
-  border-radius: var(--radius-full);
-  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
-}
-
-.theme-icon-sun {
-  background: radial-gradient(circle at 30% 30%, #ffffff 0, #fde68a 40%, #fbbf24 70%, #f59e0b 100%);
-  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
-.theme-icon-moon {
-  background:
-    radial-gradient(circle at 30% 30%, #e5e7eb 0, #9ca3af 40%, #4b5563 100%),
-    radial-gradient(circle at 65% 35%, transparent 0, transparent 55%, rgba(15, 23, 42, 0.9) 56%, rgba(15, 23, 42, 0.9) 100%);
-  box-shadow: 0 0 10px rgba(148, 163, 184, 0.5);
-  opacity: 0;
-  transform: translateX(6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-sun {
-  opacity: 0;
-  transform: translateX(-6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-moon {
-  opacity: 1;
-  transform: translateX(0) scale(1);
 }
 
 /* Search bar */
@@ -654,7 +620,7 @@ body {
 .panel-tab-dot {
   width: 7px;
   height: 7px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-friction);
   flex-shrink: 0;
 }
@@ -1120,7 +1086,7 @@ body {
   flex: 0 0 14px;
   width: 14px;
   height: 14px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   border: 1.5px solid var(--border-strong);
   background: transparent;
   cursor: pointer;
@@ -1193,7 +1159,7 @@ body {
 .mark-cat-pill {
   width: 18px;
   height: 18px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   border: 1px solid rgba(255, 255, 255, 0.12);
   cursor: pointer;
   transition: transform var(--duration-fast), box-shadow var(--duration-fast);
@@ -1779,7 +1745,7 @@ body {
 .modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1931,7 +1897,7 @@ body {
 .shortcuts-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -724,7 +724,7 @@ body {
   content: "";
   width: 28px;
   height: 28px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-border);
   opacity: 0.4;
 }

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -192,40 +192,6 @@ body[data-frontend="workflows"] {
   outline-offset: 2px;
 }
 
-.theme-toggle-icon {
-  position: absolute;
-  width: var(--icon-size-md);
-  height: var(--icon-size-md);
-  border-radius: var(--radius-full);
-  transition: opacity var(--duration-normal) ease, transform var(--duration-normal) ease;
-}
-
-.theme-icon-sun {
-  background: radial-gradient(circle at 30% 30%, #ffffff 0, #fde68a 40%, #fbbf24 70%, #f59e0b 100%);
-  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
-.theme-icon-moon {
-  background:
-    radial-gradient(circle at 30% 30%, #e5e7eb 0, #9ca3af 40%, #4b5563 100%),
-    radial-gradient(circle at 65% 35%, transparent 0, transparent 55%, rgba(15, 23, 42, 0.9) 56%, rgba(15, 23, 42, 0.9) 100%);
-  box-shadow: 0 0 10px rgba(148, 163, 184, 0.5);
-  opacity: 0;
-  transform: translateX(6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-sun {
-  opacity: 0;
-  transform: translateX(-6px) scale(0.85);
-}
-
-#themeToggle[data-theme="dark"] .theme-icon-moon {
-  opacity: 1;
-  transform: translateX(0) scale(1);
-}
-
 /* Run split-button: primary "Run" joined to a caret that opens the more-options
    menu ("Run to here"). */
 .wf-run-split {

--- a/plans/FRONTEND-REFACTORS-PLAN.md
+++ b/plans/FRONTEND-REFACTORS-PLAN.md
@@ -1,0 +1,139 @@
+# Frontend refactors & carveouts — plan
+
+Status: **proposed** (2026-06-30). Tracks a sweep of refactor/carveout opportunities
+across `assets/web/`. Each numbered item is sized to be one focused `refactor:` commit/PR.
+Check items off and add a "Done" note as they land (per AGENTS.md plan-maintenance rule).
+
+## Why
+
+Two page hubs are large outliers and are the explicit, already-in-progress
+architectural direction of the repo:
+
+| File | Lines | Satellites today | Notes |
+|------|-------|------------------|-------|
+| `screenspace.js` | 5835 | 5 (tasks, results, multitool-params, calibration, color) + utils leaf | still the largest JS file *after* carving 5 |
+| `studio.js` | 5278 | 1 (intake) | AGENTS.md: "mid-carve… generate/trim/stash/scrubber not yet carved" |
+
+`transcripts.js` and `workflows.js` are already cleanly carved and are **not** targets.
+The carve pattern, its load-order contract, and the `tests/test_frontend_satellite_wiring.py`
+guard are all established — so these carves are low-novelty, incremental, and individually shippable.
+
+The remaining themes (cross-cutting JS dedup, CSS token/duplication wins) are smaller,
+opportunistic, and independent of the carves.
+
+## Verified-false leads (do NOT action)
+
+Two "dead code" findings from analysis were checked and are **live** — left here so they
+aren't re-flagged:
+
+- `gallery.js:createGalleryLoopVideo` — used at `gallery.js:116`.
+- `screenspace.js` `_pendingFrameTs` / `_loadedFrameTs` — used in the stale-frame guard
+  (`screenspace.js:1491–1541`); the lines 1019–1020 occurrences are resets, not dead reads.
+
+---
+
+## Theme A — JS hub→satellite carveouts (headline)
+
+Procedure for every item: `agents/skills/carve-satellite/SKILL.md`. After each: `node --check`
+the touched files, run `tests/test_frontend_satellite_wiring.py` + `tests/test_studio_frontend_source.py`,
+then `/check`. Add each new satellite to the page's `<script>` load order respecting the
+load-order contract (a satellite that *destructures* another's published fn loads after it;
+otherwise late-bind `NS.fn(...)`).
+
+### Studio (`window.ClipgenStudio` / STUDIO)
+
+- [ ] **A1. `studio-scrubber.js`** (~277 lines, `studio.js:2276–2553`). Card hover-scrub
+  (sprite sheet + audio). Lowest risk: feature-gated on `state.cardScrubberEnabled`,
+  read-only state, entry point `attachQueueScrubbers` is **already published** to STUDIO
+  (`studio.js:5265`). Keep `buildQueueCardThumb`/`ssClearPending` access via STUDIO.
+- [ ] **A2. `studio-trim.js`** (~354 lines, `studio.js:2729–3083`). Duration-badge trim
+  popover + `buildCellOverrides()`. Self-contained; add hub delegators for `saveQueues()`/
+  `renderQueue()`. **Must load before A3** (generate needs `buildCellOverrides`).
+- [ ] **A3. `studio-generate.js`** (~393 lines, `studio.js:3743–4135`). Streaming artifact
+  generation. Medium risk: needs delegators for `setArtifactGenerating`/`showResult`/
+  `revealStatusOverlay`; ETA trackers + card-state painters **stay in hub** (shared with build).
+- [ ] _Defer:_ **build** (`4136–4615`, reel/timeline/gallery interleaved — needs a separate
+  reel-vs-viewer split first) and **stash** (`3240–3523`, coupled to `renderQueue`). Re-evaluate
+  after A1–A3.
+
+### Screenspace (`window.ClipgenScreenspace` / SS)
+
+- [ ] **A4. `screenspace-overlay.js`** (~218 lines, `screenspace.js:2763–2980`). Pure canvas
+  draw of regions/pending/template/heatmap/scene markers. Zero blockers — no writes; only
+  reads state + pure helpers (`regionToPixels`, `getThemeColors`, `hexToRgba`). `renderOverlay`
+  stays callable via a hub delegator (called from 6+ sites).
+- [ ] **A5. `screenspace-timeline.js`** (~643 lines, `screenspace.js:2981–3623`). Canvas ruler,
+  zoom/pan, scrubbing, markers, playhead, tooltips. Route `showSsTooltip`/`hideSsTooltip` and
+  frame-load callbacks (`loadFrame`, `seekPlayhead`) through SS. Move `timelineZoom/Offset/
+  Dragging`, `inMarker/outMarker`, `hoveredBoundaryTs` onto `state` if any hub site still reads them.
+- [ ] **A6. `screenspace-overlay-interaction.js`** (~586 lines, `screenspace.js:1818–2323`,
+  region draw/drag/resize state machine). Medium: must route `setTargetColor`/pipette
+  activation from the color satellite (already deferred via SS) and keep `renderOverlay`/
+  `renderRegionChips` as delegators.
+- [ ] **A7. `screenspace-model-view.js`** (~514 lines, `screenspace.js:4347–4860`). Live
+  preview overlay + layer UI. Publish `_collectPreviewParams` via SS (hub's `initRunButton`
+  calls it). Self-contained sessionStorage.
+- [ ] _Optional later:_ single-tool param builders (`3771–4346`, ~576) and run button
+  (`4954–5296`, ~343). Lower ROI; param rehydration (`applyColorMode`/`applyNormalizeMode`)
+  must stay hub-side for task restore.
+
+**Stays in both hubs** (do not move): the shared `state` object, request-version/cache-
+invalidation guards, participant routing, frame loading, the `DOMContentLoaded` init loop,
+settings-sync, and STUDIO/SS namespace publication.
+
+Expected outcome: studio ~5278 → ~4250 (A1–A3); screenspace ~5835 → ~4460 (A4–A7, ~1375 lines moved).
+
+---
+
+## Theme B — cross-cutting JS consolidation
+
+- [ ] **B1. `createSSEStream()` in `utils.js`.** The EventSource→`onerror`→`createPoller`
+  fallback is duplicated across 4 sites: `screenspace-tasks.js:1064` and `workflows-runs.js`
+  (run `:77`, batch `:142`, discover `:1019`). Add `createSSEStream(url, {onMessage, onError, poll})`
+  returning `{ close() }`; migrate all four. Modest, mechanical.
+- [ ] **B2. Generalize the modal focus trap.** `studio.js` `openModalTrap`/`closeModalTrap`
+  (`4627–4687`) is a reusable blocking-dialog trap; `transcripts.js confirmModelInstall`
+  (`2180–2264`) hand-rolls the same backdrop/escape lifecycle. Promote a
+  `openBlockingModal({onEscape, onBackdropClick})` to `utils.js`; migrate both. Leave singleton
+  pickers (`color-picker.js`, `settings-modal.js`) owning their own lifecycle — they are not
+  blocking dialogs.
+- [ ] _Investigate only (do not blind-merge):_ color conversion exists twice with **incompatible**
+  HSV ranges — `color-picker.js:36–77` (h∈[0,1]) vs `screenspace-utils.js:14–51` (OpenCV h 0–180,
+  s/v 0–255). Merging risks silent corruption. At most: clarify names/comments
+  (`rgbToHsvStandard` vs `rgbToHsvCv`). Likely skip.
+
+---
+
+## Theme C — CSS token & duplication wins (low risk, mechanical)
+
+These follow the "convert touched values to tokens when editing" rule. Done as their own small
+commits **or** folded into whichever page CSS a Theme-A carve touches. **Not** a blanket sweep
+(AGENTS.md: "don't bulk-rewrite either system" / page-CSS spacing left alone unless touched).
+
+- [ ] **C1. `border-radius: 50%` → `var(--radius-full)`** — 21 occurrences across 9 CSS files.
+  Token already exists (`tokens.css:83`). Pure mechanical.
+- [ ] **C2. Backdrop literal `rgba(0,0,0,0.4)` ×10** → add a `--color-backdrop` token (or a shared
+  `.modal-backdrop` utility: `position:fixed; inset:0; background; z-index`) and replace copies in
+  screenspace/studio/transcripts/settings-modal CSS.
+- [ ] **C3. Consolidate `#themeToggle` button styling.** `topnav.js` *generates* the button
+  (`topnav.js:183`) but its 32×32 styling is re-declared in 7 page CSS files. Move the canonical
+  rule into `topnav.css` (the owner). Leave `gallery.css`/`viewer.css` standalone — those pages
+  ship their own toggle markup and aren't on topnav.
+- [ ] _Opportunistic, not standalone:_ raw-px spacing/font-size/transition → tokens **only inside
+  files a carve already touches**. There are ~200 such values; a dedicated mass-conversion is out
+  of scope and against the "don't bulk-rewrite" guidance.
+
+---
+
+## Descoped (considered, not recommended now)
+
+- **Splitting large CSS files** (`screenspace.css` 4041, `studio.css` 3004, …) into multiple
+  linked stylesheets. No build step; `viewer.css` is inlined into offline exports by `viewer.py`;
+  multi-`<link>` splitting cuts against the current single-file-per-page convention. Low payoff,
+  real churn. Skip unless a concrete maintenance pain emerges.
+- **Unifying the two color systems** — see Theme B note. Risk > reward.
+
+## Suggested execution order
+
+1. C1 (trivial warm-up, isolated). 2. A1 → A2 → A4 (lowest-risk carves). 3. B1.
+4. A5, A3. 5. A6, A7, B2, C2, C3. Each lands green via `/check` before the next.

--- a/plans/FRONTEND-REFACTORS-PLAN.md
+++ b/plans/FRONTEND-REFACTORS-PLAN.md
@@ -110,15 +110,20 @@ These follow the "convert touched values to tokens when editing" rule. Done as t
 commits **or** folded into whichever page CSS a Theme-A carve touches. **Not** a blanket sweep
 (AGENTS.md: "don't bulk-rewrite either system" / page-CSS spacing left alone unless touched).
 
-- [ ] **C1. `border-radius: 50%` → `var(--radius-full)`** — 21 occurrences across 9 CSS files.
-  Token already exists (`tokens.css:83`). Pure mechanical.
-- [ ] **C2. Backdrop literal `rgba(0,0,0,0.4)` ×10** → add a `--color-backdrop` token (or a shared
-  `.modal-backdrop` utility: `position:fixed; inset:0; background; z-index`) and replace copies in
-  screenspace/studio/transcripts/settings-modal CSS.
-- [ ] **C3. Consolidate `#themeToggle` button styling.** `topnav.js` *generates* the button
-  (`topnav.js:183`) but its 32×32 styling is re-declared in 7 page CSS files. Move the canonical
-  rule into `topnav.css` (the owner). Leave `gallery.css`/`viewer.css` standalone — those pages
-  ship their own toggle markup and aren't on topnav.
+- [x] **C1. `border-radius: 50%` → `var(--radius-full)`** — Done. 21 occurrences across 7 CSS
+  files; all verified square (circles/dots/spinners) so `50%`≡`999px`. `viewer.css` already uses
+  radius tokens, confirming they reach the offline export.
+- [x] **C2. Backdrop literal `rgba(0,0,0,0.4)`** → Done. Added `--color-backdrop` token
+  (`tokens.css`) and applied to the 7 true modal overlays (screenspace/studio×4/transcripts×2).
+  Left `settings-modal.css .card-tile-text-overlay` (a card text-legibility scrim, different
+  semantic) and the two box/drop-shadow literals as-is.
+- [x] **C3. Consolidate the duplicated theme-toggle.** Done — but narrower than first framed: the
+  *button base* is entangled with topnav's intentional `.topnav-right #themeToggle` override
+  (30px, 5px radius, transparent), so it stays per-page. The genuinely-duplicated **sun/moon icon
+  visuals** (byte-identical across all 4 topnav pages) moved into `topnav.css` once; removed from
+  studio/screenspace/transcripts/workflows CSS. `gallery.css`/`viewer.css` keep their copies (no
+  topnav.css). Updated `tests/test_workflows_frontend_source.py::test_theme_toggle_icons_styled`
+  to the new location. Net −94 lines.
 - [ ] _Opportunistic, not standalone:_ raw-px spacing/font-size/transition → tokens **only inside
   files a carve already touches**. There are ~200 such values; a dedicated mass-conversion is out
   of scope and against the "don't bulk-rewrite" guidance.

--- a/plans/FRONTEND-REFACTORS-PLAN.md
+++ b/plans/FRONTEND-REFACTORS-PLAN.md
@@ -42,10 +42,11 @@ otherwise late-bind `NS.fn(...)`).
 
 ### Studio (`window.ClipgenStudio` / STUDIO)
 
-- [ ] **A1. `studio-scrubber.js`** (~277 lines, `studio.js:2276–2553`). Card hover-scrub
-  (sprite sheet + audio). Lowest risk: feature-gated on `state.cardScrubberEnabled`,
-  read-only state, entry point `attachQueueScrubbers` is **already published** to STUDIO
-  (`studio.js:5265`). Keep `buildQueueCardThumb`/`ssClearPending` access via STUDIO.
+- [x] **A1. `studio-scrubber.js`** — Done (`5ca7440`). Carved the sprite-prefetch + per-card
+  scrubber wiring (the true cluster was `studio.js:2278–2396`, ~120 lines; the rest of the
+  agent's 2276–2553 range was unrelated drag/queue code). Hub keeps `attachQueueScrubbers` +
+  a new `resetScrubberPrefetch` delegator (the latter replaces a bare `_spritePrefetchQueue = []`
+  reset so the queue stays satellite-private). Loads before `studio-intake.js`. studio.js −121/+8.
 - [ ] **A2. `studio-trim.js`** (~354 lines, `studio.js:2729–3083`). Duration-badge trim
   popover + `buildCellOverrides()`. Self-contained; add hub delegators for `saveQueues()`/
   `renderQueue()`. **Must load before A3** (generate needs `buildCellOverrides`).
@@ -58,10 +59,13 @@ otherwise late-bind `NS.fn(...)`).
 
 ### Screenspace (`window.ClipgenScreenspace` / SS)
 
-- [ ] **A4. `screenspace-overlay.js`** (~218 lines, `screenspace.js:2763–2980`). Pure canvas
-  draw of regions/pending/template/heatmap/scene markers. Zero blockers — no writes; only
-  reads state + pure helpers (`regionToPixels`, `getThemeColors`, `hexToRgba`). `renderOverlay`
-  stays callable via a hub delegator (called from 6+ sites).
+- [x] **A4. `screenspace-overlay.js`** — Done. Carved `renderOverlay` (`screenspace.js:2763–2979`,
+  217 lines). It's a pure read of `state` + 7 hub helpers (reached via SS; `hexToRgba`/`qs` are
+  ambient utils.js globals). Hub keeps a `renderOverlay` delegator for its **33** call sites;
+  published the 5 helpers the satellite needs that weren't already on SS (`regionColorForIndex`,
+  `computeLabelRect`, `getThemeColors`, `templateOverlayBounds`, `_overlayEligibleForActiveTool`).
+  Loads after the hub, **before** `screenspace-tasks.js`/`-results.js` (they destructure
+  `SS.renderOverlay`). screenspace.js −216/+11.
 - [ ] **A5. `screenspace-timeline.js`** (~643 lines, `screenspace.js:2981–3623`). Canvas ruler,
   zoom/pan, scrubbing, markers, playhead, tooltips. Route `showSsTooltip`/`hideSsTooltip` and
   frame-load callbacks (`loadFrame`, `seekPlayhead`) through SS. Move `timelineZoom/Offset/

--- a/plans/LOC-REDUCTION-PLAN.md
+++ b/plans/LOC-REDUCTION-PLAN.md
@@ -1,0 +1,107 @@
+# LOC-reduction opportunities — plan
+
+Status: **proposed** (2026-06-30). Investigation targets for genuinely *reducing* total
+lines of code (not relocating them). Each item is sized as one or more focused `refactor:`
+commits. Check items off and add a "Done" note as they land (per AGENTS.md plan-maintenance rule).
+
+## Framing
+
+Hub→satellite carves (see [FRONTEND-REFACTORS-PLAN.md](FRONTEND-REFACTORS-PLAN.md)) **relocate**
+lines — the hub shrinks but the total is unchanged. Real reduction comes from **deduplication
+and deleting redundancy**. Everything below targets repeated shapes, ordered by leverage.
+
+Baseline (2026-06-30): Python ~40.2k lines, JS ~38.8k, CSS ~17.9k. The four Flask server
+files alone are ~9.8k lines.
+
+## Do NOT chase
+
+- **The test suite** (~26k lines) — it's guard rails, not fat. Don't compress it.
+- **Comments / docstrings** — the house style is deliberately heavy inline documentation
+  (AGENTS.md). Not a target.
+- **More carves** — they don't change the total; they live in the other plan.
+
+---
+
+## 1. Flask route boilerplate — highest leverage
+
+The four server files (`server.py`, `screenspace_server.py`, `transcripts_server.py`,
+`workflows_server.py`) span ~9.8k lines across **149 routes**, with **416 `jsonify(` calls**,
+**281 `{"ok": False, "error": …}` returns**, and **113 try/excepts**. Sampling
+(`screenspace_server.py` pins routes ~461–540) confirms near-identical per-route scaffolding:
+
+```python
+return jsonify({"ok": False, "error": "timestamp must be a number"}), 400
+...
+return jsonify({"ok": True, "pin": pin})
+```
+
+- [ ] **1a. Response helpers.** Add `err(msg, code=400)` → `jsonify({"ok": False, "error": msg}), code`
+  and `ok(**fields)` → `jsonify({"ok": True, **fields})` (likely in a small shared module, or
+  `utils.py` if it stays import-clean). Collapses the ~280 error returns + ~150 success returns to
+  one line each.
+- [ ] **1b. `@json_endpoint` decorator** wrapping the repeated try/except → `err(...)` envelope, so
+  handlers raise/return data and the decorator formats failures. Removes most of the 113 server
+  try/excepts.
+- **Risk:** low. **Approach:** one blueprint at a time; every route already has test coverage, so
+  convert + run that blueprint's tests before the next. Watch for routes with non-standard
+  envelopes (not all use `{"ok": …}`) — leave those or special-case, don't force-fit.
+- **Est. payoff:** several hundred lines + far more scannable routes.
+
+## 2. Request-arg parsing/validation (rides on #1)
+
+`CODE-REVIEW.md` mandates manual `float()/int()` parsing of string route params (Flask's `<float:>`
+converter 404s when JS sends ints). The "parse → on failure return error dict" block is copy-pasted
+dozens of times.
+
+- [ ] **2. `parse_number_arg(name, *, min=None, int_only=False)`** (and siblings) that parse + raise
+  a uniform error (caught by 1b's decorator, or returning the `err(...)` tuple). Each call site
+  drops from ~4 lines to 1.
+
+## 3. Cross-cutting JS dedup (these *delete* lines)
+
+Shared with [FRONTEND-REFACTORS-PLAN.md](FRONTEND-REFACTORS-PLAN.md) Theme B — listed here because,
+unlike the carves, they remove duplication rather than move it.
+
+- [ ] **3a. `createSSEStream(url, {onMessage, onError, poll})`** in `utils.js` — collapses 4
+  near-identical `EventSource → onerror → createPoller` blocks (`screenspace-tasks.js:1064`,
+  `workflows-runs.js:77/142/1019`).
+- [ ] **3b. Generalize the modal focus-trap** — `studio.js openModalTrap` (~`4627`) vs
+  `transcripts.js confirmModelInstall` (~`2180`) are two implementations of the same lifecycle;
+  promote one `openBlockingModal({onEscape, onBackdropClick})` to `utils.js`. Leave singleton
+  pickers (`color-picker.js`, `settings-modal.js`) owning their own lifecycle.
+- [ ] **3c. Form-input factories** (`rangeInput`/`numberInput`/`textInput`) and color-conversion —
+  consolidate the duplicated copies (`screenspace-utils.js` vs `screenspace-multitool-params.js`;
+  `color-picker.js` vs `screenspace-utils.js`). **Caution:** color conversion uses two
+  *incompatible* HSV ranges (standard [0,1] vs OpenCV 0–180/0–255) — clarify names, don't blind-merge.
+- **Est. payoff:** ~100–200 lines.
+
+## 4. CSS shared-component promotion
+
+Continues today's pass (radius-full, `--color-backdrop`, theme-toggle dedup landed in `0f1012b`).
+The CSS audit flagged more repeated blocks across the page stylesheets:
+
+- [ ] **4. Promote duplicated component blocks** to `primitives.css`/`tokens.css`: webkit
+  **scrollbar** styling (~studio + start-overlay), the floating **popover/dropdown container**
+  (position+shadow+border+padding, ~screenspace + studio), **icon-sizing** classes (`.ss-icon`/
+  `.cg-icon`/`.so-icon` variants with raw px), and the **badge/pill** micro-label pattern.
+- **Est. payoff:** ~20–30 rule blocks. **Risk:** medium (visual) — needs a browser check, and
+  page CSS that loads after `primitives.css` can override, so verify specificity.
+
+## 5. Manifest load/save patterns (investigation first)
+
+`PERFORMANCE.md` notes the "load-on-startup, save-after-mutation" JSON-manifest shape recurs for
+clipgen / screenspace / transcripts / workflows / stashes / settings.
+
+- [ ] **5. Audit whether the manifest implementations are truly parallel.** If so, a small
+  load/save helper could dedup them. **Confirm they're not subtly different first** — manifests have
+  different schemas and mutation semantics; only the I/O envelope is a candidate, and forcing a
+  shared abstraction over diverging shapes would be net-negative.
+
+## Suggested order
+
+1. **1a** (response helpers — biggest, safest win). 2. **1b** + **2** (decorator + arg parsing,
+   building on 1a). 3. **3a/3b/3c** (JS dedup, independent). 4. **4** (CSS, needs browser check).
+5. **5** only after the investigation confirms it's worthwhile.
+
+Quantify before committing to a tier: a duplication scan (jscpd for JS/CSS, a `pylint`-style
+duplicate-code pass for Python) would put hard block counts behind each item.

--- a/tests/test_workflows_frontend_source.py
+++ b/tests/test_workflows_frontend_source.py
@@ -590,11 +590,13 @@ def test_run_to_selected_node():
 
 
 def test_theme_toggle_icons_styled():
-    """The TopNav renders #themeToggle, but each page must supply the sun/moon
-    icon visuals + the position:relative anchor (missing → blank toggle)."""
-    css = WORKFLOWS_CSS.read_text(encoding="utf-8")
-    assert ".theme-icon-sun" in css
-    assert ".theme-icon-moon" in css
-    assert '#themeToggle[data-theme="dark"] .theme-icon-moon' in css
+    """The sun/moon icon visuals are identical on every TopNav page, so they live
+    once in topnav.css; each page still supplies the #themeToggle button base +
+    position:relative anchor the absolutely-positioned icons hang off of."""
+    topnav_css = (_WEB / "topnav.css").read_text(encoding="utf-8")
+    assert ".theme-icon-sun" in topnav_css
+    assert ".theme-icon-moon" in topnav_css
+    assert '#themeToggle[data-theme="dark"] .theme-icon-moon' in topnav_css
     # The absolutely-positioned icons need a positioned button to anchor to.
+    css = WORKFLOWS_CSS.read_text(encoding="utf-8")
     assert "#themeToggle {" in css


### PR DESCRIPTION
Survey of refactor/carveout opportunities across assets/web/, sized as
individually-shippable refactor commits:
- Theme A: continue the studio.js (scrubber/trim/generate) and screenspace.js
  (overlay/timeline/overlay-interaction/model-view) hub→satellite carves.
- Theme B: consolidate the duplicated SSE+poller fallback into a utils.js
  helper; generalize the modal focus trap.
- Theme C: mechanical CSS token wins (radius-full, backdrop token, themeToggle).

Records two verified-false dead-code leads so they aren't re-flagged.