### PR TITLE
fix(workflows): match base typography to sibling frontends

### DIFF
--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -33,11 +33,22 @@
   --wf-type-value: var(--severity-medium); /* scalar/number/string */
 }
 
+html {
+  /* Root rem anchor — must stay a concrete px. A rem-based token (--text-md
+     is 1rem) would resolve against the browser's default font size, scaling
+     every rem-based --space-* token (and the page-local --wf-* rem dims). */
+  font-size: 16px;
+}
+
 body[data-frontend="workflows"] {
   margin: 0;
   background: var(--bg);
   color: var(--fg);
   font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.005em;
+  line-height: 1.5;
 }
 
 #wfShell {


### PR DESCRIPTION
## Summary

The shared TopNav (unchanged `topnav.js`/`topnav.css`, correctly reused) rendered slightly differently on Workflows — a few pixels taller with a heavier-looking "Quick actions" button — because `workflows.css` omitted the base typography the other three page CSS files set. This adds the `html { font-size: 16px }` root-rem pin plus `body` font-smoothing, `letter-spacing`, and `line-height: 1.5`, so the inherited font metrics match Studio/Screenspace/Transcripts.

## Test plan

- [x] `/check` green — ruff format + lint, full pytest suite pass (ty's only diagnostics are pre-existing `pytest` import-resolution noise from the dev extra not being in this worktree's venv)
- [ ] ⚠️ Not browser-verified: reload `/workflows/` and confirm the topnav height and "Quick actions" button weight now match `/screenspace/` and `/studio/`