### PR TITLE
perf: defer icecream debug imports

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,8 +16,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, NamedTuple
 
-from icecream import ic
-
 import clipgen
 import config
 import files
@@ -964,7 +962,7 @@ def select_worksheet(
             worksheet = clipgen.select_spreadsheet(gspread_client, doc_list)
 
     if worksheet and config.DEBUGGING:
-        ic(worksheet.title)
+        config.debug_ic(worksheet.title)
     if clipgen._is_excel_worksheet(worksheet):
         utils.standard_print("Using local Excel file.")
     else:
@@ -3638,7 +3636,7 @@ def main() -> None:
 
     utils.NO_INPUT_MODE = bool(getattr(args, "no_input", False))
     if config.DEBUGGING:
-        ic(args)
+        config.debug_ic(args)
 
     # Validate mutually exclusive mode flags
     modes = _validate_mode_conflicts(args)

--- a/config.py
+++ b/config.py
@@ -20,9 +20,8 @@ Sections
   Settings Metadata    Descriptions and Studio UI metadata
 """
 
+import importlib
 from typing import Any
-
-from icecream import ic
 
 # ── Core Runtime ─────────────────────────────────────────────────────
 REENCODING: bool = False
@@ -64,18 +63,26 @@ STANDARD: int = 1
 VERBOSE: int = 2
 VERBOSITY: int = STANDARD
 
+_ICECREAM_IC: Any | None = None
+
+
+def debug_ic(*args: Any, **kwargs: Any) -> Any:
+    """Lazy icecream debug printer; no import cost unless DEBUGGING is enabled."""
+    if not DEBUGGING:
+        return None
+    global _ICECREAM_IC
+    if _ICECREAM_IC is None:
+        _ICECREAM_IC = importlib.import_module("icecream").ic
+        _ICECREAM_IC.configureOutput(prefix="! DEBUG ic| ", includeContext=False)
+    return _ICECREAM_IC(*args, **kwargs)
+
+
 # ── Directories ──────────────────────────────────────────────────────
 # When left empty, clipgen will use the current working directory for
 # both input (source videos) and output (generated artifacts), matching
 # the existing default behavior.
 INPUT_DIR: str = ""
 OUTPUT_DIR: str = ""
-
-# Configure Icecream debugging
-if DEBUGGING:
-    ic.configureOutput(prefix="! DEBUG ic| ", includeContext=False)
-else:
-    ic.disable()
 
 # ── Spreadsheet ──────────────────────────────────────────────────────
 ID_HEADER: str = "ID"

--- a/files.py
+++ b/files.py
@@ -7,7 +7,6 @@ import unicodedata
 from pathlib import Path
 
 import gspread
-from icecream import ic
 
 import config
 import utils
@@ -251,7 +250,7 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
         The same dict with 'times' added and sanitized 'desc' and 'category'
     """
     if config.DEBUGGING:
-        ic(clip)
+        config.debug_ic(clip)
 
     # Pre-parsed fast path: callers (e.g. --ss-clips, --transcript-clips) build
     # synthetic clips with timestamps already resolved. Skip the cell-based parse
@@ -303,7 +302,7 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
             pair for index, pair in enumerate(clip["times"]) if index in selected_set
         ]
     if config.DEBUGGING:
-        ic(clip["times"])
+        config.debug_ic(clip["times"])
 
     # Warn if no valid timestamps were parsed, except cells with only ignored tokens (e.g. "x").
     if not clip["times"] and utils.has_non_ignored_timestamp_content(
@@ -327,7 +326,7 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
     )
     clip["desc"] = utils.sanitize_filename(cleaned_desc)
     if config.DEBUGGING:
-        ic(clip["desc"])
+        config.debug_ic(clip["desc"])
 
     # Sanitize category (handle None/empty)
     if clip["category"]:
@@ -335,8 +334,8 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
     else:
         clip["category"] = "uncategorized"
     if config.DEBUGGING:
-        ic(clip["category"])
-        ic(clip)
+        config.debug_ic(clip["category"])
+        config.debug_ic(clip)
     return clip
 
 

--- a/google_api.py
+++ b/google_api.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 import gspread
-from icecream import ic
 
 import config
 import utils
@@ -116,7 +115,7 @@ def find_spreadsheet_by_name(search_name: str, doc_list: list[str]) -> int:
         The index of matching sheet, or -1 if not found.
     """
     if config.DEBUGGING:
-        ic(search_name)
+        config.debug_ic(search_name)
     utils.debug_print("Running method find_spreadsheet_by_name()")
     search_name = search_name.strip().lower()
     search_name_guess = search_name + " data set"
@@ -127,14 +126,14 @@ def find_spreadsheet_by_name(search_name: str, doc_list: list[str]) -> int:
     for i, doc in enumerate(doc_list):
         doc_name = doc.strip().lower()
         if config.DEBUGGING:
-            ic(doc_name, search_name)
+            config.debug_ic(doc_name, search_name)
         utils.debug_print(
             f"Attempting exact match with '{doc}', formatted as '{doc_name}'"
         )
         if doc_name == search_name:
             utils.debug_print(f"Matched sheet '{doc_name}' with input '{search_name}'")
             if config.DEBUGGING:
-                ic(i)
+                config.debug_ic(i)
             return i
         utils.debug_print(f"Found no exact match at step {i}")
 
@@ -148,10 +147,10 @@ def find_spreadsheet_by_name(search_name: str, doc_list: list[str]) -> int:
                 f"Matched sheet '{doc_name}' with guess '{search_name_guess}'"
             )
             if config.DEBUGGING:
-                ic(i)
+                config.debug_ic(i)
             return i
         utils.debug_print(f"Found no guess match at step {i}")
 
     if config.DEBUGGING:
-        ic(-1)
+        config.debug_ic(-1)
     return -1

--- a/pipeline.py
+++ b/pipeline.py
@@ -23,8 +23,6 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
-from icecream import ic
-
 import config
 import files
 import titlecards
@@ -549,10 +547,10 @@ def _process_single_clip_segments(
         try:
             out_name = files.get_unique_filename(template, file_format=file_extension)
             if config.DEBUGGING:
-                ic(out_name)
+                config.debug_ic(out_name)
         except (TypeError, UnicodeEncodeError, UnicodeDecodeError) as e:
             if config.DEBUGGING:
-                ic(e, clip)
+                config.debug_ic(e, clip)
             utils.error_print(
                 f"Character encoding issue occurred: {e}",
                 [
@@ -1006,7 +1004,7 @@ def process_clips(
         Tuple of (count of files generated, list of artifact records).
     """
     if config.DEBUGGING:
-        ic(len(clips_list))
+        config.debug_ic(len(clips_list))
 
     if not clips_list:
         utils.warning_print(

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -45,7 +45,6 @@ from collections.abc import Sequence
 from typing import Any, NamedTuple
 
 import gspread
-from icecream import ic
 
 import config
 import google_api
@@ -215,7 +214,7 @@ def build_sheet_context(sheet: Any) -> SheetContext | None:
 
     id_cell, observation_cell, category_cell = header_result
     if config.DEBUGGING:
-        ic(id_cell, observation_cell, category_cell)
+        config.debug_ic(id_cell, observation_cell, category_cell)
 
     baseline_row_idx = _detect_baseline_row(sheet_data)
 
@@ -659,14 +658,14 @@ def get_line_timestamps(ctx: SheetContext, line_index: int) -> list[ClipRecord]:
         List of clip records, one per timestamp found
     """
     if config.DEBUGGING:
-        ic(line_index, ctx.num_participants, ctx.study_name)
+        config.debug_ic(line_index, ctx.num_participants, ctx.study_name)
     utils.debug_print(
         f"Running method get_line_timestamps, starting line index {line_index} (real sheet line {line_index + 1})"
     )
 
     if line_index < 0 or line_index >= len(ctx.sheet_data):
         if config.DEBUGGING:
-            ic(line_index, len(ctx.sheet_data))
+            config.debug_ic(line_index, len(ctx.sheet_data))
         utils.error_print(
             f"Line index {line_index} (row {line_index + 1}) is out of bounds.",
             [f"Spreadsheet has {len(ctx.sheet_data)} rows."],
@@ -689,12 +688,12 @@ def get_line_timestamps(ctx: SheetContext, line_index: int) -> list[ClipRecord]:
             else:
                 issue = _make_clip_record(ctx, line_index, col_index, value)
                 if config.DEBUGGING:
-                    ic(
+                    config.debug_ic(
                         issue.get("participant"),
                         issue.get("desc"),
                         issue.get("category"),
                     )
-                    ic(issue)
+                    config.debug_ic(issue)
                 utils.debug_print(
                     f"Participant ID at R{ctx.id_cell.row},C{col_index} -> '{issue.get('participant')}'"
                 )
@@ -717,7 +716,7 @@ def get_line_timestamps(ctx: SheetContext, line_index: int) -> list[ClipRecord]:
                 )
     except IndexError as e:
         if config.DEBUGGING:
-            ic(e, line_index)
+            config.debug_ic(e, line_index)
         utils.error_print(
             f"Index error while reading row {line_index + 1}: {e}",
             ["The spreadsheet structure may be malformed."],
@@ -727,7 +726,7 @@ def get_line_timestamps(ctx: SheetContext, line_index: int) -> list[ClipRecord]:
         f"Line completed, returning list of {len(clips)} potential clips."
     )
     if config.DEBUGGING:
-        ic(clips)
+        config.debug_ic(clips)
     return clips
 
 
@@ -865,7 +864,7 @@ def generate_list(
         List of clip records
     """
     if config.DEBUGGING:
-        ic(mode, line_numbers, range_start, range_end)
+        config.debug_ic(mode, line_numbers, range_start, range_end)
 
     if ctx is None:
         ctx = build_sheet_context(sheet)

--- a/tests/test_debug_imports.py
+++ b/tests/test_debug_imports.py
@@ -1,0 +1,73 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEBUG_MODULES = (
+    "config",
+    "cli",
+    "files",
+    "google_api",
+    "pipeline",
+    "spreadsheet",
+    "utils",
+    "video",
+)
+
+
+def _run_python(source: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONPATH"] = str(ROOT)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_default_debug_modules_do_not_import_icecream() -> None:
+    modules = ", ".join(repr(name) for name in DEBUG_MODULES)
+    result = _run_python(
+        f"""
+        import importlib
+        import sys
+
+        for name in ({modules},):
+            importlib.import_module(name)
+
+        if "icecream" in sys.modules:
+            raise SystemExit("icecream imported during default startup")
+        """
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_debug_ic_lazy_loads_icecream_when_debugging_enabled() -> None:
+    result = _run_python(
+        """
+        import sys
+
+        import config
+
+        assert "icecream" not in sys.modules
+        config.DEBUGGING = True
+        config.debug_ic("probe")
+        assert "icecream" in sys.modules
+        """
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_debug_modules_do_not_import_icecream_directly() -> None:
+    for module in DEBUG_MODULES:
+        source = (ROOT / f"{module}.py").read_text(encoding="utf-8")
+        assert "from icecream import ic" not in source

--- a/utils.py
+++ b/utils.py
@@ -14,8 +14,6 @@ from numbers import Integral, Real
 from pathlib import Path
 from typing import Any, Callable, TypedDict, TypeVar
 
-from icecream import ic
-
 import config
 
 
@@ -1343,14 +1341,14 @@ def parse_timestamps(
         and reported via warning_print.
     """
     if config.DEBUGGING:
-        ic(cell_value, cell_ref)
+        config.debug_ic(cell_value, cell_ref)
     parsed_timestamps = []
     skipped_timestamps = []
     ignored_tokens = get_ignored_timestamp_tokens()
     # Unify delimiters (+, ;, ,) to spaces so split() yields one token per time or range
     raw_times = _split_timestamp_tokens(cell_value)
     if config.DEBUGGING:
-        ic(raw_times)
+        config.debug_ic(raw_times)
     debug_print(f"raw_times content after split is {raw_times}")
     debug_print(f"Timestamp list raw_times is {len(raw_times)} entries long")
 
@@ -1361,7 +1359,7 @@ def parse_timestamps(
         pair = _parse_single_timestamp_token(token)
         if pair is not None:
             if config.DEBUGGING and len(pair) == 2:
-                ic(pair)
+                config.debug_ic(pair)
             parsed_timestamps.append(pair)
         elif token and token not in ignored_tokens:
             skipped_timestamps.append(token)
@@ -1369,7 +1367,7 @@ def parse_timestamps(
     # Report skipped timestamps: list up to MAX_SKIPPED_TIMESTAMPS_TO_SHOW, then "... and N more"
     if skipped_timestamps:
         if config.DEBUGGING:
-            ic(skipped_timestamps)
+            config.debug_ic(skipped_timestamps)
         # Only show detailed skipped-timestamp warnings at verbose verbosity.
         if getattr(config, "VERBOSITY", config.STANDARD) >= config.VERBOSE:
             cell_info = f" in cell {cell_ref}" if cell_ref else ""
@@ -1389,7 +1387,7 @@ def parse_timestamps(
             )
 
     if config.DEBUGGING:
-        ic(parsed_timestamps)
+        config.debug_ic(parsed_timestamps)
     return parsed_timestamps
 
 

--- a/video.py
+++ b/video.py
@@ -14,8 +14,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from icecream import ic
-
 import config
 import files
 import utils
@@ -557,7 +555,7 @@ def mux_subtitles(
 
     utils.verbose_print(f"Muxing subtitles into {Path(output_video).name} ({codec}).")
     if config.DEBUGGING:
-        ic(ffmpeg_command)
+        config.debug_ic(ffmpeg_command)
         return False
 
     result = run_ffmpeg_process(
@@ -606,7 +604,7 @@ def run_ffmpeg(
         True if video was generated successfully, False otherwise.
     """
     if config.DEBUGGING:
-        ic(input_file, output_file, start_pos, end_pos)
+        config.debug_ic(input_file, output_file, start_pos, end_pos)
     if not Path(input_file).is_file():
         utils.error_print(
             f"Input video file not found: '{input_file}'",
@@ -654,7 +652,7 @@ def run_ffmpeg(
         )
         return False
     if config.DEBUGGING:
-        ic(duration, duration_seconds)
+        config.debug_ic(duration, duration_seconds)
     if duration > config.MAX_CLIP_DURATION_SECONDS:
         if utils.NO_INPUT_MODE:
             utils.warning_print(
@@ -733,7 +731,7 @@ def extract_screenshot(
         True if screenshot was generated successfully, False otherwise.
     """
     if config.DEBUGGING:
-        ic(input_file, output_file, timestamp)
+        config.debug_ic(input_file, output_file, timestamp)
     if output_file.lower().endswith(".webp") and not check_webp_support():
         _warn_webp_unavailable_once(output_file)
         return False
@@ -824,7 +822,7 @@ def extract_thumbnail_bytes(
     failure.
     """
     if config.DEBUGGING:
-        ic(input_file, start_seconds, width)
+        config.debug_ic(input_file, start_seconds, width)
         return None
 
     if not Path(input_file).is_file():
@@ -882,7 +880,7 @@ def extract_sprite_sheet_bytes(
     failure.
     """
     if config.DEBUGGING:
-        ic(input_file, start_seconds, duration_seconds, cols, rows)
+        config.debug_ic(input_file, start_seconds, duration_seconds, cols, rows)
         return None
 
     if not Path(input_file).is_file():
@@ -940,7 +938,7 @@ def extract_audio_segment_bytes(
     a video container. Returns WAV bytes or ``None`` on failure.
     """
     if config.DEBUGGING:
-        ic(input_file, start_seconds, duration_seconds, sample_rate)
+        config.debug_ic(input_file, start_seconds, duration_seconds, sample_rate)
         return None
 
     if not Path(input_file).is_file():
@@ -1009,7 +1007,7 @@ def extract_gif(
         True if GIF was generated successfully, False otherwise.
     """
     if config.DEBUGGING:
-        ic(input_file, output_file, timestamp, duration_seconds)
+        config.debug_ic(input_file, output_file, timestamp, duration_seconds)
     if output_file.lower().endswith(".webp") and not check_webp_support():
         _warn_webp_unavailable_once(output_file)
         return False
@@ -1462,7 +1460,7 @@ def get_duration(start_time: str, end_time: str | None) -> int | None:
         Duration in seconds, or None if timestamps are invalid.
     """
     if config.DEBUGGING:
-        ic(start_time, end_time)
+        config.debug_ic(start_time, end_time)
     utils.debug_print(f"start_time is {start_time}, end_time is {end_time}")
 
     if end_time is INVALID_END_TIMESTAMP:
@@ -1493,7 +1491,7 @@ def get_duration(start_time: str, end_time: str | None) -> int | None:
 
     duration = int(end_seconds - start_seconds)
     if config.DEBUGGING:
-        ic(duration)
+        config.debug_ic(duration)
     return duration
 
 


### PR DESCRIPTION
## Summary
- Lazily import icecream only when `config.DEBUGGING` debug probes are used.
- Replace eager module-level `ic` imports with `config.debug_ic(...)` across debug call sites.
- Add regression coverage proving default startup modules do not import icecream and debug mode still lazy-loads it.

## Test plan
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --fix`
- [x] `uv run ty check`
- [x] `uv run --extra dev pytest -c tests/pytest.ini`