### PR TITLE
refactor(server): add shared ok/err/json_endpoint/parse_number_arg helpers

### DIFF
--- a/plans/LOC-REDUCTION-PLAN.md
+++ b/plans/LOC-REDUCTION-PLAN.md
@@ -1,6 +1,7 @@
 # LOC-reduction opportunities — plan
 
-Status: **proposed** (2026-06-30). Investigation targets for genuinely *reducing* total
+Status: **in progress** (2026-06-30). Items **1 (1a + 1b)** and **2** landed (see check-marks
+below); items 3–5 still open. Investigation targets for genuinely *reducing* total
 lines of code (not relocating them). Each item is sized as one or more focused `refactor:`
 commits. Check items off and add a "Done" note as they land (per AGENTS.md plan-maintenance rule).
 
@@ -35,17 +36,22 @@ return jsonify({"ok": False, "error": "timestamp must be a number"}), 400
 return jsonify({"ok": True, "pin": pin})
 ```
 
-- [ ] **1a. Response helpers.** Add `err(msg, code=400)` → `jsonify({"ok": False, "error": msg}), code`
-  and `ok(**fields)` → `jsonify({"ok": True, **fields})` (likely in a small shared module, or
-  `utils.py` if it stays import-clean). Collapses the ~280 error returns + ~150 success returns to
-  one line each.
-- [ ] **1b. `@json_endpoint` decorator** wrapping the repeated try/except → `err(...)` envelope, so
-  handlers raise/return data and the decorator formats failures. Removes most of the 113 server
-  try/excepts.
+- [x] **1a. Response helpers.** **Done** — `ok(**fields)` / `err(msg, code=400)` live in the new
+  Flask-only `server_utils.py` (not `utils.py`, which is deliberately Flask-free). Applied across all
+  four blueprints: workflows, transcripts, screenspace, server. Non-standard envelopes left raw on
+  purpose (`{"ok": False}` with no `error`; `{"ok": False, "generating": True, ...}` poll/cancelled
+  payloads; `{"errors": [...]}` plural; the 202 google-auth envelope; bare `jsonify(var)`; the two
+  `api_sheet` payloads `test_shared_constants` guards by source text; binary/SSE/VTT routes).
+- [x] **1b. `@json_endpoint` decorator** — **Done** (added to `server_utils.py`). Catches **only**
+  `ApiError` (not bare `Exception`) so it never swallows real 500s or fights routes with their own
+  cleanup/`finally`. Applied conservatively: most server try/excepts catch *specific* exceptions or do
+  resource cleanup (`_release_busy`), so they were left intact; the decorator currently backs the one
+  `parse_number_arg` site (screenspace `api_pins_create`). It's in place for future raise-based routes.
 - **Risk:** low. **Approach:** one blueprint at a time; every route already has test coverage, so
   convert + run that blueprint's tests before the next. Watch for routes with non-standard
   envelopes (not all use `{"ok": …}`) — leave those or special-case, don't force-fit.
-- **Est. payoff:** several hundred lines + far more scannable routes.
+- **Payoff (realized):** net **~−310 lines** across the four files (workflows −15, transcripts −38,
+  screenspace −120, server −138) + far more scannable routes. Full suite green (1745 passed).
 
 ## 2. Request-arg parsing/validation (rides on #1)
 
@@ -53,9 +59,13 @@ return jsonify({"ok": True, "pin": pin})
 converter 404s when JS sends ints). The "parse → on failure return error dict" block is copy-pasted
 dozens of times.
 
-- [ ] **2. `parse_number_arg(name, *, min=None, int_only=False)`** (and siblings) that parse + raise
-  a uniform error (caught by 1b's decorator, or returning the `err(...)` tuple). Each call site
-  drops from ~4 lines to 1.
+- [x] **2. `parse_number_arg(raw, name, *, int_only=False, min_=None, max_=None, finite=False)`** —
+  **Done** (in `server_utils.py`). Parses one numeric value and raises `ApiError(400)` (caught by 1b's
+  decorator) on bad value / out-of-bounds / non-finite. Applied where the clean *error-on-failure* shape
+  existed (screenspace `api_pins_create`: an isinstance + `float()` + finite/bounds block → one line).
+  **Note:** most numeric parsing in these files is *silent-fallback* (`except: x = default`) or
+  *returns `None`*, which deliberately must NOT raise — those sites were left as-is, so #2's reach is
+  smaller than the "dozens" first estimated. The helper is in place for future error-on-failure sites.
 
 ## 3. Cross-cutting JS dedup (these *delete* lines)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ py-modules = [
     "screenspace_manifest", "screenspace_multitool", "screenspace_ocr",
     "screenspace_preview", "screenspace_primitives", "screenspace_scans",
     "screenspace_server", "screenspace_tools", "screenspace_worker", "server",
-    "spreadsheet", "start_settings", "thinking_agents", "titlecards",
+    "server_utils", "spreadsheet", "start_settings", "thinking_agents", "titlecards",
     "transcripts", "transcripts_server", "utils", "video", "viewer",
     "workflows", "workflows_server",
 ]

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -69,6 +69,7 @@ import screenspace
 import spreadsheet
 import utils
 import video
+from server_utils import err, json_endpoint, ok, parse_number_arg
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -263,38 +264,38 @@ def api_participants() -> FlaskResponse:
                     for path, dur, cum in timeline
                 ]
         payload.append(entry)
-    return jsonify({"ok": True, "participants": payload})
+    return ok(participants=payload)
 
 
 @screenspace_bp.route("/api/participants/<pid>/notes")
 def api_participant_notes_get(pid: str) -> FlaskResponse:
     """Return persisted free-form notes for a participant."""
     if not _participant_exists(pid):
-        return jsonify({"ok": False, "error": f"Unknown participant {pid}"}), 404
+        return err(f"Unknown participant {pid}", 404)
     with _manifest_lock:
         entry = _manifest.get("per_participant", {}).get(pid, {})
         notes = entry.get("notes", "")
-    return jsonify({"ok": True, "notes": notes})
+    return ok(notes=notes)
 
 
 @screenspace_bp.route("/api/participants/<pid>/notes", methods=["PUT"])
 def api_participant_notes_set(pid: str) -> FlaskResponse:
     """Persist free-form notes for a participant."""
     if not _participant_exists(pid):
-        return jsonify({"ok": False, "error": f"Unknown participant {pid}"}), 404
+        return err(f"Unknown participant {pid}", 404)
     data = request.get_json(silent=True) or {}
     notes = data.get("notes", "")
     if not isinstance(notes, str):
-        return jsonify({"ok": False, "error": "notes must be a string"}), 400
+        return err("notes must be a string")
     if len(notes.encode("utf-8")) > _NOTES_MAX_BYTES:
-        return jsonify({"ok": False, "error": "notes too large"}), 413
+        return err("notes too large", 413)
 
     with _manifest_lock:
         per_participant = _manifest.setdefault("per_participant", {})
         entry = per_participant.setdefault(pid, {})
         entry["notes"] = notes
         _do_persist(drain_events=False)
-    return jsonify({"ok": True})
+    return ok()
 
 
 @screenspace_bp.route("/api/participants/<pid>/issues")
@@ -307,13 +308,13 @@ def api_participant_issues(pid: str) -> FlaskResponse:
     match Studio's view.
     """
     if not _participant_exists(pid):
-        return jsonify({"ok": False, "error": f"Unknown participant {pid}"}), 404
+        return err(f"Unknown participant {pid}", 404)
 
     import server  # lazy: avoid module-level snapshot of _sheet_context
 
     ctx = getattr(server, "_sheet_context", None)
     if ctx is None:
-        return jsonify({"ok": True, "issues": []})
+        return ok(issues=[])
 
     import spreadsheet
 
@@ -321,7 +322,7 @@ def api_participant_issues(pid: str) -> FlaskResponse:
         ctx.header_row, ctx.id_cell, ctx.num_participants
     )
     if pid not in participants:
-        return jsonify({"ok": True, "issues": []})
+        return ok(issues=[])
     p_idx = participants.index(pid)
     col_idx = ctx.id_cell.col + p_idx
 
@@ -366,7 +367,7 @@ def api_participant_issues(pid: str) -> FlaskResponse:
     )
     chosen = candidates[:5]
     issues = [{k: v for k, v in c.items() if not k.startswith("_")} for c in chosen]
-    return jsonify({"ok": True, "issues": issues})
+    return ok(issues=issues)
 
 
 @screenspace_bp.route("/api/participants/<pid>/marks")
@@ -378,12 +379,12 @@ def api_participant_marks(pid: str) -> FlaskResponse:
     Returns an empty list when the participant has no resolvable marks.
     """
     if not _participant_exists(pid):
-        return jsonify({"ok": False, "error": f"Unknown participant {pid}"}), 404
+        return err(f"Unknown participant {pid}", 404)
 
     import transcripts_server  # lazy: mirrors the `import server` pattern above
 
     marks = transcripts_server.marks_for_participant(pid)
-    return jsonify({"ok": True, "marks": marks, "categories": config.MARK_CATEGORIES})
+    return ok(marks=marks, categories=config.MARK_CATEGORIES)
 
 
 # ---- Calibration pins ----
@@ -462,48 +463,34 @@ def _find_pin(pin_id: str) -> tuple[str, list[dict[str, Any]], int] | None:
 def api_pins_list(participant: str) -> FlaskResponse:
     """List calibration pins for a participant (annotated with a stale flag)."""
     if not _participant_exists(participant):
-        return jsonify(
-            {"ok": False, "error": f"Unknown participant {participant}"}
-        ), 404
+        return err(f"Unknown participant {participant}", 404)
     with _manifest_lock:
         pins = copy.deepcopy(_participant_pin_list(participant))
-    return jsonify(
-        {
-            "ok": True,
-            "pins": _annotate_pin_staleness(participant, pins),
-            "max_pins": config.SCREENSPACE_MAX_PINS,
-        }
+    return ok(
+        pins=_annotate_pin_staleness(participant, pins),
+        max_pins=config.SCREENSPACE_MAX_PINS,
     )
 
 
 @screenspace_bp.route("/api/pins/<participant>", methods=["POST"])
+@json_endpoint
 def api_pins_create(participant: str) -> FlaskResponse:
     """Pin the given frame as a positive or negative calibration anchor."""
     if not _participant_exists(participant):
-        return jsonify(
-            {"ok": False, "error": f"Unknown participant {participant}"}
-        ), 404
+        return err(f"Unknown participant {participant}", 404)
     data = request.get_json(silent=True) or {}
 
-    raw_ts = data.get("timestamp")
-    if not isinstance(raw_ts, (int, float, str)):
-        return jsonify({"ok": False, "error": "timestamp must be a number"}), 400
-    try:
-        timestamp = float(raw_ts)
-    except (TypeError, ValueError):
-        return jsonify({"ok": False, "error": "timestamp must be a number"}), 400
-    if not math.isfinite(timestamp) or timestamp < 0:
-        return jsonify({"ok": False, "error": "timestamp must be >= 0"}), 400
+    timestamp = parse_number_arg(
+        data.get("timestamp"), "timestamp", min_=0, finite=True
+    )
 
     polarity = data.get("polarity")
     if polarity not in _PIN_POLARITIES:
-        return jsonify(
-            {"ok": False, "error": "polarity must be 'positive' or 'negative'"}
-        ), 400
+        return err("polarity must be 'positive' or 'negative'")
 
     label = data.get("label", "")
     if not isinstance(label, str):
-        return jsonify({"ok": False, "error": "label must be a string"}), 400
+        return err("label must be a string")
     label = label.strip()[:_PIN_LABEL_MAX_CHARS]
 
     pin = {
@@ -516,15 +503,10 @@ def api_pins_create(participant: str) -> FlaskResponse:
     with _manifest_lock:
         pins = _participant_pin_list(participant, create=True)
         if len(pins) >= config.SCREENSPACE_MAX_PINS:
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": f"Pin limit reached (max {config.SCREENSPACE_MAX_PINS})",
-                }
-            ), 409
+            return err(f"Pin limit reached (max {config.SCREENSPACE_MAX_PINS})", 409)
         pins.append(pin)
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "pin": pin})
+    return ok(pin=pin)
 
 
 @screenspace_bp.route("/api/pins/<pin_id>", methods=["PUT"])
@@ -534,21 +516,19 @@ def api_pins_update(pin_id: str) -> FlaskResponse:
     with _manifest_lock:
         found = _find_pin(pin_id)
         if found is None:
-            return jsonify({"ok": False, "error": "Pin not found"}), 404
+            return err("Pin not found", 404)
         _participant_id, pins, idx = found
         pin = pins[idx]
         if "polarity" in data:
             if data["polarity"] not in _PIN_POLARITIES:
-                return jsonify(
-                    {"ok": False, "error": "polarity must be 'positive' or 'negative'"}
-                ), 400
+                return err("polarity must be 'positive' or 'negative'")
             pin["polarity"] = data["polarity"]
         if "label" in data:
             if not isinstance(data["label"], str):
-                return jsonify({"ok": False, "error": "label must be a string"}), 400
+                return err("label must be a string")
             pin["label"] = data["label"].strip()[:_PIN_LABEL_MAX_CHARS]
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "pin": pin})
+    return ok(pin=pin)
 
 
 @screenspace_bp.route("/api/pins/<pin_id>", methods=["DELETE"])
@@ -557,13 +537,13 @@ def api_pins_delete(pin_id: str) -> FlaskResponse:
     with _manifest_lock:
         found = _find_pin(pin_id)
         if found is None:
-            return jsonify({"ok": False, "error": "Pin not found"}), 404
+            return err("Pin not found", 404)
         participant_id, pins, idx = found
         pins.pop(idx)
         if not pins:
             _pin_manifest().pop(participant_id, None)
         _do_persist(drain_events=False)
-    return jsonify({"ok": True})
+    return ok()
 
 
 @screenspace_bp.route("/api/pins/<participant>/all", methods=["DELETE"])
@@ -574,13 +554,11 @@ def api_pins_delete_all(participant: str) -> FlaskResponse:
     ``DELETE /api/pins/<pin_id>`` route above (both use the DELETE method).
     """
     if not _participant_exists(participant):
-        return jsonify(
-            {"ok": False, "error": f"Unknown participant {participant}"}
-        ), 404
+        return err(f"Unknown participant {participant}", 404)
     with _manifest_lock:
         _pin_manifest().pop(participant, None)
         _do_persist(drain_events=False)
-    return jsonify({"ok": True})
+    return ok()
 
 
 # ---- Pin calibration (synchronous, off the task queue) ----
@@ -688,13 +666,11 @@ def api_calibrate() -> FlaskResponse:
     """
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
 
     tool = (data.get("tool") or "").strip()
     if not _calibratable_tool(tool):
-        return jsonify(
-            {"ok": False, "error": f"Tool '{tool}' is not calibratable"}
-        ), 400
+        return err(f"Tool '{tool}' is not calibratable")
 
     # Reuse task-creation validation by reshaping the body into a task request.
     validated = _validate_task_request(
@@ -709,7 +685,7 @@ def api_calibrate() -> FlaskResponse:
     if _is_flask_error_response(validated):
         return validated
     if not (isinstance(validated, tuple) and len(validated) == 6):
-        return jsonify({"ok": False, "error": "Invalid calibration request"}), 400
+        return err("Invalid calibration request")
     (
         task_type,
         participant,
@@ -724,9 +700,7 @@ def api_calibrate() -> FlaskResponse:
 
     resolved = _find_participant_video_with_mtime(participant)
     if resolved is None:
-        return jsonify(
-            {"ok": False, "error": f"No video for participant {participant}"}
-        ), 404
+        return err(f"No video for participant {participant}", 404)
     video_path, mtime_ns = resolved
 
     props = video.probe_video_properties(video_path)
@@ -769,7 +743,7 @@ def api_calibrate() -> FlaskResponse:
 
     pin_ids = data.get("pin_ids")
     if pin_ids is not None and not isinstance(pin_ids, list):
-        return jsonify({"ok": False, "error": "pin_ids must be a list"}), 400
+        return err("pin_ids must be a list")
 
     with _manifest_lock:
         all_pins = copy.deepcopy(_participant_pin_list(participant))
@@ -1017,15 +991,13 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     try:
         ts = float(timestamp)
     except (ValueError, TypeError):
-        return jsonify({"ok": False, "error": "Invalid timestamp"}), 400
+        return err("Invalid timestamp")
 
     # Map the global timestamp into the owning sub-video (multi-video) so the
     # frontend can keep requesting frames by global time; single-video unchanged.
     mapped = _map_participant_time(participant, ts)
     if mapped is None:
-        return jsonify(
-            {"ok": False, "error": f"No video for participant {participant}"}
-        ), 404
+        return err(f"No video for participant {participant}", 404)
     video_path, local_ts = mapped
     mtime_ns = _mtime_or_zero(video_path)
 
@@ -1048,18 +1020,16 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     else:
         frame = video.extract_frame_at_timestamp(video_path, local_ts)
         if frame is None:
-            return jsonify(
-                {"ok": False, "error": "Could not read frame at timestamp"}
-            ), 400
+            return err("Could not read frame at timestamp")
         import cv2
 
         success, jpeg = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
         if not success:
-            return jsonify({"ok": False, "error": "Could not extract frame"}), 400
+            return err("Could not extract frame")
         jpeg_bytes = jpeg.tobytes()
 
     if jpeg_bytes is None:
-        return jsonify({"ok": False, "error": "Could not extract frame"}), 400
+        return err("Could not extract frame")
 
     with _frame_cache_lock:
         _frame_cache[cache_key] = jpeg_bytes
@@ -1103,13 +1073,11 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
     try:
         ts = float(timestamp)
     except (ValueError, TypeError):
-        return jsonify({"ok": False, "error": "Invalid timestamp"}), 400
+        return err("Invalid timestamp")
 
     video_path = _find_participant_video(participant)
     if video_path is None:
-        return jsonify(
-            {"ok": False, "error": f"No video for participant {participant}"}
-        ), 404
+        return err(f"No video for participant {participant}", 404)
 
     def _frame_at(global_ts: float) -> "Any | None":
         # Map a global timestamp into the owning sub-video (multi-video) before
@@ -1121,11 +1089,11 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
 
     tool = (request.args.get("tool") or "").strip() or "color"
     if tool not in _VALID_TASK_TYPES:
-        return jsonify({"ok": False, "error": f"Unknown tool: {tool}"}), 400
+        return err(f"Unknown tool: {tool}")
 
     frame = _frame_at(ts)
     if frame is None:
-        return jsonify({"ok": False, "error": "Could not read frame"}), 400
+        return err("Could not read frame")
     frame_h, frame_w = frame.shape[:2]
 
     region_coords: dict[str, int] | None = None
@@ -1136,7 +1104,7 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
             try:
                 rx, ry, rw, rh = (float(p) for p in parts)
             except ValueError:
-                return jsonify({"ok": False, "error": "Invalid region"}), 400
+                return err("Invalid region")
             region_coords = {
                 "x": int(round(rx * frame_w)),
                 "y": int(round(ry * frame_h)),
@@ -1217,9 +1185,7 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
             try:
                 bgr, mask = _template_bgr_and_mask_from_b64(upload_b64)
             except ValueError:
-                return jsonify(
-                    {"ok": False, "error": "Could not decode uploaded image"}
-                ), 400
+                return err("Could not decode uploaded image")
             params["template_image"] = bgr
             if mask is not None:
                 params["template_mask"] = mask
@@ -1254,20 +1220,15 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
             )
         }
         if layer not in valid:
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": f"Layer '{layer}' not available for tool '{tool}'",
-                }
-            ), 400
+            return err(f"Layer '{layer}' not available for tool '{tool}'")
         layer_img = screenspace_preview.build_overlay_layer(
             frame, prev_frame, region_coords, tool, layer, params
         )
         if layer_img is None or getattr(layer_img, "size", 0) == 0:
-            return jsonify({"ok": False, "error": "Could not build overlay layer"}), 500
+            return err("Could not build overlay layer", 500)
         png_bytes = screenspace_preview.encode_png(layer_img, cap_width=False)
         if not png_bytes:
-            return jsonify({"ok": False, "error": "Could not encode overlay"}), 500
+            return err("Could not encode overlay", 500)
         return Response(
             png_bytes,
             mimetype="image/png",
@@ -1278,11 +1239,11 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
         frame, prev_frame, region_coords, tool, params
     )
     if img is None or getattr(img, "size", 0) == 0:
-        return jsonify({"ok": False, "error": "Could not build preview"}), 500
+        return err("Could not build preview", 500)
 
     png_bytes = screenspace_preview.encode_png(img)
     if not png_bytes:
-        return jsonify({"ok": False, "error": "Could not encode preview"}), 500
+        return err("Could not encode preview", 500)
     return Response(
         png_bytes,
         mimetype="image/png",
@@ -1305,7 +1266,7 @@ def api_preview_layers() -> FlaskResponse:
         ]
         for tool, layers in screenspace_preview.OVERLAY_LAYERS.items()
     }
-    return jsonify({"ok": True, "layers": out})
+    return ok(layers=out)
 
 
 @screenspace_bp.route("/api/video/info/<participant>")
@@ -1337,23 +1298,21 @@ def api_video_info(participant: str) -> FlaskResponse:
                 for p, d, c in timeline
             ],
         }
-        return jsonify({"ok": True, "info": info})
+        return ok(info=info)
 
     resolved = _find_participant_video_with_mtime(participant)
     if resolved is None:
-        return jsonify(
-            {"ok": False, "error": f"No video for participant {participant}"}
-        ), 404
+        return err(f"No video for participant {participant}", 404)
     video_path, mtime_ns = resolved
 
     with _video_metadata_cache_lock:
         cached = _video_metadata_cache.get(participant)
     if cached is not None and cached[0] == mtime_ns:
-        return jsonify({"ok": True, "info": cached[1]})
+        return ok(info=cached[1])
 
     props = video.probe_video_properties(video_path)
     if props is None:
-        return jsonify({"ok": False, "error": "Could not probe video file"}), 500
+        return err("Could not probe video file", 500)
 
     vid_fps = props.get("fps", 0.0) or 30.0
     width = props.get("width", 0)
@@ -1377,7 +1336,7 @@ def api_video_info(participant: str) -> FlaskResponse:
     with _video_metadata_cache_lock:
         _video_metadata_cache[participant] = (mtime_ns, info)
 
-    return jsonify({"ok": True, "info": info})
+    return ok(info=info)
 
 
 @screenspace_bp.route("/api/video/stream/<participant>")
@@ -1393,10 +1352,7 @@ def api_video_stream(participant: str) -> FlaskResponse:
     """
     paths = _participant_video_paths(participant)
     if not paths:
-        return (
-            jsonify({"ok": False, "error": f"No video for participant {participant}"}),
-            404,
-        )
+        return err(f"No video for participant {participant}", 404)
     # Multi-video participants: ?part=N selects the sub-video; the frontend swaps
     # the <video> source per part as it scrubs the global timeline. Defaults to
     # part 0 (and is the only file for single-video participants).
@@ -1456,7 +1412,7 @@ def _resolve_region_request(
     try:
         return screenspace.resolve_region_request(region_name, region_ref, _manifest)
     except ValueError as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+        return err(str(exc))
 
 
 def _is_flask_error_response(value: Any) -> TypeGuard[FlaskResponse]:
@@ -1473,7 +1429,7 @@ def api_regions_list() -> FlaskResponse:
     """List all saved region definitions."""
     with _manifest_lock:
         regions = copy.deepcopy(_manifest.get("regions", {}))
-    return jsonify({"ok": True, "regions": regions})
+    return ok(regions=regions)
 
 
 @screenspace_bp.route("/api/regions", methods=["POST"])
@@ -1481,16 +1437,16 @@ def api_regions_create() -> FlaskResponse:
     """Create or update a named region."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
 
     name = data.get("name", "").strip()
     if not name:
-        return jsonify({"ok": False, "error": "Region name is required"}), 400
+        return err("Region name is required")
 
     for field in ("x", "y", "w", "h"):
         val = data.get(field)
         if val is None or not isinstance(val, (int, float)):
-            return jsonify({"ok": False, "error": f"'{field}' must be a number"}), 400
+            return err(f"'{field}' must be a number")
 
     canvas_w = data.get("canvas_width")
     canvas_h = data.get("canvas_height")
@@ -1500,15 +1456,7 @@ def api_regions_create() -> FlaskResponse:
         or canvas_w <= 0
         or canvas_h <= 0
     ):
-        return (
-            jsonify(
-                {
-                    "ok": False,
-                    "error": "'canvas_width' and 'canvas_height' must be positive numbers",
-                }
-            ),
-            400,
-        )
+        return err("'canvas_width' and 'canvas_height' must be positive numbers")
 
     region = _normalize_region(
         data["x"], data["y"], data["w"], data["h"], int(canvas_w), int(canvas_h)
@@ -1520,7 +1468,7 @@ def api_regions_create() -> FlaskResponse:
         _manifest.setdefault("regions", {})[name] = region
         _do_persist(drain_events=False)
 
-    return jsonify({"ok": True, "region": region})
+    return ok(region=region)
 
 
 @screenspace_bp.route("/api/regions/<name>", methods=["DELETE"])
@@ -1529,11 +1477,11 @@ def api_regions_delete(name: str) -> FlaskResponse:
     with _manifest_lock:
         regions = _manifest.get("regions", {})
         if name not in regions:
-            return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 404
+            return err(f"Region '{name}' not found", 404)
         del regions[name]
         _do_persist(drain_events=False)
 
-    return jsonify({"ok": True})
+    return ok()
 
 
 @screenspace_bp.route("/api/regions", methods=["DELETE"])
@@ -1543,7 +1491,7 @@ def api_regions_delete_all() -> FlaskResponse:
         _manifest["regions"] = {}
         _do_persist(drain_events=False)
 
-    return jsonify({"ok": True})
+    return ok()
 
 
 @screenspace_bp.route("/api/regions/reorder", methods=["PUT"])
@@ -1551,25 +1499,20 @@ def api_regions_reorder() -> FlaskResponse:
     """Reorder active regions to match the given name order."""
     data = request.get_json(silent=True)
     if not data or not isinstance(data.get("names"), list):
-        return jsonify({"ok": False, "error": "names list required"}), 400
+        return err("names list required")
 
     with _manifest_lock:
         regions = _manifest.get("regions", {})
         names = data["names"]
         if not all(isinstance(name, str) for name in names):
-            return jsonify({"ok": False, "error": "names must be strings"}), 400
+            return err("names must be strings")
         region_names = list(regions.keys())
         if len(names) != len(region_names) or set(names) != set(region_names):
-            return (
-                jsonify(
-                    {"ok": False, "error": "names must match current regions exactly"}
-                ),
-                400,
-            )
+            return err("names must match current regions exactly")
         _manifest["regions"] = {name: regions[name] for name in names}
         _do_persist(drain_events=False)
 
-    return jsonify({"ok": True})
+    return ok()
 
 
 # ---- Stashes CRUD ----
@@ -1580,7 +1523,7 @@ def api_stashes_list() -> FlaskResponse:
     """List all region stashes."""
     with _manifest_lock:
         stashes = copy.deepcopy(_manifest.get("stashes", []))
-    return jsonify({"ok": True, "stashes": stashes})
+    return ok(stashes=stashes)
 
 
 @screenspace_bp.route("/api/stashes", methods=["POST"])
@@ -1588,7 +1531,7 @@ def api_stashes_create() -> FlaskResponse:
     """Stash all current regions and clear the active set."""
     regions = _manifest.get("regions", {})
     if not regions:
-        return jsonify({"ok": False, "error": "No regions to stash"}), 400
+        return err("No regions to stash")
 
     stash = {
         "id": "stash_" + uuid.uuid4().hex[:8],
@@ -1600,7 +1543,7 @@ def api_stashes_create() -> FlaskResponse:
         _manifest.setdefault("stashes", []).append(stash)
         _manifest["regions"] = {}
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "stash": stash})
+    return ok(stash=stash)
 
 
 @screenspace_bp.route("/api/stashes/<stash_id>", methods=["PUT"])
@@ -1608,18 +1551,18 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
     """Update a stash (rename)."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
 
     name = data.get("name", "").strip()
     with _manifest_lock:
         stashes = _manifest.get("stashes", [])
         stash = next((s for s in stashes if s["id"] == stash_id), None)
         if stash is None:
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+            return err("Stash not found", 404)
         if name:
             stash["name"] = name
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "stash": stash})
+    return ok(stash=stash)
 
 
 @screenspace_bp.route("/api/stashes/<stash_id>", methods=["DELETE"])
@@ -1629,10 +1572,10 @@ def api_stashes_delete(stash_id: str) -> FlaskResponse:
         stashes = _manifest.get("stashes", [])
         idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
         if idx is None:
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+            return err("Stash not found", 404)
         stashes.pop(idx)
         _do_persist(drain_events=False)
-    return jsonify({"ok": True})
+    return ok()
 
 
 @screenspace_bp.route("/api/stashes/<stash_id>/restore", methods=["POST"])
@@ -1642,10 +1585,10 @@ def api_stashes_restore(stash_id: str) -> FlaskResponse:
         stashes = _manifest.get("stashes", [])
         stash = next((s for s in stashes if s["id"] == stash_id), None)
         if stash is None:
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+            return err("Stash not found", 404)
         _manifest["regions"] = copy.deepcopy(stash["regions"])
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "regions": _manifest["regions"]})
+    return ok(regions=_manifest["regions"])
 
 
 @screenspace_bp.route("/api/stashes/<stash_id>/regions", methods=["POST"])
@@ -1657,24 +1600,24 @@ def api_stashes_add_region(stash_id: str) -> FlaskResponse:
     """
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
     name = data.get("name", "").strip()
     if not name:
-        return jsonify({"ok": False, "error": "Region name is required"}), 400
+        return err("Region name is required")
 
     with _manifest_lock:
         regions = _manifest.get("regions", {})
         if name not in regions:
-            return jsonify({"ok": False, "error": f"Region '{name}' not found"}), 404
+            return err(f"Region '{name}' not found", 404)
         stash = next(
             (s for s in _manifest.get("stashes", []) if s["id"] == stash_id), None
         )
         if stash is None:
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+            return err("Stash not found", 404)
         stash.setdefault("regions", {})[name] = copy.deepcopy(regions[name])
         _do_persist(drain_events=False)
 
-    return jsonify({"ok": True, "stash": stash})
+    return ok(stash=stash)
 
 
 # ---- Tasks CRUD ----
@@ -1725,20 +1668,18 @@ def api_tasks_list() -> FlaskResponse:
     clean = [_clean_task(t) for t in tasks]
     paused = _worker.is_paused if _worker else False
     alive = _worker.is_alive if _worker else False
-    return jsonify(
-        {"ok": True, "tasks": clean, "paused": paused, "worker_alive": alive}
-    )
+    return ok(tasks=clean, paused=paused, worker_alive=alive)
 
 
 @screenspace_bp.route("/api/tasks/<task_id>")
 def api_tasks_get(task_id: str) -> FlaskResponse:
     """Get task detail including results."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
     task = _worker.get_task(task_id)
     if task is None:
-        return jsonify({"ok": False, "error": "Task not found"}), 404
-    return jsonify({"ok": True, "task": _clean_task(task)})
+        return err("Task not found", 404)
+    return ok(task=_clean_task(task))
 
 
 # ---- Task creation helpers ----
@@ -1762,16 +1703,11 @@ def _validate_task_request(
     """
     task_type = data.get("type", "").strip()
     if task_type not in _VALID_TASK_TYPES:
-        return jsonify(
-            {
-                "ok": False,
-                "error": f"type must be one of: {', '.join(_VALID_TASK_TYPES)}",
-            }
-        ), 400
+        return err(f"type must be one of: {', '.join(_VALID_TASK_TYPES)}")
 
     participant = data.get("participant", "").strip()
     if not participant:
-        return jsonify({"ok": False, "error": "participant is required"}), 400
+        return err("participant is required")
 
     region_name = data.get("region", "").strip()
     region_ref = data.get("region_ref")
@@ -1781,7 +1717,7 @@ def _validate_task_request(
     elif isinstance(raw_parameters, dict):
         parameters = raw_parameters
     else:
-        return jsonify({"ok": False, "error": "parameters must be an object"}), 400
+        return err("parameters must be an object")
 
     # Template tasks with an uploaded image scan the full frame; no region needed
     has_uploaded_template = task_type == "template" and parameters.get(
@@ -1797,51 +1733,33 @@ def _validate_task_request(
         and not has_uploaded_template
         and task_type != "multitool"
     ):
-        return jsonify({"ok": False, "error": "region is required"}), 400
+        return err("region is required")
 
     # Early validation for multitool steps
     if task_type == "multitool":
         mt_steps = parameters.get("steps")
         if not mt_steps or not isinstance(mt_steps, list) or len(mt_steps) < 2:
-            return jsonify(
-                {"ok": False, "error": "Multitool requires at least 2 steps"}
-            ), 400
+            return err("Multitool requires at least 2 steps")
         for i, step_raw in enumerate(mt_steps):
             if not isinstance(step_raw, dict):
-                return jsonify(
-                    {"ok": False, "error": f"Step {i}: must be an object"}
-                ), 400
+                return err(f"Step {i}: must be an object")
             step_v = cast(dict[str, Any], step_raw)
             stype = step_v.get("type", "")
             if stype not in _VALID_STEP_TYPES:
-                return jsonify(
-                    {"ok": False, "error": f"Step {i}: invalid type '{stype}'"}
-                ), 400
+                return err(f"Step {i}: invalid type '{stype}'")
             logic = step_v.get("logic")
             if logic is not None and logic not in ("AND", "NOT"):
-                return jsonify(
-                    {"ok": False, "error": f"Step {i}: logic must be 'AND' or 'NOT'"}
-                ), 400
+                return err(f"Step {i}: logic must be 'AND' or 'NOT'")
             offset = step_v.get("offset")
             if offset is not None:
                 if i == 0:
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": "Step 0: offset is not allowed on the first step",
-                        }
-                    ), 400
+                    return err("Step 0: offset is not allowed on the first step")
                 if (
                     not isinstance(offset, dict)
                     or offset.get("min") is None
                     or offset.get("max") is None
                 ):
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Step {i}: offset requires numeric min and max",
-                        }
-                    ), 400
+                    return err(f"Step {i}: offset requires numeric min and max")
 
     all_known_regions = _combined_region_lookup()
     requested_region: dict[str, Any] | None = None
@@ -1860,20 +1778,13 @@ def _validate_task_request(
             if not step_region and step_region_ref is None:
                 if step_uploaded_template:
                     continue
-                return jsonify(
-                    {"ok": False, "error": f"Step {i}: region is required"}
-                ), 400
+                return err(f"Step {i}: region is required")
             if step_region_ref is not None:
                 resolved = _resolve_region_request(step_region, step_region_ref)
                 if _is_flask_error_response(resolved):
                     return resolved
             elif step_region not in all_known_regions:
-                return jsonify(
-                    {
-                        "ok": False,
-                        "error": f"Step {i}: region '{step_region}' not found",
-                    }
-                ), 400
+                return err(f"Step {i}: region '{step_region}' not found")
     elif has_region_request:
         resolved = _resolve_region_request(region_name, region_ref)
         if _is_flask_error_response(resolved):
@@ -1952,7 +1863,7 @@ def _coerce_task_params(
         if task_type == "template":
             _coerce_template_controls(parameters)
     except ValueError as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+        return err(str(exc))
 
     return parameters
 
@@ -1973,9 +1884,7 @@ def _extract_task_media(
         ref_ts = cast(float, parameters["reference_timestamp"])
         frame = frame_at(float(ref_ts))
         if frame is None:
-            return jsonify(
-                {"ok": False, "error": "Could not read reference frame"}
-            ), 400
+            return err("Could not read reference frame")
         ref_region = screenspace.extract_region(frame, region_coords)
         parameters["reference_frame"] = ref_region
 
@@ -1985,9 +1894,7 @@ def _extract_task_media(
             try:
                 bgr, mask = _template_bgr_and_mask_from_b64(upload_b64)
             except ValueError:
-                return jsonify(
-                    {"ok": False, "error": "Could not decode uploaded image"}
-                ), 400
+                return err("Could not decode uploaded image")
             parameters["template_image"] = bgr
             if mask is not None:
                 parameters["template_mask"] = mask
@@ -1995,9 +1902,7 @@ def _extract_task_media(
             ref_ts = cast(float, parameters["reference_timestamp"])
             frame = frame_at(float(ref_ts))
             if frame is None:
-                return jsonify(
-                    {"ok": False, "error": "Could not read template frame"}
-                ), 400
+                return err("Could not read template frame")
             parameters["template_image"] = screenspace.extract_region(
                 frame, region_coords
             )
@@ -2008,12 +1913,7 @@ def _extract_task_media(
         for ref in scene_refs:
             frame = frame_at(float(ref["timestamp"]))
             if frame is None:
-                return jsonify(
-                    {
-                        "ok": False,
-                        "error": f"Could not read frame for scene '{ref['name']}'",
-                    }
-                ), 400
+                return err(f"Could not read frame for scene '{ref['name']}'")
             ref_region = screenspace.extract_region(frame, region_coords)
             scene_entry: dict = {"name": ref["name"], "frame": ref_region}
             if "threshold" in ref:
@@ -2059,12 +1959,7 @@ def _prepare_multitool_steps(
             ref_ts = cast(float, step["reference_timestamp"])
             frame = frame_at(float(ref_ts))
             if frame is None:
-                return jsonify(
-                    {
-                        "ok": False,
-                        "error": f"Step {i}: could not read reference frame",
-                    }
-                ), 400
+                return err(f"Step {i}: could not read reference frame")
             step["reference_frame"] = screenspace.extract_region(frame, step_rc)
 
         elif stype == "template":
@@ -2073,12 +1968,7 @@ def _prepare_multitool_steps(
                 try:
                     bgr, mask = _template_bgr_and_mask_from_b64(upload_b64)
                 except ValueError:
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Step {i}: could not decode uploaded image",
-                        }
-                    ), 400
+                    return err(f"Step {i}: could not decode uploaded image")
                 step["template_image"] = bgr
                 if mask is not None:
                     step["template_mask"] = mask
@@ -2086,12 +1976,7 @@ def _prepare_multitool_steps(
                 ref_ts = cast(float, step["reference_timestamp"])
                 frame = frame_at(float(ref_ts))
                 if frame is None:
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Step {i}: could not read template frame",
-                        }
-                    ), 400
+                    return err(f"Step {i}: could not read template frame")
                 step["template_image"] = screenspace.extract_region(frame, step_rc)
 
         elif stype == "scene":
@@ -2100,12 +1985,9 @@ def _prepare_multitool_steps(
             for ref in scene_refs:
                 frame = frame_at(float(ref["timestamp"]))
                 if frame is None:
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": f"Step {i}: could not read frame for scene '{ref['name']}'",
-                        }
-                    ), 400
+                    return err(
+                        f"Step {i}: could not read frame for scene '{ref['name']}'"
+                    )
                 ref_region = screenspace.extract_region(frame, step_rc)
                 scene_entry: dict = {"name": ref["name"], "frame": ref_region}
                 if "threshold" in ref:
@@ -2120,11 +2002,11 @@ def _prepare_multitool_steps(
 def api_tasks_create() -> FlaskResponse:
     """Enqueue a new analysis task."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
 
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
 
     # Boundary is full-frame only by contract: ignore any caller-supplied region
     # so events and manifest metadata are never labeled with a region the scan
@@ -2157,9 +2039,7 @@ def api_tasks_create() -> FlaskResponse:
 
     video_paths = _participant_video_paths(participant)
     if not video_paths:
-        return jsonify(
-            {"ok": False, "error": f"No video for participant {participant}"}
-        ), 400
+        return err(f"No video for participant {participant}")
     video_path = video_paths[0]
 
     # Default per-task source label; the per-part scan tags each event with the
@@ -2241,72 +2121,72 @@ def api_tasks_create() -> FlaskResponse:
     _schedule_persist()
     _notify_sse_clients("task_created")
 
-    return jsonify({"ok": True, "task": _clean_task(task)})
+    return ok(task=_clean_task(task))
 
 
 @screenspace_bp.route("/api/tasks/<task_id>", methods=["DELETE"])
 def api_tasks_cancel(task_id: str) -> FlaskResponse:
     """Cancel or dismiss a task.  ?dismiss=true fully removes the task."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
     if request.args.get("dismiss") == "true":
         if not _worker.remove_task(task_id):
-            return jsonify({"ok": False, "error": "Task not found"}), 404
+            return err("Task not found", 404)
         _schedule_persist()
         _notify_sse_clients("task_dismissed")
-        return jsonify({"ok": True})
+        return ok()
     if _worker.cancel(task_id):
         _schedule_persist()
         _notify_sse_clients("task_cancelled")
-        return jsonify({"ok": True})
-    return jsonify({"ok": False, "error": "Task not found or already finished"}), 400
+        return ok()
+    return err("Task not found or already finished")
 
 
 @screenspace_bp.route("/api/tasks/reorder", methods=["PUT"])
 def api_tasks_reorder() -> FlaskResponse:
     """Reorder queued tasks by priority."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
     data = request.get_json(silent=True)
     if not data or "task_ids" not in data:
-        return jsonify({"ok": False, "error": "task_ids list required"}), 400
+        return err("task_ids list required")
     _worker.reorder(data["task_ids"])
     _schedule_persist()
     _notify_sse_clients("reorder")
-    return jsonify({"ok": True})
+    return ok()
 
 
 @screenspace_bp.route("/api/tasks/pause", methods=["POST"])
 def api_tasks_pause() -> FlaskResponse:
     """Pause the task queue."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
     _worker.pause()
     _schedule_persist()
     _notify_sse_clients("pause")
-    return jsonify({"ok": True, "paused": True})
+    return ok(paused=True)
 
 
 @screenspace_bp.route("/api/tasks/resume", methods=["POST"])
 def api_tasks_resume() -> FlaskResponse:
     """Resume the task queue."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
     _worker.resume()
     _schedule_persist()
     _notify_sse_clients("resume")
-    return jsonify({"ok": True, "paused": False})
+    return ok(paused=False)
 
 
 @screenspace_bp.route("/api/tasks/<task_id>/results")
 def api_tasks_results(task_id: str) -> FlaskResponse:
     """Get task results (timestamps, artifacts)."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
     task = _worker.get_task(task_id)
     if task is None:
-        return jsonify({"ok": False, "error": "Task not found"}), 404
-    return jsonify({"ok": True, "results": utils.sanitize_floats(task.get("result"))})
+        return err("Task not found", 404)
+    return ok(results=utils.sanitize_floats(task.get("result")))
 
 
 # ---- Events CRUD ----
@@ -2328,7 +2208,7 @@ def api_events_list() -> FlaskResponse:
     task_id = request.args.get("task_id")
     if task_id:
         events = [e for e in events if e.get("task_id") == task_id]
-    return jsonify({"ok": True, "events": utils.sanitize_floats(events)})
+    return ok(events=utils.sanitize_floats(events))
 
 
 @screenspace_bp.route("/api/export/events")
@@ -2377,8 +2257,8 @@ def api_export_events() -> FlaskResponse:
         )
         return response
     if fmt == "json":
-        return jsonify({"ok": True, "events": utils.sanitize_floats(records)})
-    return jsonify({"ok": False, "error": f"Unsupported format: {fmt}"}), 400
+        return ok(events=utils.sanitize_floats(records))
+    return err(f"Unsupported format: {fmt}")
 
 
 @screenspace_bp.route("/api/events/<event_id>/exclude", methods=["PUT"])
@@ -2389,8 +2269,8 @@ def api_event_exclude(event_id: str) -> FlaskResponse:
             if e["id"] == event_id:
                 e["excluded"] = True
                 _do_persist(drain_events=False)
-                return jsonify({"ok": True})
-    return jsonify({"ok": False, "error": "Event not found"}), 404
+                return ok()
+    return err("Event not found", 404)
 
 
 @screenspace_bp.route("/api/events/<event_id>/include", methods=["PUT"])
@@ -2401,8 +2281,8 @@ def api_event_include(event_id: str) -> FlaskResponse:
             if e["id"] == event_id:
                 e["excluded"] = False
                 _do_persist(drain_events=False)
-                return jsonify({"ok": True})
-    return jsonify({"ok": False, "error": "Event not found"}), 404
+                return ok()
+    return err("Event not found", 404)
 
 
 @screenspace_bp.route("/api/events/bulk-exclude", methods=["PUT"])
@@ -2411,7 +2291,7 @@ def api_events_bulk_exclude() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     ids = set(data.get("ids", []))
     if not ids:
-        return jsonify({"ok": False, "error": "ids list required"}), 400
+        return err("ids list required")
     with _manifest_lock:
         count = 0
         for e in _manifest.get("events", []):
@@ -2419,7 +2299,7 @@ def api_events_bulk_exclude() -> FlaskResponse:
                 e["excluded"] = True
                 count += 1
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "updated": count})
+    return ok(updated=count)
 
 
 @screenspace_bp.route("/api/events/bulk-include", methods=["PUT"])
@@ -2428,7 +2308,7 @@ def api_events_bulk_include() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     ids = set(data.get("ids", []))
     if not ids:
-        return jsonify({"ok": False, "error": "ids list required"}), 400
+        return err("ids list required")
     with _manifest_lock:
         count = 0
         for e in _manifest.get("events", []):
@@ -2436,7 +2316,7 @@ def api_events_bulk_include() -> FlaskResponse:
                 e["excluded"] = False
                 count += 1
         _do_persist(drain_events=False)
-    return jsonify({"ok": True, "updated": count})
+    return ok(updated=count)
 
 
 # ---- Helpers ----

--- a/server.py
+++ b/server.py
@@ -73,6 +73,7 @@ import titlecards
 import utils
 import video
 import viewer
+from server_utils import err, ok
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -495,7 +496,7 @@ def _resolve_source_video(participant: str) -> Path | None:
 @studio_bp.route("/api/thumbnail/<participant>/<start_seconds>")
 def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
     if _sheet_context is None:
-        return jsonify({"ok": False, "error": "No spreadsheet loaded"}), 404
+        return err("No spreadsheet loaded", 404)
 
     try:
         # Parse via float so a fractional second (thumbnails are second-granular,
@@ -503,10 +504,10 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
         # float-tolerant parsing the project's other media routes use.
         start_sec = max(0, int(float(start_seconds)))
     except (ValueError, TypeError):
-        return jsonify({"ok": False, "error": "Invalid timestamp"}), 400
+        return err("Invalid timestamp")
     sources = _resolve_participant_sources(participant)
     if not sources or not sources[0].is_file():
-        return jsonify({"ok": False, "error": "Source video not found"}), 404
+        return err("Source video not found", 404)
 
     # Multi-video participant: map the global second into the owning sub-video so
     # the hover thumbnail comes from the right file at the right local offset.
@@ -515,10 +516,10 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
     if len(sources) >= 2:
         timeline = video.build_source_timeline([str(p) for p in sources])
         if timeline is None:
-            return jsonify({"ok": False, "error": "Source video not found"}), 404
+            return err("Source video not found", 404)
         mapped = utils.resolve_timeline_segment(timeline, start_sec)
         if mapped is None:
-            return jsonify({"ok": False, "error": "Timestamp beyond recording"}), 404
+            return err("Timestamp beyond recording", 404)
         video_path = Path(mapped[0])
         cut_sec = int(mapped[1])
 
@@ -543,7 +544,7 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
         str(video_path), cut_sec, width=config.STUDIO_THUMBNAIL_WIDTH
     )
     if jpeg_bytes is None:
-        return jsonify({"ok": False, "error": "Thumbnail extraction failed"}), 404
+        return err("Thumbnail extraction failed", 404)
 
     _thumbnail_cache_put(cache_key, jpeg_bytes)
     return Response(
@@ -599,15 +600,15 @@ def api_sprite(participant: str) -> FlaskResponse:
     sub-video and the sprite samples that file's tail (hover preview only).
     """
     if _sheet_context is None:
-        return jsonify({"ok": False, "error": "No spreadsheet loaded"}), 404
+        return err("No spreadsheet loaded", 404)
     window = _parse_clip_window()
     if window is None:
-        return jsonify({"ok": False, "error": "Invalid clip range"}), 400
+        return err("Invalid clip range")
     start_sec, duration = window
 
     resolved = _resolve_clip_media_source(participant, start_sec)
     if resolved is None:
-        return jsonify({"ok": False, "error": "Source video not found"}), 404
+        return err("Source video not found", 404)
     video_path, local_start = resolved
     cols = config.STUDIO_SCRUBBER_SPRITE_COLS
     rows = config.STUDIO_SCRUBBER_SPRITE_ROWS
@@ -639,7 +640,7 @@ def api_sprite(participant: str) -> FlaskResponse:
         str(video_path), local_start, duration, cols, rows
     )
     if sprite_bytes is None:
-        return jsonify({"ok": False, "error": "Sprite extraction failed"}), 404
+        return err("Sprite extraction failed", 404)
 
     _sprite_cache_put(cache_key, sprite_bytes)
     return Response(
@@ -658,15 +659,15 @@ def api_clip_audio(participant: str) -> FlaskResponse:
     *start* into the owning sub-video (hover preview only).
     """
     if _sheet_context is None:
-        return jsonify({"ok": False, "error": "No spreadsheet loaded"}), 404
+        return err("No spreadsheet loaded", 404)
     window = _parse_clip_window()
     if window is None:
-        return jsonify({"ok": False, "error": "Invalid clip range"}), 400
+        return err("Invalid clip range")
     start_sec, duration = window
 
     resolved = _resolve_clip_media_source(participant, start_sec)
     if resolved is None:
-        return jsonify({"ok": False, "error": "Source video not found"}), 404
+        return err("Source video not found", 404)
     video_path, local_start = resolved
 
     try:
@@ -689,7 +690,7 @@ def api_clip_audio(participant: str) -> FlaskResponse:
         str(video_path), local_start, duration
     )
     if wav_bytes is None:
-        return jsonify({"ok": False, "error": "Audio extraction failed"}), 404
+        return err("Audio extraction failed", 404)
 
     _audio_cache_put(cache_key, wav_bytes)
     return Response(
@@ -805,11 +806,11 @@ def api_sheet_baseline() -> FlaskResponse:
     Empty baselines dict when no baseline row exists.
     """
     if _sheet_context is None:
-        return jsonify({"ok": True, "sheet_loaded": False, "baselines": {}})
+        return ok(sheet_loaded=False, baselines={})
 
     ctx = _sheet_context
     if ctx.baseline_row_idx is None:
-        return jsonify({"ok": True, "baselines": {}})
+        return ok(baselines={})
 
     participants = spreadsheet.get_participant_list(
         ctx.header_row, ctx.id_cell, ctx.num_participants
@@ -824,7 +825,7 @@ def api_sheet_baseline() -> FlaskResponse:
             value = ctx.sheet_data[ctx.baseline_row_idx][col_idx].strip()
         baselines[pid] = utils._clock_to_seconds(value) or 0
 
-    return jsonify({"ok": True, "baselines": baselines})
+    return ok(baselines=baselines)
 
 
 def _clean_convergence_offsets(raw: object) -> dict[str, dict[str, float]]:
@@ -873,7 +874,7 @@ def api_convergence_offsets_get() -> FlaskResponse:
         config.CONVERGENCE_OFFSETS_FILENAME, default={"offsets": {}}
     )
     raw = data.get("offsets") if isinstance(data, dict) else None
-    return jsonify({"ok": True, "offsets": _clean_convergence_offsets(raw)})
+    return ok(offsets=_clean_convergence_offsets(raw))
 
 
 @studio_bp.route("/api/convergence/offsets", methods=["PUT"])
@@ -888,7 +889,7 @@ def api_convergence_offsets_put() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     raw = data.get("offsets")
     if not isinstance(raw, dict):
-        return jsonify({"ok": False, "error": "Invalid offsets payload"}), 400
+        return err("Invalid offsets payload")
 
     cleaned = _clean_convergence_offsets(raw)
 
@@ -906,24 +907,19 @@ def api_convergence_offsets_put() -> FlaskResponse:
             config.CONVERGENCE_OFFSETS_FILENAME, {"offsets": cleaned}
         )
 
-    return jsonify({"ok": True, "offsets": cleaned})
+    return ok(offsets=cleaned)
 
 
 @studio_bp.route("/api/sheet/refresh", methods=["POST"])
 def api_sheet_refresh() -> FlaskResponse:
     global _sheet_context
     if _worksheet is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No spreadsheet loaded — pick one from the Start panel.",
-            }
-        ), 400
+        return err("No spreadsheet loaded — pick one from the Start panel.")
     new_context = spreadsheet.build_sheet_context(_worksheet)
     if new_context is None:
-        return jsonify({"ok": False, "error": "Failed to refresh sheet data"}), 500
+        return err("Failed to refresh sheet data", 500)
     _sheet_context = new_context
-    return jsonify({"ok": True})
+    return ok()
 
 
 def _save_manifest_quiet() -> None:
@@ -1411,12 +1407,7 @@ def _apply_time_overrides(clips: list[Any], overrides: dict[str, Any]) -> None:
 @studio_bp.route("/api/generate", methods=["POST"])
 def api_generate() -> FlaskResponse:
     if _worksheet is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No spreadsheet loaded — pick one from the Start panel.",
-            }
-        ), 400
+        return err("No spreadsheet loaded — pick one from the Start panel.")
 
     data = request.get_json(silent=True) or {}
     cell_strings = data.get("cells", [])
@@ -1425,24 +1416,20 @@ def api_generate() -> FlaskResponse:
     titlecards_enabled, titlecard_duration_seconds = _parse_titlecard_request(data)
 
     if not cell_strings:
-        return jsonify({"ok": False, "error": "No cells specified"}), 400
+        return err("No cells specified")
 
     if output_format not in ("clip", "screen", "gif"):
-        return jsonify({"ok": False, "error": f"Invalid format: {output_format}"}), 400
+        return err(f"Invalid format: {output_format}")
 
     if not _try_claim_busy("generate"):
-        return jsonify(
-            {"ok": False, "error": "A clip generation is already in progress"}
-        ), 409
+        return err("A clip generation is already in progress", 409)
 
     try:
         cell_input = ", ".join(cell_strings)
         cell_specs = spreadsheet.parse_cell_specifications(cell_input)
         if not cell_specs:
             _release_busy("generate")
-            return jsonify(
-                {"ok": False, "error": "Could not parse cell specifications"}
-            ), 400
+            return err("Could not parse cell specifications")
 
         clips = spreadsheet.generate_list(
             _worksheet,
@@ -1454,7 +1441,7 @@ def api_generate() -> FlaskResponse:
         _apply_time_overrides(clips, overrides)
     except Exception as e:
         _release_busy("generate")
-        return jsonify({"ok": False, "error": str(e)}), 500
+        return err(str(e), 500)
 
     def stream() -> Any:
         _generate_cancel_event.clear()
@@ -1666,12 +1653,7 @@ def api_generate() -> FlaskResponse:
 @studio_bp.route("/api/highlights-preview", methods=["POST"])
 def api_highlights_preview() -> FlaskResponse:
     if _worksheet is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No spreadsheet loaded — pick one from the Start panel.",
-            }
-        ), 400
+        return err("No spreadsheet loaded — pick one from the Start panel.")
 
     data = request.get_json(silent=True) or {}
     highlights_duration = data.get("highlights_duration")
@@ -1695,9 +1677,7 @@ def api_highlights_preview() -> FlaskResponse:
         )
 
     if not clips:
-        return jsonify(
-            {"ok": False, "error": "No clips found for highlights selection"}
-        ), 400
+        return err("No clips found for highlights selection")
 
     result = []
     for clip in clips:
@@ -1711,18 +1691,13 @@ def api_highlights_preview() -> FlaskResponse:
             }
         )
 
-    return jsonify({"ok": True, "clips": result})
+    return ok(clips=result)
 
 
 @studio_bp.route("/api/reel", methods=["POST"])
 def api_reel() -> FlaskResponse:
     if _worksheet is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No spreadsheet loaded — pick one from the Start panel.",
-            }
-        ), 400
+        return err("No spreadsheet loaded — pick one from the Start panel.")
 
     data = request.get_json(silent=True) or {}
     cell_strings = data.get("cells", [])
@@ -1731,7 +1706,7 @@ def api_reel() -> FlaskResponse:
     titlecards_enabled, titlecard_duration_seconds = _parse_titlecard_request(data)
 
     if not cell_strings:
-        return jsonify({"ok": False, "error": "No cells specified"}), 400
+        return err("No cells specified")
 
     highlights_overrides: dict[str, Any] = {}
     if highlights_duration is not None:
@@ -1743,9 +1718,7 @@ def api_reel() -> FlaskResponse:
             pass
 
     if not _try_claim_busy("reel"):
-        return jsonify(
-            {"ok": False, "error": "A reel build is already in progress"}
-        ), 409
+        return err("A reel build is already in progress", 409)
 
     def stream() -> Any:
         # _stream_process_reel's worker takes ownership of the busy slot once
@@ -1863,12 +1836,7 @@ def api_viewer() -> FlaskResponse:
     with _generated_output_lock:
         artifacts = list(_generated_artifacts)
     if not artifacts:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No artifacts to build viewer from. Generate artifacts first.",
-            }
-        ), 400
+        return err("No artifacts to build viewer from. Generate artifacts first.")
 
     try:
         study = artifacts[0].get("study", "")
@@ -1883,11 +1851,11 @@ def api_viewer() -> FlaskResponse:
         )
         viewer_path = viewer.generate_timeline_viewer(data)
         if viewer_path:
-            return jsonify({"ok": True, "file": str(viewer_path)})
-        return jsonify({"ok": False, "error": "Failed to generate viewer"}), 500
+            return ok(file=str(viewer_path))
+        return err("Failed to generate viewer", 500)
 
     except Exception as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
+        return err(str(e), 500)
 
 
 def _discard_artifact_files(artifacts: list[dict[str, Any]]) -> None:
@@ -1907,17 +1875,10 @@ def _discard_artifact_files(artifacts: list[dict[str, Any]]) -> None:
 @studio_bp.route("/api/timeline-viewer", methods=["POST"])
 def api_timeline_viewer() -> FlaskResponse:
     if _worksheet is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No spreadsheet loaded — pick one from the Start panel.",
-            }
-        ), 400
+        return err("No spreadsheet loaded — pick one from the Start panel.")
 
     if not _try_claim_busy("timeline_viewer"):
-        return jsonify(
-            {"ok": False, "error": "A timeline viewer build is already in progress."}
-        ), 409
+        return err("A timeline viewer build is already in progress.", 409)
 
     try:
         _timeline_viewer_cancel_event.clear()
@@ -1929,7 +1890,7 @@ def api_timeline_viewer() -> FlaskResponse:
             _worksheet, "batch", ctx=_sheet_context, skip_prompts=True
         )
         if not clips_list:
-            return jsonify({"ok": False, "error": "No clips found in sheet"}), 400
+            return err("No clips found in sheet")
 
         generated, artifacts = pipeline.process_clips(
             clips_list,
@@ -1940,7 +1901,7 @@ def api_timeline_viewer() -> FlaskResponse:
             _discard_artifact_files(artifacts)
             return jsonify({"ok": False, "cancelled": True})
         if not artifacts:
-            return jsonify({"ok": False, "error": "No artifacts were generated"}), 400
+            return err("No artifacts were generated")
 
         # Generate intake clips if requested. Accumulate (but don't publish)
         # alongside the sheet clips so a cancel anywhere below discards them all.
@@ -1982,19 +1943,14 @@ def api_timeline_viewer() -> FlaskResponse:
         )
         if viewer_path:
             _save_manifest_quiet()
-            return jsonify(
-                {
-                    "ok": True,
-                    "file": str(viewer_path),
-                    "generated": generated + len(intake_artifacts),
-                }
+            return ok(
+                file=str(viewer_path),
+                generated=generated + len(intake_artifacts),
             )
-        return jsonify(
-            {"ok": False, "error": "Failed to generate timeline viewer"}
-        ), 500
+        return err("Failed to generate timeline viewer", 500)
 
     except Exception as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
+        return err(str(e), 500)
     finally:
         _release_busy("timeline_viewer")
 
@@ -2002,12 +1958,7 @@ def api_timeline_viewer() -> FlaskResponse:
 @studio_bp.route("/api/gallery", methods=["POST"])
 def api_gallery() -> FlaskResponse:
     if _sheet_context is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No spreadsheet loaded — pick one from the Start panel.",
-            }
-        ), 400
+        return err("No spreadsheet loaded — pick one from the Start panel.")
 
     data = request.get_json(silent=True) or {}
     participant = data.get("participant", "")
@@ -2016,15 +1967,13 @@ def api_gallery() -> FlaskResponse:
     bundle = bool(data.get("bundle", config.GALLERY_BUNDLE_ENABLED))
 
     if not participant:
-        return jsonify({"ok": False, "error": "No participant specified"}), 400
+        return err("No participant specified")
 
     if output_format not in ("screen", "gif"):
-        return jsonify({"ok": False, "error": f"Invalid format: {output_format}"}), 400
+        return err(f"Invalid format: {output_format}")
 
     if not _try_claim_busy("gallery"):
-        return jsonify(
-            {"ok": False, "error": "A gallery build is already in progress."}
-        ), 409
+        return err("A gallery build is already in progress.", 409)
 
     try:
         try:
@@ -2036,9 +1985,7 @@ def api_gallery() -> FlaskResponse:
 
         sources = _resolve_participant_sources(participant)
         if not sources or not sources[0].is_file():
-            return jsonify(
-                {"ok": False, "error": f"Source video not found for {participant}"}
-            ), 404
+            return err(f"Source video not found for {participant}", 404)
 
         _gallery_cancel_event.clear()
         # Multi-video participants form one continuous timeline: capture each part
@@ -2087,7 +2034,7 @@ def api_gallery() -> FlaskResponse:
             _discard_artifact_files(artifacts)
             return jsonify({"ok": False, "cancelled": True})
         if not artifacts:
-            return jsonify({"ok": False, "error": "No captures generated"}), 500
+            return err("No captures generated", 500)
 
         gallery_data = viewer.finalize_gallery_data(
             artifacts,
@@ -2105,11 +2052,11 @@ def api_gallery() -> FlaskResponse:
             return jsonify({"ok": False, "cancelled": True})
         gallery_path = viewer.generate_gallery_viewer(gallery_data)
         if gallery_path:
-            return jsonify({"ok": True, "file": str(gallery_path)})
-        return jsonify({"ok": False, "error": "Failed to generate gallery viewer"}), 500
+            return ok(file=str(gallery_path))
+        return err("Failed to generate gallery viewer", 500)
 
     except Exception as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
+        return err(str(e), 500)
     finally:
         _release_busy("gallery")
 
@@ -2120,26 +2067,26 @@ def api_open_viewer() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     file_path = data.get("file", "")
     if not file_path:
-        return jsonify({"ok": False, "error": "No file specified"}), 400
+        return err("No file specified")
 
     p = Path(file_path).resolve()
     output_dir = Path(utils.get_effective_output_dir()).resolve()
 
     if p.suffix != ".html" or not p.is_relative_to(output_dir):
-        return jsonify({"ok": False, "error": "Invalid file path"}), 403
+        return err("Invalid file path", 403)
 
     if not p.is_file():
-        return jsonify({"ok": False, "error": "File not found"}), 404
+        return err("File not found", 404)
 
     webbrowser.open(p.as_uri())
-    return jsonify({"ok": True})
+    return ok()
 
 
 @studio_bp.route("/api/manifest", methods=["GET", "POST"])
 def api_manifest() -> FlaskResponse:
     if request.method == "GET":
         artifacts, reels = viewer._load_manifest_both()
-        return jsonify({"ok": True, "artifacts": artifacts, "reels": reels})
+        return ok(artifacts=artifacts, reels=reels)
 
     # Snapshot the shared lists so a worker thread extending mid-export
     # can't produce a partial/aliased manifest snapshot.
@@ -2147,12 +2094,7 @@ def api_manifest() -> FlaskResponse:
         artifacts = list(_generated_artifacts)
         reels = list(_generated_reels)
     if not artifacts and not reels:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "No artifacts to export. Generate artifacts first.",
-            }
-        ), 400
+        return err("No artifacts to export. Generate artifacts first.")
 
     try:
         study = ""
@@ -2170,11 +2112,11 @@ def api_manifest() -> FlaskResponse:
             mode="studio",
         )
         if manifest_path:
-            return jsonify({"ok": True, "file": str(manifest_path)})
-        return jsonify({"ok": False, "error": "Failed to write manifest"}), 500
+            return ok(file=str(manifest_path))
+        return err("Failed to write manifest", 500)
 
     except Exception as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
+        return err(str(e), 500)
 
 
 @studio_bp.route("/api/regenerate", methods=["POST"])
@@ -2182,22 +2124,17 @@ def api_regenerate() -> FlaskResponse:
     try:
         artifacts, reels = viewer._load_manifest_both()
         if not artifacts and not reels:
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": "No manifest found on disk. Export a manifest first.",
-                }
-            ), 400
+            return err("No manifest found on disk. Export a manifest first.")
 
         media_count = sum(1 for a in artifacts if a.get("type") != "transcript")
         reel_count = len(reels)
         total = media_count + reel_count
 
         regenerated = pipeline.regenerate_from_manifest(artifacts, reels=reels)
-        return jsonify({"ok": True, "regenerated": regenerated, "total": total})
+        return ok(regenerated=regenerated, total=total)
 
     except Exception as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
+        return err(str(e), 500)
 
 
 def _handle_stash_crud(load_fn: Any, save_fn: Any, id_prefix: str) -> FlaskResponse:
@@ -2217,7 +2154,7 @@ def _handle_stash_crud(load_fn: Any, save_fn: Any, id_prefix: str) -> FlaskRespo
         if action == "create":
             items = data.get("items", [])
             if not items:
-                return jsonify({"ok": False, "error": "No items to stash"}), 400
+                return err("No items to stash")
             name = data.get("name", "")
             total_duration = data.get("totalDuration") or sum(
                 item.get("segDuration", 0) for item in items
@@ -2232,38 +2169,38 @@ def _handle_stash_crud(load_fn: Any, save_fn: Any, id_prefix: str) -> FlaskRespo
             }
             stashes.append(stash)
             save_fn(stashes)
-            return jsonify({"ok": True, "stash": stash})
+            return ok(stash=stash)
 
         if action == "update":
             stash_id = data.get("id")
             if not stash_id:
-                return jsonify({"ok": False, "error": "No stash ID"}), 400
+                return err("No stash ID")
             for s in stashes:
                 if s["id"] == stash_id:
                     name = data.get("name")
                     if name is not None:
                         s["name"] = name
                     save_fn(stashes)
-                    return jsonify({"ok": True, "stash": s})
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+                    return ok(stash=s)
+            return err("Stash not found", 404)
 
         if action == "delete":
             stash_id = data.get("id")
             if not stash_id:
-                return jsonify({"ok": False, "error": "No stash ID"}), 400
+                return err("No stash ID")
             for i, s in enumerate(stashes):
                 if s["id"] == stash_id:
                     stashes.pop(i)
                     save_fn(stashes)
-                    return jsonify({"ok": True})
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+                    return ok()
+            return err("Stash not found", 404)
 
-        return jsonify({"ok": False, "error": f"Unknown action: {action}"}), 400
+        return err(f"Unknown action: {action}")
 
 
 @studio_bp.route("/api/stashes", methods=["GET"])
 def api_stashes_get() -> FlaskResponse:
-    return jsonify({"ok": True, "stashes": _load_stashes()})
+    return ok(stashes=_load_stashes())
 
 
 @studio_bp.route("/api/stashes", methods=["POST"])
@@ -2273,7 +2210,7 @@ def api_stashes_post() -> FlaskResponse:
 
 @studio_bp.route("/api/artifact-stashes", methods=["GET"])
 def api_artifact_stashes_get() -> FlaskResponse:
-    return jsonify({"ok": True, "stashes": _load_artifact_stashes()})
+    return ok(stashes=_load_artifact_stashes())
 
 
 @studio_bp.route("/api/artifact-stashes", methods=["POST"])
@@ -2484,7 +2421,7 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
 
 @studio_bp.route("/api/settings", methods=["GET"])
 def api_settings_get() -> FlaskResponse:
-    return jsonify({"ok": True, "settings": _settings_records()})
+    return ok(settings=_settings_records())
 
 
 @studio_bp.route("/api/settings", methods=["PUT"])
@@ -2492,8 +2429,8 @@ def api_settings_put() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     applied, error = _apply_settings_payload(data)
     if error is not None:
-        return jsonify({"ok": False, "error": error}), 400
-    return jsonify({"ok": True, "applied": applied})
+        return err(error)
+    return ok(applied=applied)
 
 
 # ── Titlecard / endcard background picker ────────────────────────────────
@@ -2598,12 +2535,9 @@ def _card_picker_payload(kind: str) -> dict[str, Any]:
 @studio_bp.route("/api/titlecards", methods=["GET"])
 def api_titlecards_list() -> FlaskResponse:
     """List background choices (default, color, none, uploads) for both cards."""
-    return jsonify(
-        {
-            "ok": True,
-            "title": _card_picker_payload("title"),
-            "end": _card_picker_payload("end"),
-        }
+    return ok(
+        title=_card_picker_payload("title"),
+        end=_card_picker_payload("end"),
     )
 
 
@@ -2611,11 +2545,11 @@ def api_titlecards_list() -> FlaskResponse:
 def api_titlecard_default(kind: str) -> FlaskResponse:
     """Serve the bundled default titlecard/endcard image for previews."""
     if kind not in ("title", "end"):
-        return jsonify({"ok": False, "error": "Invalid kind"}), 400
+        return err("Invalid kind")
     asset = "titlecard.png" if kind == "title" else "endcard.png"
     path = utils.get_bundled_assets_root() / "assets" / asset
     if not path.is_file():
-        return jsonify({"ok": False, "error": "No default image"}), 404
+        return err("No default image", 404)
     return send_file(str(path))
 
 
@@ -2624,9 +2558,9 @@ def api_titlecard_image(name: str) -> FlaskResponse:
     """Serve an uploaded card background by filename (used for previews)."""
     safe = Path(name).name
     if safe != name or Path(safe).suffix.lower() not in _ALLOWED_CARD_EXTS:
-        return jsonify({"ok": False, "error": "Invalid filename"}), 400
+        return err("Invalid filename")
     if not (_titlecard_images_dir() / safe).is_file():
-        return jsonify({"ok": False, "error": "Not found"}), 404
+        return err("Not found", 404)
     return send_from_directory(str(_titlecard_images_dir()), safe)
 
 
@@ -2636,20 +2570,15 @@ def api_titlecard_upload() -> FlaskResponse:
     file = request.files.get("file")
     filename = file.filename if file is not None else None
     if file is None or not filename:
-        return jsonify({"ok": False, "error": "No file provided"}), 400
+        return err("No file provided")
     ext = Path(filename).suffix.lower()
     if ext not in _ALLOWED_CARD_EXTS:
-        return jsonify(
-            {
-                "ok": False,
-                "error": f"Unsupported file type '{ext}'. Use PNG, JPG, or WebP.",
-            }
-        ), 400
+        return err(f"Unsupported file type '{ext}'. Use PNG, JPG, or WebP.")
     file.seek(0, os.SEEK_END)
     size = file.tell()
     file.seek(0)
     if size > _MAX_CARD_UPLOAD_BYTES:
-        return jsonify({"ok": False, "error": "File too large (max 10 MB)."}), 400
+        return err("File too large (max 10 MB).")
 
     # sanitize_filename strips the dot from extensions, so clean the stem only,
     # then replace URL-reserved chars so the served image URL isn't truncated.
@@ -2667,18 +2596,15 @@ def api_titlecard_upload() -> FlaskResponse:
     try:
         file.save(str(images_dir / candidate))
     except OSError as error:
-        return jsonify({"ok": False, "error": str(error)}), 500
-    return jsonify(
-        {
-            "ok": True,
-            "item": {
-                "id": candidate,
-                "label": candidate,
-                "kind": "upload",
-                "url": f"/api/titlecards/image/{candidate}",
-                "deletable": True,
-            },
-        }
+        return err(str(error), 500)
+    return ok(
+        item={
+            "id": candidate,
+            "label": candidate,
+            "kind": "upload",
+            "url": f"/api/titlecards/image/{candidate}",
+            "deletable": True,
+        },
     )
 
 
@@ -2687,14 +2613,14 @@ def api_titlecard_delete(name: str) -> FlaskResponse:
     """Delete an uploaded card background; reset any selection that used it."""
     safe = Path(name).name
     if safe != name:
-        return jsonify({"ok": False, "error": "Invalid filename"}), 400
+        return err("Invalid filename")
     target = _titlecard_images_dir() / safe
     if not target.is_file():
-        return jsonify({"ok": False, "error": "Not found"}), 404
+        return err("Not found", 404)
     try:
         target.unlink()
     except OSError as error:
-        return jsonify({"ok": False, "error": str(error)}), 500
+        return err(str(error), 500)
     reset: dict[str, str] = {}
     for setting in ("TITLECARD_IMAGE", "ENDCARD_IMAGE"):
         if getattr(config, setting, "") == safe:
@@ -2703,7 +2629,7 @@ def api_titlecard_delete(name: str) -> FlaskResponse:
     if reset:
         merged = {n: getattr(config, n) for n in config.STUDIO_SETTINGS.keys()}
         _save_studio_settings(merged)
-    return jsonify({"ok": True, "reset": reset})
+    return ok(reset=reset)
 
 
 # ---- Screenspace Intake ----
@@ -2720,7 +2646,7 @@ def api_generate_intake() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     items = data.get("items", [])
     if not items:
-        return jsonify({"ok": False, "error": "No intake items specified"}), 400
+        return err("No intake items specified")
 
     output_format = data.get("format", "clip")
     study = _sheet_context.study_name if _sheet_context else ""
@@ -2825,12 +2751,10 @@ def api_reel_direct() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     segments = data.get("segments", [])
     if not segments:
-        return jsonify({"ok": False, "error": "No segments specified"}), 400
+        return err("No segments specified")
 
     if not _try_claim_busy("reel"):
-        return jsonify(
-            {"ok": False, "error": "A reel build is already in progress"}
-        ), 409
+        return err("A reel build is already in progress", 409)
 
     _reel_cancel_event.clear()
     _reset_reel_job_state("reel-direct")
@@ -3065,25 +2989,22 @@ def api_job_status() -> FlaskResponse:
         reel_snapshot = dict(_reel_job_state)
         generate_snapshot = dict(_generate_job_state)
         intake_snapshot = dict(_intake_job_state)
-    return jsonify(
-        {
-            "ok": True,
-            "reel": {
-                "in_progress": reel_busy,
-                "cancelling": reel_busy and _reel_cancel_event.is_set(),
-                **reel_snapshot,
-            },
-            "generate": {
-                "in_progress": generate_busy,
-                "cancelling": generate_busy and _generate_cancel_event.is_set(),
-                **generate_snapshot,
-            },
-            "intake": {
-                "in_progress": intake_busy,
-                "cancelling": intake_busy and _intake_cancel_event.is_set(),
-                **intake_snapshot,
-            },
-        }
+    return ok(
+        reel={
+            "in_progress": reel_busy,
+            "cancelling": reel_busy and _reel_cancel_event.is_set(),
+            **reel_snapshot,
+        },
+        generate={
+            "in_progress": generate_busy,
+            "cancelling": generate_busy and _generate_cancel_event.is_set(),
+            **generate_snapshot,
+        },
+        intake={
+            "in_progress": intake_busy,
+            "cancelling": intake_busy and _intake_cancel_event.is_set(),
+            **intake_snapshot,
+        },
     )
 
 
@@ -3091,14 +3012,14 @@ def api_job_status() -> FlaskResponse:
 def api_reel_cancel() -> FlaskResponse:
     """Signal cancellation for the in-progress reel build."""
     _reel_cancel_event.set()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @studio_bp.route("/api/generate/cancel", methods=["POST"])
 def api_generate_cancel() -> FlaskResponse:
     """Signal cancellation for the in-progress clip generation."""
     _generate_cancel_event.set()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @studio_bp.route("/api/generate-intake/cancel", methods=["POST"])
@@ -3110,21 +3031,21 @@ def api_generate_intake_cancel() -> FlaskResponse:
     endpoints to stop the full set of in-flight ffmpeg subprocesses.
     """
     _intake_cancel_event.set()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @studio_bp.route("/api/timeline-viewer/cancel", methods=["POST"])
 def api_timeline_viewer_cancel() -> FlaskResponse:
     """Signal cancellation for the in-progress timeline-viewer build."""
     _timeline_viewer_cancel_event.set()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @studio_bp.route("/api/gallery/cancel", methods=["POST"])
 def api_gallery_cancel() -> FlaskResponse:
     """Signal cancellation for the in-progress gallery build."""
     _gallery_cancel_event.set()
-    return jsonify({"ok": True})
+    return ok()
 
 
 # ---- State initialization ----
@@ -3391,13 +3312,10 @@ def build_combined_app(
         output_dir = Path(utils.get_effective_output_dir())
         screenspace = (output_dir / config.SCREENSPACE_MANIFEST_FILENAME).is_file()
         transcripts = (output_dir / config.TRANSCRIPTS_MANIFEST_FILENAME).is_file()
-        return jsonify(
-            {
-                "ok": True,
-                "screenspace": screenspace,
-                "transcripts": transcripts,
-                "any": screenspace or transcripts,
-            }
+        return ok(
+            screenspace=screenspace,
+            transcripts=transcripts,
+            any=screenspace or transcripts,
         )
 
     @combined.route("/api/export", methods=["POST"])
@@ -3408,25 +3326,18 @@ def build_combined_app(
         output_dir = Path(utils.get_effective_output_dir())
         try:
             written = data_export.write_export_bundle(output_dir)
-        except Exception as err:
-            return jsonify({"ok": False, "error": str(err)}), 500
+        except Exception as exc:
+            return err(str(exc), 500)
         if not written:
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": (
-                        "No manifests in output directory. Expected one of "
-                        f"{config.SCREENSPACE_MANIFEST_FILENAME} or "
-                        f"{config.TRANSCRIPTS_MANIFEST_FILENAME}."
-                    ),
-                }
-            ), 404
-        return jsonify(
-            {
-                "ok": True,
-                "written": [p.name for p in written],
-                "output_dir": str(output_dir),
-            }
+            return err(
+                "No manifests in output directory. Expected one of "
+                f"{config.SCREENSPACE_MANIFEST_FILENAME} or "
+                f"{config.TRANSCRIPTS_MANIFEST_FILENAME}.",
+                404,
+            )
+        return ok(
+            written=[p.name for p in written],
+            output_dir=str(output_dir),
         )
 
     # ---- Start overlay: directories, spreadsheet picker, persistence ----
@@ -3436,14 +3347,11 @@ def build_combined_app(
         import start_settings
 
         s = start_settings.load_start_settings()
-        return jsonify(
-            {
-                "ok": True,
-                "input": str(utils.get_effective_input_dir()),
-                "output": str(utils.get_effective_output_dir()),
-                "recent_inputs": s.get("recent_inputs", []),
-                "recent_outputs": s.get("recent_outputs", []),
-            }
+        return ok(
+            input=str(utils.get_effective_input_dir()),
+            output=str(utils.get_effective_output_dir()),
+            recent_inputs=s.get("recent_inputs", []),
+            recent_outputs=s.get("recent_outputs", []),
         )
 
     @combined.route("/api/dirs", methods=["POST"])
@@ -3486,51 +3394,42 @@ def build_combined_app(
                 if p.name.startswith("~$"):
                     continue
                 files_list.append({"path": str(p), "name": p.name})
-        return jsonify({"ok": True, "input_dir": str(input_dir), "files": files_list})
+        return ok(input_dir=str(input_dir), files=files_list)
 
     @combined.route("/api/spreadsheets/google", methods=["GET"])
     def api_spreadsheets_google() -> Response:
         if _google_auth.client is None:
-            return jsonify(
-                {
-                    "ok": True,
-                    "authenticated": False,
-                    "auth_in_flight": _google_auth.in_flight,
-                    "auth_error": _google_auth.error,
-                    "sheets": [],
-                }
+            return ok(
+                authenticated=False,
+                auth_in_flight=_google_auth.in_flight,
+                auth_error=_google_auth.error,
+                sheets=[],
             )
         import google_api
 
         try:
             names = google_api.get_all_spreadsheets(_google_auth.client)
         except Exception as exc:
-            return jsonify(
-                {
-                    "ok": True,
-                    "authenticated": True,
-                    "auth_in_flight": False,
-                    "auth_error": str(exc),
-                    "sheets": [],
-                }
+            return ok(
+                authenticated=True,
+                auth_in_flight=False,
+                auth_error=str(exc),
+                sheets=[],
             )
-        return jsonify(
-            {
-                "ok": True,
-                "authenticated": True,
-                "auth_in_flight": False,
-                "auth_error": "",
-                "sheets": [{"name": n, "id": n} for n in names],
-            }
+        return ok(
+            authenticated=True,
+            auth_in_flight=False,
+            auth_error="",
+            sheets=[{"name": n, "id": n} for n in names],
         )
 
     @combined.route("/api/spreadsheets/google/auth", methods=["POST"])
     def api_spreadsheets_google_auth() -> FlaskResponse:
         with _google_auth.lock:
             if _google_auth.in_flight:
-                return jsonify({"ok": True, "started": False, "in_flight": True})
+                return ok(started=False, in_flight=True)
             if _google_auth.client is not None:
-                return jsonify({"ok": True, "started": False, "authenticated": True})
+                return ok(started=False, authenticated=True)
             _google_auth.in_flight = True
             _google_auth.error = ""
 
@@ -3564,23 +3463,14 @@ def build_combined_app(
         type_ = data.get("type", "")
         id_or_path = (data.get("id_or_path") or "").strip()
         if type_ not in ("google", "excel") or not id_or_path:
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": "Required: type ('google'|'excel') and id_or_path",
-                }
-            ), 400
+            return err("Required: type ('google'|'excel') and id_or_path")
 
         if _generation_busy():
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": (
-                        "Generation is in progress — wait for it to finish "
-                        "before switching spreadsheets."
-                    ),
-                }
-            ), 409
+            return err(
+                "Generation is in progress — wait for it to finish "
+                "before switching spreadsheets.",
+                409,
+            )
 
         new_ws: Any = None
         label = ""
@@ -3592,15 +3482,9 @@ def build_combined_app(
                 label = Path(id_or_path).name
             else:
                 if _google_auth.client is None:
-                    return jsonify(
-                        {
-                            "ok": False,
-                            "error": (
-                                "Not authenticated with Google — "
-                                "click 'Connect Google' first."
-                            ),
-                        }
-                    ), 400
+                    return err(
+                        "Not authenticated with Google — click 'Connect Google' first."
+                    )
                 import clipgen as _clipgen
                 import google_api
 
@@ -3619,16 +3503,14 @@ def build_combined_app(
                     parent = getattr(new_ws, "spreadsheet", None)
                     label = getattr(parent, "title", "") or id_or_path
         except Exception as exc:
-            return jsonify({"ok": False, "error": str(exc)}), 500
+            return err(str(exc), 500)
 
         if new_ws is None:
-            return jsonify({"ok": False, "error": "Could not open spreadsheet"}), 404
+            return err("Could not open spreadsheet", 404)
 
         _swap_worksheet(new_ws)
         if _sheet_context is None:
-            return jsonify(
-                {"ok": False, "error": "Could not parse the spreadsheet"}
-            ), 500
+            return err("Could not parse the spreadsheet", 500)
 
         start_settings.record_recent_spreadsheet(type_, id_or_path, label)
         start_settings.record_project_session(
@@ -3642,27 +3524,19 @@ def build_combined_app(
             "id_or_path": id_or_path,
             "label": label,
         }
-        return jsonify(
-            {
-                "ok": True,
-                "sheet_loaded": True,
-                "spreadsheet_label": _spreadsheet_label(),
-            }
+        return ok(
+            sheet_loaded=True,
+            spreadsheet_label=_spreadsheet_label(),
         )
 
     @combined.route("/api/spreadsheets/close", methods=["POST"])
     def api_spreadsheets_close() -> FlaskResponse:
         global _active_sheet_meta
         if _generation_busy():
-            return jsonify(
-                {
-                    "ok": False,
-                    "error": "Generation is in progress — wait for it to finish.",
-                }
-            ), 409
+            return err("Generation is in progress — wait for it to finish.", 409)
         _swap_worksheet(None)
         _active_sheet_meta = None
-        return jsonify({"ok": True, "sheet_loaded": False})
+        return ok(sheet_loaded=False)
 
     @combined.route("/api/folder-picker", methods=["POST"])
     def api_folder_picker() -> Response:
@@ -3675,7 +3549,7 @@ def build_combined_app(
         data = request.get_json(silent=True) or {}
         initial = (data.get("initial") or "").strip()
         path = utils.open_native_folder_picker(initial)
-        return jsonify({"ok": True, "path": path})
+        return ok(path=path)
 
     @combined.route("/api/sessions/record", methods=["POST"])
     def api_sessions_record() -> FlaskResponse:
@@ -3691,9 +3565,9 @@ def build_combined_app(
         input_raw = data.get("input")
         output_raw = data.get("output")
         if input_raw is not None and not isinstance(input_raw, str):
-            return jsonify({"ok": False, "error": "input must be a string"}), 400
+            return err("input must be a string")
         if output_raw is not None and not isinstance(output_raw, str):
-            return jsonify({"ok": False, "error": "output must be a string"}), 400
+            return err("output must be a string")
         input_dir = (input_raw or "").strip()
         output_dir = (output_raw or "").strip()
 
@@ -3701,23 +3575,14 @@ def build_combined_app(
         spreadsheet_dict: dict[str, Any] | None = None
         if spreadsheet_payload is not None:
             if not isinstance(spreadsheet_payload, dict):
-                return jsonify(
-                    {"ok": False, "error": "spreadsheet must be an object or null"}
-                ), 400
+                return err("spreadsheet must be an object or null")
             ss_type = (spreadsheet_payload.get("type") or "").strip()
             ss_id = (spreadsheet_payload.get("id_or_path") or "").strip()
             ss_label = (spreadsheet_payload.get("label") or "").strip()
             if ss_type not in ("google", "excel"):
-                return jsonify(
-                    {
-                        "ok": False,
-                        "error": "spreadsheet.type must be 'google' or 'excel'",
-                    }
-                ), 400
+                return err("spreadsheet.type must be 'google' or 'excel'")
             if not ss_id:
-                return jsonify(
-                    {"ok": False, "error": "spreadsheet.id_or_path is required"}
-                ), 400
+                return err("spreadsheet.id_or_path is required")
             spreadsheet_dict = {
                 "type": ss_type,
                 "id_or_path": ss_id,
@@ -3728,19 +3593,19 @@ def build_combined_app(
             output_dir or str(utils.get_effective_output_dir()),
             spreadsheet_dict,
         )
-        return jsonify({"ok": True})
+        return ok()
 
     @combined.route("/api/changelog")
     def api_changelog() -> Response:
         import changelog
 
-        return jsonify({"ok": True, "entries": changelog.load_entries()})
+        return ok(entries=changelog.load_entries())
 
     @combined.route("/api/start-settings", methods=["GET"])
     def api_start_settings_get() -> Response:
         import start_settings
 
-        return jsonify({"ok": True, "settings": start_settings.load_start_settings()})
+        return ok(settings=start_settings.load_start_settings())
 
     @combined.route("/api/start-settings", methods=["POST"])
     def api_start_settings_post() -> FlaskResponse:
@@ -3749,21 +3614,21 @@ def build_combined_app(
         data = request.get_json(silent=True) or {}
         if "persist_enabled" in data:
             start_settings.set_persist_enabled(bool(data["persist_enabled"]))
-        return jsonify({"ok": True, "settings": start_settings.load_start_settings()})
+        return ok(settings=start_settings.load_start_settings())
 
     # ---- Shared settings (available from any page) ----
 
     @combined.route("/api/settings", methods=["GET"])
     def combined_settings_get() -> FlaskResponse:
-        return jsonify({"ok": True, "settings": _settings_records()})
+        return ok(settings=_settings_records())
 
     @combined.route("/api/settings", methods=["PUT"])
     def combined_settings_put() -> FlaskResponse:
         data = request.get_json(silent=True) or {}
         applied, error = _apply_settings_payload(data)
         if error is not None:
-            return jsonify({"ok": False, "error": error}), 400
-        return jsonify({"ok": True, "applied": applied})
+            return err(error)
+        return ok(applied=applied)
 
     # ---- Titlecard / endcard background picker (shared settings modal) ----
     combined.add_url_rule(
@@ -3840,17 +3705,14 @@ def build_combined_app(
                 }
             )
 
-        return jsonify(
-            {
-                "ok": True,
-                "whisper": {"models": whisper_models},
-                "ollama": {
-                    "available": ollama_available,
-                    "models": ollama_models,
-                    "agents": ollama_agents,
-                    "base_url": config.OLLAMA_BASE_URL,
-                },
-            }
+        return ok(
+            whisper={"models": whisper_models},
+            ollama={
+                "available": ollama_available,
+                "models": ollama_models,
+                "agents": ollama_agents,
+                "base_url": config.OLLAMA_BASE_URL,
+            },
         )
 
     return combined

--- a/server_utils.py
+++ b/server_utils.py
@@ -1,0 +1,99 @@
+"""Shared Flask helpers for the four server blueprints.
+
+All four server modules (``server``, ``screenspace_server``,
+``transcripts_server``, ``workflows_server``) return the same JSON envelope —
+``{"ok": True, ...}`` on success and ``{"ok": False, "error": msg}`` with an
+HTTP status on failure — and repeat the same numeric-arg parse-and-validate
+block dozens of times. This module collapses that scaffolding:
+
+- :func:`ok` / :func:`err` build the success / error envelope in one call.
+- :class:`ApiError` + :func:`json_endpoint` let a handler ``raise`` a uniform
+  400/4xx instead of threading an ``err(...)`` tuple back through every guard.
+- :func:`parse_number_arg` parses + bound-checks one numeric value, raising
+  :class:`ApiError` on bad input (caught by :func:`json_endpoint`).
+
+Kept deliberately tiny and Flask-only (no ``config``/``utils`` imports) so it
+stays import-clean — ``utils`` is Flask-free on purpose and imported by
+non-server modules, so these helpers must not live there.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import wraps
+from typing import Any, Callable
+
+from flask import jsonify
+
+
+def ok(**fields: Any):
+    """Success envelope: ``jsonify({"ok": True, **fields})``."""
+    return jsonify({"ok": True, **fields})
+
+
+def err(message: str, code: int = 400):
+    """Error envelope: ``(jsonify({"ok": False, "error": message}), code)``."""
+    return jsonify({"ok": False, "error": message}), code
+
+
+class ApiError(Exception):
+    """Raised inside a :func:`json_endpoint` handler to short-circuit to ``err``.
+
+    Carries the user-facing message and the HTTP status to emit. Handlers raise
+    it (directly or via :func:`parse_number_arg`) instead of returning an
+    ``err(...)`` tuple, so deeply-nested validation guards stay one-liners.
+    """
+
+    def __init__(self, message: str, code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def json_endpoint(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a route so a raised :class:`ApiError` becomes an ``err`` response.
+
+    Catches **only** ``ApiError`` — never bare ``Exception`` — so it never
+    swallows real 500s or interferes with routes that keep their own
+    try/except / resource cleanup. Pairs with :func:`parse_number_arg`.
+    """
+
+    @wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any):
+        try:
+            return fn(*args, **kwargs)
+        except ApiError as exc:
+            return err(exc.message, exc.code)
+
+    return wrapper
+
+
+def parse_number_arg(
+    raw: Any,
+    name: str,
+    *,
+    int_only: bool = False,
+    min_: float | None = None,
+    max_: float | None = None,
+    finite: bool = False,
+) -> Any:
+    """Parse + bound-check a single numeric value, raising ``ApiError`` on failure.
+
+    The caller passes the already-fetched raw value (``request.args.get(...)``,
+    a JSON-body ``dict.get(...)``, or a route param). Returns an ``int`` when
+    ``int_only`` else a ``float``. ``int_only`` parses via ``int(float(raw))`` so
+    ``"3.0"`` and ``3`` both work. Bounds are inclusive. ``finite`` rejects
+    ``inf``/``nan``. Every failure raises :class:`ApiError` (HTTP 400) with a
+    uniform message, caught by :func:`json_endpoint`.
+    """
+    try:
+        value: float = float(raw)
+    except (TypeError, ValueError):
+        raise ApiError(f"{name} must be a number")
+    if (finite or int_only) and not math.isfinite(value):
+        raise ApiError(f"{name} must be a finite number")
+    if min_ is not None and value < min_:
+        raise ApiError(f"{name} must be >= {min_}")
+    if max_ is not None and value > max_:
+        raise ApiError(f"{name} must be <= {max_}")
+    return int(value) if int_only else value

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -1,0 +1,137 @@
+"""Unit tests for the shared Flask response/parse helpers in server_utils.
+
+These back the LOC-reduction refactor of the four server blueprints: the
+helpers must preserve the exact ``{"ok": ...}`` envelope + status codes the
+blueprint tests assert on, and ``parse_number_arg`` must raise a uniform
+``ApiError`` that ``json_endpoint`` turns into a 400.
+"""
+
+import math
+
+import pytest
+
+Flask = pytest.importorskip("flask").Flask
+
+import server_utils  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    return Flask(__name__)
+
+
+def test_ok_envelope(app):
+    with app.app_context():
+        resp = server_utils.ok(pin=3, items=["a"])
+        body = resp.get_json()
+    assert body == {"ok": True, "pin": 3, "items": ["a"]}
+
+
+def test_ok_empty(app):
+    with app.app_context():
+        body = server_utils.ok().get_json()
+    assert body == {"ok": True}
+
+
+def test_err_default_code(app):
+    with app.app_context():
+        resp, code = server_utils.err("bad input")
+    assert code == 400
+    assert resp.get_json() == {"ok": False, "error": "bad input"}
+
+
+def test_err_custom_code(app):
+    with app.app_context():
+        resp, code = server_utils.err("missing", 404)
+    assert code == 404
+    assert resp.get_json() == {"ok": False, "error": "missing"}
+
+
+# ---- parse_number_arg ----
+
+
+def test_parse_float():
+    assert server_utils.parse_number_arg("1.5", "x") == 1.5
+
+
+def test_parse_int_only_from_float_string():
+    # int_only parses via int(float(...)) so "3.0" and "3" both work.
+    assert server_utils.parse_number_arg("3.0", "n", int_only=True) == 3
+    assert server_utils.parse_number_arg(3, "n", int_only=True) == 3
+    assert isinstance(server_utils.parse_number_arg("3.0", "n", int_only=True), int)
+
+
+def test_parse_bad_value_raises():
+    with pytest.raises(server_utils.ApiError) as ei:
+        server_utils.parse_number_arg("abc", "timestamp")
+    assert ei.value.code == 400
+    assert "timestamp must be a number" in ei.value.message
+
+
+def test_parse_none_raises():
+    with pytest.raises(server_utils.ApiError):
+        server_utils.parse_number_arg(None, "x")
+
+
+def test_parse_min_bound():
+    assert server_utils.parse_number_arg("0", "x", min_=0) == 0.0
+    with pytest.raises(server_utils.ApiError) as ei:
+        server_utils.parse_number_arg("-1", "x", min_=0)
+    assert "must be >= 0" in ei.value.message
+
+
+def test_parse_max_bound():
+    with pytest.raises(server_utils.ApiError) as ei:
+        server_utils.parse_number_arg("11", "x", max_=10)
+    assert "must be <= 10" in ei.value.message
+
+
+def test_parse_finite_rejects_inf():
+    with pytest.raises(server_utils.ApiError) as ei:
+        server_utils.parse_number_arg("inf", "x", finite=True)
+    assert "finite" in ei.value.message
+
+
+def test_parse_int_only_rejects_nan():
+    # int_only implies finite (int(nan) would raise anyway).
+    with pytest.raises(server_utils.ApiError):
+        server_utils.parse_number_arg("nan", "x", int_only=True)
+
+
+def test_parse_non_finite_allowed_without_flag():
+    # Without finite/int_only, inf passes through (matches lenient call sites).
+    assert math.isinf(server_utils.parse_number_arg("inf", "x"))
+
+
+# ---- json_endpoint ----
+
+
+def test_json_endpoint_catches_apierror(app):
+    @server_utils.json_endpoint
+    def handler():
+        raise server_utils.ApiError("nope", 422)
+
+    with app.app_context():
+        resp, code = handler()
+    assert code == 422
+    assert resp.get_json() == {"ok": False, "error": "nope"}
+
+
+def test_json_endpoint_passes_through_success(app):
+    @server_utils.json_endpoint
+    def handler():
+        return server_utils.ok(value=1)
+
+    with app.app_context():
+        body = handler().get_json()
+    assert body == {"ok": True, "value": 1}
+
+
+def test_json_endpoint_does_not_swallow_other_exceptions(app):
+    @server_utils.json_endpoint
+    def handler():
+        raise ValueError("real bug")
+
+    with app.app_context():
+        with pytest.raises(ValueError):
+            handler()

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -58,6 +58,7 @@ import thinking_agents
 import transcripts
 import utils
 import video
+from server_utils import err, ok
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -283,12 +284,9 @@ def api_participants() -> FlaskResponse:
                 break
         info["has_stale_artifacts"] = has_stale
 
-    return jsonify(
-        {
-            "ok": True,
-            "participants": result,
-            "transcribe_prewarm": _transcribe_prewarm_setting(),
-        }
+    return ok(
+        participants=result,
+        transcribe_prewarm=_transcribe_prewarm_setting(),
     )
 
 
@@ -343,7 +341,7 @@ def api_transcript(participant: str) -> FlaskResponse:
         src = _manifest.get("source_transcripts", {})
         entry = src.get(participant)
     if not entry or not entry.get("segments"):
-        return jsonify({"ok": False, "error": "No transcript for participant"}), 404
+        return err("No transcript for participant", 404)
 
     raw_segments = entry["segments"]
     corrections = _manifest.get("corrections", [])
@@ -371,15 +369,12 @@ def api_transcript(participant: str) -> FlaskResponse:
         }
         segments.append(seg)
 
-    return jsonify(
-        {
-            "ok": True,
-            "participant": participant,
-            "segments": segments,
-            "language": entry.get("language", ""),
-            "model": entry.get("model", ""),
-            "transcribed_at": entry.get("transcribed_at", ""),
-        }
+    return ok(
+        participant=participant,
+        segments=segments,
+        language=entry.get("language", ""),
+        model=entry.get("model", ""),
+        transcribed_at=entry.get("transcribed_at", ""),
     )
 
 
@@ -388,18 +383,18 @@ def api_edit_segment(participant: str) -> FlaskResponse:
     """Edit a segment's text. Creates a correction entry automatically."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+        return err("Missing JSON body")
 
     segment_id = data.get("segment_id", "")
     new_text = data.get("text", "").strip()
     if not segment_id or not new_text:
-        return jsonify({"ok": False, "error": "segment_id and text required"}), 400
+        return err("segment_id and text required")
 
     with _manifest_lock:
         src = _manifest.get("source_transcripts", {})
         entry = src.get(participant)
         if not entry:
-            return jsonify({"ok": False, "error": "No transcript for participant"}), 404
+            return err("No transcript for participant", 404)
 
         # Find the raw segment by ID
         raw_seg = None
@@ -408,11 +403,11 @@ def api_edit_segment(participant: str) -> FlaskResponse:
                 raw_seg = seg
                 break
         if raw_seg is None:
-            return jsonify({"ok": False, "error": "Segment not found"}), 404
+            return err("Segment not found", 404)
 
         original_text = raw_seg["text"]
         if original_text == new_text:
-            return jsonify({"ok": True, "correction": None})
+            return ok(correction=None)
 
         # Create correction
         correction = {
@@ -426,7 +421,7 @@ def api_edit_segment(participant: str) -> FlaskResponse:
         _mark_friction_stale(entry)  # edited segment text invalidates friction scores
 
     _schedule_persist()
-    return jsonify({"ok": True, "correction": correction})
+    return ok(correction=correction)
 
 
 # ---- WebVTT ----
@@ -576,14 +571,11 @@ def api_embed_subtitle(participant: str) -> FlaskResponse:
     outcome = _embed_subtitle_for_participant(participant, output_dir)
     if not outcome["ok"]:
         status = 404 if outcome["error"] == "No transcript for participant" else 500
-        return jsonify({"ok": False, "error": outcome["error"]}), status
-    return jsonify(
-        {
-            "ok": True,
-            "output_path": outcome["output_path"],
-            "output_filename": outcome["output_filename"],
-            "output_dir": str(output_dir),
-        }
+        return err(outcome["error"], status)
+    return ok(
+        output_path=outcome["output_path"],
+        output_filename=outcome["output_filename"],
+        output_dir=str(output_dir),
     )
 
 
@@ -595,16 +587,11 @@ def api_embed_all_subtitles() -> FlaskResponse:
         src = _manifest.get("source_transcripts", {})
         targets = [pid for pid, entry in src.items() if entry.get("segments")]
     if not targets:
-        return jsonify(
-            {"ok": False, "error": "No transcripts available to embed."}
-        ), 404
+        return err("No transcripts available to embed.", 404)
     results = [_embed_subtitle_for_participant(pid, output_dir) for pid in targets]
-    return jsonify(
-        {
-            "ok": True,
-            "results": results,
-            "output_dir": str(output_dir),
-        }
+    return ok(
+        results=results,
+        output_dir=str(output_dir),
     )
 
 
@@ -647,17 +634,17 @@ def api_summary_regenerate(participant: str) -> FlaskResponse:
     so the frontend's per-participant controls can force a run.
     """
     if _orchestrator.is_generating(participant, "summary"):
-        return jsonify({"ok": True, "generating": True})
+        return ok(generating=True)
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry or not entry.get("segments"):
-            return jsonify({"ok": False, "error": "No transcript found"}), 404
+            return err("No transcript found", 404)
         entry["summary"] = ""
         entry.pop("citations", None)
         _mark_friction_stale(entry)  # the new summary feeds the friction prompt
     _persist_manifest()
     _orchestrator.run_chain(participant, force=True)
-    return jsonify({"ok": True, "generating": True})
+    return ok(generating=True)
 
 
 @transcripts_bp.route("/api/summary/<participant>/stop", methods=["POST"])
@@ -673,7 +660,7 @@ def api_summary_stop(participant: str) -> FlaskResponse:
         model = _agent_model("summary")
         if model:
             _schedule_model_unload(model)
-    return jsonify({"ok": True, "running": False})
+    return ok(running=False)
 
 
 @transcripts_bp.route("/api/summary/<participant>", methods=["PUT"])
@@ -681,16 +668,16 @@ def api_summary_save(participant: str) -> FlaskResponse:
     """Save a user-edited summary for a participant."""
     data = request.get_json(silent=True)
     if not data or not data.get("summary", "").strip():
-        return jsonify({"ok": False, "error": "Summary text is required"}), 400
+        return err("Summary text is required")
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry:
-            return jsonify({"ok": False, "error": "Participant not found"}), 404
+            return err("Participant not found", 404)
         entry["summary"] = data["summary"].strip()
         entry.pop("citations", None)  # invalidate citations on edit
         _mark_friction_stale(entry)  # summary text feeds the friction prompt
     _schedule_persist()
-    return jsonify({"ok": True})
+    return ok()
 
 
 # ---- Citations ----
@@ -705,7 +692,7 @@ def api_citations(participant: str) -> FlaskResponse:
             return jsonify({"ok": False}), 404
         citations = entry.get("citations")
     if citations:
-        return jsonify({"ok": True, "citations": citations})
+        return ok(citations=citations)
     if _orchestrator.is_generating(participant, "citations"):
         return jsonify(
             {
@@ -724,17 +711,15 @@ def api_citations_regenerate(participant: str) -> FlaskResponse:
     Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False.
     """
     if _orchestrator.is_generating(participant, "citations"):
-        return jsonify({"ok": True, "generating": True})
+        return ok(generating=True)
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry or not entry.get("summary") or not entry.get("segments"):
-            return jsonify(
-                {"ok": False, "error": "No summary or transcript found"}
-            ), 404
+            return err("No summary or transcript found", 404)
         entry.pop("citations", None)
     _persist_manifest()
     _orchestrator.run_agent("citations", participant, force=True)
-    return jsonify({"ok": True, "generating": True})
+    return ok(generating=True)
 
 
 @transcripts_bp.route("/api/citations/<participant>/stop", methods=["POST"])
@@ -750,7 +735,7 @@ def api_citations_stop(participant: str) -> FlaskResponse:
         model = _agent_model("citations")
         if model:
             _schedule_model_unload(model)
-    return jsonify({"ok": True, "running": False})
+    return ok(running=False)
 
 
 # ---- Friction ----
@@ -769,7 +754,7 @@ def api_friction(participant: str) -> FlaskResponse:
             return jsonify({"ok": False}), 404
         friction_data = entry.get("friction")
     if friction_data:
-        return jsonify({"ok": True, "friction": friction_data})
+        return ok(friction=friction_data)
     if _orchestrator.is_generating(participant, "friction"):
         return jsonify(
             {
@@ -789,17 +774,15 @@ def api_friction_regenerate(participant: str) -> FlaskResponse:
     frontend's per-participant controls can force a run. Requires a summary.
     """
     if _orchestrator.is_generating(participant, "friction"):
-        return jsonify({"ok": True, "generating": True})
+        return ok(generating=True)
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry or not entry.get("summary") or not entry.get("segments"):
-            return jsonify(
-                {"ok": False, "error": "No summary or transcript found"}
-            ), 404
+            return err("No summary or transcript found", 404)
         entry.pop("friction", None)
     _persist_manifest()
     _orchestrator.run_agent("friction", participant, force=True)
-    return jsonify({"ok": True, "generating": True})
+    return ok(generating=True)
 
 
 @transcripts_bp.route("/api/friction/<participant>/stop", methods=["POST"])
@@ -815,7 +798,7 @@ def api_friction_stop(participant: str) -> FlaskResponse:
         model = _agent_model("friction")
         if model:
             _schedule_model_unload(model)
-    return jsonify({"ok": True, "running": False})
+    return ok(running=False)
 
 
 # ---- Corrections ----
@@ -826,7 +809,7 @@ def api_corrections_list() -> FlaskResponse:
     """List all study-local corrections."""
     with _manifest_lock:
         corrections = list(_manifest.get("corrections", []))
-    return jsonify({"ok": True, "corrections": corrections})
+    return ok(corrections=corrections)
 
 
 @transcripts_bp.route("/api/corrections", methods=["POST"])
@@ -834,12 +817,12 @@ def api_corrections_add() -> FlaskResponse:
     """Add a manual correction."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+        return err("Missing JSON body")
 
     from_text = data.get("from", "").strip()
     to_text = data.get("to", "").strip()
     if not from_text or not to_text:
-        return jsonify({"ok": False, "error": "'from' and 'to' required"}), 400
+        return err("'from' and 'to' required")
 
     removed_id = None
     with _manifest_lock:
@@ -876,8 +859,8 @@ def api_corrections_add() -> FlaskResponse:
     # routes, so we never nest _manifest_lock -> _persist_timer_lock.
     _schedule_persist()
     if removed_id is not None:
-        return jsonify({"ok": True, "correction": None, "removed": removed_id})
-    return jsonify({"ok": True, "correction": correction})
+        return ok(correction=None, removed=removed_id)
+    return ok(correction=correction)
 
 
 @transcripts_bp.route("/api/corrections/<correction_id>", methods=["DELETE"])
@@ -894,10 +877,10 @@ def api_corrections_delete(correction_id: str) -> FlaskResponse:
             _bump_corrections_version()  # deletion invalidates corrected cache
 
     if removed == 0:
-        return jsonify({"ok": False, "error": "Correction not found"}), 404
+        return err("Correction not found", 404)
 
     _schedule_persist()
-    return jsonify({"ok": True})
+    return ok()
 
 
 # ---- Marks ----
@@ -1019,12 +1002,9 @@ def api_marks_list() -> FlaskResponse:
     with _manifest_lock:
         raw_marks = list(_manifest.get("marks", []))
         resolved = [_resolve_mark(m, partial_lookup) for m in raw_marks]
-    return jsonify(
-        {
-            "ok": True,
-            "marks": resolved,
-            "categories": config.MARK_CATEGORIES,
-        }
+    return ok(
+        marks=resolved,
+        categories=config.MARK_CATEGORIES,
     )
 
 
@@ -1033,11 +1013,11 @@ def api_marks_add() -> FlaskResponse:
     """Create marks for one or more segments."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+        return err("Missing JSON body")
 
     segment_ids = data.get("segment_ids", [])
     if not segment_ids:
-        return jsonify({"ok": False, "error": "segment_ids required"}), 400
+        return err("segment_ids required")
 
     category = data.get("category") or None
     label = data.get("label") or None
@@ -1070,7 +1050,7 @@ def api_marks_add() -> FlaskResponse:
                 created.append(m)
 
     _schedule_persist()
-    return jsonify({"ok": True, "marks": created})
+    return ok(marks=created)
 
 
 @transcripts_bp.route("/api/marks/<mark_id>", methods=["PUT"])
@@ -1078,7 +1058,7 @@ def api_marks_update(mark_id: str) -> FlaskResponse:
     """Update a mark's category or label."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+        return err("Missing JSON body")
 
     with _manifest_lock:
         marks = _manifest.get("marks", [])
@@ -1088,7 +1068,7 @@ def api_marks_update(mark_id: str) -> FlaskResponse:
                 target = m
                 break
         if not target:
-            return jsonify({"ok": False, "error": "Mark not found"}), 404
+            return err("Mark not found", 404)
 
         if "category" in data:
             target["category"] = data["category"] or None
@@ -1096,7 +1076,7 @@ def api_marks_update(mark_id: str) -> FlaskResponse:
             target["label"] = data["label"] or None
 
     _schedule_persist()
-    return jsonify({"ok": True, "mark": target})
+    return ok(mark=target)
 
 
 @transcripts_bp.route("/api/marks/<mark_id>", methods=["DELETE"])
@@ -1119,10 +1099,10 @@ def api_marks_delete(mark_id: str) -> FlaskResponse:
         removed = before - len(_manifest["marks"])
 
     if removed == 0:
-        return jsonify({"ok": False, "error": "Mark not found"}), 404
+        return err("Mark not found", 404)
 
     _schedule_persist()
-    return jsonify({"ok": True, "removed": removed})
+    return ok(removed=removed)
 
 
 # ---- Search ----
@@ -1133,14 +1113,11 @@ def api_search() -> FlaskResponse:
     """Keyword search across all transcribed participants."""
     query = request.args.get("q", "").strip()
     if not query:
-        return jsonify(
-            {
-                "ok": True,
-                "query": "",
-                "total_count": 0,
-                "results": [],
-                "counts_by_participant": {},
-            }
+        return ok(
+            query="",
+            total_count=0,
+            results=[],
+            counts_by_participant={},
         )
 
     query_lower = query.lower()
@@ -1176,14 +1153,11 @@ def api_search() -> FlaskResponse:
                 counts[pid] = participant_count
 
     total = sum(counts.values())
-    return jsonify(
-        {
-            "ok": True,
-            "query": query,
-            "total_count": total,
-            "results": results,
-            "counts_by_participant": counts,
-        }
+    return ok(
+        query=query,
+        total_count=total,
+        results=results,
+        counts_by_participant=counts,
     )
 
 
@@ -1208,16 +1182,13 @@ def api_transcribe_warmup() -> FlaskResponse:
     proceed after the user agrees.
     """
     if _transcribe_prewarm_setting() == "off":
-        return jsonify(
-            {
-                "ok": True,
-                "skipped": True,
-                "reason": "prewarm_disabled",
-            }
+        return ok(
+            skipped=True,
+            reason="prewarm_disabled",
         )
 
     if transcripts.is_transcription_model_loaded():
-        return jsonify({"ok": True, "already_loaded": True})
+        return ok(already_loaded=True)
 
     # Never download a model silently during prewarm. When the configured model
     # isn't cached yet, skip and report it so the frontend can confirm the
@@ -1226,23 +1197,20 @@ def api_transcribe_warmup() -> FlaskResponse:
     force = bool(data.get("force"))
     model = config.TRANSCRIBE_MODEL
     if not force and not transcripts.is_whisper_model_cached(model):
-        return jsonify(
-            {
-                "ok": True,
-                "skipped": True,
-                "reason": "model_not_cached",
-                "model": model,
-                "size_mb": _whisper_model_size_mb(model),
-            }
+        return ok(
+            skipped=True,
+            reason="model_not_cached",
+            model=model,
+            size_mb=_whisper_model_size_mb(model),
         )
 
     global _transcript_model_warming  # noqa: PLW0603
 
     with _transcript_model_warming_lock:
         if _transcript_model_warming:
-            return jsonify({"ok": True, "already_warming": True})
+            return ok(already_warming=True)
         if transcripts.is_transcription_model_loaded():
-            return jsonify({"ok": True, "already_loaded": True})
+            return ok(already_loaded=True)
         _transcript_model_warming = True
 
     def _run_warmup() -> None:
@@ -1256,7 +1224,7 @@ def api_transcribe_warmup() -> FlaskResponse:
     threading.Thread(
         target=_run_warmup, daemon=True, name="transcript-model-warmup"
     ).start()
-    return jsonify({"ok": True, "started": True})
+    return ok(started=True)
 
 
 @transcripts_bp.route("/api/transcribe/model-status")
@@ -1264,14 +1232,11 @@ def api_transcribe_model_status() -> FlaskResponse:
     """Report whether faster-whisper is loaded or a warm-up is in progress."""
     with _transcript_model_warming_lock:
         warming = _transcript_model_warming
-    return jsonify(
-        {
-            "ok": True,
-            "loaded": transcripts.is_transcription_model_loaded(),
-            "warming": warming,
-            "model": config.TRANSCRIBE_MODEL,
-            "prewarm": _transcribe_prewarm_setting(),
-        }
+    return ok(
+        loaded=transcripts.is_transcription_model_loaded(),
+        warming=warming,
+        model=config.TRANSCRIBE_MODEL,
+        prewarm=_transcribe_prewarm_setting(),
     )
 
 
@@ -1285,12 +1250,12 @@ def api_ollama_pull() -> FlaskResponse:
     data = request.get_json(silent=True) or {}
     model = (data.get("model") or "").strip()
     if not model:
-        return jsonify({"ok": False, "error": "Missing model"}), 400
+        return err("Missing model")
 
     with _ollama_pull_lock:
         existing = _ollama_pull_status.get(model)
         if existing is not None and not existing.get("done"):
-            return jsonify({"ok": True, "already_pulling": True})
+            return ok(already_pulling=True)
         _ollama_pull_status[model] = {
             "status": "starting",
             "completed": 0,
@@ -1331,7 +1296,7 @@ def api_ollama_pull() -> FlaskResponse:
                         st["error"] = "Pull failed"
 
     threading.Thread(target=_run_pull, daemon=True, name=f"ollama-pull-{model}").start()
-    return jsonify({"ok": True, "started": True})
+    return ok(started=True)
 
 
 @transcripts_bp.route("/api/models/ollama/pull-status")
@@ -1339,12 +1304,12 @@ def api_ollama_pull_status() -> FlaskResponse:
     """Report progress for a model pull started via /api/models/ollama/pull."""
     model = (request.args.get("model") or "").strip()
     if not model:
-        return jsonify({"ok": False, "error": "Missing model"}), 400
+        return err("Missing model")
     with _ollama_pull_lock:
         st = _ollama_pull_status.get(model)
         snapshot = dict(st) if st is not None else None
     if snapshot is None:
-        return jsonify({"ok": True, "found": False})
+        return ok(found=False)
     snapshot["ok"] = True
     snapshot["found"] = True
     return jsonify(snapshot)
@@ -1355,7 +1320,7 @@ def api_transcribe() -> FlaskResponse:
     """Enqueue participant(s) for background transcription."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "Missing JSON body"}), 400
+        return err("Missing JSON body")
 
     participant_ids = data.get("participants", [])
     force = data.get("force", False)
@@ -1363,7 +1328,7 @@ def api_transcribe() -> FlaskResponse:
     allow_download = bool(data.get("allow_download"))
 
     if not participant_ids:
-        return jsonify({"ok": False, "error": "No participants specified"}), 400
+        return err("No participants specified")
 
     # Build a lookup of available participants
     available = {p["id"]: p for p in _participants}
@@ -1430,7 +1395,7 @@ def api_transcribe() -> FlaskResponse:
                 }
             )
 
-    return jsonify({"ok": True, "tasks": enqueued})
+    return ok(tasks=enqueued)
 
 
 @transcripts_bp.route("/api/transcribe/status")
@@ -1451,12 +1416,9 @@ def api_transcribe_status() -> FlaskResponse:
             if t["status"] == transcripts.TASK_STATUS_RUNNING:
                 task_info["partial_segments"] = t.get("partial_segments", [])
             tasks.append(task_info)
-    return jsonify(
-        {
-            "ok": True,
-            "tasks": tasks,
-            "worker_alive": _worker.is_alive if _worker else False,
-        }
+    return ok(
+        tasks=tasks,
+        worker_alive=_worker.is_alive if _worker else False,
     )
 
 
@@ -1464,19 +1426,19 @@ def api_transcribe_status() -> FlaskResponse:
 def api_transcribe_cancel(task_id: str) -> FlaskResponse:
     """Cancel or dismiss a transcription task. ?dismiss=true fully removes it."""
     if not _worker:
-        return jsonify({"ok": False, "error": "Worker not initialized"}), 500
+        return err("Worker not initialized", 500)
 
     if request.args.get("dismiss") == "true":
         if not _worker.remove_task(task_id):
-            return jsonify({"ok": False, "error": "Task not found"}), 404
+            return err("Task not found", 404)
         _persist_manifest()
-        return jsonify({"ok": True})
+        return ok()
 
     if _worker.cancel(task_id):
         _persist_manifest()
-        return jsonify({"ok": True})
+        return ok()
 
-    return jsonify({"ok": False, "error": "Task not found or already finished"}), 400
+    return err("Task not found or already finished")
 
 
 # ---- Manifest persistence ----

--- a/workflows_server.py
+++ b/workflows_server.py
@@ -29,11 +29,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, request
 
 import config
 import utils
 import workflows
+from server_utils import err, ok
 
 # ---- Module state (initialized by _init_workflows_state) ----
 
@@ -127,22 +128,19 @@ def api_catalog() -> Any:
     run can't resolve).
     """
     videos = utils.discover_participant_videos()
-    return jsonify(
-        {
-            "ok": True,
-            "catalog": workflows.serialize_catalog(),
-            # Adapter pairs the runner coerces across (events→clipRecords, …) so
-            # the frontend's canConnect accepts the same wires the runner runs.
-            "adapters": workflows.serialize_adapters(),
-            "context": {
-                "sheet": _sheet_context is not None,
-                "videoDir": bool(videos),
-                "participants": [v["id"] for v in videos if v.get("has_video")],
-                # Where a run's artifacts land — surfaced in the run panel so the
-                # user knows where to find their clips/reels/viewers.
-                "outputDir": str(utils.get_effective_output_dir()),
-            },
-        }
+    return ok(
+        catalog=workflows.serialize_catalog(),
+        # Adapter pairs the runner coerces across (events→clipRecords, …) so
+        # the frontend's canConnect accepts the same wires the runner runs.
+        adapters=workflows.serialize_adapters(),
+        context={
+            "sheet": _sheet_context is not None,
+            "videoDir": bool(videos),
+            "participants": [v["id"] for v in videos if v.get("has_video")],
+            # Where a run's artifacts land — surfaced in the run panel so the
+            # user knows where to find their clips/reels/viewers.
+            "outputDir": str(utils.get_effective_output_dir()),
+        },
     )
 
 
@@ -154,7 +152,7 @@ def api_blueprints() -> Any:
     """Return the persisted workflow blueprints."""
     with _manifest_lock:
         blueprints = copy.deepcopy(_manifest.get("blueprints", []))
-    return jsonify({"ok": True, "blueprints": blueprints})
+    return ok(blueprints=blueprints)
 
 
 @workflows_bp.route("/api/blueprints", methods=["POST"])
@@ -173,7 +171,7 @@ def api_blueprints_create() -> Any:
     with _manifest_lock:
         _manifest.setdefault("blueprints", []).append(blueprint)
         _persist_locked()
-    return jsonify({"ok": True, "blueprint": blueprint})
+    return ok(blueprint=blueprint)
 
 
 @workflows_bp.route("/api/blueprints/<bp_id>", methods=["PUT"])
@@ -181,17 +179,17 @@ def api_blueprints_update(bp_id: str) -> Any:
     """Update a blueprint's name/nodes/edges/viewport (the debounced autosave)."""
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
     with _manifest_lock:
         blueprints = _manifest.get("blueprints", [])
         blueprint = next((b for b in blueprints if b.get("id") == bp_id), None)
         if blueprint is None:
-            return jsonify({"ok": False, "error": "Blueprint not found"}), 404
+            return err("Blueprint not found", 404)
         for key in ("name", "nodes", "edges", "viewport"):
             if key in data:
                 blueprint[key] = data[key]
         _persist_locked()
-    return jsonify({"ok": True, "blueprint": blueprint})
+    return ok(blueprint=blueprint)
 
 
 @workflows_bp.route("/api/blueprints/<bp_id>", methods=["DELETE"])
@@ -201,10 +199,10 @@ def api_blueprints_delete(bp_id: str) -> Any:
         blueprints = _manifest.get("blueprints", [])
         idx = next((i for i, b in enumerate(blueprints) if b.get("id") == bp_id), None)
         if idx is None:
-            return jsonify({"ok": False, "error": "Blueprint not found"}), 404
+            return err("Blueprint not found", 404)
         blueprints.pop(idx)
         _persist_locked()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @workflows_bp.route("/api/blueprints/<bp_id>/trigger", methods=["PUT"])
@@ -224,22 +222,14 @@ def api_blueprint_trigger(bp_id: str) -> Any:
         blueprints = _manifest.get("blueprints", [])
         target = next((b for b in blueprints if b.get("id") == bp_id), None)
         if target is None:
-            return jsonify({"ok": False, "error": "Blueprint not found"}), 404
+            return err("Blueprint not found", 404)
         if enabled:
             try:
                 workflows.topo_order(target.get("nodes", []), target.get("edges", []))
             except workflows.WorkflowCycleError as exc:
-                return jsonify({"ok": False, "error": str(exc)}), 400
+                return err(str(exc))
             if not workflows.blueprint_participant_nodes(target):
-                return (
-                    jsonify(
-                        {
-                            "ok": False,
-                            "error": "Add a Video Source node before arming auto-run",
-                        }
-                    ),
-                    400,
-                )
+                return err("Add a Video Source node before arming auto-run")
             for b in blueprints:
                 if b is target:
                     b["trigger"] = {"type": "watch_dir", "enabled": True}
@@ -254,7 +244,7 @@ def api_blueprint_trigger(bp_id: str) -> Any:
     # work then), so this arm-time re-seed is what upholds the no-retro-fire promise.
     if enabled:
         _seed_watch_seen()
-    return jsonify({"ok": True, "blueprint": result})
+    return ok(blueprint=result)
 
 
 def _disarmed_trigger(trigger: Any) -> Any:
@@ -278,7 +268,7 @@ def api_stashes() -> Any:
     """Return the built-in recipes (read-only) followed by the user's stashes."""
     with _manifest_lock:
         user_stashes = copy.deepcopy(_manifest.get("stashes", []))
-    return jsonify({"ok": True, "stashes": workflows.BUILTIN_STASHES + user_stashes})
+    return ok(stashes=workflows.BUILTIN_STASHES + user_stashes)
 
 
 @workflows_bp.route("/api/stashes", methods=["POST"])
@@ -287,7 +277,7 @@ def api_stashes_create() -> Any:
     data = request.get_json(silent=True) or {}
     nodes = data.get("nodes", [])
     if not nodes:
-        return jsonify({"ok": False, "error": "No nodes to stash"}), 400
+        return err("No nodes to stash")
     stash = {
         "id": "stash_" + uuid.uuid4().hex[:8],
         "name": (data.get("name") or "Stash").strip() or "Stash",
@@ -299,41 +289,41 @@ def api_stashes_create() -> Any:
     with _manifest_lock:
         _manifest.setdefault("stashes", []).append(stash)
         _persist_locked()
-    return jsonify({"ok": True, "stash": stash})
+    return ok(stash=stash)
 
 
 @workflows_bp.route("/api/stashes/<stash_id>", methods=["PUT"])
 def api_stashes_update(stash_id: str) -> Any:
     """Rename a user stash. Built-in recipes are read-only (403)."""
     if any(s["id"] == stash_id for s in workflows.BUILTIN_STASHES):
-        return jsonify({"ok": False, "error": "Built-in recipes are read-only"}), 403
+        return err("Built-in recipes are read-only", 403)
     data = request.get_json(silent=True)
     if not data:
-        return jsonify({"ok": False, "error": "JSON body required"}), 400
+        return err("JSON body required")
     with _manifest_lock:
         stashes = _manifest.get("stashes", [])
         stash = next((s for s in stashes if s.get("id") == stash_id), None)
         if stash is None:
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+            return err("Stash not found", 404)
         if "name" in data:
             stash["name"] = (data["name"] or stash["name"]).strip() or stash["name"]
         _persist_locked()
-    return jsonify({"ok": True, "stash": stash})
+    return ok(stash=stash)
 
 
 @workflows_bp.route("/api/stashes/<stash_id>", methods=["DELETE"])
 def api_stashes_delete(stash_id: str) -> Any:
     """Delete a user stash by id. Built-in recipes are read-only (403)."""
     if any(s["id"] == stash_id for s in workflows.BUILTIN_STASHES):
-        return jsonify({"ok": False, "error": "Built-in recipes are read-only"}), 403
+        return err("Built-in recipes are read-only", 403)
     with _manifest_lock:
         stashes = _manifest.get("stashes", [])
         idx = next((i for i, s in enumerate(stashes) if s.get("id") == stash_id), None)
         if idx is None:
-            return jsonify({"ok": False, "error": "Stash not found"}), 404
+            return err("Stash not found", 404)
         stashes.pop(idx)
         _persist_locked()
-    return jsonify({"ok": True})
+    return ok()
 
 
 # ---- Run lifecycle (M4) ----
@@ -523,18 +513,18 @@ def api_run_create() -> Any:
         )
         blueprint = copy.deepcopy(blueprint) if blueprint else None
     if blueprint is None:
-        return jsonify({"ok": False, "error": "Blueprint not found"}), 404
+        return err("Blueprint not found", 404)
     try:
         workflows.topo_order(blueprint.get("nodes", []), blueprint.get("edges", []))
     except workflows.WorkflowCycleError as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+        return err(str(exc))
     # Optional partial run: restrict to this node + its ancestors. Reject an
     # unknown id rather than silently running the whole graph (the runner would
     # ignore it), so a stale selection surfaces as a clear error.
     target = str(data.get("targetNodeId") or "")
     if target and not any(n.get("id") == target for n in blueprint.get("nodes", [])):
-        return jsonify({"ok": False, "error": "Unknown target node"}), 400
-    return jsonify({"ok": True, "run": _launch_run(blueprint, target_node_id=target)})
+        return err("Unknown target node")
+    return ok(run=_launch_run(blueprint, target_node_id=target))
 
 
 def _merged_runs() -> dict[str, dict[str, Any]]:
@@ -558,7 +548,7 @@ def api_runs_list() -> Any:
     if bp_filter:
         runs = [r for r in runs if r.get("blueprintId") == bp_filter]
     runs.sort(key=lambda r: r.get("startedAt") or "", reverse=True)
-    return jsonify({"ok": True, "runs": runs})
+    return ok(runs=runs)
 
 
 @workflows_bp.route("/api/runs/<run_id>")
@@ -566,8 +556,8 @@ def api_run_get(run_id: str) -> Any:
     """Polling fallback for one run's live/persisted snapshot."""
     snap = _run_snapshot(run_id)
     if snap is None:
-        return jsonify({"ok": False, "error": "Run not found"}), 404
-    return jsonify({"ok": True, "run": snap})
+        return err("Run not found", 404)
+    return ok(run=snap)
 
 
 @workflows_bp.route("/api/runs/<run_id>/nodes/<node_id>/result")
@@ -581,7 +571,7 @@ def api_run_node_result(run_id: str, node_id: str) -> Any:
     safe_node = node_id == os.path.basename(node_id) and node_id not in (".", "..")
     safe_run = run_id == os.path.basename(run_id) and run_id not in (".", "..")
     if not (safe_node and safe_run):
-        return jsonify({"ok": False, "error": "Invalid id"}), 404
+        return err("Invalid id", 404)
     path = (
         workflows.run_results_dir(utils.get_effective_output_dir(), run_id)
         / f"{node_id}.json"
@@ -589,8 +579,8 @@ def api_run_node_result(run_id: str, node_id: str) -> Any:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return jsonify({"ok": False, "error": "No result for node"}), 404
-    return jsonify({"ok": True, "result": payload})
+        return err("No result for node", 404)
+    return ok(result=payload)
 
 
 @workflows_bp.route("/api/runs/<run_id>/cancel", methods=["POST"])
@@ -599,9 +589,9 @@ def api_run_cancel(run_id: str) -> Any:
     with _runs_lock:
         runner = _runs.get(run_id)
     if runner is None:
-        return jsonify({"ok": False, "error": "Run not found or finished"}), 404
+        return err("Run not found or finished", 404)
     runner.cancel()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @workflows_bp.route("/api/runs/<run_id>/stream")
@@ -845,19 +835,14 @@ def api_batch_create() -> Any:
         )
         blueprint = copy.deepcopy(blueprint) if blueprint else None
     if blueprint is None:
-        return jsonify({"ok": False, "error": "Blueprint not found"}), 404
+        return err("Blueprint not found", 404)
     bp_id = str(blueprint.get("id", "") or "")
     if not workflows.blueprint_participant_nodes(blueprint):
-        return (
-            jsonify(
-                {"ok": False, "error": "Blueprint has no Video Source to fan out over"}
-            ),
-            400,
-        )
+        return err("Blueprint has no Video Source to fan out over")
     try:
         workflows.topo_order(blueprint.get("nodes", []), blueprint.get("edges", []))
     except workflows.WorkflowCycleError as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 400
+        return err(str(exc))
 
     available = [
         v["id"] for v in utils.discover_participant_videos() if v.get("has_video")
@@ -868,7 +853,7 @@ def api_batch_create() -> Any:
     else:
         participants = available
     if not participants:
-        return jsonify({"ok": False, "error": "No participants with video found"}), 400
+        return err("No participants with video found")
 
     batch_id = "batch_" + uuid.uuid4().hex[:8]
     # Child runs are persisted as they execute, not up front: pre-persisting one
@@ -892,7 +877,7 @@ def api_batch_create() -> Any:
         daemon=True,
         name=f"workflow-batch-{batch_id}",
     ).start()
-    return jsonify({"ok": True, "batch": _batch_summary(batch_id)})
+    return ok(batch=_batch_summary(batch_id))
 
 
 @workflows_bp.route("/api/batches")
@@ -915,7 +900,7 @@ def api_batches_list() -> Any:
     if bp_filter:
         summaries = [s for s in summaries if s.get("blueprintId") == bp_filter]
     summaries.sort(key=lambda s: s.get("createdAt") or "", reverse=True)
-    return jsonify({"ok": True, "batches": summaries})
+    return ok(batches=summaries)
 
 
 @workflows_bp.route("/api/batches/<batch_id>")
@@ -923,10 +908,10 @@ def api_batch_get(batch_id: str) -> Any:
     """One batch's summary + per-child run snapshots (drill-in)."""
     summary = _batch_summary(batch_id)
     if summary is None:
-        return jsonify({"ok": False, "error": "Batch not found"}), 404
+        return err("Batch not found", 404)
     all_runs = _merged_runs()
     runs = [all_runs[c["runId"]] for c in summary["children"] if c["runId"] in all_runs]
-    return jsonify({"ok": True, "batch": summary, "runs": runs})
+    return ok(batch=summary, runs=runs)
 
 
 @workflows_bp.route("/api/batches/<batch_id>/cancel", methods=["POST"])
@@ -935,13 +920,13 @@ def api_batch_cancel(batch_id: str) -> Any:
     with _batches_lock:
         record = _batches.get(batch_id)
     if record is None:
-        return jsonify({"ok": False, "error": "Batch not found or finished"}), 404
+        return err("Batch not found or finished", 404)
     record["cancel_event"].set()
     with _runs_lock:
         for runner in _runs.values():
             if getattr(runner, "batch_id", "") == batch_id:
                 runner.cancel()
-    return jsonify({"ok": True})
+    return ok()
 
 
 @workflows_bp.route("/api/batches/<batch_id>/stream")


### PR DESCRIPTION
New server_utils.py collapses the per-route Flask scaffolding the four
server blueprints repeat ~400 times: ok()/err() build the {"ok": ...}
envelope in one call, ApiError + json_endpoint let handlers raise a
uniform 4xx, and parse_number_arg parses+bound-checks one numeric arg.
Kept Flask-only (no config/utils imports) so it stays import-clean —
utils.py is deliberately Flask-free. Listed in pyproject py-modules
(guarded by test_packaging) and covered by test_server_utils.py.