### PR TITLE
fix: harden input validation across three minor bug-hunt findings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1045,11 +1045,18 @@ def _generate_cli_clips(
     # Apply custom highlights duration if specified (e.g. -H 120)
     if args.highlights and args.highlights != "highlights":
         try:
-            config.HIGHLIGHTS_REEL_DURATION_SECONDS = int(args.highlights)
+            duration = int(args.highlights)
         except ValueError:
             utils.warning_print(
                 f"Invalid highlights duration '{args.highlights}', using default ({config.HIGHLIGHTS_REEL_DURATION_SECONDS}s)."
             )
+        else:
+            if duration <= 0:
+                utils.warning_print(
+                    f"Invalid highlights duration '{args.highlights}', using default ({config.HIGHLIGHTS_REEL_DURATION_SECONDS}s)."
+                )
+            else:
+                config.HIGHLIGHTS_REEL_DURATION_SECONDS = duration
 
     mode_dispatch: list[tuple] = [
         (

--- a/screenspace_multitool.py
+++ b/screenspace_multitool.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 import numpy as np
 
 import config
+import utils
 from screenspace_tools import (
     _extract_confidence,
     check_frame_for_tool,
@@ -89,6 +90,28 @@ def scan_multitool(
     if scan_end is None or scan_end > vid_duration:
         scan_end = vid_duration
     total_range = scan_end - scan_start
+
+    # Validate offset windows so a misconfigured offset doesn't silently yield an
+    # empty result with no explanation. Direct callers (MultitoolTool.scan, the
+    # Workflows ss_scan node) bypass the server route's _coerce_offset check.
+    for i in range(1, len(steps)):
+        off = steps[i].get("offset")
+        if not isinstance(off, dict):
+            continue
+        off_min = off.get("min")
+        off_max = off.get("max")
+        if off_min is None or off_max is None:
+            continue
+        if off_min > off_max:
+            utils.warning_print(
+                f"Multitool step {i}: offset min ({off_min}s) > max ({off_max}s) — "
+                "window is empty, this step will match nothing."
+            )
+        elif off_min > total_range or off_max < -total_range:
+            utils.warning_print(
+                f"Multitool step {i}: offset window [{off_min}s, {off_max}s] cannot "
+                f"overlap the {total_range:.1f}s scan span — this step will match nothing."
+            )
 
     tool_types = [s["type"] for s in steps]
     step_regions = [s.get("region_coords", region) for s in steps]

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -90,6 +90,8 @@ def dispatch_tool_scan(
     Shared by :meth:`ScreenspaceWorker._dispatch` and the Workflows ``ss_scan``
     node so both get identical single/multi-video behavior.
     """
+    if not video_paths:
+        return []
     timeline = video.timeline_or_none(video_paths)
     if timeline is None:
         return tool.scan(

--- a/tests/screenspace/test_multitool_scoring.py
+++ b/tests/screenspace/test_multitool_scoring.py
@@ -832,6 +832,50 @@ class TestScanMultitool:
         monkeypatch.setattr(screenspace_multitool, "scan_video_full_frames", fake_scan)
         monkeypatch.setattr(screenspace_multitool, "check_frame_for_tool", check)
 
+    def test_offset_inverted_window_warns(self, monkeypatch):
+        # min > max is an empty window: warn, but don't raise.
+        from unittest.mock import Mock
+
+        warn = Mock()
+        monkeypatch.setattr(screenspace_multitool.utils, "warning_print", warn)
+
+        def check(ts, ttype, step):
+            return True, {"_confidence": 0.9}
+
+        self._setup_multiframe_stubs(monkeypatch, [0, 1, 2], check)
+        results = screenspace.scan_multitool(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            steps=[
+                {"type": "color"},
+                {"type": "change", "offset": {"min": 5, "max": 1}},
+            ],
+        )
+        assert results == []
+        warn.assert_called_once()
+
+    def test_offset_out_of_range_window_warns(self, monkeypatch):
+        # Window starts beyond the whole scan span → can never match: warn.
+        from unittest.mock import Mock
+
+        warn = Mock()
+        monkeypatch.setattr(screenspace_multitool.utils, "warning_print", warn)
+
+        def check(ts, ttype, step):
+            return True, {"_confidence": 0.9}
+
+        # _probe_video_meta -> duration = max(ts)+1 = 4, so total_range ~= 4.
+        self._setup_multiframe_stubs(monkeypatch, [0, 1, 2, 3], check)
+        screenspace.scan_multitool(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            steps=[
+                {"type": "color"},
+                {"type": "change", "offset": {"min": 100, "max": 200}},
+            ],
+        )
+        warn.assert_called_once()
+
     def test_offset_and_hit(self, monkeypatch):
         # color @2; change @4 within the [+0,+3] window from the anchor.
         def check(ts, ttype, step):

--- a/tests/screenspace/test_worker.py
+++ b/tests/screenspace/test_worker.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import config
 import screenspace
+import screenspace_worker
 
 
 class TestCreateTask:
@@ -23,6 +24,25 @@ class TestCreateTask:
         assert task["type"] == "color"
         assert task["status"] == "queued"
         assert task["progress"] == 0.0
+
+
+class TestDispatchToolScan:
+    def test_empty_video_paths_returns_empty_without_touching_tool(self):
+        tool = mock.Mock()
+        result = screenspace_worker.dispatch_tool_scan(
+            tool,
+            [],
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            {},
+            task_id="ss_1",
+            scan_mode="full",
+            on_progress=lambda _p: None,
+            cancel_flag=lambda: False,
+            on_result=None,
+            fast_opts=None,
+        )
+        assert result == []
+        tool.scan.assert_not_called()
 
 
 class TestScreenspaceWorker:

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -86,6 +86,34 @@ def test_generate_cli_clips_prefers_mixed_over_batch(monkeypatch):
     assert call_args.kwargs.get("reel_input") == "11, P01.5"
 
 
+@pytest.mark.parametrize("bad", ["0", "-5"])
+def test_generate_cli_clips_rejects_nonpositive_highlights(monkeypatch, bad):
+    """-H 0 / -H -5 keep the default duration and warn instead of applying it."""
+    monkeypatch.setattr(config, "HIGHLIGHTS_REEL_DURATION_SECONDS", 180)
+    monkeypatch.setattr(cli.spreadsheet, "generate_list", Mock(return_value=[]))
+    warn = Mock()
+    monkeypatch.setattr(cli.utils, "warning_print", warn)
+
+    cli._generate_cli_clips(
+        object(), _args(highlights=bad), cli.CliModeArgs(None, None, None, None)
+    )
+
+    assert config.HIGHLIGHTS_REEL_DURATION_SECONDS == 180
+    warn.assert_called_once()
+
+
+def test_generate_cli_clips_applies_positive_highlights(monkeypatch):
+    """A valid positive -H duration overrides the default."""
+    monkeypatch.setattr(config, "HIGHLIGHTS_REEL_DURATION_SECONDS", 180)
+    monkeypatch.setattr(cli.spreadsheet, "generate_list", Mock(return_value=[]))
+
+    cli._generate_cli_clips(
+        object(), _args(highlights="120"), cli.CliModeArgs(None, None, None, None)
+    )
+
+    assert config.HIGHLIGHTS_REEL_DURATION_SECONDS == 120
+
+
 def test_run_cli_mode_chronologic_reel_and_viewer(monkeypatch):
     worksheet = Namespace(title="Sheet", spreadsheet=Namespace(url="http://example"))
     args = _args(chronologic="P01", viewer=True)

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -678,6 +678,26 @@ class TestTranscriptWorker:
         worker = transcripts.TranscriptWorker()
         assert worker.cancel("nonexistent") is False
 
+    def test_execute_task_empty_video_paths_fails_cleanly(self, monkeypatch):
+        """A task with no video files fails cleanly instead of raising IndexError."""
+        from unittest.mock import Mock
+
+        import video as video_mod
+
+        probe = Mock()
+        monkeypatch.setattr(video_mod, "probe_video_properties", probe)
+
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", [])
+        task["status"] = "running"
+
+        worker._execute_task(task)
+
+        assert task["status"] == transcripts.TASK_STATUS_FAILED
+        assert task["partial_segments"] == []
+        assert task["error"]
+        probe.assert_not_called()
+
     def test_execute_task_cancelled_before_model_load(self, monkeypatch):
         """A task cancelled before model load aborts without loading a model."""
         from unittest.mock import Mock

--- a/transcripts.py
+++ b/transcripts.py
@@ -967,6 +967,14 @@ class TranscriptWorker:
         import video as video_mod
 
         video_paths = task["video_paths"]
+        if not video_paths:
+            with self._lock:
+                task["status"] = TASK_STATUS_FAILED
+                task["error"] = "No video files — nothing to transcribe."
+                task["partial_segments"] = []
+                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+            return
+
         # Multi-video participants form one continuous timeline; transcribe each
         # part and merge with global-shifted times. Single video → fast path,
         # no extra duration probe beyond the audio guard below.


### PR DESCRIPTION
## Summary

Three narrow input-validation fixes from a bug hunt — none is a live crash, each closes a sharp edge:
- **Empty `video_paths` guards** in `transcripts._execute_task` and `screenspace_worker.dispatch_tool_scan` fail cleanly / return `[]` instead of indexing `[0]` (defensive for future call sites).
- **`cli.py`** rejects `-H <= 0` highlights durations (warn + keep the 180s default) so `0`/negative no longer set a zero-length reel budget.
- **`scan_multitool`** validates offset windows at scan start (`min <= max`, window must overlap the scan span) and warns the user, covering the direct callers (`MultitoolTool.scan`, Workflows `ss_scan`) that bypass the server route's `_coerce_offset` check.

## Test plan

- [x] Added tests per fix (cli highlights, empty-paths dispatch/execute, inverted/out-of-range offsets)
- [x] Full suite green — `uv run --extra dev pytest -c tests/pytest.ini` (1758 passed)
- [x] `ruff format --check`, `ruff check`, `ty check` clean on touched source