### PR TITLE
fix(server): silence macOS cv2/av libavdevice ObjC duplicate-class warning

### DIFF
--- a/agents/skills/debug/SKILL.md
+++ b/agents/skills/debug/SKILL.md
@@ -22,13 +22,15 @@
 
 8. **DBus errors in logs** — harmless. They come from Chrome attempting DBus connections in headless environments. Ignore them.
 
+9. **`objc[...] Class AVFFrameReceiver/AVFAudioReceiver is implemented in both ...` on macOS** — harmless. Both `opencv-python-headless` (cv2, Screenspace) and `av` (PyAV, pulled in by `faster-whisper` for Transcripts) bundle their own FFmpeg `libavdevice`, an AVFoundation capture-device library clipgen never uses; the ObjC runtime warns when both load in one process. `start_combined_server()` pre-loads both via `utils.preload_av_libs_quietly()` with native stderr silenced, so the combined web server stays quiet. A rare pure-CLI run that loads both libs may still print it — it's benign.
+
 ## Development / debugging
 
-9. **Enable debug mode** — set `config.DEBUGGING = True` to:
+10. **Enable debug mode** — set `config.DEBUGGING = True` to:
    - Enable icecream (`ic()`) output
    - Skip ffmpeg execution (video.py returns stubs)
    - Return stub transcript results without loading a Whisper model
 
-10. **Type errors in ty** — see [agents/skills/check/SKILL.md](../check/SKILL.md) for common ty failure patterns.
+11. **Type errors in ty** — see [agents/skills/check/SKILL.md](../check/SKILL.md) for common ty failure patterns.
 
-11. **Tests unexpectedly passing despite broken behavior** — check whether the test is mocking at too high a level. The project avoids mocking the database/sheets layer; if a test uses a mock that doesn't reflect reality, consider replacing it with a real fixture.
+12. **Tests unexpectedly passing despite broken behavior** — check whether the test is mocking at too high a level. The project avoids mocking the database/sheets layer; if a test uses a mock that doesn't reflect reality, consider replacing it with a real fixture.

--- a/server.py
+++ b/server.py
@@ -3776,6 +3776,12 @@ def start_combined_server(
     # workflow runs alike.
     utils.NO_INPUT_MODE = True
 
+    # Pre-load the two FFmpeg-bundling libs (av via faster-whisper, cv2 via
+    # Screenspace) with native stderr silenced, so the macOS libavdevice
+    # ObjC duplicate-class warning never reaches the console once both
+    # subsystems are reachable on this combined server.
+    utils.preload_av_libs_quietly()
+
     # Reclaim orphaned scratch files (atomic-write .tmp siblings, reel temp-clips)
     # a prior hard kill may have left in the output dir, before workers spin up.
     utils.sweep_stale_temp_artifacts()

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """Utility functions for clipgen."""
 
+import contextlib
 import difflib
 import functools
 import json
 import math
+import os
 import subprocess
 import sys
 from datetime import datetime
@@ -22,6 +24,58 @@ import config
 # clipgen.py / excel_io.py / pipeline.py / video.py / utils.suggest_close_match
 # read this flag to fail fast (or skip) instead of blocking on stdin.
 NO_INPUT_MODE: bool = False
+
+
+# ---- Native (C/ObjC-level) stderr suppression ----
+
+
+@contextlib.contextmanager
+def suppress_native_stderr():
+    """Temporarily silence OS file descriptor 2 (stderr) for the duration.
+
+    Redirects fd 2 to /dev/null and restores it in ``finally``. Unlike
+    reassigning ``sys.stderr``, this also swallows writes from C/Objective-C
+    libraries (e.g. the dynamic linker / ObjC runtime), which write to the
+    fd directly. Use sparingly and around the narrowest possible block.
+    """
+    saved_fd = os.dup(2)
+    null_fd = os.open(os.devnull, os.O_WRONLY)
+    try:
+        os.dup2(null_fd, 2)
+        yield
+    finally:
+        os.dup2(saved_fd, 2)
+        os.close(null_fd)
+        os.close(saved_fd)
+
+
+_av_libs_preloaded = False
+
+
+def preload_av_libs_quietly() -> None:
+    """Import ``av`` and ``cv2`` once, early, with native stderr silenced.
+
+    Both wheels bundle their own FFmpeg ``libavdevice`` (an AVFoundation
+    capture-device library clipgen never uses). On macOS, whichever loads
+    *second* makes the ObjC runtime print a "Class AVFFrameReceiver is
+    implemented in both ..." duplicate-class warning. Pre-loading both here
+    under :func:`suppress_native_stderr` means later lazy ``import cv2`` /
+    ``import av`` calls find them already resident (no second dlopen, no
+    warning). Idempotent; either import missing is a no-op.
+    """
+    global _av_libs_preloaded
+    if _av_libs_preloaded:
+        return
+    _av_libs_preloaded = True
+    with suppress_native_stderr():
+        try:
+            import av  # noqa: F401
+        except ImportError:
+            pass
+        try:
+            import cv2  # noqa: F401
+        except ImportError:
+            pass
 
 
 # ---- Shared type definitions ----


### PR DESCRIPTION
## Summary

`opencv-python-headless` (cv2, Screenspace) and `av` (PyAV, pulled in by `faster-whisper` for Transcripts) each bundle their own FFmpeg `libavdevice` — an AVFoundation capture lib clipgen never uses — so the macOS ObjC runtime prints a spurious `Class AVFFrameReceiver/AVFAudioReceiver is implemented in both ...` warning when both load in one process (the combined web server). `start_combined_server()` now pre-loads both libs once via new `utils.suppress_native_stderr()` / `utils.preload_av_libs_quietly()` with native stderr silenced, so later lazy imports find them resident and never re-trigger the warning; CLI paths are untouched and it's documented as benign in the debug skill.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` clean on changed files
- [x] Full test suite: 1747 passed
- [x] Launched `--screenspace` end-to-end — zero `objc[...]` lines at startup; verified `suppress_native_stderr()` restores fd 2 (real stderr still works) and the preloader is idempotent