### PR TITLE
fix(screenspace): serialize EasyOCR inference on the shared Reader

### DIFF
--- a/screenspace.py
+++ b/screenspace.py
@@ -69,6 +69,7 @@ from screenspace_primitives import (
 from screenspace_ocr import (
     _get_ocr_reader,
     _ocr_readers,
+    _ocr_readtext,
     _preprocess_for_ocr,
     _score_numbers_readings,
     _score_text_readings,

--- a/screenspace_ocr.py
+++ b/screenspace_ocr.py
@@ -25,6 +25,8 @@ from screenspace_primitives import extract_region
 
 _ocr_readers: dict[tuple, Any] = {}
 _ocr_lock = threading.Lock()
+# serializes readtext on the shared (non-thread-safe) Reader
+_ocr_infer_lock = threading.Lock()
 
 
 def _get_ocr_reader(languages: list[str]) -> Any:
@@ -36,6 +38,18 @@ def _get_ocr_reader(languages: list[str]) -> Any:
         if key not in _ocr_readers:
             _ocr_readers[key] = easyocr.Reader(list(key), verbose=False)
         return _ocr_readers[key]
+
+
+def _ocr_readtext(reader: Any, image: np.ndarray, **kwargs: Any) -> list[Any]:
+    """Run ``reader.readtext`` under a global lock.
+
+    EasyOCR/torch inference on a shared cached Reader is not thread-safe; with
+    parallel Screenspace workers (and the calibration route thread) hitting the
+    same Reader, concurrent readtext calls can corrupt results or crash. Reader
+    creation is already guarded by ``_ocr_lock``; this serializes inference.
+    """
+    with _ocr_infer_lock:
+        return reader.readtext(image, **kwargs)
 
 
 def _preprocess_for_ocr(pixels: np.ndarray, *, min_height: int = 0) -> np.ndarray:
@@ -174,7 +188,7 @@ def _ocr_region_readings(
     kwargs: dict[str, Any] = {"detail": 1}
     if allowlist is not None:
         kwargs["allowlist"] = allowlist
-    return reader.readtext(pixels, **kwargs)
+    return _ocr_readtext(reader, pixels, **kwargs)
 
 
 def _score_text_readings(

--- a/screenspace_scans.py
+++ b/screenspace_scans.py
@@ -42,6 +42,7 @@ from screenspace_ocr import (
     _effective_ocr_confidence_threshold,
     _get_ocr_reader,
     _normalize_ocr_text,
+    _ocr_readtext,
     _number_matches,
     _preprocess_for_ocr,
 )
@@ -406,7 +407,7 @@ def scan_text(
         ):
             return None
         ocr_input = _preprocess_for_ocr(pixels) if ocr_preprocess else pixels
-        ocr_results = reader.readtext(ocr_input, detail=1)
+        ocr_results = _ocr_readtext(reader, ocr_input, detail=1)
         matched_rd: dict[str, Any] | None = None
         for _, text, conf in ocr_results:
             if conf < ocr_confidence_threshold:
@@ -523,7 +524,7 @@ def scan_numbers(
         ):
             return None
         ocr_input = _preprocess_for_ocr(pixels) if ocr_preprocess else pixels
-        ocr_results = reader.readtext(ocr_input, **ocr_kwargs)
+        ocr_results = _ocr_readtext(reader, ocr_input, **ocr_kwargs)
         matched_rd: dict[str, Any] | None = None
         for _, text, conf in ocr_results:
             if conf < ocr_confidence_threshold:


### PR DESCRIPTION
## Summary

The cached EasyOCR `Reader` was used for `readtext` inference outside any lock while only creation was guarded, so parallel Screenspace workers (or a worker plus the calibration-route thread) could run torch inference on the same non-thread-safe model concurrently — risking corrupted readings or crashes. Adds a module-level `_ocr_infer_lock` and an `_ocr_readtext` helper that runs `readtext` under it, and routes all three call sites (`_ocr_region_readings`, `scan_text`, `scan_numbers`) through the helper.

## Test plan

- [x] `ruff format --check` + `ruff check` clean
- [x] Full suite green (1748 passed), incl. `tests/screenspace/` + `tests/test_screenspace_api.py`