### PR TITLE
perf(screenspace): cache heatmap-GIF accumulators to halve accumulation passes

### DIFF
--- a/screenspace_heatmap.py
+++ b/screenspace_heatmap.py
@@ -194,29 +194,28 @@ def generate_heatmap_gif(
     if heatmap_type in ("flow", "change"):
         acc_h = acc_w = 256
 
-    # First pass: compute global max for consistent normalization
-    global_acc = np.zeros((acc_h, acc_w), dtype=np.float32)
-    for r in results:
-        _accumulate_heatmap_result(global_acc, r, heatmap_type)
-    global_max = float(global_acc.max())
-    if global_max == 0:
-        return None
-
-    # Second pass: build progressive frames
+    # Single pass: accumulate progressively, snapshotting each frame's state.
     accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
-    frames: list[Image.Image] = []
-
+    snapshots: list[np.ndarray | None] = []
     for frame_idx in range(num_frames):
         start_idx, end_idx = _frame_bucket_bounds(frame_idx, len(results), num_frames)
         for r_idx in range(start_idx, end_idx):
             _accumulate_heatmap_result(accumulator, results[r_idx], heatmap_type)
+        snapshots.append(accumulator.copy())
 
-        frames.append(
-            _heatmap_frame_image(accumulator, global_max, heatmap_type, width, height)
-        )
-
-    if not frames:
+    # Monotonic accumulation → the final cumulative state carries the global max.
+    global_max = float(accumulator.max())
+    if global_max == 0:
         return None
+
+    frames: list[Image.Image] = []
+    for idx in range(num_frames):
+        snap = snapshots[idx]
+        assert snap is not None  # freshly filled above; released only after use
+        frames.append(
+            _heatmap_frame_image(snap, global_max, heatmap_type, width, height)
+        )
+        snapshots[idx] = None  # release the array once colorized (bound peak memory)
 
     frames[0].save(
         output_path,
@@ -266,21 +265,24 @@ def generate_rolling_heatmap_gif(
                 _accumulate_heatmap_result(acc, results[r_idx], heatmap_type)
         return acc
 
-    # First pass: densest window sets the shared normalization ceiling.
-    global_max = 0.0
-    for frame_idx in range(num_frames):
-        global_max = max(global_max, float(_accumulate_window(frame_idx).max()))
+    # Single pass: build each window once, cache it, and track the shared ceiling.
+    window_accs: list[np.ndarray | None] = [
+        _accumulate_window(i) for i in range(num_frames)
+    ]
+    global_max = max(
+        (float(a.max()) for a in window_accs if a is not None), default=0.0
+    )
     if global_max == 0:
         return None
 
-    # Second pass: render each window as a frame.
     frames: list[Image.Image] = []
-    for frame_idx in range(num_frames):
+    for idx in range(num_frames):
+        acc = window_accs[idx]
+        assert acc is not None  # freshly filled above; released only after use
         frames.append(
-            _heatmap_frame_image(
-                _accumulate_window(frame_idx), global_max, heatmap_type, width, height
-            )
+            _heatmap_frame_image(acc, global_max, heatmap_type, width, height)
         )
+        window_accs[idx] = None  # release once colorized
 
     frames[0].save(
         output_path,

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -184,6 +184,43 @@ class TestGenerateTemplateHeatmap:
         assert screenspace.generate_template_heatmap(results, 200, 200, out) is None
 
 
+class TestGenerateHeatmapGif:
+    def _matches(self, n):
+        return [
+            {
+                "timestamp": float(i),
+                "matches": [{"x": 10 + i, "y": 10, "w": 30, "h": 30, "score": 0.9}],
+            }
+            for i in range(n)
+        ]
+
+    def test_basic_gif(self, tmp_path):
+        out = str(tmp_path / "heatmap.gif")
+        path = screenspace.generate_heatmap_gif(self._matches(8), 200, 200, out)
+        assert path == out
+        assert (tmp_path / "heatmap.gif").stat().st_size > 0
+
+    def test_empty_returns_none(self, tmp_path):
+        out = str(tmp_path / "heatmap.gif")
+        assert screenspace.generate_heatmap_gif([], 200, 200, out) is None
+
+    def test_single_result_returns_none(self, tmp_path):
+        out = str(tmp_path / "heatmap.gif")
+        assert screenspace.generate_heatmap_gif(self._matches(1), 200, 200, out) is None
+
+    def test_change_type_gif(self, tmp_path):
+        results = [
+            {"timestamp": float(i), "change_grid": [{"x": 0.5, "y": 0.5, "mag": 0.7}]}
+            for i in range(8)
+        ]
+        out = str(tmp_path / "heatmap_change.gif")
+        path = screenspace.generate_heatmap_gif(
+            results, 200, 150, out, heatmap_type="change"
+        )
+        assert path == out
+        assert (tmp_path / "heatmap_change.gif").stat().st_size > 0
+
+
 class TestGenerateRollingHeatmapGif:
     def _matches(self, n):
         return [


### PR DESCRIPTION
## Summary

Both animated-GIF heatmap builders in `screenspace_heatmap.py` accumulated every result twice — once to compute the shared normalization ceiling (`global_max`), then again to render — with `generate_rolling_heatmap_gif` worse still, calling `_accumulate_window()` twice per frame. Each is now folded into a single accumulation pass that caches per-frame accumulator arrays, derives `global_max` from them, then colorizes (releasing each array once used), so output is byte-for-byte identical.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 1828 passed (incl. new `TestGenerateHeatmapGif` smoke tests, which previously had no direct coverage)
- [x] `ruff format --check`, `ruff check`, `ty check` — all clean
- [ ] Screenspace template scan not manually re-run in a browser; output is identical by construction (`global_max` unchanged)