### PR TITLE
fix(screenspace): align preview mask prep with scan; clamp inactivity span start

### DIFF
--- a/screenspace.py
+++ b/screenspace.py
@@ -52,6 +52,7 @@ from screenspace_primitives import (
     _merge_timestamp_spans,
     _morph_kernel,
     _prepare_template,
+    _template_correlation_map,
     average_color_hsv,
     color_matches,
     color_present,

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -341,23 +341,17 @@ def _overlay_template_heatmap(
     template = params.get("template_image")
     if not (isinstance(template, np.ndarray) and template.size > 0):
         return None
-    k = config.SCREENSPACE_BLUR_KERNEL
-    frame_gray = cv2.cvtColor(cv2.GaussianBlur(frame, (k, k), 0), cv2.COLOR_BGR2GRAY)
-    tmpl_gray = cv2.cvtColor(cv2.GaussianBlur(template, (k, k), 0), cv2.COLOR_BGR2GRAY)
-    if (
-        tmpl_gray.shape[0] > frame_gray.shape[0]
-        or tmpl_gray.shape[1] > frame_gray.shape[1]
-        or float(np.std(tmpl_gray)) < 1e-6
-    ):
-        return None
     mask = params.get("template_mask")
-    gray_mask = None
-    if isinstance(mask, np.ndarray) and mask.size > 0:
-        gray_mask = cv2.GaussianBlur(mask, (k, k), 0)
-    result = cv2.matchTemplate(
-        frame_gray, tmpl_gray, cv2.TM_CCOEFF_NORMED, mask=gray_mask
-    )
-    result = np.nan_to_num(result, nan=0.0, posinf=1.0, neginf=-1.0)
+    if not (isinstance(mask, np.ndarray) and mask.size > 0):
+        mask = None
+    # Reuse the scan's template-prep + correlation helpers so the preview
+    # heatmap reflects exactly what a real scan computes: the mask is binarized
+    # (not blurred), and the degeneracy/oversize checks match the scan path.
+    prepared = screenspace._prepare_template(template, mask)
+    result = screenspace._template_correlation_map(frame, prepared)
+    if result is None:
+        return None
+    tmpl_gray = prepared[0]
     norm = np.empty_like(result)
     cv2.normalize(result, norm, 0, 255, cv2.NORM_MINMAX)
     heat = cv2.applyColorMap(norm.astype(np.uint8), cv2.COLORMAP_JET)

--- a/screenspace_scans.py
+++ b/screenspace_scans.py
@@ -1048,7 +1048,10 @@ def scan_inactivity(
             if dist <= threshold:
                 # Frame is similar — extend or start span
                 if span_start[0] is None:
-                    span_start[0] = ts - interval_seconds
+                    # Clamp to the scan start so a match early in the video
+                    # (ts < interval_seconds, or start_seconds > 0) can't begin
+                    # the span before 0:00 / the requested start.
+                    span_start[0] = max(start_seconds, ts - interval_seconds)
                 span_distances[0].append(dist)
             else:
                 # Frame changed — flush any active span

--- a/tests/screenspace/test_inactivity.py
+++ b/tests/screenspace/test_inactivity.py
@@ -41,6 +41,59 @@ class TestScanInactivity:
         assert results[0]["duration"] == 4.0
         assert results[0]["avg_distance"] == 0.0
 
+    def test_span_start_not_negative_early_match(self, monkeypatch):
+        """First similar pair with ts < interval must not start before 0:00."""
+        frame = np.full((50, 50, 3), 128, dtype=np.uint8)
+        # First similar pair lands at ts=0.5 with a 1.0s interval, so the
+        # naive ``ts - interval_seconds`` would be -0.5.
+        timestamps = [0.0, 0.5, 1.5, 2.5, 3.5]
+
+        def fake_scan(video_path, region, interval, callback, **kwargs):
+            for ts in timestamps:
+                if callback(ts, frame.copy()) is False:
+                    break
+
+        monkeypatch.setattr(screenspace_scans, "scan_video_frames", fake_scan)
+        monkeypatch.setattr(
+            screenspace_scans, "_probe_video_meta", lambda p: (30.0, 5.0)
+        )
+
+        results = screenspace.scan_inactivity(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 50, "h": 50},
+            threshold=15,
+            min_duration=1.0,
+            interval_seconds=1.0,
+        )
+        assert len(results) == 1
+        assert results[0]["start"] >= 0.0
+
+    def test_span_start_clamped_to_scan_start(self, monkeypatch):
+        """With start_seconds > 0 the span can't begin before the requested start."""
+        frame = np.full((50, 50, 3), 128, dtype=np.uint8)
+        timestamps = [10.0, 11.0, 12.0, 13.0]
+
+        def fake_scan(video_path, region, interval, callback, **kwargs):
+            for ts in timestamps:
+                if callback(ts, frame.copy()) is False:
+                    break
+
+        monkeypatch.setattr(screenspace_scans, "scan_video_frames", fake_scan)
+        monkeypatch.setattr(
+            screenspace_scans, "_probe_video_meta", lambda p: (30.0, 20.0)
+        )
+
+        results = screenspace.scan_inactivity(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 50, "h": 50},
+            threshold=15,
+            min_duration=1.0,
+            interval_seconds=1.0,
+            start_seconds=10.0,
+        )
+        assert len(results) == 1
+        assert results[0]["start"] >= 10.0
+
     def test_different_frames_not_detected(self, monkeypatch):
         """Frames with very different content should not produce a span."""
         timestamps = [0.0, 1.0, 2.0, 3.0]

--- a/tests/test_screenspace_preview.py
+++ b/tests/test_screenspace_preview.py
@@ -204,6 +204,28 @@ def test_overlay_layer_encodes_at_native_resolution(
     assert decoded.shape[:2] == (region["h"], region["w"])
 
 
+def test_template_heatmap_with_mask_matches_scan_prep(
+    synthetic_frame: np.ndarray,
+) -> None:
+    """A masked template heatmap uses the scan's binarized-mask prep helper."""
+    template = synthetic_frame[10:50, 10:50].copy()
+    # Soft-alpha mask: an opaque center on a semi-transparent border. The scan
+    # binarizes this (>=128 -> 255); the preview must do the same so its heatmap
+    # reflects the real scan rather than a blurred approximation.
+    mask = np.full((40, 40), 100, dtype=np.uint8)
+    mask[10:30, 10:30] = 255
+    params = {"template_image": template, "template_mask": mask}
+
+    img = screenspace_preview.build_overlay_layer(
+        synthetic_frame, None, None, "template", "match_heatmap", params
+    )
+    assert img is not None
+    assert img.dtype == np.uint8
+    assert img.ndim == 3 and img.shape[2] == 3
+    # Frame-scoped: the heatmap covers the whole frame after border replication.
+    assert img.shape[:2] == synthetic_frame.shape[:2]
+
+
 def test_overlay_multitool_inherits_first_step(
     synthetic_frame: np.ndarray, region: dict[str, int]
 ) -> None:


### PR DESCRIPTION
## Summary

Two isolated Screenspace fixes:
- Model-view template heatmap prepared the alpha mask with a Gaussian blur while the real scan binarizes it (`THRESH_BINARY`), so the live preview didn't reflect what the scan computes. It now reuses the scan's `_prepare_template` / `_template_correlation_map` helpers (also aligning the degeneracy check); `_template_correlation_map` is re-exported from the `screenspace` facade.
- Inactivity scan clamped the first span start to `max(start_seconds, ts - interval_seconds)` so an early match can no longer begin before `0:00` / the requested start.

## Test plan

- [x] `ruff format` + `ruff check` + `ty check` clean, full `pytest` suite green
- [x] Added regression tests: masked template heatmap prep, and inactivity span start clamping (early match + `start_seconds > 0`)
- [ ] ⚠️ Model-view preview not browser-checked — visual confirmation that a masked template's heatmap now matches scan results is pending