### PR TITLE
perf: stream status/poll deltas instead of deep-copying growing state

### DIFF
--- a/assets/web/screenspace-results.js
+++ b/assets/web/screenspace-results.js
@@ -312,6 +312,14 @@
       .then(function (data) {
         if (resultsRequestVersion !== state.resultsRequestVersion || state.selectedTaskId !== selectedTaskId) return null;
         state.selectedTaskResults = data.results;
+        // Seed the shared per-task cache so the timeline draws these results and
+        // _syncTaskResults appends further tails from here rather than re-fetching.
+        // Redraw now: when the cache was empty (fresh completed task) nothing else
+        // fires renderTimeline, so the markers would otherwise never paint.
+        if (Array.isArray(data.results)) {
+          state.taskResults[selectedTaskId] = data.results;
+          renderTimeline();
+        }
         return apiGet("api/events?task_id=" + selectedTaskId);
       })
       .then(function (evData) {
@@ -321,6 +329,9 @@
         state.resultsLoading = false;
         renderResults();
         renderTaskList();
+        // Repaint the timeline now that excluded events are known, so excluded
+        // markers get their dashed/faded styling.
+        renderTimeline();
         updateResultsCrumb();
       })
       .catch(function () {

--- a/assets/web/screenspace-tasks.js
+++ b/assets/web/screenspace-tasks.js
@@ -892,24 +892,23 @@
 
       // Status text
       var statusText = task.status;
+      // Ticks carry result_count (not the result list); use it for the badge.
+      var rLen = task.result_count || 0;
       if (task.status === "running") {
         var rPct = Math.round((task.progress || 0) * 100);
-        var rLen = Array.isArray(task.result) ? task.result.length : 0;
         // "0% \u00b7 scanning\u2026" reads as in-progress rather than hung when a running
         // task hasn't produced any hits yet.
         statusText = rPct + "%" + (rLen ? " \u00b7 " + rLen + " result" + (rLen !== 1 ? "s" : "") : " \u00b7 scanning\u2026");
       }
       if (task.status === "paused") {
         var pPct = Math.round((task.progress || 0) * 100);
-        var pLen = Array.isArray(task.result) ? task.result.length : 0;
-        statusText = "paused " + pPct + "%" + (pLen ? " \u00b7 " + pLen + " result" + (pLen !== 1 ? "s" : "") : "");
+        statusText = "paused " + pPct + "%" + (rLen ? " \u00b7 " + rLen + " result" + (rLen !== 1 ? "s" : "") : "");
       }
       if (task.status === "failed" && task.error) {
         statusText = task.error;
         card.title = task.error;
       }
-      if (task.status === "completed" && task.result) {
-        rLen = Array.isArray(task.result) ? task.result.length : (typeof task.result === "string" ? 1 : 0);
+      if (task.status === "completed" && rLen) {
         statusText = rLen + " result" + (rLen !== 1 ? "s" : "");
       }
       var statusSpan = el("span", "task-card-status", statusText);
@@ -1008,6 +1007,81 @@
     return (t.heatmap || "") + "|" + (t.heatmap_gif || "") + "|" + (t.heatmap_rolling_gif || "");
   }
 
+  // Per-task result sync. Status ticks no longer carry result lists (just
+  // result_count), so we pull the tail beyond our cached length and append into
+  // state.taskResults[id]. result is append-only during a scan, so the count is
+  // a safe cursor and each fetch payload stays flat. The timeline and results
+  // panel both read from the cache, so one sync feeds both. Scoped to the
+  // selected participant's tasks — the only ones the timeline draws.
+  var _resultFetching = {};
+  var _taskStatusSeen = {};
+
+  // Drop cached results that are no longer append-consistent so _syncTaskResults
+  // refetches the authoritative list. Two cases: (1) a task transitions into a
+  // terminal state — color/inactivity reshape point hits into merged spans on
+  // completion, so the tail cursor would otherwise keep stale point rows;
+  // (2) result_count drops below what we cached (pause/resume clears results).
+  function _reconcileResultCache(tasks) {
+    var seenNow = {};
+    tasks.forEach(function (t) {
+      seenNow[t.id] = t.status;
+      var prev = _taskStatusSeen[t.id];
+      var terminal = t.status === "completed" || t.status === "failed" || t.status === "cancelled";
+      if (prev && prev !== t.status && terminal) {
+        delete state.taskResults[t.id];
+      }
+      var cached = state.taskResults[t.id];
+      if (Array.isArray(cached) && (t.result_count || 0) < cached.length) {
+        delete state.taskResults[t.id];
+      }
+    });
+    // Prune cache/fetch state for tasks that no longer exist (dismissed).
+    Object.keys(state.taskResults).forEach(function (id) {
+      if (!(id in seenNow)) delete state.taskResults[id];
+    });
+    Object.keys(_resultFetching).forEach(function (id) {
+      if (!(id in seenNow)) delete _resultFetching[id];
+    });
+    _taskStatusSeen = seenNow;
+  }
+
+  function _syncTaskResults() {
+    if (!Array.isArray(state.tasks)) return;
+    state.tasks.forEach(function (t) {
+      if (t.status === "cancelled") return;
+      if (t.participant && t.participant !== state.selectedParticipant) return;
+      var count = t.result_count || 0;
+      var cached = state.taskResults[t.id];
+      var have = Array.isArray(cached) ? cached.length : 0;
+      if (count <= have || _resultFetching[t.id]) return;
+      _resultFetching[t.id] = true;
+      var reqId = t.id;
+      var since = have;
+      apiGet("api/tasks/" + reqId + "/results?since=" + since).then(
+        function (data) {
+          _resultFetching[reqId] = false;
+          if (!data || !data.ok) return;
+          var base = Array.isArray(state.taskResults[reqId]) ? state.taskResults[reqId] : [];
+          // Reject if the cursor moved under us; the next tick reconciles.
+          if (since !== base.length) return;
+          if (data.results && data.results.length) {
+            state.taskResults[reqId] = base.concat(data.results);
+          } else if (!Array.isArray(state.taskResults[reqId])) {
+            state.taskResults[reqId] = base;
+          }
+          if (reqId === state.selectedTaskId) {
+            state.selectedTaskResults = state.taskResults[reqId];
+            SS.renderResults();
+          }
+          renderTimeline();
+        },
+        function () {
+          _resultFetching[reqId] = false;
+        }
+      );
+    });
+  }
+
   function handleTaskData(data) {
     if (!data.ok) return;
     var oldSelected = state.selectedTaskId;
@@ -1015,6 +1089,7 @@
     var wasRunning = oldTask && (oldTask.status === "queued" || oldTask.status === "running");
     var oldHeatmapSig = _heatmapSig(oldTask);
     state.tasks = data.tasks;
+    _reconcileResultCache(data.tasks);
     // Only rebuild the pause/play icon when the queue state actually flips —
     // handleTaskData runs on every SSE push (≈2/s while a task streams
     // progress), and re-creating the icon span each time re-fetches its svg.
@@ -1033,14 +1108,9 @@
       renderTaskList();
       renderTimeline();
     }
-    // Auto-update results for selected running task
-    if (oldSelected) {
-      var selTask = findTask(oldSelected);
-      if (selTask && selTask.status === "running" && selTask.result) {
-        state.selectedTaskResults = selTask.result;
-        SS.renderResults();
-      }
-    }
+    // Pull result tails for the selected participant's tasks (ticks no longer
+    // carry result lists) so the timeline and results panel stay current.
+    _syncTaskResults();
     // Auto-load results when selected task completes
     if (wasRunning && oldSelected) {
       var newTask = findTask(oldSelected);
@@ -1154,6 +1224,11 @@
   SS.focusedTaskId = focusedTaskId;
   SS.renderTaskList = renderTaskList;
   SS.startSSE = startSSE;
+  // The result cache is normally kept current inside handleTaskData (SSE/poll),
+  // but the boot path and participant switches also need it filled so the
+  // timeline has markers without waiting for a tick.
+  SS.syncTaskResults = _syncTaskResults;
+  SS.reconcileResultCache = _reconcileResultCache;
   SS.setRightPaneTab = setRightPaneTab;
   SS.updateResultsCrumb = updateResultsCrumb;
   SS.initRightPaneTabs = initRightPaneTabs;

--- a/assets/web/screenspace-timeline.js
+++ b/assets/web/screenspace-timeline.js
@@ -37,6 +37,16 @@
   var _timelineHitRects = [];
   var _cachedTimelineRect = null;
 
+  // Status ticks no longer carry result lists; results live in the per-task
+  // cache (state.taskResults), filled by _syncTaskResults in the tasks satellite.
+  // Returns the cached array, or null when this task's results aren't loaded yet
+  // (mirrors the old `task.result` absent-check; a renderTimeline fires once the
+  // tail lands).
+  function _taskResults(task) {
+    var r = state.taskResults[task.id];
+    return Array.isArray(r) ? r : null;
+  }
+
   function getTimelineRect(canvas) {
     if (!_cachedTimelineRect) _cachedTimelineRect = canvas.getBoundingClientRect();
     return _cachedTimelineRect;
@@ -344,7 +354,8 @@
     if (ampOn) {
       var seriesByType = {};
       state.tasks.forEach(function (task) {
-        if (!task.result || task.status === "cancelled") return;
+        var ampRes = _taskResults(task);
+        if (!ampRes || task.status === "cancelled") return;
         if (task.participant && task.participant !== state.selectedParticipant) return;
         if (task.type === "timelapse") return;
         // Boundaries are orientation scaffolding, not events — keep them out of
@@ -354,7 +365,7 @@
           seriesByType[task.type] = { key: task.type, color: taskTypeColor(task.type), timestamps: [] };
         }
         var dst = seriesByType[task.type].timestamps;
-        var results = task.result || [];
+        var results = ampRes;
         for (var ri = 0; ri < results.length; ri++) {
           var r = results[ri];
           var ts = r.timestamp !== undefined ? r.timestamp : r.start;
@@ -388,14 +399,15 @@
     });
 
     state.tasks.forEach(function (task) {
-      if (!task.result || task.status === "cancelled") return;
+      var taskRes = _taskResults(task);
+      if (!taskRes || task.status === "cancelled") return;
       if (task.participant && task.participant !== state.selectedParticipant) return;
       var color = taskTypeColor(task.type);
       var dimmed = focused && task.id !== focused;
       var taskExcluded = excludedByTask[task.id] || {};
       if ((task.type === "color" || task.type === "inactivity") && task.status === "completed") {
         // Completed color: merged spans
-        task.result.forEach(function (span) {
+        taskRes.forEach(function (span) {
           var isExcluded = taskExcluded[span.start.toFixed(2)];
           ctx.fillStyle = hexToRgba(color, isExcluded ? 0.05 : (dimmed ? 0.10 : 0.35));
           var x1 = timeToX(span.start);
@@ -412,7 +424,7 @@
       } else {
         // Point markers (change, similarity, text, numbers, template, flow, scene, running color)
         ctx.lineWidth = 1.5;
-        var results = task.result || [];
+        var results = taskRes;
         results.forEach(function (r) {
           var ts = r.timestamp !== undefined ? r.timestamp : r.start;
           if (ts === undefined) return;
@@ -491,11 +503,12 @@
     var frag = document.createDocumentFragment();
     state.tasks.forEach(function (task) {
       if (task.type !== "boundary") return;
-      if (!task.result || task.status === "cancelled") return;
+      var bRes = _taskResults(task);
+      if (!bRes || task.status === "cancelled") return;
       if (task.participant && task.participant !== state.selectedParticipant) return;
       var dimmed = focused && task.id !== focused;
       var taskExcluded = excludedByTask[task.id] || {};
-      task.result.forEach(function (r) {
+      bRes.forEach(function (r) {
         var ts = r.timestamp !== undefined ? r.timestamp : r.start;
         if (ts === undefined) return;
         var x = ((ts - visStart) / visLen) * w;
@@ -687,7 +700,7 @@
     container.innerHTML = "";
     var hasTypes = {};
     state.tasks.forEach(function (t) {
-      if ((t.status === "completed" || t.status === "running") && t.result) hasTypes[t.type] = true;
+      if ((t.status === "completed" || t.status === "running") && t.result_count) hasTypes[t.type] = true;
     });
     var types = Object.keys(hasTypes);
     if (types.length === 0) return;

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -222,6 +222,10 @@
     selectedTaskId: null,
     hoveredTaskId: null,
     selectedTaskResults: null,
+    // Per-task result cache (taskId -> results array). Status ticks no longer
+    // carry result lists; the timeline and results panel read from here, kept
+    // current by appending result tails (see _syncTaskResults in tasks).
+    taskResults: {},
     resultsLoading: false,
     resultsLazyObserver: null,
     // Coordination flags shared between the hub and screenspace-tasks.js:
@@ -977,6 +981,10 @@
     state.heatmapOverlayRequestVersion += 1;
     state.selectedParticipant = pid;
     setStoredUIStateField("screenspace", "selectedParticipant", pid);
+    // Fill the result cache for the newly selected participant's tasks so the
+    // timeline draws their markers (the sync is participant-scoped, and no SSE
+    // tick may follow when their tasks are already completed).
+    if (SS.syncTaskResults) SS.syncTaskResults();
     state.currentTimestamp = 0;
     state.videoInfo = null;
     state.videoActivePart = 0;
@@ -3828,6 +3836,11 @@
           state.tasks = data.tasks || [];
           renderTaskList();
           renderTimeline();
+          // Fill the per-task result cache so the timeline has markers on load.
+          // handleTaskData does this on every tick, but with all tasks already
+          // completed the SSE stream below never starts, so seed it here too.
+          if (SS.reconcileResultCache) SS.reconcileResultCache(state.tasks);
+          if (SS.syncTaskResults) SS.syncTaskResults();
           if (state.tasks.some(function (t) { return t.status === "queued" || t.status === "running"; })) {
             startSSE();
           }

--- a/assets/web/transcripts-search.js
+++ b/assets/web/transcripts-search.js
@@ -101,15 +101,12 @@
   function _searchPartialSegments(query, pid) {
     var results = [];
     var lowerQ = query.toLowerCase();
-    var task = null;
-    state.tasks.forEach(function (t) {
-      if (t.participant === pid && t.status === "running" && t.partial_segments) {
-        task = t;
-      }
-    });
-    if (!task) return results;
-    for (var i = 0; i < task.partial_segments.length; i++) {
-      var seg = task.partial_segments[i];
+    // Status polls carry partial_count, not the segment array; the streaming
+    // participant's accumulated segments live in the hub (fetched via the tail
+    // cursor). This is only called for state.streamingParticipant.
+    var segments = TS.streamingSegmentsFor(pid);
+    for (var i = 0; i < segments.length; i++) {
+      var seg = segments[i];
       if (seg.text.toLowerCase().indexOf(lowerQ) >= 0) {
         results.push({
           participant: pid,

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -743,10 +743,12 @@
       loadTranscript(pid);
       loadSummary(pid);
       loadFriction(pid);
-    } else if (taskForPid && taskForPid.status === "running" && taskForPid.partial_segments && taskForPid.partial_segments.length > 0) {
-      renderPartialSegments(taskForPid.partial_segments, taskForPid.progress);
+    } else if (taskForPid && taskForPid.status === "running" && taskForPid.partial_count > 0) {
       state.streamingParticipant = pid;
       clearAnalysisPanel();
+      _syncStreamSegs(taskForPid, function (segs) {
+        if (segs.length > 0) renderPartialSegments(segs, taskForPid.progress);
+      });
     } else {
       state.segments = [];
       state.streamingParticipant = null;
@@ -913,6 +915,46 @@
     segments: null,
     marksVersion: 0,
   };
+
+  // Client-side accumulator for streaming partial segments. The status poll only
+  // carries partial_count now (not the full array), so we fetch the tail beyond
+  // our cursor and append. partial_segments is append-only server-side, so the
+  // count is a safe cursor and the request payload stays flat as the transcript
+  // grows. Resets when the streamed task changes.
+  var _streamSegs = { taskId: null, segments: [], fetching: false };
+
+  function _syncStreamSegs(task, cb) {
+    if (_streamSegs.taskId !== task.id) {
+      _streamSegs.taskId = task.id;
+      _streamSegs.segments = [];
+      _streamSegs.fetching = false;
+    }
+    var count = task.partial_count || 0;
+    var have = _streamSegs.segments.length;
+    if (count <= have || _streamSegs.fetching) {
+      cb(_streamSegs.segments);
+      return;
+    }
+    _streamSegs.fetching = true;
+    var reqTaskId = task.id;
+    var since = have;
+    apiGet(
+      "api/transcribe/" + encodeURIComponent(task.id) + "/segments?since=" + since
+    ).then(
+      function (data) {
+        _streamSegs.fetching = false;
+        // Reject if the streamed task changed or our cursor moved under us.
+        if (!data.ok || _streamSegs.taskId !== reqTaskId) return;
+        if (since === _streamSegs.segments.length && data.segments && data.segments.length) {
+          _streamSegs.segments = _streamSegs.segments.concat(data.segments);
+        }
+        cb(_streamSegs.segments);
+      },
+      function () {
+        _streamSegs.fetching = false;
+      }
+    );
+  }
 
   function _renderPartialSegmentRow(seg, i, pid) {
     var segId = pid + ":" + i;
@@ -1947,15 +1989,17 @@
       var selectedRunningTask = null;
       if (state.selectedParticipant) {
         data.tasks.forEach(function (t) {
-          if (t.participant === state.selectedParticipant && t.status === "running" && t.partial_segments) {
+          if (t.participant === state.selectedParticipant && t.status === "running" && t.partial_count) {
             selectedRunningTask = t;
           }
         });
       }
-      if (selectedRunningTask && selectedRunningTask.partial_segments.length > 0) {
-        renderPartialSegments(selectedRunningTask.partial_segments, selectedRunningTask.progress);
+      if (selectedRunningTask) {
         state.streamingParticipant = state.selectedParticipant;
         _loadStreamingMarks(state.selectedParticipant);
+        _syncStreamSegs(selectedRunningTask, function (segs) {
+          if (segs.length > 0) renderPartialSegments(segs, selectedRunningTask.progress);
+        });
       } else if (state.streamingParticipant) {
         // The selected participant's streaming view is up but it has no running
         // task. Finalize in place once its transcript is ready. This is
@@ -2562,6 +2606,11 @@
   TS.loadTranscript = loadTranscript; // corrections, search, agents
   TS.findOverlapsForSearch = findOverlapsForSearch; // search
   TS.selectParticipant = selectParticipant; // search, pills
+  // Accumulated streaming segments for the currently-streamed participant. The
+  // status poll no longer carries partial_segments, so search reads them here.
+  TS.streamingSegmentsFor = function (pid) {
+    return pid && pid === state.streamingParticipant ? _streamSegs.segments : [];
+  }; // search
   TS.getMarkForSegment = getMarkForSegment; // video (timeline markers + tooltip)
   TS.toggleMark = toggleMark; // video (keyboard marking)
   TS.updateMarkCategory = updateMarkCategory; // video (keyboard category set)

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -210,7 +210,8 @@ def _notify_sse_clients(event_type: str = "update") -> None:
 
 def _sse_task_payload() -> str:
     """Build an SSE data line with current task state."""
-    tasks = _worker.get_all_tasks() if _worker else []
+    # Slim ticks: no result lists (clients pull tails via /api/tasks/<id>/results).
+    tasks = _worker.get_all_tasks(include_results=False) if _worker else []
     clean = [_clean_task(t) for t in tasks]
     paused = _worker.is_paused if _worker else False
     alive = _worker.is_alive if _worker else False
@@ -1670,7 +1671,8 @@ def api_tasks_stream() -> FlaskResponse:
 @screenspace_bp.route("/api/tasks")
 def api_tasks_list() -> FlaskResponse:
     """List all tasks with status and progress."""
-    tasks = _worker.get_all_tasks() if _worker else []
+    # Polling fallback for the SSE stream — slim, same as _sse_task_payload.
+    tasks = _worker.get_all_tasks(include_results=False) if _worker else []
     clean = [_clean_task(t) for t in tasks]
     paused = _worker.is_paused if _worker else False
     alive = _worker.is_alive if _worker else False
@@ -2186,13 +2188,24 @@ def api_tasks_resume() -> FlaskResponse:
 
 @screenspace_bp.route("/api/tasks/<task_id>/results")
 def api_tasks_results(task_id: str) -> FlaskResponse:
-    """Get task results (timestamps, artifacts)."""
+    """Get task results (timestamps, artifacts).
+
+    ``?since=N`` returns only the result tail beyond index N (results are
+    append-only during a scan), letting the frontend stream live results for a
+    running task without re-fetching the whole list each tick. Omit for the full
+    list (completion load). Always reports ``total`` for the next cursor.
+    """
     if not _worker:
         return err("Worker not initialized", 500)
-    task = _worker.get_task(task_id)
-    if task is None:
+    try:
+        since = int(request.args.get("since", 0))
+    except (TypeError, ValueError):
+        since = 0
+    out = _worker.get_task_result_tail(task_id, since)
+    if out is None:
         return err("Task not found", 404)
-    return ok(results=utils.sanitize_floats(task.get("result")))
+    results, total = out
+    return ok(results=utils.sanitize_floats(results), total=total)
 
 
 # ---- Events CRUD ----

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -42,7 +42,9 @@ from screenspace_multitool import _multitool_has_offset
 from screenspace_frames import _probe_video_meta
 
 
-def _copy_task_for_read(task: dict[str, Any]) -> dict[str, Any]:
+def _copy_task_for_read(
+    task: dict[str, Any], include_results: bool = True
+) -> dict[str, Any]:
     """Deep-copy a task for external reads, omitting server-only ``change_grid``.
 
     ``change_grid`` is large per-frame data consumed once by heatmap generation
@@ -50,17 +52,30 @@ def _copy_task_for_read(task: dict[str, Any]) -> dict[str, Any]:
     needs). Excluding it before the deep copy keeps progress-driven SSE reads
     (~every 0.5s on long Change scans) from repeatedly duplicating per-frame
     grids that are immediately discarded by the API layer.
+
+    ``include_results=False`` drops the ever-growing ``result``/``_raw_results``
+    lists entirely (reporting ``result_count`` instead), so status ticks stop
+    deep-copying the whole detection list every 0.5s; clients pull new results
+    via :meth:`ScreenspaceWorker.get_task_result_tail`.
     """
     slim = dict(task)
-    for key in ("result", "_raw_results"):
-        seq = task.get(key)
-        if isinstance(seq, list) and seq:
-            slim[key] = [
-                {k: v for k, v in r.items() if k != "change_grid"}
-                if isinstance(r, dict)
-                else r
-                for r in seq
-            ]
+    if include_results:
+        for key in ("result", "_raw_results"):
+            seq = task.get(key)
+            if isinstance(seq, list) and seq:
+                slim[key] = [
+                    {k: v for k, v in r.items() if k != "change_grid"}
+                    if isinstance(r, dict)
+                    else r
+                    for r in seq
+                ]
+    else:
+        res = task.get("result")
+        # Mirror the frontend's old count logic: list → len, truthy non-list
+        # (e.g. a single string artifact path) → 1, empty/None → 0.
+        slim["result_count"] = len(res) if isinstance(res, list) else (1 if res else 0)
+        slim.pop("result", None)
+        slim.pop("_raw_results", None)
     return copy.deepcopy(slim)
 
 
@@ -244,19 +259,48 @@ class ScreenspaceWorker:
                 return None
             return _copy_task_for_read(task)
 
-    def get_all_tasks(self) -> list[dict[str, Any]]:
+    def get_all_tasks(self, include_results: bool = True) -> list[dict[str, Any]]:
         """Return all tasks (thread-safe copies).
 
         Tasks flagged ``_remove_on_finish`` (dismissed while running) are hidden:
         they are gone as far as the UI and manifest are concerned, even though
         they linger in ``_tasks`` until their worker thread notices the cancel.
+
+        ``include_results=False`` returns slim status copies (no ``result``/
+        ``_raw_results``, just ``result_count``) for the ≈0.5s SSE/poll ticks.
         """
         with self._lock:
             return [
-                _copy_task_for_read(t)
+                _copy_task_for_read(t, include_results=include_results)
                 for t in self._tasks.values()
                 if not t.get("_remove_on_finish")
             ]
+
+    def get_task_result_tail(
+        self, task_id: str, since: int = 0
+    ) -> tuple[list[dict[str, Any]], int] | None:
+        """Thread-safe copy of a task's result tail from index ``since``.
+
+        Results are appended in scan order during a run (see ``_on_result``), so a
+        count cursor yields exactly the new detections and keeps the live-results
+        fetch flat. Strips server-only ``change_grid`` like :func:`_copy_task_for_read`.
+        Returns ``(tail, total)``, or ``None`` if the task is unknown.
+        """
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return None
+            res = task.get("result") or []
+            total = len(res)
+            start = max(since, 0)
+            tail = res[start:] if start < total else []
+            stripped = [
+                {k: v for k, v in r.items() if k != "change_grid"}
+                if isinstance(r, dict)
+                else r
+                for r in tail
+            ]
+            return copy.deepcopy(stripped), total
 
     def reorder(self, task_ids: list[str]) -> bool:
         """Reorder queued tasks by the given ID sequence.

--- a/tests/screenspace/test_worker.py
+++ b/tests/screenspace/test_worker.py
@@ -77,6 +77,49 @@ class TestScreenspaceWorker:
         ids = {t["id"] for t in all_tasks}
         assert t1["id"] in ids and t2["id"] in ids
 
+    def test_get_all_tasks_slim_omits_results(self):
+        """include_results=False drops the growing result lists, reports count."""
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "change", "P01", "s.mp4", ["/v.mp4"], "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+        )
+        worker.enqueue(task)
+        with worker._lock:
+            worker._tasks[task["id"]]["result"] = [
+                {"timestamp": 0.0, "magnitude": 0.1, "change_grid": [[1, 2]]},
+                {"timestamp": 1.0, "magnitude": 0.2},
+            ]
+            worker._tasks[task["id"]]["_raw_results"] = [{"timestamp": 0.0}]
+        slim = worker.get_all_tasks(include_results=False)[0]
+        assert "result" not in slim
+        assert "_raw_results" not in slim
+        assert slim["result_count"] == 2
+        # Default path still carries results (change_grid stripped as before).
+        full = worker.get_all_tasks()[0]
+        assert len(full["result"]) == 2
+        assert "change_grid" not in full["result"][0]
+
+    def test_get_task_result_tail(self):
+        """Since-cursor returns the appended tail (change_grid stripped) + total."""
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "change", "P01", "s.mp4", ["/v.mp4"], "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+        )
+        worker.enqueue(task)
+        with worker._lock:
+            worker._tasks[task["id"]]["result"] = [
+                {"timestamp": float(i), "magnitude": 0.1, "change_grid": [[i]]}
+                for i in range(3)
+            ]
+        out = worker.get_task_result_tail(task["id"], since=1)
+        assert out is not None
+        tail, total = out
+        assert total == 3
+        assert [r["timestamp"] for r in tail] == [1.0, 2.0]
+        assert all("change_grid" not in r for r in tail)
+        assert worker.get_task_result_tail(task["id"], since=3) == ([], 3)
+        assert worker.get_task_result_tail("nope", 0) is None
+
     def test_cancel_queued_task(self):
         worker = screenspace.ScreenspaceWorker()
         task = screenspace.create_task(

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1508,6 +1508,41 @@ def test_task_results_not_found(client):
     assert resp.status_code == 404
 
 
+def test_task_results_since_cursor(client):
+    """?since=N returns only the result tail plus the running total."""
+    worker = screenspace_server._worker
+    assert worker is not None
+    task = screenspace.create_task(
+        "change", "P01", "s.mp4", ["/v.mp4"], "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
+    with worker._lock:
+        worker._tasks[task["id"]]["result"] = [
+            {"timestamp": float(i), "magnitude": 0.1} for i in range(3)
+        ]
+    full = client.get(f"/screenspace/api/tasks/{task['id']}/results").get_json()
+    assert full["ok"] and len(full["results"]) == 3 and full["total"] == 3
+    tail = client.get(f"/screenspace/api/tasks/{task['id']}/results?since=2").get_json()
+    assert [r["timestamp"] for r in tail["results"]] == [2.0]
+    assert tail["total"] == 3
+
+
+def test_tasks_list_slim_omits_results(client):
+    """The polling/SSE task list carries result_count, not the result list."""
+    worker = screenspace_server._worker
+    assert worker is not None
+    task = screenspace.create_task(
+        "change", "P01", "s.mp4", ["/v.mp4"], "r", {"x": 0, "y": 0, "w": 1, "h": 1}
+    )
+    worker.enqueue(task)
+    with worker._lock:
+        worker._tasks[task["id"]]["result"] = [{"timestamp": 0.0, "magnitude": 0.1}]
+    data = client.get("/screenspace/api/tasks").get_json()
+    t = next(t for t in data["tasks"] if t["id"] == task["id"])
+    assert "result" not in t
+    assert t["result_count"] == 1
+
+
 def test_reorder_missing_body(client):
     resp = client.put("/screenspace/api/tasks/reorder", json={})
     assert resp.status_code == 400

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -675,6 +675,39 @@ class TestTranscriptWorker:
         assert task["id"] == "tr_test1234"
         assert worker.get_task("nonexistent") is None
 
+    def test_get_all_tasks_slim_omits_partial_segments(self):
+        """include_partials=False drops the growing segment tail, reports count."""
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", ["/v.mp4"])
+        worker.enqueue(task)
+        with worker._lock:
+            worker._tasks[task["id"]]["partial_segments"] = [
+                {"start": 0.0, "end": 1.0, "text": "a"},
+                {"start": 1.0, "end": 2.0, "text": "b"},
+            ]
+        slim = worker.get_all_tasks(include_partials=False)[0]
+        assert "partial_segments" not in slim
+        assert slim["partial_count"] == 2
+        # Default path still carries the full array.
+        full = worker.get_all_tasks()[0]
+        assert len(full["partial_segments"]) == 2
+
+    def test_get_partial_segments_tail(self):
+        """Since-cursor returns exactly the appended tail plus the running total."""
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", ["/v.mp4"])
+        worker.enqueue(task)
+        segs = [{"start": float(i), "end": i + 1.0, "text": str(i)} for i in range(3)]
+        with worker._lock:
+            worker._tasks[task["id"]]["partial_segments"] = segs
+        tail, total = worker.get_partial_segments(task["id"], since=1)
+        assert total == 3
+        assert [s["text"] for s in tail] == ["1", "2"]
+        # A cursor at/after the end yields no new segments.
+        assert worker.get_partial_segments(task["id"], since=3) == ([], 3)
+        # Unknown task → empty tail (the endpoint just reports no new segments).
+        assert worker.get_partial_segments("nope", 0) == ([], 0)
+
     def test_cancel_queued_task(self):
         worker = transcripts.TranscriptWorker()
         task = transcripts.create_transcript_task("P01", ["/v.mp4"])

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -73,6 +73,32 @@ def test_prewarm_invalid_config_normalized_in_participants(tr_client, monkeypatc
     assert resp.get_json()["transcribe_prewarm"] == "queue_open"
 
 
+def test_transcribe_status_slim_and_segments_tail(tr_client):
+    """Status poll reports partial_count (not the array); the segments endpoint
+    serves the tail from a cursor."""
+    worker = transcripts.TranscriptWorker()
+    task = transcripts.create_transcript_task("P01", ["/v.mp4"])
+    worker.enqueue(task)
+    with worker._lock:
+        t = worker._tasks[task["id"]]
+        t["status"] = transcripts.TASK_STATUS_RUNNING
+        t["partial_segments"] = [
+            {"start": float(i), "end": i + 1.0, "text": str(i)} for i in range(3)
+        ]
+    transcripts_server._worker = worker
+
+    status = tr_client.get("/transcripts/api/transcribe/status").get_json()
+    entry = next(x for x in status["tasks"] if x["id"] == task["id"])
+    assert "partial_segments" not in entry
+    assert entry["partial_count"] == 3
+
+    seg = tr_client.get(
+        f"/transcripts/api/transcribe/{task['id']}/segments?since=1"
+    ).get_json()
+    assert [s["text"] for s in seg["segments"]] == ["1", "2"]
+    assert seg["total"] == 3
+
+
 def test_participants_includes_video_version(tr_client, tmp_path):
     """video_version (mtime_ns) drives the frontend's media/<file>?v=… cache-bust."""
     video_file = tmp_path / "study_P09.mp4"

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -857,6 +857,56 @@ def test_batches_list_and_filter(wf_client, monkeypatch):
     )
 
 
+def test_batch_summary_historical_from_persisted_runs(wf_client):
+    """A finished batch (no live record) is rebuilt from persisted runs by reading
+    scalars only, and its summary stays stable as unrelated history grows."""
+    workflows_server._manifest["runs"] = [
+        {
+            "id": "run_a",
+            "batchId": "batch_x",
+            "participant": "P01",
+            "blueprintId": "bp1",
+            "startedAt": "2026-01-01T00:00:00",
+            "status": workflows.RUN_STATUS_COMPLETED,
+        },
+        {
+            "id": "run_b",
+            "batchId": "batch_x",
+            "participant": "P02",
+            "blueprintId": "bp1",
+            "startedAt": "2026-01-01T00:00:01",
+            "status": workflows.RUN_STATUS_FAILED,
+        },
+    ]
+    summary = workflows_server._batch_summary("batch_x")
+    assert summary is not None
+    assert summary["blueprintId"] == "bp1"
+    assert summary["participants"] == ["P01", "P02"]
+    assert summary["counts"] == {
+        workflows.RUN_STATUS_COMPLETED: 1,
+        workflows.RUN_STATUS_FAILED: 1,
+    }
+    child_status = {c["runId"]: c["status"] for c in summary["children"]}
+    assert child_status == {
+        "run_a": workflows.RUN_STATUS_COMPLETED,
+        "run_b": workflows.RUN_STATUS_FAILED,
+    }
+
+    # Growing unrelated run history must not perturb this batch's summary.
+    workflows_server._manifest["runs"].append(
+        {
+            "id": "run_c",
+            "batchId": "batch_other",
+            "participant": "P09",
+            "blueprintId": "bp2",
+            "startedAt": "2026-01-02T00:00:00",
+            "status": workflows.RUN_STATUS_RUNNING,
+        }
+    )
+    assert workflows_server._batch_summary("batch_x") == summary
+    assert workflows_server._batch_summary("batch_missing") is None
+
+
 def test_batch_get_and_cancel_404_when_unknown(wf_client):
     assert wf_client.get("/workflows/api/batches/batch_nope").status_code == 404
     assert wf_client.post("/workflows/api/batches/batch_nope/cancel").status_code == 404

--- a/transcripts.py
+++ b/transcripts.py
@@ -946,10 +946,42 @@ class TranscriptWorker:
             t = self._tasks.get(task_id)
             return copy.deepcopy(t) if t else None
 
-    def get_all_tasks(self) -> list[dict[str, Any]]:
-        """Return all tasks (thread-safe copies)."""
+    def get_all_tasks(self, include_partials: bool = True) -> list[dict[str, Any]]:
+        """Return all tasks (thread-safe copies).
+
+        ``include_partials=False`` omits each task's ever-growing
+        ``partial_segments`` list (reporting ``partial_count`` instead), so the
+        3 s status poll no longer deep-copies the whole segment tail on every
+        tick; clients pull new segments via :meth:`get_partial_segments`.
+        """
         with self._lock:
-            return [copy.deepcopy(t) for t in self._tasks.values()]
+            if include_partials:
+                return [copy.deepcopy(t) for t in self._tasks.values()]
+            slim: list[dict[str, Any]] = []
+            for t in self._tasks.values():
+                segs = t.get("partial_segments") or []
+                light = {k: v for k, v in t.items() if k != "partial_segments"}
+                copied = copy.deepcopy(light)
+                copied["partial_count"] = len(segs)
+                slim.append(copied)
+            return slim
+
+    def get_partial_segments(
+        self, task_id: str, since: int = 0
+    ) -> tuple[list[TranscriptSegment], int]:
+        """Thread-safe copy of a task's partial-segment tail from index ``since``.
+
+        ``partial_segments`` is append-only during transcription (see
+        :meth:`_on_seg`), so a count cursor yields exactly the new segments.
+        Returns ``(tail, total)`` where ``total`` is the current segment count.
+        """
+        with self._lock:
+            t = self._tasks.get(task_id)
+            segs = (t.get("partial_segments") if t else None) or []
+            total = len(segs)
+            start = max(since, 0)
+            tail = copy.deepcopy(segs[start:]) if start < total else []
+            return tail, total
 
     @property
     def is_alive(self) -> bool:

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1403,7 +1403,10 @@ def api_transcribe_status() -> FlaskResponse:
     """Poll transcription task status."""
     tasks = []
     if _worker:
-        for t in _worker.get_all_tasks():
+        # include_partials=False keeps the 3 s poll from deep-copying every
+        # running task's growing segment tail; clients pull new segments via
+        # /api/transcribe/<task_id>/segments?since=N using partial_count.
+        for t in _worker.get_all_tasks(include_partials=False):
             task_info = {
                 "id": t["id"],
                 "participant": t["participant"],
@@ -1414,12 +1417,25 @@ def api_transcribe_status() -> FlaskResponse:
                 "completed_at": t.get("completed_at"),
             }
             if t["status"] == transcripts.TASK_STATUS_RUNNING:
-                task_info["partial_segments"] = t.get("partial_segments", [])
+                task_info["partial_count"] = t.get("partial_count", 0)
             tasks.append(task_info)
     return ok(
         tasks=tasks,
         worker_alive=_worker.is_alive if _worker else False,
     )
+
+
+@transcripts_bp.route("/api/transcribe/<task_id>/segments")
+def api_transcribe_segments(task_id: str) -> FlaskResponse:
+    """Return a running task's partial-segment tail from ``?since=N`` (append-only)."""
+    if not _worker:
+        return err("Worker not initialized", 500)
+    try:
+        since = int(request.args.get("since", 0))
+    except (TypeError, ValueError):
+        since = 0
+    segments, total = _worker.get_partial_segments(task_id, since)
+    return ok(segments=segments, total=total)
 
 
 @transcripts_bp.route("/api/transcribe/<task_id>", methods=["DELETE"])

--- a/workflows_server.py
+++ b/workflows_server.py
@@ -354,6 +354,41 @@ def _run_snapshot(run_id: str) -> dict[str, Any] | None:
     return None
 
 
+def _run_meta_index() -> dict[str, dict[str, Any]]:
+    """Per-run scalar metadata keyed by id, without deep-copying run records.
+
+    The batch-summary and batch-discover paths only read a handful of scalars per
+    child run (status + grouping fields), yet fire on every child node transition
+    and every discover poll. Reading scalars here avoids ``_merged_runs``'s
+    whole-history deep copy on those hot paths.
+    """
+    meta: dict[str, dict[str, Any]] = {}
+    with _manifest_lock:
+        for record in _manifest.get("runs", []):
+            rid = record.get("id")
+            if rid:
+                meta[rid] = {
+                    "id": rid,
+                    "status": record.get("status", workflows.RUN_STATUS_QUEUED),
+                    "batchId": record.get("batchId", ""),
+                    "participant": record.get("participant", ""),
+                    "blueprintId": record.get("blueprintId", ""),
+                    "startedAt": record.get("startedAt"),
+                }
+    with _runs_lock:
+        live = list(_runs.items())
+    for run_id, runner in live:
+        meta[run_id] = {
+            "id": run_id,
+            "status": runner.status,
+            "batchId": runner.batch_id,
+            "participant": runner.participant,
+            "blueprintId": runner.blueprint_id,
+            "startedAt": runner.started_at,
+        }
+    return meta
+
+
 def _trim_run_history(runs: list[dict[str, Any]]) -> list[str]:
     """Cap persisted run history in place, evicting whole units oldest-first.
 
@@ -681,7 +716,7 @@ def _batch_summary(batch_id: str) -> dict[str, Any] | None:
     grouping the persisted runs that carry this ``batchId``. Returns ``None`` if no
     such batch exists in either place.
     """
-    all_runs = _merged_runs()
+    all_meta = _run_meta_index()
     with _batches_lock:
         live = _batches.get(batch_id)
         record = dict(live) if live else None
@@ -693,7 +728,7 @@ def _batch_summary(batch_id: str) -> dict[str, Any] | None:
         created_at = record.get("createdAt")
     else:
         grouped = [
-            r for r in all_runs.values() if r.get("batchId") == batch_id and r.get("id")
+            r for r in all_meta.values() if r.get("batchId") == batch_id and r.get("id")
         ]
         if not grouped:
             return None
@@ -707,8 +742,8 @@ def _batch_summary(batch_id: str) -> dict[str, Any] | None:
     counts: dict[str, int] = {}
     child_statuses: list[str] = []
     for run_id, participant in zip(run_ids, participants):
-        snap = all_runs.get(run_id)
-        status = (snap or {}).get("status", workflows.RUN_STATUS_QUEUED)
+        meta = all_meta.get(run_id)
+        status = (meta or {}).get("status", workflows.RUN_STATUS_QUEUED)
         child_statuses.append(status)
         counts[status] = counts.get(status, 0) + 1
         children.append({"runId": run_id, "participant": participant, "status": status})
@@ -891,7 +926,7 @@ def api_batches_list() -> Any:
             if bid not in seen:
                 batch_ids.append(bid)
                 seen.add(bid)
-    for run in _merged_runs().values():
+    for run in _run_meta_index().values():
         bid = run.get("batchId")
         if bid and bid not in seen:
             batch_ids.append(bid)


### PR DESCRIPTION
## Summary

Kill a quadratic deep-copy that hit the same status/poll path in three servers: the live tick deep-copied ever-growing state every time (worse while a long task is watched), then discarded most of it.
- **Workflows**: `_batch_summary` reads run **scalars** (`_run_meta_index`) instead of deep-copying the whole ≤50-run history on every child transition / discover poll.
- **Transcripts**: status poll carries `partial_count`; a new `/api/transcribe/<id>/segments?since=N` streams the append-only tail (header search reads the client-side accumulator).
- **Screenspace**: SSE/`/api/tasks` ticks are slim (`result_count`, no `result`/`_raw_results`); `/api/tasks/<id>/results?since=N` serves tails into a per-task client cache that the timeline, task-list counts, and results panel read from.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check`, full pytest suite, `node --check`, frontend wiring/DOM tests
- [x] New tests: workflows historical `_batch_summary`; transcripts slim tasks + segment-tail endpoint; screenspace slim task read + result-tail endpoint
- [x] Screenspace timeline markers (reload/all-completed, participant switch) and Transcripts streaming search
