### PR TITLE
fix(server): apply static-asset cache TTLs that after_request hook dropped

### DIFF
--- a/server.py
+++ b/server.py
@@ -3199,6 +3199,28 @@ def _swap_worksheet(new_worksheet: Any) -> None:
         raise
 
 
+def _set_cache_headers(response):
+    """after_request hook: apply content-type-aware caching to static assets.
+
+    ``send_from_directory`` stamps a bare ``Cache-Control: no-cache`` by default
+    (Werkzeug, when ``max_age`` is unset), which carries no real caching intent —
+    let it fall through so static css/js/svg get their TTLs. Deliberate cache
+    headers set by a route (thumbnails, SSE streams, video previews) are anything
+    other than a bare ``no-cache`` and are preserved untouched.
+    """
+    existing = response.headers.get("Cache-Control")
+    if existing and existing != "no-cache":
+        return response
+    ct = response.content_type or ""
+    if ct.startswith("text/html"):
+        response.headers["Cache-Control"] = "no-cache"
+    elif ct.startswith(("text/css", "application/javascript", "text/javascript")):
+        response.headers["Cache-Control"] = "public, max-age=3600"
+    elif ct.startswith("image/svg"):
+        response.headers["Cache-Control"] = "public, max-age=86400"
+    return response
+
+
 def build_combined_app(
     worksheet: Any = None,
     default_page: str = "studio",
@@ -3261,19 +3283,7 @@ def build_combined_app(
     )
     combined.register_blueprint(workflows_server.workflows_bp, url_prefix="/workflows")
 
-    @combined.after_request
-    def _set_cache_headers(response):
-        # Skip if a route already set Cache-Control (e.g. thumbnails)
-        if "Cache-Control" in response.headers:
-            return response
-        ct = response.content_type or ""
-        if ct.startswith("text/html"):
-            response.headers["Cache-Control"] = "no-cache"
-        elif ct.startswith(("text/css", "application/javascript", "text/javascript")):
-            response.headers["Cache-Control"] = "public, max-age=3600"
-        elif ct.startswith("image/svg"):
-            response.headers["Cache-Control"] = "public, max-age=86400"
-        return response
+    combined.after_request(_set_cache_headers)
 
     @combined.route("/")
     def root():

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -4184,3 +4184,29 @@ def test_api_clip_audio_happy_path(client, monkeypatch):
     assert resp.mimetype == "audio/wav"
     assert resp.headers["Cache-Control"] == "public, max-age=86400"
     assert resp.data == b"WAVDATA"
+
+
+def test_static_cache_headers():
+    """Static css/js/svg get their content-type TTLs; html stays no-cache.
+
+    Regression guard: ``send_from_directory`` defaults to a bare ``no-cache``,
+    which the ``_set_cache_headers`` after_request hook must override rather than
+    treat as a deliberate cache header (server.py). The ``client`` fixture omits
+    the hook, so register it explicitly here.
+    """
+    app = Flask(__name__)
+    app.register_blueprint(server.studio_bp, url_prefix="/studio")
+    app.after_request(server._set_cache_headers)
+    with app.test_client() as c:
+        assert (
+            c.get("/studio/utils.js").headers["Cache-Control"] == "public, max-age=3600"
+        )
+        assert (
+            c.get("/studio/tokens.css").headers["Cache-Control"]
+            == "public, max-age=3600"
+        )
+        assert (
+            c.get("/studio/icons/x-mark.svg").headers["Cache-Control"]
+            == "public, max-age=86400"
+        )
+        assert c.get("/studio/").headers["Cache-Control"] == "no-cache"


### PR DESCRIPTION
## Summary

`send_from_directory` stamps a bare `Cache-Control: no-cache` by default, which tripped the `after_request` guard's "already set" early-return — so the intended `public, max-age` TTLs were dead code for **every** static asset (js, css, AND svg icons/logos), making each page load and Studio↔Screenspace↔Transcripts tab switch fire ~15–20 needless conditional revalidations at the single dev server. The guard now overrides a bare `no-cache` (js/css → 3600, svg → 86400, html → no-cache) while preserving deliberately-set headers (thumbnails, SSE, video previews — none on css/js/svg content types); ETag revalidation still applies after the TTL.

## Test plan

- [x] Extracted `_set_cache_headers` to module scope and added `test_static_cache_headers` asserting js/css → `max-age=3600`, svg → `max-age=86400`, html → `no-cache`
- [x] Full `/check` green: ruff format + lint, ty, 1772 tests pass
- [ ] Manual `curl -sI` spot-check against a running `--studio` server (not run)