### PR TITLE
fix: enforce clip size cap after titlecard wrap, not before

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -488,6 +488,7 @@ def _process_single_clip_segments(
     output_format: str = "clip",
     collect_paths: bool = False,
     include_severity: bool = False,
+    enforce_size: bool = True,
     cancel_flag: Callable[[], bool] | None = None,
     titlecards_enabled: bool | None = None,
     titlecard_duration_seconds: int | None = None,
@@ -502,6 +503,10 @@ def _process_single_clip_segments(
         missing_videos: Set of already-reported missing paths (read-only here)
         filename_prefix: Prefix for output filename (e.g. '_reel_part_' for reel)
         collect_paths: If True, return list of (output_path, time_index) pairs; otherwise return empty list
+        enforce_size: If True (default), compress each final clip to config.MAX_FILESIZE_MB
+            after the titlecard wrap. Pass False for intermediate cuts (e.g. reel parts)
+            that get concatenated/re-encoded downstream, so the size cap is applied once
+            to the final artifact rather than wasted on throwaway pieces.
         include_severity: If True and clip has severity, include [Severity] in filename
         cancel_flag: Optional callable; checked before each segment and forwarded to
             ffmpeg helpers so an in-flight encode can be terminated. Already-finished
@@ -604,6 +609,10 @@ def _process_single_clip_segments(
                     titlecards_enabled=cards_enabled,
                     titlecard_duration_seconds=card_duration,
                 )
+            # Enforce the size cap on the finished clip (after any wrap re-encode),
+            # not on intermediate reel parts (enforce_size=False).
+            if ok and enforce_size:
+                video.enforce_filesize_limit(out_name, cancel_flag=cancel_flag)
         else:  # output_format == 'screen' or 'gif' — keys off the start time only
             src_path: str | None = base_video
             cut_ts = start_time
@@ -1471,6 +1480,7 @@ def _process_reel(
             missing_videos,
             filename_prefix="_reel_part_",
             collect_paths=True,
+            enforce_size=False,  # parts are concatenated into an uncapped reel
             cancel_flag=cancel_flag,
             titlecards_enabled=titlecards_enabled,
             titlecard_duration_seconds=titlecard_duration_seconds,
@@ -1875,6 +1885,8 @@ def _regenerate_single_artifact(
             Path(p).unlink(missing_ok=True)
         if ok and artifact.get("titlecards"):
             ok = _reapply_titlecards(artifact, output_path)
+        if ok:
+            video.enforce_filesize_limit(output_path)
         return ok
 
     source_name = artifact.get("sourceVideo", "")
@@ -1907,6 +1919,8 @@ def _regenerate_single_artifact(
         # Reapply titlecards if the manifest entry was generated with them.
         if ok and artifact.get("titlecards"):
             ok = _reapply_titlecards(artifact, output_path)
+        if ok:
+            video.enforce_filesize_limit(output_path)
         return ok
     elif artifact_type == "screen":
         return video.extract_screenshot(

--- a/server.py
+++ b/server.py
@@ -1064,6 +1064,11 @@ def _process_intake_item(
         files.release_reservation(out_path)
         return {"_ok": False, "_error": "ffmpeg failed"}
 
+    # Enforce the size cap on the finished clip (intake has no titlecard wrap, so
+    # this is the only gate). Screenshots/GIFs are never compressed.
+    if output_format == "clip":
+        video.enforce_filesize_limit(out_path, cancel_flag=cancel_flag)
+
     default_desc = (
         "Transcript intake" if source == "transcript" else "Screenspace intake"
     )

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -470,6 +470,72 @@ def test_process_clips_forwards_titlecard_options_to_wrap(monkeypatch, make_clip
     assert captured["titlecard_duration_seconds"] == 6
 
 
+def test_process_clips_compresses_after_titlecard_wrap(monkeypatch, make_clip):
+    """The size cap is enforced on the final clip AFTER the wrap, not before it.
+
+    Regression for the compress-before-wrap bug: compression used to run inside
+    run_ffmpeg (before the CRF wrap discarded it), wasting passes and letting the
+    output exceed the cap.
+    """
+    raw_clip = make_clip()
+    monkeypatch.setattr(
+        clipgen.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(clipgen.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(clipgen.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+    monkeypatch.setattr(config, "MAX_FILESIZE_MB", 50)
+    monkeypatch.setattr(
+        clipgen.files, "get_unique_filename", lambda *_a, **_k: "out.mp4"
+    )
+    monkeypatch.setattr(clipgen.video, "run_ffmpeg", lambda **_k: True)
+
+    order: list[str] = []
+
+    def fake_wrap(_clip, _out_name, **_kwargs):
+        order.append("wrap")
+        return True
+
+    def fake_enforce(_path, **_kwargs):
+        order.append("enforce")
+
+    monkeypatch.setattr(pipeline.titlecards, "wrap_clip_with_cards", fake_wrap)
+    monkeypatch.setattr(pipeline.video, "enforce_filesize_limit", fake_enforce)
+
+    pipeline.process_clips([raw_clip], output_format="clip", titlecards_enabled=True)
+
+    assert order == ["wrap", "enforce"]
+
+
+def test_reel_part_cut_is_not_size_capped(monkeypatch, make_clip):
+    """Reel parts (enforce_size=False) skip compression; the cap applies to the reel-less final clip only."""
+    monkeypatch.setattr(config, "MAX_FILESIZE_MB", 50)
+    monkeypatch.setattr(
+        clipgen.files, "get_unique_filename", lambda *_a, **_k: "out.mp4"
+    )
+    monkeypatch.setattr(clipgen.video, "run_ffmpeg", lambda **_k: True)
+    monkeypatch.setattr(config, "TITLECARDS_ENABLED", False)
+
+    enforce = Mock()
+    monkeypatch.setattr(pipeline.video, "enforce_filesize_limit", enforce)
+
+    prepared = _prepared_clip(make_clip(), [("00:10", "00:20")])
+
+    # enforce_size=False (reel-part path) → no compression.
+    pipeline._process_single_clip_segments(
+        prepared, "src.mp4", set(), collect_paths=True, enforce_size=False
+    )
+    assert enforce.call_count == 0
+
+    # enforce_size defaults True (final clip) → compression runs once.
+    pipeline._process_single_clip_segments(
+        prepared, "src.mp4", set(), collect_paths=True
+    )
+    assert enforce.call_count == 1
+
+
 def test_build_reel_transcript_uses_request_titlecard_duration(monkeypatch):
     """Reel transcript offsets honor per-request titlecard duration."""
     components = [

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1,6 +1,7 @@
 import io
 import json
 from collections import OrderedDict
+from unittest.mock import Mock
 
 import pytest
 
@@ -182,6 +183,33 @@ def test_process_intake_item_releases_reservation_on_cut_exception(
     with pytest.raises(RuntimeError):
         server._process_intake_item(item, "clip", "study")
     assert list(tmp_path.glob("*.mp4")) == []
+
+
+def test_process_intake_item_enforces_size_cap_for_clip_only(tmp_path, monkeypatch):
+    """A clip intake compresses to the cap (no wrap here); screenshots/GIFs do not."""
+    monkeypatch.setattr(server.config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(server.config, "MAX_FILESIZE_MB", 50)
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_paths", lambda *a, **k: ["v.mp4"]
+    )
+    monkeypatch.setattr(server.video, "timeline_or_none", lambda *a, **k: None)
+    monkeypatch.setattr(
+        server.pipeline,
+        "cut_global_range",
+        lambda *a, **k: {"sourceVideo": "v.mp4", "localStart": 0.0, "localEnd": 5.0},
+    )
+
+    enforce = Mock()
+    monkeypatch.setattr(server.video, "enforce_filesize_limit", enforce)
+
+    item = {"participant": "P01", "start": 0.0, "end": 5.0}
+
+    server._process_intake_item(item, "clip", "study")
+    assert enforce.call_count == 1
+
+    server._process_intake_item(item, "screen", "study")
+    server._process_intake_item(item, "gif", "study")
+    assert enforce.call_count == 1  # unchanged — only the clip was compressed
 
 
 def test_settings_records_include_card_pickers(client):

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1012,7 +1012,14 @@ def test_run_ffmpeg_forwards_cancel_flag(monkeypatch):
     monkeypatch.setattr(video, "get_duration", lambda *_a: 5)
     monkeypatch.setattr(video, "get_file_duration", lambda *_a: 60)
     monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
-    monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 0)
+    # Even with a size cap set, run_ffmpeg is a pure cut and must NOT compress —
+    # enforcement moved to the callers, applied after any titlecard wrap/concat.
+    monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 50)
+
+    def _no_compress(*_a, **_kw):
+        raise AssertionError("run_ffmpeg must not call compress_to_size")
+
+    monkeypatch.setattr(video, "compress_to_size", _no_compress)
 
     captured: list = []
     monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
@@ -1023,6 +1030,33 @@ def test_run_ffmpeg_forwards_cancel_flag(monkeypatch):
     )
     assert ok is True
     assert captured == [sentinel]
+
+
+def test_enforce_filesize_limit_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 0)
+
+    def _no_compress(*_a, **_kw):
+        raise AssertionError("compress_to_size must not run when the cap is disabled")
+
+    monkeypatch.setattr(video, "compress_to_size", _no_compress)
+    # Should return without touching compress_to_size.
+    video.enforce_filesize_limit("out.mp4")
+
+
+def test_enforce_filesize_limit_compresses_and_forwards_cancel_flag(monkeypatch):
+    monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 50)
+
+    captured: list = []
+
+    def _fake_compress(path, target_mb, *, cancel_flag=None):
+        captured.append((path, target_mb, cancel_flag))
+        return True
+
+    monkeypatch.setattr(video, "compress_to_size", _fake_compress)
+
+    sentinel = lambda: False  # noqa: E731
+    video.enforce_filesize_limit("out.mp4", cancel_flag=sentinel)
+    assert captured == [("out.mp4", 50, sentinel)]
 
 
 def test_extract_screenshot_forwards_cancel_flag(monkeypatch):

--- a/video.py
+++ b/video.py
@@ -702,12 +702,11 @@ def run_ffmpeg(
     if not verify_output_file(output_file, "ffmpeg"):
         return False
 
-    if config.MAX_FILESIZE_MB and config.MAX_FILESIZE_MB > 0:
-        if not compress_to_size(
-            output_file, config.MAX_FILESIZE_MB, cancel_flag=cancel_flag
-        ):
-            utils.warning_print(f"Could not compress '{output_file}' to target size")
-
+    # NB: file-size enforcement is deliberately NOT done here. A cut is often
+    # followed by a titlecard wrap or a concat that re-encodes the body, which
+    # would discard any bitrate targeting applied at cut time (and waste two
+    # passes). Callers apply enforce_filesize_limit() to the *final* artifact
+    # after all wrapping/concat instead.
     utils.verbose_print(
         f"+ Generated video '{output_file}' successfully.\n File size: {utils.format_filesize(Path(output_file).stat().st_size)}\n Expected duration: {duration} s\n"
     )
@@ -1498,6 +1497,20 @@ def calculate_target_bitrate(
 
     video_bitrate_kbps = int(total_bitrate_kbps - audio_bitrate_kbps)
     return max(video_bitrate_kbps, config.MIN_VIDEO_BITRATE_KBPS)
+
+
+def enforce_filesize_limit(
+    path: str, *, cancel_flag: Callable[[], bool] | None = None
+) -> None:
+    """Compress *path* down to ``config.MAX_FILESIZE_MB`` when the limit is set.
+
+    No-op when the limit is disabled (``0``). Apply this to a *final* clip
+    artifact after any titlecard wrap or concat — never to an intermediate cut
+    that will be re-encoded downstream (see the note in :func:`run_ffmpeg`).
+    """
+    if config.MAX_FILESIZE_MB and config.MAX_FILESIZE_MB > 0:
+        if not compress_to_size(path, config.MAX_FILESIZE_MB, cancel_flag=cancel_flag):
+            utils.warning_print(f"Could not compress '{path}' to target size")
 
 
 def compress_to_size(


### PR DESCRIPTION
## Summary

`compress_to_size` ran inside `run_ffmpeg`, *before* `wrap_clip_with_cards` re-encoded the body with CRF and discarded the bitrate targeting — so with `MAX_FILESIZE_MB>0` and titlecards on, two compression passes were wasted and the output could exceed the cap (plus intermediate temp cuts were compressed needlessly and multipart clips escaped the cap entirely).

- Made `run_ffmpeg` a pure cut and added `video.enforce_filesize_limit()`, applied to the *final* artifact after any wrap/concat (`process_clips`, both regen paths, and Studio intake).
- Reel parts opt out via a new `enforce_size=False` param so the cap is enforced once on the final clip, never on throwaway pieces; reels themselves stay uncapped (pre-existing behavior).

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` all clean
- [x] Full suite green (1776 passed), incl. new tests: wrap-before-compress ordering, reel-part guard, `enforce_filesize_limit` unit, and intake clip-only enforcement
- [ ] ⚠️ Not verified end-to-end in a real run: generate clips with `MAX_FILESIZE_MB` set + titlecards on and confirm outputs stay under the cap with only cut + wrap + one compress pass