### PR TITLE
refactor(web): share floating-menu + thin-scrollbar CSS via tokens.css

### DIFF
--- a/assets/web/start-overlay.css
+++ b/assets/web/start-overlay.css
@@ -648,20 +648,20 @@
   color: var(--fg-muted);
 }
 
-.start-overlay .recent-pop {
+/* Recent-folders + sheet-picker dropdowns share one anchored body; the visual
+   shell (bg/border/shadow/z-index) comes from .cg-menu. Only the overflow axis
+   differs, split out below. */
+.start-overlay .recent-pop,
+.start-overlay .sheet-picker__menu {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + var(--space-1-5));
   left: 0;
   right: 0;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
   border-radius: 10px;
-  box-shadow: var(--shadow-pop);
-  padding: 6px;
-  z-index: 10;
+  padding: var(--space-1-5);
   max-height: 220px;
-  overflow: auto;
 }
+.start-overlay .recent-pop { overflow: auto; }
 
 .start-overlay .recent-pop.hidden {
   display: none;
@@ -847,20 +847,8 @@
   color: var(--accent);
 }
 
-.start-overlay .sheet-picker__menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  right: 0;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  box-shadow: var(--shadow-pop);
-  padding: 6px;
-  z-index: 10;
-  max-height: 220px;
-  overflow-y: auto;
-}
+/* Body shared with .recent-pop above; this only sets the vertical overflow. */
+.start-overlay .sheet-picker__menu { overflow-y: auto; }
 
 .start-overlay .sheet-picker__menu.hidden {
   display: none;
@@ -1254,16 +1242,6 @@
   padding-right: 4px;
 }
 
-.start-overlay .changelog::-webkit-scrollbar { width: 6px; }
-.start-overlay .changelog::-webkit-scrollbar-track { background: transparent; }
-.start-overlay .changelog::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 3px;
-}
-.start-overlay .changelog::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.16);
-}
-
 .start-overlay .changelog__empty {
   font-size: 12px;
   color: var(--fg-faint);
@@ -1352,12 +1330,6 @@
   padding-right: 4px;
 }
 
-.start-overlay .about::-webkit-scrollbar { width: 6px; }
-.start-overlay .about::-webkit-scrollbar-track { background: transparent; }
-.start-overlay .about::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 3px;
-}
 
 .start-overlay .about__row {
   display: grid;

--- a/assets/web/start-overlay.html
+++ b/assets/web/start-overlay.html
@@ -54,7 +54,7 @@
             </button>
             <button type="button" class="path-input__btn path-input__btn--browse" data-role="input-browse">Browse…</button>
           </div>
-          <div class="recent-pop hidden" data-role="input-recents-list" role="menu"></div>
+          <div class="recent-pop cg-menu hidden" data-role="input-recents-list" role="menu"></div>
         </div>
 
         <div class="path-field" data-role="output-field">
@@ -72,7 +72,7 @@
             </button>
             <button type="button" class="path-input__btn path-input__btn--browse" data-role="output-browse">Browse…</button>
           </div>
-          <div class="recent-pop hidden" data-role="output-recents-list" role="menu"></div>
+          <div class="recent-pop cg-menu hidden" data-role="output-recents-list" role="menu"></div>
         </div>
       </section>
 
@@ -108,7 +108,7 @@
                   <span class="sheet-picker__label" data-role="google-picker-label">Select a Google Sheet…</span>
                   <span class="sheet-picker__caret so-icon so-icon--sm" data-icon="chevron-down" aria-hidden="true"></span>
                 </button>
-                <div class="sheet-picker__menu hidden" data-role="google-picker-menu" role="listbox"></div>
+                <div class="sheet-picker__menu cg-menu hidden" data-role="google-picker-menu" role="listbox"></div>
               </div>
               <div class="sheet-panel__paste">
                 <label for="startGooglePaste">Or paste a spreadsheet URL or name</label>
@@ -128,7 +128,7 @@
                   <span class="sheet-picker__label" data-role="excel-picker-label">Select an Excel file…</span>
                   <span class="sheet-picker__caret so-icon so-icon--sm" data-icon="chevron-down" aria-hidden="true"></span>
                 </button>
-                <div class="sheet-picker__menu hidden" data-role="excel-picker-menu" role="listbox"></div>
+                <div class="sheet-picker__menu cg-menu hidden" data-role="excel-picker-menu" role="listbox"></div>
               </div>
               <div class="sheet-panel__paste">
                 <label for="startExcelPaste">Or paste a full path to an .xlsx file</label>
@@ -340,11 +340,11 @@
             </div>
 
             <div data-extras-panel="updates" hidden>
-              <ul class="changelog" data-role="changelog-list"></ul>
+              <ul class="changelog cg-scroll-thin" data-role="changelog-list"></ul>
             </div>
 
             <div data-extras-panel="about" hidden>
-              <div class="about" data-role="about-grid"></div>
+              <div class="about cg-scroll-thin" data-role="about-grid"></div>
             </div>
           </div>
         </div>

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -135,6 +135,7 @@
     els.backdrop = root.querySelector('[data-role="backdrop"]');
     els.closeBtn = root.querySelector('[data-role="close"]');
     els.wordmark = root.querySelector('[data-role="wordmark"]');
+    els.mark = root.querySelector(".rail__mark");
 
     els.cascades = root.querySelectorAll(".cascade-in");
 
@@ -1090,6 +1091,26 @@
     }, 460);
   }
 
+  // Replay the rail brand-mark stroke-draw on every overlay open. The shared
+  // per-session gate in clipgenInitBrandMark (utils.js) draws only the first
+  // .brand-mark hydrated on the page — usually the topnav logo — so the launcher
+  // forces its own replay here, independent of that flag. Retries across a few
+  // animation frames because hydration (an async favicon.svg fetch) may not have
+  // landed yet on the first open; it no-ops once attempts run out.
+  function replayBrandMark(attempts) {
+    var mark = els.mark;
+    if (!mark) return;
+    if (mark.classList.contains("is-hydrated")) {
+      mark.classList.remove("is-animated");
+      void mark.offsetWidth; // force reflow so the draw-on restarts
+      mark.classList.add("is-animated");
+      return;
+    }
+    if (attempts > 0) {
+      requestAnimationFrame(function () { replayBrandMark(attempts - 1); });
+    }
+  }
+
   function runIntro() {
     if (!root) return;
     // Reset cascade-in elements so the animation can replay.
@@ -1118,6 +1139,9 @@
       void els.wordmark.offsetWidth;
       els.wordmark.style.animation = "";
     }
+
+    // Replay the brand-mark stroke-draw alongside the wordmark.
+    replayBrandMark(30);
 
     // Section cascade.
     Array.prototype.forEach.call(els.cascades, function (node) {

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -219,18 +219,7 @@ body {
   border-right: 1px solid var(--hairline);
   overflow-x: hidden;
   overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-}
-#studioSidebar::-webkit-scrollbar {
-  width: 6px;
-}
-#studioSidebar::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 3px;
-}
-#studioSidebar::-webkit-scrollbar-track {
-  background: transparent;
+  /* Thin themed scrollbar from .cg-scroll-thin (class on the element). */
 }
 /* Transition is gated on `tx-ready`, applied by studio.js after the first
  * paint. Otherwise the attribute flip from the persisted-collapsed state

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -40,7 +40,7 @@
   <section id="sheetPreview">
   <!-- Sheet + preview tabs (intake, convergence, metadata) -->
 
-    <aside id="studioSidebar" data-open="true" aria-label="Sheet filters">
+    <aside id="studioSidebar" class="cg-scroll-thin" data-open="true" aria-label="Sheet filters">
       <button id="studioSidebarToggle" type="button" aria-label="Toggle sidebar"><span class="studio-sidebar-toggle-icon" aria-hidden="true"></span></button>
       <section class="studio-sidebar-section" data-section="views">
         <header class="studio-sidebar-header">Views</header>

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -559,6 +559,34 @@ html[data-theme="light"] .cg-logo {
    still blocks click regardless of pointer-events. */
 button[data-tooltip]:disabled { pointer-events: auto; cursor: not-allowed; }
 
+/* Floating menu / dropdown visual shell — shared across pages. Add ALONGSIDE a
+   page-local class that owns geometry (display, position, anchor offsets, sizing)
+   and the show/hide toggle, e.g. class="wf-run-menu cg-menu". Deliberately does
+   NOT set `display`, so it never fights a page's .hidden / display:none toggle
+   (those toggles are defined per-component and vary in specificity). */
+.cg-menu {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-pop);
+  padding: var(--space-1);
+  z-index: var(--z-dropdown);
+}
+
+/* Thin custom scrollbar — theme-aware thumb (adapts to light mode via --border).
+   Apply to any overflow container that wants the slim 6px scrollbar. */
+.cg-scroll-thin {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.cg-scroll-thin::-webkit-scrollbar { width: 6px; }
+.cg-scroll-thin::-webkit-scrollbar-track { background: transparent; }
+.cg-scroll-thin::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+.cg-scroll-thin::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
 /* Base button — shared across Studio / Screenspace / Transcripts. (Was copy-pasted
  * verbatim into all three page CSS files; consolidated here.) `.cg-btn`
  * (primitives.css, Studio-only) is a deliberately separate, richer button language

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -258,18 +258,14 @@ body.dragging .topnav {
 }
 
 .topnav-qa-panel {
+  /* Shell (bg/border/radius/shadow/z-index) from .cg-menu; keeps roomier padding. */
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
   min-width: 240px;
-  padding: 6px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  box-shadow: var(--shadow-pop);
+  padding: var(--space-1-5);
   display: none;
   flex-direction: column;
-  z-index: var(--z-dropdown);
   font-size: 12.5px;
 }
 .topnav-qa-panel.is-open {

--- a/assets/web/topnav.js
+++ b/assets/web/topnav.js
@@ -110,7 +110,7 @@
     qaTrigger.setAttribute("aria-expanded", "false");
     qaTrigger.innerHTML = '<span>Quick actions</span><span class="topnav-icon topnav-qa-caret" aria-hidden="true"></span>';
     var qaPanel = document.createElement("div");
-    qaPanel.className = "topnav-qa-panel";
+    qaPanel.className = "topnav-qa-panel cg-menu";
     qaPanel.setAttribute("role", "menu");
     qaWrap.appendChild(qaTrigger);
     qaWrap.appendChild(qaPanel);

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1133,13 +1133,10 @@ body {
    colors still come from the manifest, not a hard-coded six. */
 
 .mark-popover {
+  /* Shell (bg/border/shadow/z-index) from .cg-menu; keeps its tighter radius. */
   position: fixed;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
   border-radius: 6px;
-  box-shadow: var(--shadow-pop);
   padding: var(--space-2-5);
-  z-index: var(--z-dropdown);
   display: flex;
   flex-direction: column;
   gap: var(--space-2);

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -199,7 +199,7 @@
   </div>
 
   <!-- Mark popover (shared, repositioned per use) -->
-  <div id="markPopover" class="mark-popover hidden">
+  <div id="markPopover" class="mark-popover cg-menu hidden">
     <div class="mark-popover-categories"></div>
     <input class="mark-popover-label" type="text" placeholder="Label (optional)" autocomplete="off">
     <button class="mark-popover-remove btn btn-small">Remove</button>

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -228,16 +228,11 @@ body[data-frontend="workflows"] {
 }
 
 .wf-run-menu {
+  /* Shell (bg/border/radius/shadow/padding/z-index) from .cg-menu. */
   position: absolute;
   top: calc(100% + var(--space-1));
   right: 0;
-  z-index: var(--z-dropdown);
   min-width: 9rem;
-  padding: var(--space-1);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-pop);
 }
 
 .wf-run-menu-item {
@@ -329,16 +324,12 @@ body[data-frontend="workflows"] {
 }
 
 .wf-shortcuts-menu {
+  /* Shell from .cg-menu; roomier padding override for the legend. */
   position: absolute;
   top: calc(100% + var(--space-1));
   right: 0;
-  z-index: var(--z-dropdown);
   min-width: 16rem;
   padding: var(--space-3);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-pop);
 }
 
 .wf-shortcuts-title {

--- a/assets/web/workflows.html
+++ b/assets/web/workflows.html
@@ -88,7 +88,7 @@
                   aria-label="More run options" title="More run options">
             <span class="wf-run-caret-icon" aria-hidden="true"></span>
           </button>
-          <div id="wfRunMenu" class="wf-run-menu hidden" role="menu">
+          <div id="wfRunMenu" class="wf-run-menu cg-menu hidden" role="menu">
             <button id="wfRunToItem" class="wf-run-menu-item" type="button" role="menuitem"
                     disabled
                     title="Run only the selected node and the nodes it depends on">
@@ -115,7 +115,7 @@
                   aria-label="Keyboard shortcuts" title="Keyboard &amp; mouse shortcuts">
             <span class="wf-btn-icon wf-shortcuts-icon" aria-hidden="true"></span>
           </button>
-          <div id="wfShortcutsMenu" class="wf-shortcuts-menu hidden" role="menu">
+          <div id="wfShortcutsMenu" class="wf-shortcuts-menu cg-menu hidden" role="menu">
             <div class="wf-shortcuts-title">Keyboard &amp; mouse</div>
             <dl class="wf-shortcuts-list">
               <div><dt>Undo / Redo</dt><dd><kbd>⌘Z</kbd> <kbd>⌘⇧Z</kbd></dd></div>

--- a/plans/LOC-REDUCTION-PLAN.md
+++ b/plans/LOC-REDUCTION-PLAN.md
@@ -1,7 +1,7 @@
 # LOC-reduction opportunities — plan
 
-Status: **in progress** (2026-06-30). Items **1 (1a + 1b)**, **2**, and **3** landed (see
-check-marks below); items 4–5 still open. Investigation targets for genuinely *reducing* total
+Status: **in progress** (2026-07-01). Items **1 (1a + 1b)**, **2**, **3**, and **4** landed (see
+check-marks below); item **5** still open. Investigation targets for genuinely *reducing* total
 lines of code (not relocating them). Each item is sized as one or more focused `refactor:`
 commits. Check items off and add a "Done" note as they land (per AGENTS.md plan-maintenance rule).
 
@@ -103,12 +103,32 @@ unlike the carves, they remove duplication rather than move it.
 Continues today's pass (radius-full, `--color-backdrop`, theme-toggle dedup landed in `0f1012b`).
 The CSS audit flagged more repeated blocks across the page stylesheets:
 
-- [ ] **4. Promote duplicated component blocks** to `primitives.css`/`tokens.css`: webkit
-  **scrollbar** styling (~studio + start-overlay), the floating **popover/dropdown container**
-  (position+shadow+border+padding, ~screenspace + studio), **icon-sizing** classes (`.ss-icon`/
-  `.cg-icon`/`.so-icon` variants with raw px), and the **badge/pill** micro-label pattern.
-- **Est. payoff:** ~20–30 rule blocks. **Risk:** medium (visual) — needs a browser check, and
-  page CSS that loads after `primitives.css` can override, so verify specificity.
+- [x] **4. Promote duplicated component blocks** — **Done (popover + scrollbar; icon/badge
+  descoped).** Two new primitives live in `tokens.css` (loaded on every page; `primitives.css` is
+  Studio-only so it can't host cross-page shared classes):
+  - **`.cg-menu`** — the floating-menu/dropdown *visual* shell (bg/border/radius/shadow/padding/
+    z-index). Deliberately sets **no `display`**, so it never fights a page's per-component
+    `.hidden`/`display:none` toggle. Adopted by adding `cg-menu` alongside the page class (like
+    `.btn`) and deleting the duplicated shell props from page CSS — `.wf-run-menu`,
+    `.wf-shortcuts-menu` (workflows), `.topnav-qa-panel` (topnav), `.mark-popover` (transcripts),
+    and the two start-overlay dropdowns. The two byte-identical start-overlay blocks
+    (`.recent-pop` / `.sheet-picker__menu`) were also merged into one grouped body (their
+    hardcoded `z-index: 10` now resolves to `var(--z-dropdown)`). Left as-is on purpose:
+    `.trim-popover` (bespoke dark blur), `.cgcp-popover` (singleton picker, `z-toast`), and
+    Screenspace's `.rp-switcher-panel`/`.rp-export-menu` (legacy `--color-*` + `--shadow-lg`, not
+    `--shadow-pop` — adopting would change the shadow).
+  - **`.cg-scroll-thin`** — theme-aware thin scrollbar (thumb `var(--border)`, hover
+    `var(--border-strong)`). Applied to `#studioSidebar` and the start-overlay Changelog/About
+    panels; the two always-dark launcher panels shifted from a hardcoded `rgba(255,255,255,0.08)`
+    thumb to the theme border color (accepted). `#regionChips` (hidden scrollbar) left untouched.
+  - **Descoped:** the **icon-mask base** (dedup needs either grouped selectors coupling the shared
+    file to page-local names, or markup+JS churn across pages; `.xref-badge-icon` already is the
+    base — not worth the churn) and the **badge/pill** micro-label (good `.filter-chip`/
+    `.participant-pill` primitives already exist in `primitives.css`; page-local badges are
+    context-specific — the item-5 over-abstraction risk).
+- **Payoff (realized):** net **~−55 lines** across `tokens.css`/`studio.css`/`start-overlay.css`/
+  `workflows.css`/`topnav.css`/`transcripts.css`, plus consistent menu + scrollbar styling.
+  **Risk:** medium (visual) — needs a browser check (menus + the two launcher scrollbars).
 
 ## 5. Manifest load/save patterns (investigation first)
 
@@ -124,8 +144,8 @@ clipgen / screenspace / transcripts / workflows / stashes / settings.
 
 1. ~~**1a** (response helpers — biggest, safest win).~~ ✓ 2. ~~**1b** + **2** (decorator + arg
    parsing, building on 1a).~~ ✓ 3. ~~**3a/3b** (JS dedup; 3c descoped — factories already
-   shared).~~ ✓ 4. **4** (CSS, needs browser check). 5. **5** only after the investigation
-   confirms it's worthwhile.
+   shared).~~ ✓ 4. ~~**4** (CSS `.cg-menu` + `.cg-scroll-thin`; icon/badge descoped).~~ ✓
+   5. **5** only after the investigation confirms it's worthwhile.
 
 Quantify before committing to a tier: a duplication scan (jscpd for JS/CSS, a `pylint`-style
 duplicate-code pass for Python) would put hard block counts behind each item.


### PR DESCRIPTION
## Summary

- Promote two shared primitives to `tokens.css` (loaded on every page) — `.cg-menu`, the floating-menu/dropdown visual shell (deliberately sets no `display`, so it never fights a page's `.hidden` toggle), and `.cg-scroll-thin`, a theme-aware thin scrollbar — then adopt them across Workflows / TopNav / Transcripts / Studio / start-overlay and delete the duplicated blocks (net ~55 CSS lines; icon-mask and badge/pill dedup were investigated and descoped — see `plans/LOC-REDUCTION-PLAN.md` item 4).
- Also fix the start-overlay rail logo so its stroke-draw replays on **every** open: `runIntro()` now re-triggers `is-animated` (remove → reflow → re-add), independent of the shared once-per-session brand-mark flag that the topnav logo consumes on load.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check`, full pytest — 1748 passed
- [x] `node --check` on touched JS + frontend-source / satellite-wiring tests
- [ ] ⚠️ Browser not yet verified: menus render unchanged (Workflows/TopNav/Transcripts/start-overlay); Studio sidebar + launcher scrollbars (incl. light theme); launcher logo draws on each open
