### PR TITLE
fix(viewer): escape HTML-script break sequences in embedded viewer data

### DIFF
--- a/tests/test_viewer_inline.py
+++ b/tests/test_viewer_inline.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import viewer
@@ -33,6 +34,39 @@ def test_generate_timeline_viewer_inlines_css_and_js(tmp_path, monkeypatch):
     assert "<style>" in html
     assert "<script defer>" in html
     assert "window.CLIPGEN_DATA" in html
+
+
+def test_viewer_data_escapes_script_break_sequences(tmp_path, monkeypatch):
+    # Regression: user text is embedded into an HTML <script> tag as JSON. json.dumps
+    # does not escape `<`, so `</script>` (and the `<!--<script>` double-escape variant)
+    # in an observation could close/confuse the tag, breaking the exported viewer and
+    # injecting arbitrary HTML. The embed must escape these so the page stays intact.
+    monkeypatch.chdir(tmp_path)
+    hostile = "see </script><!--<script><b>x</b> &  more"
+    data = {
+        "meta": {},
+        "artifacts": [{"desc": hostile}],
+        "timeline": {"duration": 0, "startOffset": 0},
+    }
+
+    out_path = viewer.generate_timeline_viewer(data, output_basename="viewer.html")
+    assert out_path is not None and out_path.is_file()
+    html = out_path.read_text(encoding="utf-8")
+
+    # Isolate the embedded payload from the surrounding template/inlined assets.
+    marker = "window.CLIPGEN_DATA="
+    start = html.index(marker) + len(marker)
+    end = html.index(";</script>", start)
+    payload = html[start:end]
+
+    # The raw break sequences from user text must not survive into the payload.
+    assert "</script>" not in payload
+    assert "<script" not in payload
+    assert "<!--" not in payload
+    assert " " not in payload
+
+    # ...but the payload is still valid JSON and round-trips the original text unchanged.
+    assert json.loads(payload)["artifacts"][0]["desc"] == hostile
 
 
 def test_viewer_renders_reels_from_data():

--- a/viewer.py
+++ b/viewer.py
@@ -353,6 +353,16 @@ def _generate_viewer_html(
         template_html = template_html.replace("</body>", f"{inline_js_block}\n</body>")
 
     data_json = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    # Escape chars that could break out of the <script> tag or a JS string literal
+    # (</script>, <!--, <script, and the U+2028/U+2029 line separators). All stay valid
+    # JSON via \uXXXX, so JSON.parse decodes the payload back to the original unchanged.
+    data_json = (
+        data_json.replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
     script_block = f"<script>window.CLIPGEN_DATA={data_json};</script>"
 
     if _CLIPGEN_DATA_PLACEHOLDER in template_html:


### PR DESCRIPTION
## Summary

The exported timeline/gallery viewers embed their data payload as `<script>window.CLIPGEN_DATA={json}</script>`, but `json.dumps` doesn't escape `<`, so a spreadsheet observation containing `</script>` (or the `<!--<script>` double-escape variant) closed/confused the tag — blanking the exported page and injecting arbitrary HTML from the sheet. Fixed by escaping `<`, `>`, `&`, and U+2028/U+2029 to `\uXXXX` at the single shared embed site (covers both viewers); output stays valid JSON and `JSON.parse` decodes it back unchanged.

## Test plan

- [x] New regression test `test_viewer_data_escapes_script_break_sequences` — hostile description round-trips while no raw `</script>`/`<script`/`<!--`/U+2028 survives into the payload
- [x] `/check` green: ruff format + lint, ty, full suite (1749 passed)