### PR TITLE
perf(studio): memoize sheet payload

### DIFF
--- a/server.py
+++ b/server.py
@@ -775,10 +775,12 @@ def _get_sheet_payload(ctx: spreadsheet.SheetContext) -> dict[str, Any]:
         return payload
 
 
-def _invalidate_sheet_payload_cache() -> None:
-    global _sheet_payload_cache
+def _set_sheet_context(ctx: spreadsheet.SheetContext | None) -> None:
+    """Replace the active sheet context and clear derived row payloads atomically."""
+    global _sheet_context, _sheet_payload_cache
 
     with _sheet_payload_cache_lock:
+        _sheet_context = ctx
         _sheet_payload_cache = None
 
 
@@ -940,14 +942,12 @@ def api_convergence_offsets_put() -> FlaskResponse:
 
 @studio_bp.route("/api/sheet/refresh", methods=["POST"])
 def api_sheet_refresh() -> FlaskResponse:
-    global _sheet_context
     if _worksheet is None:
         return err("No spreadsheet loaded — pick one from the Start panel.")
     new_context = spreadsheet.build_sheet_context(_worksheet)
     if new_context is None:
         return err("Failed to refresh sheet data", 500)
-    _sheet_context = new_context
-    _invalidate_sheet_payload_cache()
+    _set_sheet_context(new_context)
     return ok()
 
 
@@ -3103,14 +3103,13 @@ def _init_studio_state(worksheet: Any) -> None:
 
     _load_studio_settings()
     _worksheet = worksheet
+    new_context = None
     if worksheet is not None:
-        _sheet_context = spreadsheet.build_sheet_context(worksheet)
-        if _sheet_context is None:
+        new_context = spreadsheet.build_sheet_context(worksheet)
+        if new_context is None:
             utils.error_print("Could not load spreadsheet data for Studio.")
             sys.exit(1)
-    else:
-        _sheet_context = None
-    _invalidate_sheet_payload_cache()
+    _set_sheet_context(new_context)
     # Rebind the shared generated lists under their lock so a streaming
     # generate/intake append can't run against a half-swapped reference.
     with _generated_output_lock:
@@ -3209,7 +3208,7 @@ def _swap_worksheet(new_worksheet: Any) -> None:
         )
     except Exception:
         _worksheet = prev_worksheet
-        _sheet_context = prev_sheet_context
+        _set_sheet_context(prev_sheet_context)
         with _generated_output_lock:
             _generated_artifacts = prev_artifacts
             _generated_reels = prev_reels

--- a/server.py
+++ b/server.py
@@ -81,6 +81,8 @@ FlaskResponse = Response | tuple[Response, int]
 
 _worksheet: Any = None
 _sheet_context: spreadsheet.SheetContext | None = None
+_sheet_payload_cache: tuple[Any, dict[str, Any]] | None = None
+_sheet_payload_cache_lock = threading.Lock()
 # Metadata for the active spreadsheet — used by /api/status so the Start
 # overlay can pre-select the right tab (Google/Excel) and re-highlight the
 # right item. Only set when the spreadsheet was opened via the runtime
@@ -700,27 +702,7 @@ def api_clip_audio(participant: str) -> FlaskResponse:
     )
 
 
-@studio_bp.route("/api/sheet")
-def api_sheet() -> FlaskResponse:
-    if _sheet_context is None:
-        return jsonify(
-            {
-                "ok": True,
-                "sheet_loaded": False,
-                "study": "",
-                "version": utils.get_version(),
-                "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
-                "titlecardsEnabled": config.TITLECARDS_ENABLED,
-                "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
-                "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
-                "cardScrubberEnabled": config.STUDIO_CARD_SCRUBBER,
-                "config": utils.get_frontend_config(),
-                "participants": [],
-                "rows": [],
-            }
-        )
-
-    ctx = _sheet_context
+def _build_sheet_payload(ctx: spreadsheet.SheetContext) -> dict[str, Any]:
     participants = spreadsheet.get_participant_list(
         ctx.header_row, ctx.id_cell, ctx.num_participants
     )
@@ -777,6 +759,52 @@ def api_sheet() -> FlaskResponse:
             }
         )
 
+    return {"participants": participants, "rows": rows}
+
+
+def _get_sheet_payload(ctx: spreadsheet.SheetContext) -> dict[str, Any]:
+    global _sheet_payload_cache
+
+    with _sheet_payload_cache_lock:
+        if _sheet_payload_cache is not None:
+            cached_ctx, cached_payload = _sheet_payload_cache
+            if cached_ctx is ctx:
+                return cached_payload
+        payload = _build_sheet_payload(ctx)
+        _sheet_payload_cache = (ctx, payload)
+        return payload
+
+
+def _invalidate_sheet_payload_cache() -> None:
+    global _sheet_payload_cache
+
+    with _sheet_payload_cache_lock:
+        _sheet_payload_cache = None
+
+
+@studio_bp.route("/api/sheet")
+def api_sheet() -> FlaskResponse:
+    if _sheet_context is None:
+        return jsonify(
+            {
+                "ok": True,
+                "sheet_loaded": False,
+                "study": "",
+                "version": utils.get_version(),
+                "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
+                "titlecardsEnabled": config.TITLECARDS_ENABLED,
+                "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
+                "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
+                "cardScrubberEnabled": config.STUDIO_CARD_SCRUBBER,
+                "config": utils.get_frontend_config(),
+                "participants": [],
+                "rows": [],
+            }
+        )
+
+    ctx = _sheet_context
+    sheet_payload = _get_sheet_payload(ctx)
+
     return jsonify(
         {
             "ok": True,
@@ -790,8 +818,8 @@ def api_sheet() -> FlaskResponse:
             "cardScrubberEnabled": config.STUDIO_CARD_SCRUBBER,
             "defaultDuration": config.DEFAULT_DURATION_SECONDS,
             "config": utils.get_frontend_config(),
-            "participants": participants,
-            "rows": rows,
+            "participants": sheet_payload["participants"],
+            "rows": sheet_payload["rows"],
         }
     )
 
@@ -919,6 +947,7 @@ def api_sheet_refresh() -> FlaskResponse:
     if new_context is None:
         return err("Failed to refresh sheet data", 500)
     _sheet_context = new_context
+    _invalidate_sheet_payload_cache()
     return ok()
 
 
@@ -3081,6 +3110,7 @@ def _init_studio_state(worksheet: Any) -> None:
             sys.exit(1)
     else:
         _sheet_context = None
+    _invalidate_sheet_payload_cache()
     # Rebind the shared generated lists under their lock so a streaming
     # generate/intake append can't run against a half-swapped reference.
     with _generated_output_lock:

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -2434,6 +2434,61 @@ def test_api_sheet_refresh_invalidates_derived_payload(client, monkeypatch):
     assert parse_calls == {"annotations": 2, "timestamps": 2}
 
 
+def test_swap_worksheet_rollback_clears_sheet_payload_cache(monkeypatch):
+    """A failed sheet swap must not leave the attempted sheet payload cached."""
+    import types
+
+    import spreadsheet
+
+    prev_ctx = spreadsheet.SheetContext(
+        sheet_data=[["ID"]],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        observation_cell=types.SimpleNamespace(row=1, col=1),
+        category_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=0,
+        study_name="previous",
+    )
+    attempted_ctx = spreadsheet.SheetContext(
+        sheet_data=[["ID"]],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        observation_cell=types.SimpleNamespace(row=1, col=1),
+        category_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=0,
+        study_name="attempted",
+    )
+
+    def fake_init_studio_state(new_worksheet):
+        server._worksheet = new_worksheet
+        server._sheet_context = attempted_ctx
+        server._sheet_payload_cache = (attempted_ctx, {"participants": [], "rows": []})
+
+    def fail_screenspace_init(**kwargs):
+        raise RuntimeError("screenspace failed")
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr(server, "_sheet_context", prev_ctx)
+    monkeypatch.setattr(server, "_sheet_payload_cache", (prev_ctx, {}))
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_init_studio_state", fake_init_studio_state)
+
+    import screenspace_server
+    import transcripts_server
+
+    monkeypatch.setattr(
+        screenspace_server, "_init_screenspace_state", fail_screenspace_init
+    )
+    monkeypatch.setattr(
+        transcripts_server, "_init_transcripts_state", lambda **kw: None
+    )
+
+    with pytest.raises(RuntimeError, match="screenspace failed"):
+        server._swap_worksheet(object())
+
+    assert server._sheet_context is prev_ctx
+    assert server._sheet_payload_cache is None
+
+
 def test_api_generate_passes_titlecard_options_to_pipeline(client, monkeypatch):
     """Generate passes per-request titlecard options without mutating config."""
     import types

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -24,6 +24,7 @@ def client(monkeypatch):
     # Default: no worksheet/context loaded (error state)
     monkeypatch.setattr(server, "_worksheet", None)
     monkeypatch.setattr(server, "_sheet_context", None)
+    monkeypatch.setattr(server, "_sheet_payload_cache", None)
     _set_artifacts(monkeypatch, [])
     monkeypatch.setattr(server, "_generated_reels", [])
     server._release_busy("generate")
@@ -2334,6 +2335,103 @@ def test_api_sheet_marks_valid_timestamps_only(client, monkeypatch):
     assert row_empty["P01"]["hasText"] is False
     assert row_empty["P02"]["valid"] is False
     assert row_empty["P02"]["hasText"] is True
+
+
+def test_api_sheet_reuses_derived_payload_for_same_context(client, monkeypatch):
+    """Repeated /api/sheet calls should not re-parse unchanged sheet cells."""
+    import types
+
+    sheet_data = [
+        ["ID", "P01", "Observation", "Category"],
+        ["1", "0:10-0:20 !key", "obs A", "catA"],
+    ]
+    ctx = types.SimpleNamespace(
+        header_row=sheet_data[0],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=1,
+        study_name="study",
+        observation_cell=types.SimpleNamespace(col=3),
+        category_cell=types.SimpleNamespace(col=4),
+        severity_cell=None,
+        baseline_row_idx=None,
+        filename_row_idx=None,
+        first_data_row_idx=1,
+        sheet_data=sheet_data,
+    )
+    parse_calls = {"annotations": 0, "timestamps": 0}
+
+    def fake_parse_cell_annotations(value):
+        parse_calls["annotations"] += 1
+        return value.replace(" !key", ""), set(), {"key"}
+
+    def fake_parse_timestamps(value):
+        parse_calls["timestamps"] += 1
+        return [("0:10", "0:20")]
+
+    monkeypatch.setattr(server, "_sheet_context", ctx)
+    monkeypatch.setattr(
+        server.utils, "parse_cell_annotations", fake_parse_cell_annotations
+    )
+    monkeypatch.setattr(server.utils, "parse_timestamps", fake_parse_timestamps)
+
+    first = client.get("/studio/api/sheet").get_json()
+    second = client.get("/studio/api/sheet").get_json()
+
+    assert first["rows"] == second["rows"]
+    assert parse_calls == {"annotations": 1, "timestamps": 1}
+
+
+def test_api_sheet_refresh_invalidates_derived_payload(client, monkeypatch):
+    """Refreshing the sheet swaps context and rebuilds the cached row payload."""
+    import types
+
+    def make_context(timestamp, observation):
+        sheet_data = [
+            ["ID", "P01", "Observation", "Category"],
+            ["1", timestamp, observation, "catA"],
+        ]
+        return types.SimpleNamespace(
+            header_row=sheet_data[0],
+            id_cell=types.SimpleNamespace(row=1, col=1),
+            num_participants=1,
+            study_name="study",
+            observation_cell=types.SimpleNamespace(col=3),
+            category_cell=types.SimpleNamespace(col=4),
+            severity_cell=None,
+            baseline_row_idx=None,
+            filename_row_idx=None,
+            first_data_row_idx=1,
+            sheet_data=sheet_data,
+        )
+
+    old_ctx = make_context("0:10-0:20", "old obs")
+    new_ctx = make_context("0:30-0:40", "new obs")
+    parse_calls = {"annotations": 0, "timestamps": 0}
+
+    def fake_parse_cell_annotations(value):
+        parse_calls["annotations"] += 1
+        return value, set(), set()
+
+    def fake_parse_timestamps(value):
+        parse_calls["timestamps"] += 1
+        return [tuple(value.split("-", 1))]
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr(server, "_sheet_context", old_ctx)
+    monkeypatch.setattr(server.spreadsheet, "build_sheet_context", lambda ws: new_ctx)
+    monkeypatch.setattr(
+        server.utils, "parse_cell_annotations", fake_parse_cell_annotations
+    )
+    monkeypatch.setattr(server.utils, "parse_timestamps", fake_parse_timestamps)
+
+    old_data = client.get("/studio/api/sheet").get_json()
+    refresh = client.post("/studio/api/sheet/refresh").get_json()
+    new_data = client.get("/studio/api/sheet").get_json()
+
+    assert refresh["ok"] is True
+    assert old_data["rows"][0]["observation"] == "old obs"
+    assert new_data["rows"][0]["observation"] == "new obs"
+    assert parse_calls == {"annotations": 2, "timestamps": 2}
 
 
 def test_api_generate_passes_titlecard_options_to_pipeline(client, monkeypatch):


### PR DESCRIPTION
## Summary
- Memoizes the derived Studio sheet rows/participants payload by active sheet context identity.
- Keeps dynamic `/studio/api/sheet` response fields live while avoiding repeated per-cell timestamp parsing.
- Invalidates the cached payload on sheet refresh and Studio sheet state initialization/swaps.

## Test plan
- `uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_api.py -k "api_sheet"`
- `uv run --extra dev pytest -c tests/pytest.ini tests/test_studio_api.py tests/test_shared_constants.py`
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run ty check`