### PR TITLE
fix(pipeline): fail reel regen when a component is missing or fails

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1938,11 +1938,21 @@ def _regenerate_reel(reel: dict[str, Any], missing_videos: set[str]) -> bool:
         return False
 
     temp_paths: list[str] = []
+
+    def _cleanup() -> None:
+        for p in temp_paths:
+            try:
+                Path(p).unlink(missing_ok=True)
+            except OSError:
+                pass
+
     for comp in components:
         # A boundary-spanning component carries a ``parts`` list; each part is a
         # separate cut. Since a reel is a concatenation, the parts simply become
         # consecutive entries in the temp list. Single-segment components cut
-        # directly from their mapped sub-video using local offsets.
+        # directly from their mapped sub-video using local offsets. Any missing
+        # source or failed cut aborts the whole reel (matching the multipart-clip
+        # path) rather than silently producing a shorter reel.
         segments = comp.get("parts") or [comp]
         for segment in segments:
             source = segment.get("sourceVideo", "")
@@ -1951,7 +1961,8 @@ def _regenerate_reel(reel: dict[str, Any], missing_videos: set[str]) -> bool:
                 if source_path not in missing_videos:
                     missing_videos.add(source_path)
                     utils.warning_print(f"Source video not found: '{source}'")
-                continue
+                _cleanup()
+                return False
 
             local_start = segment.get("localStart", segment.get("start", 0))
             local_end = segment.get("localEnd", segment.get("end", 0))
@@ -1970,6 +1981,8 @@ def _regenerate_reel(reel: dict[str, Any], missing_videos: set[str]) -> bool:
                 temp_paths.append(out_name)
             else:
                 files.release_reservation(out_name)
+                _cleanup()
+                return False
 
     if not temp_paths:
         return False
@@ -1977,9 +1990,5 @@ def _regenerate_reel(reel: dict[str, Any], missing_videos: set[str]) -> bool:
     output_file = str(utils.resolve_output_path(reel.get("file", "reel.mp4")))
     ok = video.concatenate_clips(temp_paths, output_file, reencode_on_fail=True)
 
-    for p in temp_paths:
-        try:
-            Path(p).unlink(missing_ok=True)
-        except OSError:
-            pass
+    _cleanup()
     return ok

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -705,6 +705,85 @@ def test_regenerate_reel_releases_reservation_on_ffmpeg_failure(monkeypatch, tmp
     assert list(output_dir.iterdir()) == []
 
 
+def test_regenerate_reel_aborts_when_component_source_missing(monkeypatch, tmp_path):
+    """A missing source for any component must fail the whole reel rather than
+    silently concatenating the surviving components into a shorter reel."""
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    (input_dir / "study_P01.mp4").write_bytes(b"\x00")
+    monkeypatch.setattr(config, "INPUT_DIR", str(input_dir), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(output_dir), raising=False)
+
+    # The present component would cut fine; the second source is absent.
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", lambda **_k: True)
+    concat_calls: list = []
+    monkeypatch.setattr(
+        pipeline.video,
+        "concatenate_clips",
+        lambda *a, **k: concat_calls.append(a) or True,
+    )
+
+    missing: set[str] = set()
+    reel = {
+        "file": "reel.mp4",
+        "components": [
+            {"sourceVideo": "study_P01.mp4", "start": 0, "end": 10},
+            {"sourceVideo": "gone_P02.mp4", "start": 0, "end": 10},
+        ],
+    }
+    ok = pipeline._regenerate_reel(reel, missing)
+
+    assert ok is False
+    assert concat_calls == []  # never concatenated a partial reel
+    assert any("gone_P02.mp4" in p for p in missing)  # missing source recorded
+    # No truncated output or leftover temp segments remain.
+    assert list(output_dir.iterdir()) == []
+
+
+def test_regenerate_reel_aborts_on_component_ffmpeg_failure(monkeypatch, tmp_path):
+    """An ffmpeg failure on any component aborts the reel without concatenating
+    or leaving temp segments behind."""
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    (input_dir / "study_P01.mp4").write_bytes(b"\x00")
+    (input_dir / "study_P02.mp4").write_bytes(b"\x00")
+    monkeypatch.setattr(config, "INPUT_DIR", str(input_dir), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(output_dir), raising=False)
+
+    # First component's cut succeeds, second fails.
+    calls = {"n": 0}
+
+    def fake_ffmpeg(**_k):
+        calls["n"] += 1
+        return calls["n"] == 1
+
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", fake_ffmpeg)
+    concat_calls: list = []
+    monkeypatch.setattr(
+        pipeline.video,
+        "concatenate_clips",
+        lambda *a, **k: concat_calls.append(a) or True,
+    )
+
+    reel = {
+        "file": "reel.mp4",
+        "components": [
+            {"sourceVideo": "study_P01.mp4", "start": 0, "end": 10},
+            {"sourceVideo": "study_P02.mp4", "start": 0, "end": 10},
+        ],
+    }
+    ok = pipeline._regenerate_reel(reel, set())
+
+    assert ok is False
+    assert concat_calls == []  # never concatenated a partial reel
+    # The first component's temp segment and the failed reservation are cleaned up.
+    assert list(output_dir.iterdir()) == []
+
+
 def test_regenerate_from_manifest_parallel(monkeypatch):
     """Independent artifacts regenerate concurrently when workers >= 2."""
     artifacts = [


### PR DESCRIPTION
## Summary

`_regenerate_reel` warned-and-continued on a missing source video or failed ffmpeg cut, then concatenated the surviving segments and returned `True` — silently replacing a correct reel with a shorter one. It now cleans up temp segments and returns `False` before concatenating whenever any component is missing or fails, matching the multipart-clip path in the same file (which already aborts on any bad part).

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite green, incl. two new regression tests (missing-source component; mid-reel ffmpeg failure)
- [x] `ruff format` / `ruff check` / `ty check` all clean