### PR TITLE
perf: reuse SheetContext to avoid redundant Google Sheets fetches

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -473,18 +473,24 @@ def _print_completion_message(
     )
 
 
-def _prompt_chronologic_participant_selection(worksheet: Any) -> str | None:
-    """Prompt user to pick exactly one participant for chronologic reels."""
+def _prompt_chronologic_participant_selection(
+    worksheet: Any,
+) -> tuple[str | None, spreadsheet.SheetContext | None]:
+    """Prompt user to pick exactly one participant for chronologic reels.
+
+    Returns (selected_participant_id, ctx). The context built here is handed
+    back so the caller can pass it to generate_list and avoid a second fetch.
+    """
     ctx = spreadsheet.build_sheet_context(worksheet)
     if ctx is None:
-        return None
+        return None, None
 
     available_list = spreadsheet.get_participant_list(
         ctx.header_row, ctx.id_cell, ctx.num_participants
     )
     if not available_list:
         utils.info_print("No participants found in the spreadsheet.")
-        return None
+        return None, None
 
     utils.print_mode_heading("Chronologic participant", "mode.chronologic")
     utils.info_print("Chronologic mode requires exactly one participant.")
@@ -508,7 +514,7 @@ def _prompt_chronologic_participant_selection(worksheet: Any) -> str | None:
         if token.isdigit():
             idx = int(token)
             if 1 <= idx <= len(available_list):
-                return available_list[idx - 1]
+                return available_list[idx - 1], ctx
             utils.info_print(
                 f"Not found: {token}. Available: {', '.join(available_list)}"
             )
@@ -523,8 +529,8 @@ def _prompt_chronologic_participant_selection(worksheet: Any) -> str | None:
             )
             continue
         if col_idx < len(ctx.header_row):
-            return utils.normalize_participant_id(ctx.header_row[col_idx])
-        return token
+            return utils.normalize_participant_id(ctx.header_row[col_idx]), ctx
+        return token, ctx
 
 
 def _run_reel_mode_interactive(
@@ -559,6 +565,9 @@ def _run_reel_mode_interactive(
         utils.info_print("No input. Skipping reel.")
         return ([], False, None)
 
+    # Reused by generate_list below when the chronologic prompt builds it; stays
+    # None for every other reel path (generate_list then fetches once itself).
+    reel_ctx: spreadsheet.SheetContext | None = None
     parsed_reel = spreadsheet.parse_reel_input(reel_input)
     if parsed_reel.get("highlights") and (
         parsed_reel["severity"] or parsed_reel["chronologic"]
@@ -584,13 +593,17 @@ def _run_reel_mode_interactive(
             )
             return ([], False, None)
         if len(parsed_reel["participants"]) == 0:
-            selected_pid = _prompt_chronologic_participant_selection(worksheet)
+            selected_pid, reel_ctx = _prompt_chronologic_participant_selection(
+                worksheet
+            )
             if not selected_pid:
                 return ([], False, None)
             reel_input = f"{reel_input}, {selected_pid}"
             parsed_reel["participants"] = [selected_pid]
 
-    clips_list = spreadsheet.generate_list(worksheet, "reel", reel_input=reel_input)
+    clips_list = spreadsheet.generate_list(
+        worksheet, "reel", ctx=reel_ctx, reel_input=reel_input
+    )
     if not clips_list:
         utils.info_print("No clips matched. Try different selectors.")
         return ([], False, None)

--- a/interactive.py
+++ b/interactive.py
@@ -17,7 +17,6 @@ import webbrowser
 from typing import Any, Callable
 
 import config
-import google_api
 import spreadsheet
 import utils
 from spreadsheet import SheetContext
@@ -433,39 +432,24 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
         process_fn: Optional callback (clips_list, output_format) -> (outputs_generated, artifacts).
     """
 
-    def _load_browse_data() -> tuple:
-        sheet_data = google_api.get_sheet_values(sheet)
-        if len(sheet_data) <= 1:
-            return (None, None)
-        header_result = spreadsheet.validate_spreadsheet_headers(sheet_data)
-        if header_result is None:
-            return (None, None)
-        return (header_result, sheet_data)
-
-    header_result, sheet_data = (
-        utils.run_with_spinner("Loading spreadsheet...", _load_browse_data)
-        if utils.use_progress()
-        else _load_browse_data()
-    )
-    if header_result is None:
-        return
-
-    id_cell, observation_cell, category_cell = header_result
-    utils.debug_print(f"Sheet dumped into memory at {utils.get_current_time()}")
-
-    # Get participant info
-    header_row = sheet_data[id_cell.row - 1]
-    col_count = max(len(row) for row in sheet_data)
-    num_participants = spreadsheet.get_num_participants(header_row, id_cell, col_count)
-
-    if num_participants == 0:
-        utils.warning_print(
-            "No participant columns found in the spreadsheet.",
-            [
-                f"Looking for columns starting with: {', '.join(config.PARTICIPANT_PREFIXES)}"
-            ],
+    # Build the context once on entry; reuse it for both display and any
+    # generate action below so we never re-fetch the sheet per generate.
+    ctx = (
+        utils.run_with_spinner(
+            "Loading spreadsheet...", lambda: spreadsheet.build_sheet_context(sheet)
         )
+        if utils.use_progress()
+        else spreadsheet.build_sheet_context(sheet)
+    )
+    if ctx is None:
         return
+
+    id_cell = ctx.id_cell
+    observation_cell = ctx.observation_cell
+    category_cell = ctx.category_cell
+    sheet_data = ctx.sheet_data
+    header_row = ctx.header_row
+    num_participants = ctx.num_participants
 
     # Browse state: all row indices are 0-based (into sheet_data).
     # Data starts immediately below the Observation header row.
@@ -780,7 +764,9 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
                         "Chronologic selector is not supported in browse mode."
                     )
                 else:
-                    clips = spreadsheet.generate_list(sheet, "reel", reel_input=raw)
+                    clips = spreadsheet.generate_list(
+                        sheet, "reel", ctx=ctx, reel_input=raw
+                    )
                     if clips:
                         format_label = {
                             "clip": "clip(s)",


### PR DESCRIPTION
## Summary

Two interactive flows fetched the Google Sheet twice per action; both now thread the existing optional `generate_list(ctx=...)` through so each action does one fetch.

- Browse mode builds a single `SheetContext` on entry (via `build_sheet_context`) and reuses it for display and every generate action instead of re-fetching per generate — browse-generated clips also now match the displayed rows.
- Chronologic reel returns the context its participant prompt already built and passes it to `generate_list` instead of rebuilding it.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 1771 passed
- [x] `uv run ruff format --check && uv run ruff check` — clean
- [x] `uv run ty check` — no new diagnostics on touched files
- [ ] Not browser/CLI-exercised against a live sheet