### PR TITLE
fix(screenspace): hold manifest lock while reading regions in stash create

### DIFF
--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -1529,17 +1529,17 @@ def api_stashes_list() -> FlaskResponse:
 @screenspace_bp.route("/api/stashes", methods=["POST"])
 def api_stashes_create() -> FlaskResponse:
     """Stash all current regions and clear the active set."""
-    regions = _manifest.get("regions", {})
-    if not regions:
-        return err("No regions to stash")
-
-    stash = {
-        "id": "stash_" + uuid.uuid4().hex[:8],
-        "name": "Stashed Regions",
-        "createdAt": datetime.now(timezone.utc).isoformat(),
-        "regions": copy.deepcopy(regions),
-    }
     with _manifest_lock:
+        regions = _manifest.get("regions", {})
+        if not regions:
+            return err("No regions to stash")
+
+        stash = {
+            "id": "stash_" + uuid.uuid4().hex[:8],
+            "name": "Stashed Regions",
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "regions": copy.deepcopy(regions),
+        }
         _manifest.setdefault("stashes", []).append(stash)
         _manifest["regions"] = {}
         _do_persist(drain_events=False)


### PR DESCRIPTION
## Summary

`api_stashes_create` read, empty-checked, and deep-copied `_manifest["regions"]` *outside* `_manifest_lock`, then cleared the active set inside the lock — so a region created by a concurrent request in that gap was dropped from both the new stash and the active set. Moved the read/check/copy inside the lock so the snapshot and clear are atomic, matching the sibling stash routes.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini -k stash` (47 pass)
- [x] `ruff format --check`, `ruff check`, `ty check` all clean