### PR TITLE
refactor: extract SSE stream and modal lifecycle to utils.js

### DIFF
--- a/assets/web/screenspace-tasks.js
+++ b/assets/web/screenspace-tasks.js
@@ -1061,31 +1061,21 @@
 
   function startSSE() {
     if (state.eventSource) return;
-    var es = new EventSource("api/tasks/stream");
-    state.eventSource = es;
-
-    es.onopen = function () {
+    state.eventSource = createSSEStream("api/tasks/stream", {
       // A live connection re-arms the one-shot drop notice for any later drop.
-      state.sseFellBack = false;
-    };
-
-    es.onmessage = function (e) {
-      var data;
-      try { data = JSON.parse(e.data); } catch (_) { return; }
-      handleTaskData(data);
-    };
-
-    es.onerror = function () {
-      // Connection lost — fall back to polling. onerror can fire repeatedly, so
-      // toast only once per drop (the flag resets when SSE is re-established).
-      es.close();
-      state.eventSource = null;
-      if (!state.sseFellBack) {
-        state.sseFellBack = true;
-        showToast("Live updates interrupted — falling back to polling");
-      }
-      startPolling();
-    };
+      onOpen: function () { state.sseFellBack = false; },
+      onMessage: handleTaskData,
+      onError: function () {
+        // Connection lost — fall back to polling. onError can fire repeatedly,
+        // so toast only once per drop (the flag resets when SSE is re-established).
+        state.eventSource = null;
+        if (!state.sseFellBack) {
+          state.sseFellBack = true;
+          showToast("Live updates interrupted — falling back to polling");
+        }
+        startPolling();
+      },
+    });
   }
 
   // ---- Polling (fallback) ----

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -4501,68 +4501,22 @@
 
   // ---- Modal focus trap (shared by the blocking overlays) ----
   //
-  // Keeps Tab/Shift+Tab inside the overlay, closes on Escape, and restores focus
-  // to the trigger on release. role=dialog + aria-modal live statically on each
-  // overlay's card in the HTML. Studio never stacks these overlays, so one active
-  // trap is enough — opening a new one releases the previous. release() is
-  // idempotent cleanup-only, so any dismiss path (button, backdrop, Escape) can
-  // call closeModalTrap safely.
-  var _activeTrap = null;
-  var _TRAP_FOCUSABLE =
-    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-
+  // Thin delegators onto utils.js's openBlockingModal — Studio's overlays all
+  // want the full lifecycle (Tab/Shift+Tab trap, Escape close, focus restore to
+  // the trigger). role=dialog + aria-modal live statically on each overlay's
+  // card in the HTML. Studio never stacks these overlays, so the helper's single
+  // active modal is enough. release() is idempotent cleanup-only, so any dismiss
+  // path (button, backdrop, Escape) can call closeModalTrap safely.
   function openModalTrap(overlayEl, onEscape) {
-    if (!overlayEl) return null;
-    if (_activeTrap && _activeTrap.el === overlayEl) {
-      _activeTrap.onEscape = onEscape;
-      return _activeTrap;
-    }
-    if (_activeTrap) _activeTrap.release();
-    var prevFocus = document.activeElement;
-
-    function visibleFocusable() {
-      return Array.prototype.slice
-        .call(overlayEl.querySelectorAll(_TRAP_FOCUSABLE))
-        .filter(function (n) { return !n.disabled && n.offsetParent !== null; });
-    }
-    function onKey(ev) {
-      if (ev.key === "Escape") {
-        ev.preventDefault();
-        if (trap.onEscape) trap.onEscape();
-        return;
-      }
-      if (ev.key !== "Tab") return;
-      // Re-query each Tab — overlay button visibility changes between phases
-      // (e.g. the status overlay's in-progress vs result state).
-      var f = visibleFocusable();
-      if (f.length === 0) { ev.preventDefault(); return; }
-      var first = f[0];
-      var last = f[f.length - 1];
-      if (ev.shiftKey && document.activeElement === first) {
-        ev.preventDefault();
-        last.focus();
-      } else if (!ev.shiftKey && document.activeElement === last) {
-        ev.preventDefault();
-        first.focus();
-      }
-    }
-    function release() {
-      if (_activeTrap !== trap) return;
-      document.removeEventListener("keydown", onKey, true);
-      _activeTrap = null;
-      if (prevFocus && prevFocus.focus) prevFocus.focus();
-    }
-
-    var trap = { el: overlayEl, onEscape: onEscape, release: release };
-    document.addEventListener("keydown", onKey, true);
-    var initial = visibleFocusable();
-    if (initial.length) initial[0].focus();
-    _activeTrap = trap;
-    return trap;
+    return openBlockingModal(overlayEl, {
+      onEscape: onEscape,
+      trapFocus: true,
+      restoreFocus: true,
+    });
   }
 
   function closeModalTrap(overlayEl) {
-    if (_activeTrap && _activeTrap.el === overlayEl) _activeTrap.release();
+    closeBlockingModal(overlayEl);
   }
 
   // ---- Status overlay ----

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2216,8 +2216,7 @@
       function cleanup() {
         cancelBtn.removeEventListener("click", onCancel);
         confirmBtn.removeEventListener("click", onConfirm);
-        modal.removeEventListener("click", onBackdrop);
-        document.removeEventListener("keydown", onKey);
+        closeBlockingModal(modal);
       }
       function close(result) {
         cancelled = true; // stop any in-flight pull poll and its late callbacks
@@ -2226,8 +2225,6 @@
         resolve(result);
       }
       function onCancel() { close(false); }
-      function onBackdrop(e) { if (e.target === modal) close(false); }
-      function onKey(e) { if (e.key === "Escape") close(false); }
       function onConfirm() {
         if (opts.kind === "whisper") { close(true); return; }
         // Ollama: kick off the pull and show progress in place. Cancel stays
@@ -2261,9 +2258,10 @@
 
       cancelBtn.addEventListener("click", onCancel);
       confirmBtn.addEventListener("click", onConfirm);
-      modal.addEventListener("click", onBackdrop);
-      document.addEventListener("keydown", onKey);
       modal.classList.remove("hidden");
+      // Escape and backdrop click both cancel (no focus trap — matches prior
+      // behavior for this lightweight progress dialog).
+      openBlockingModal(modal, { onEscape: onCancel, onBackdropClick: onCancel });
     });
   }
 

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -946,6 +946,90 @@ var createSSEStream = function (url, opts) {
   return es;
 };
 
+// ---- Blocking modal lifecycle (Escape / backdrop / optional focus trap) ----
+// Shared lifecycle for blocking overlays: closes on Escape, optionally on
+// backdrop click, optionally traps Tab/Shift+Tab inside the overlay and restores
+// focus to the trigger on release. Singleton — opening a new modal releases the
+// previous one (callers never stack blocking overlays). The returned trap's
+// release() is idempotent cleanup-only, so any dismiss path (button, backdrop,
+// Escape) can call closeBlockingModal safely.
+//
+// Options:
+//   onEscape()        — fired on Escape
+//   onBackdropClick() — fired when the overlay element itself is clicked
+//   trapFocus         — keep Tab/Shift+Tab inside the overlay and focus its first
+//                       control on open
+//   restoreFocus      — restore focus to the prior element on release
+var _TRAP_FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+var _activeBlockingModal = null;
+
+var openBlockingModal = function (overlayEl, opts) {
+  opts = opts || {};
+  if (!overlayEl) return null;
+  if (_activeBlockingModal && _activeBlockingModal.el === overlayEl) {
+    _activeBlockingModal.opts = opts;
+    return _activeBlockingModal;
+  }
+  if (_activeBlockingModal) _activeBlockingModal.release();
+  var prevFocus = opts.restoreFocus ? document.activeElement : null;
+
+  function visibleFocusable() {
+    return Array.prototype.slice
+      .call(overlayEl.querySelectorAll(_TRAP_FOCUSABLE))
+      .filter(function (n) { return !n.disabled && n.offsetParent !== null; });
+  }
+  function onKey(ev) {
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      if (trap.opts.onEscape) trap.opts.onEscape();
+      return;
+    }
+    if (!trap.opts.trapFocus || ev.key !== "Tab") return;
+    // Re-query each Tab — overlay button visibility can change between phases
+    // (e.g. a status overlay's in-progress vs result state).
+    var f = visibleFocusable();
+    if (f.length === 0) { ev.preventDefault(); return; }
+    var first = f[0];
+    var last = f[f.length - 1];
+    if (ev.shiftKey && document.activeElement === first) {
+      ev.preventDefault();
+      last.focus();
+    } else if (!ev.shiftKey && document.activeElement === last) {
+      ev.preventDefault();
+      first.focus();
+    }
+  }
+  function onClick(ev) {
+    if (ev.target === overlayEl && trap.opts.onBackdropClick) {
+      trap.opts.onBackdropClick();
+    }
+  }
+  function release() {
+    if (_activeBlockingModal !== trap) return;
+    document.removeEventListener("keydown", onKey, true);
+    overlayEl.removeEventListener("click", onClick);
+    _activeBlockingModal = null;
+    if (prevFocus && prevFocus.focus) prevFocus.focus();
+  }
+
+  var trap = { el: overlayEl, opts: opts, release: release };
+  document.addEventListener("keydown", onKey, true);
+  if (opts.onBackdropClick) overlayEl.addEventListener("click", onClick);
+  if (opts.trapFocus) {
+    var initial = visibleFocusable();
+    if (initial.length) initial[0].focus();
+  }
+  _activeBlockingModal = trap;
+  return trap;
+};
+
+var closeBlockingModal = function (overlayEl) {
+  if (_activeBlockingModal && _activeBlockingModal.el === overlayEl) {
+    _activeBlockingModal.release();
+  }
+};
+
 // ---- Mark categories ----
 // Hardcoded fallback that mirrors config.MARK_CATEGORIES defaults; the live
 // values are repopulated in place by setMarkCategories() once the page fetches

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -914,6 +914,38 @@ var createPoller = function (fn, intervalMs, opts) {
   };
 };
 
+// ---- SSE stream with standard parse + fallback hook ----
+// Open an EventSource with the project's standard JSON-parse onmessage wrapper
+// and auto-close-on-error. The caller owns its polling fallback — each subscriber
+// stores its own stream/poller and reacts to a drop differently — so onError
+// fires AFTER the stream is closed. Returns the EventSource (or null if the
+// browser lacks EventSource, in which case onUnsupported runs).
+//
+// Options:
+//   onMessage(data)   — called with the parsed JSON of each message
+//   onOpen()          — called when the connection (re)opens
+//   onError()         — called once the dropped stream has been closed
+//   onUnsupported()   — called instead of opening when window.EventSource is absent
+var createSSEStream = function (url, opts) {
+  opts = opts || {};
+  if (!window.EventSource) {
+    if (opts.onUnsupported) opts.onUnsupported();
+    return null;
+  }
+  var es = new EventSource(url);
+  if (opts.onOpen) es.onopen = function () { opts.onOpen(); };
+  es.onmessage = function (e) {
+    var data;
+    try { data = JSON.parse(e.data); } catch (_) { return; }
+    if (opts.onMessage) opts.onMessage(data);
+  };
+  es.onerror = function () {
+    es.close();
+    if (opts.onError) opts.onError();
+  };
+  return es;
+};
+
 // ---- Mark categories ----
 // Hardcoded fallback that mirrors config.MARK_CATEGORIES defaults; the live
 // values are repopulated in place by setMarkCategories() once the page fetches

--- a/assets/web/workflows-runs.js
+++ b/assets/web/workflows-runs.js
@@ -70,29 +70,20 @@
   function subscribeRun(runId) {
     stopTransport();
     _reconnecting = false; // fresh subscription — clear any stale gap state
-    if (!window.EventSource) {
-      startPolling(runId);
-      return;
-    }
-    var es = new EventSource("api/runs/" + encodeURIComponent(runId) + "/stream");
-    _stream = es;
-    es.onmessage = function (e) {
-      var data;
-      try {
-        data = JSON.parse(e.data);
-      } catch (_) {
-        return;
-      }
-      if (data && data.run) handleRunData(data.run);
-    };
-    es.onerror = function () {
-      // SSE dropped — flag the gap (surfaces a "Reconnecting…" pill) and fall
-      // back to polling so progress still flows; the next poll clears the flag.
-      _reconnecting = true;
-      stopStream();
-      startPolling(runId);
-      renderRuns();
-    };
+    _stream = createSSEStream("api/runs/" + encodeURIComponent(runId) + "/stream", {
+      onUnsupported: function () { startPolling(runId); },
+      onMessage: function (data) {
+        if (data && data.run) handleRunData(data.run);
+      },
+      onError: function () {
+        // SSE dropped — flag the gap (surfaces a "Reconnecting…" pill) and fall
+        // back to polling so progress still flows; the next poll clears the flag.
+        _reconnecting = true;
+        _stream = null;
+        startPolling(runId);
+        renderRuns();
+      },
+    });
   }
 
   function startPolling(runId) {
@@ -135,29 +126,21 @@
   function subscribeBatch(batchId) {
     stopBatchTransport();
     _reconnecting = false; // fresh subscription — clear any stale gap state
-    if (!window.EventSource) {
-      startBatchPolling(batchId);
-      return;
-    }
-    var es = new EventSource(
+    _batchStream = createSSEStream(
       "api/batches/" + encodeURIComponent(batchId) + "/stream",
+      {
+        onUnsupported: function () { startBatchPolling(batchId); },
+        onMessage: function (data) {
+          if (data && data.batch) handleBatchData(data.batch);
+        },
+        onError: function () {
+          _reconnecting = true;
+          _batchStream = null;
+          startBatchPolling(batchId);
+          renderRuns();
+        },
+      },
     );
-    _batchStream = es;
-    es.onmessage = function (e) {
-      var data;
-      try {
-        data = JSON.parse(e.data);
-      } catch (_) {
-        return;
-      }
-      if (data && data.batch) handleBatchData(data.batch);
-    };
-    es.onerror = function () {
-      _reconnecting = true;
-      stopBatchStream();
-      startBatchPolling(batchId);
-      renderRuns();
-    };
   }
 
   function startBatchPolling(batchId) {

--- a/plans/LOC-REDUCTION-PLAN.md
+++ b/plans/LOC-REDUCTION-PLAN.md
@@ -1,7 +1,7 @@
 # LOC-reduction opportunities — plan
 
-Status: **in progress** (2026-06-30). Items **1 (1a + 1b)** and **2** landed (see check-marks
-below); items 3–5 still open. Investigation targets for genuinely *reducing* total
+Status: **in progress** (2026-06-30). Items **1 (1a + 1b)**, **2**, and **3** landed (see
+check-marks below); items 4–5 still open. Investigation targets for genuinely *reducing* total
 lines of code (not relocating them). Each item is sized as one or more focused `refactor:`
 commits. Check items off and add a "Done" note as they land (per AGENTS.md plan-maintenance rule).
 
@@ -72,18 +72,31 @@ dozens of times.
 Shared with [FRONTEND-REFACTORS-PLAN.md](FRONTEND-REFACTORS-PLAN.md) Theme B — listed here because,
 unlike the carves, they remove duplication rather than move it.
 
-- [ ] **3a. `createSSEStream(url, {onMessage, onError, poll})`** in `utils.js` — collapses 4
-  near-identical `EventSource → onerror → createPoller` blocks (`screenspace-tasks.js:1064`,
-  `workflows-runs.js:77/142/1019`).
-- [ ] **3b. Generalize the modal focus-trap** — `studio.js openModalTrap` (~`4627`) vs
-  `transcripts.js confirmModelInstall` (~`2180`) are two implementations of the same lifecycle;
-  promote one `openBlockingModal({onEscape, onBackdropClick})` to `utils.js`. Leave singleton
-  pickers (`color-picker.js`, `settings-modal.js`) owning their own lifecycle.
-- [ ] **3c. Form-input factories** (`rangeInput`/`numberInput`/`textInput`) and color-conversion —
-  consolidate the duplicated copies (`screenspace-utils.js` vs `screenspace-multitool-params.js`;
-  `color-picker.js` vs `screenspace-utils.js`). **Caution:** color conversion uses two
-  *incompatible* HSV ranges (standard [0,1] vs OpenCV 0–180/0–255) — clarify names, don't blind-merge.
-- **Est. payoff:** ~100–200 lines.
+- [x] **3a. `createSSEStream(url, {onMessage, onOpen, onError, onUnsupported})`** in `utils.js` —
+  **Done.** Collapsed **3** (not 4 — `workflows-runs.js:1019` is a plain `createPoller` call, no
+  `EventSource`) near-identical `new EventSource → JSON-parse onmessage → onerror-fallback` blocks
+  (`screenspace-tasks.js startSSE`, `workflows-runs.js subscribeRun`/`subscribeBatch`). Each caller
+  keeps its own stream/poller state and drop handling; only the EventSource setup + parse wrapper are
+  shared. `tests/test_workflows_frontend_source.py` now asserts `createSSEStream` (the raw
+  `EventSource` literal moved to `utils.js`).
+- [x] **3b. Generalize the modal focus-trap** — **Done.** Promoted `openBlockingModal` /
+  `closeBlockingModal` to `utils.js` (focus-trap + focus-restore opt-in flags, optional
+  `onBackdropClick`). `studio.js openModalTrap`/`closeModalTrap` became thin delegators
+  (`trapFocus`+`restoreFocus` on) — the ~50-line implementation + `_activeTrap`/`_TRAP_FOCUSABLE`
+  moved to `utils.js`; Studio has 4 trap call sites (gallery/status/confirm/log), so wrappers beat
+  inlining. `transcripts.js _confirmModelInstallNow` dropped its hand-rolled Escape/backdrop
+  listeners for `openBlockingModal` (no trap, matching prior behavior). Singleton pickers
+  (`color-picker.js`, `settings-modal.js`) left owning their own lifecycle.
+- [x] **3c. Form-input factories + color-conversion** — **Descoped (investigated).** The form-input
+  factories (`rangeInput`/`numberInput`/`textInput`) are *already* shared: they live once in
+  `screenspace-utils.js` and `screenspace-multitool-params.js` just calls them — no duplication to
+  remove. The only real dup is `hexToRgb`/`rgbToHex` between `color-picker.js` and
+  `screenspace-utils.js` (~8 lines), and the two `rgbToHsv`/`hsvToRgb` pairs use **incompatible
+  ranges** (standard 0–360/[0,1] vs OpenCV 0–180/0–255) and must stay separate. Not worth churning
+  ~8 lines across two pages' load graphs; left as-is.
+- **Payoff (realized):** 3a + 3b deduped the SSE-setup and modal-lifecycle shapes onto `utils.js`
+  globals (one implementation each instead of per-page copies). Frontend-source + satellite-wiring
+  tests green.
 
 ## 4. CSS shared-component promotion
 
@@ -109,9 +122,10 @@ clipgen / screenspace / transcripts / workflows / stashes / settings.
 
 ## Suggested order
 
-1. **1a** (response helpers — biggest, safest win). 2. **1b** + **2** (decorator + arg parsing,
-   building on 1a). 3. **3a/3b/3c** (JS dedup, independent). 4. **4** (CSS, needs browser check).
-5. **5** only after the investigation confirms it's worthwhile.
+1. ~~**1a** (response helpers — biggest, safest win).~~ ✓ 2. ~~**1b** + **2** (decorator + arg
+   parsing, building on 1a).~~ ✓ 3. ~~**3a/3b** (JS dedup; 3c descoped — factories already
+   shared).~~ ✓ 4. **4** (CSS, needs browser check). 5. **5** only after the investigation
+   confirms it's worthwhile.
 
 Quantify before committing to a tier: a duplication scan (jscpd for JS/CSS, a `pylint`-style
 duplicate-code pass for Python) would put hard block counts behind each item.

--- a/tests/test_workflows_frontend_source.py
+++ b/tests/test_workflows_frontend_source.py
@@ -224,11 +224,13 @@ def test_run_panel_satellite_present_and_wired():
         "WF.renderRuns",
     ):
         assert fn in src, fn
-    # SSE stream with a polling fallback (mirrors screenspace-tasks).
+    # SSE stream with a polling fallback (mirrors screenspace-tasks). The raw
+    # EventSource setup now lives in utils.js's createSSEStream helper.
     runs = (_WEB / "workflows-runs.js").read_text(encoding="utf-8")
-    assert "EventSource" in runs
+    assert "createSSEStream" in runs
     assert "createPoller" in runs
     assert "api/runs" in runs
+    assert "createSSEStream" in (_WEB / "utils.js").read_text(encoding="utf-8")
 
 
 def test_batch_via_all_participants_option():


### PR DESCRIPTION
## Summary

Extracted two frequently-duplicated patterns into shared utilities in `utils.js`:

- **`createSSEStream(url, opts)`** — Wraps `EventSource` with standard JSON-parse error handling and auto-close-on-error. Replaces near-identical setup blocks in `screenspace-tasks.js`, `workflows-runs.js` (2 call sites), and reduces boilerplate across the codebase. Each caller retains its own stream/poller state and drop-handling logic.

- **`openBlockingModal(overlayEl, opts)` / `closeBlockingModal(overlayEl)`** — Generalized modal lifecycle (Escape close, optional backdrop click, optional focus trap with Tab wrapping, optional focus restore). Replaces ~50 lines of hand-rolled implementation in `studio.js` and eliminates duplicate Escape/backdrop listeners in `transcripts.js`. Studio's `openModalTrap`/`closeModalTrap` now delegate to the shared helper.

Updated call sites in `screenspace-tasks.js`, `workflows-runs.js`, `studio.js`, and `transcripts.js` to use the new helpers. Marked items 3a and 3b complete in `LOC-REDUCTION-PLAN.md`; descoped 3c (form-input factories already shared; color-conversion helpers use incompatible ranges and not worth churning).

## Test plan

- Existing `test_workflows_frontend_source.py` assertions updated to verify `createSSEStream` is present in `utils.js` and called from `workflows-runs.js`.
- Frontend-source and satellite-wiring tests pass (CI green).
- No new manual testing needed; refactor preserves existing behavior (SSE fallback to polling, modal focus trap, Escape/backdrop close).