### PR TITLE
perf(screenspace): gate expensive scans on cheap static-frame check

### DIFF
--- a/screenspace.py
+++ b/screenspace.py
@@ -48,6 +48,7 @@ from screenspace_primitives import (
     FULL_FRAME_REGION_NAME,
     ScanCallback,
     _ConsecutiveBuffer,
+    _frame_is_static,
     _is_static_skip,
     _merge_timestamp_spans,
     _morph_kernel,

--- a/screenspace_primitives.py
+++ b/screenspace_primitives.py
@@ -130,6 +130,25 @@ def _is_static_skip(
     return False
 
 
+def _frame_is_static(prev_gray: np.ndarray | None, curr_gray: np.ndarray) -> bool:
+    """True when *curr_gray* is a near-duplicate of the last processed gray frame.
+
+    A frame is "static" when its mean grayscale diff from *prev_gray* is below
+    ``SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD``. Returns False when *prev_gray*
+    is ``None`` (no baseline yet). Unlike :func:`_is_static_skip`, this is a bare
+    predicate with no consecutive-buffer/progress side effects, so callers apply
+    whatever skip semantics fit their scan (reset a motion run, extend a span,
+    skip a per-frame op, or carry the last result). Shared by scan_similarity,
+    scan_flow, scan_inactivity, scan_boundaries, and scan_template.
+    """
+    if prev_gray is None:
+        return False
+    return (
+        float(np.mean(cv2.absdiff(prev_gray, curr_gray)))
+        < config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD
+    )
+
+
 # ---------------------------------------------------------------------------
 # Analysis primitives
 # ---------------------------------------------------------------------------

--- a/screenspace_scans.py
+++ b/screenspace_scans.py
@@ -21,6 +21,7 @@ import config
 import utils
 from screenspace_primitives import (
     _ConsecutiveBuffer,
+    _frame_is_static,
     _is_static_skip,
     _match_template_prepared,
     _merge_timestamp_spans,
@@ -294,14 +295,10 @@ def scan_similarity(
             return False
         # Static-frame skip
         gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
-        if prev_skip_gray[0] is not None:
-            if (
-                float(np.mean(cv2.absdiff(prev_skip_gray[0], gray)))
-                < config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD
-            ):
-                if on_progress and total_range > 0:
-                    on_progress((ts - start_seconds) / total_range)
-                return None
+        if _frame_is_static(prev_skip_gray[0], gray):
+            if on_progress and total_range > 0:
+                on_progress((ts - start_seconds) / total_range)
+            return None
         prev_skip_gray[0] = gray
 
         frame_phash = compute_phash(pixels)
@@ -720,9 +717,37 @@ def scan_template(
         else 1.0
     )
 
+    # Static-frame carry: template results are per-frame rows with no consecutive
+    # buffer, so a naive skip would drop a persistent match's rows and make the
+    # detection flicker. Cache the last processed frame's result and, on a static
+    # frame, re-emit it (re-stamped) instead of re-running the expensive match.
+    prev_skip_gray: list[np.ndarray | None] = [None]
+    last_rd: list[dict[str, Any] | None] = [None]
+
     def _cb(ts: float, frame: np.ndarray) -> bool | None:
         if cancel_flag and cancel_flag():
             return False
+        curr_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if _frame_is_static(prev_skip_gray[0], curr_gray):
+            # Near-duplicate of the last matched frame — matches (already in
+            # original-frame coords) still hold. Carry the row forward; keep
+            # prev_skip_gray as the baseline so drift out of the run recomputes.
+            if last_rd[0] is not None:
+                carried = dict(last_rd[0])
+                carried["timestamp"] = ts
+                results.append(carried)
+                if on_result:
+                    on_result(
+                        {
+                            "timestamp": ts,
+                            "best_score": carried["best_score"],
+                            "match_count": carried["match_count"],
+                        }
+                    )
+            if on_progress and total_range > 0:
+                on_progress((ts - start_seconds) / total_range)
+            return None
+        prev_skip_gray[0] = curr_gray
         work_frame = frame
         scale_back = 1
         if _tmpl_downscale:
@@ -754,6 +779,7 @@ def scan_template(
                 "match_count": len(matches),
             }
             results.append(rd)
+            last_rd[0] = rd
             if on_result:
                 on_result(
                     {
@@ -762,6 +788,9 @@ def scan_template(
                         "match_count": rd["match_count"],
                     }
                 )
+        else:
+            # No match this frame — a subsequent static frame has nothing to carry.
+            last_rd[0] = None
         if on_progress and total_range > 0:
             on_progress((ts - start_seconds) / total_range)
         return None
@@ -822,6 +851,16 @@ def scan_flow(
         if cancel_flag and cancel_flag():
             return False
         curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        # Static-frame skip: a near-duplicate of the previous frame produces
+        # ~zero optical flow, so the expensive Farneback pass would only confirm
+        # magnitude < threshold and reset the run anyway. Short-circuit to that
+        # outcome, still advancing prev_gray (flow is measured frame-to-frame).
+        if _frame_is_static(prev_gray[0], curr_gray):
+            buf.reset()
+            prev_gray[0] = curr_gray
+            if on_progress and total_range > 0:
+                on_progress((ts - start_seconds) / total_range)
+            return None
         if prev_gray[0] is not None:
             flow_result = compute_optical_flow(
                 prev_gray[0], curr_gray, return_grid=True
@@ -1015,9 +1054,19 @@ def scan_inactivity(
 
     results: list[dict[str, Any]] = []
     prev_hash: list["imagehash.ImageHash | None"] = [None]
+    prev_skip_gray: list[np.ndarray | None] = [None]
     span_start: list[float | None] = [None]
     span_distances: list[list[int]] = [[]]
     last_ts: list[float] = [start_seconds]
+
+    def _extend_span(ts: float, dist: int) -> None:
+        # Frame is similar — extend or start span.
+        if span_start[0] is None:
+            # Clamp to the scan start so a match early in the video
+            # (ts < interval_seconds, or start_seconds > 0) can't begin
+            # the span before 0:00 / the requested start.
+            span_start[0] = max(start_seconds, ts - interval_seconds)
+        span_distances[0].append(dist)
 
     def _flush_span(span_end: float) -> None:
         if span_start[0] is not None:
@@ -1041,19 +1090,28 @@ def scan_inactivity(
         if cancel_flag and cancel_flag():
             return False
 
-        curr_hash = compute_phash(pixels)
         last_ts[0] = ts
+
+        # Static-frame fast-path: a gray mean-diff below the static threshold
+        # implies a phash Hamming distance of ~0 — well within the (always ≥1)
+        # inactivity threshold — so the frame is provably inactive. Extend the
+        # span with a nominal 0 distance and skip the much heavier compute_phash.
+        # prev_hash/prev_skip_gray are left as the run baseline so slow drift is
+        # still measured against the start of the frozen run.
+        curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        if _frame_is_static(prev_skip_gray[0], curr_gray):
+            _extend_span(ts, 0)
+            if on_progress and total_range > 0:
+                on_progress((ts - start_seconds) / total_range)
+            return None
+        prev_skip_gray[0] = curr_gray
+
+        curr_hash = compute_phash(pixels)
 
         if prev_hash[0] is not None:
             dist = int(curr_hash - prev_hash[0])
             if dist <= threshold:
-                # Frame is similar — extend or start span
-                if span_start[0] is None:
-                    # Clamp to the scan start so a match early in the video
-                    # (ts < interval_seconds, or start_seconds > 0) can't begin
-                    # the span before 0:00 / the requested start.
-                    span_start[0] = max(start_seconds, ts - interval_seconds)
-                span_distances[0].append(dist)
+                _extend_span(ts, dist)
             else:
                 # Frame changed — flush any active span
                 _flush_span(ts - interval_seconds)
@@ -1349,9 +1407,21 @@ def scan_boundaries(
 
     if not use_scene:
         # ---- v1 phash path: consecutive-frame spike, streamed live ----
+        prev_skip_gray: list[np.ndarray | None] = [None]
+
         def _cb_phash(ts: float, pixels: np.ndarray) -> bool | None:
             if cancel_flag and cancel_flag():
                 return False
+            # Static-frame skip: a near-duplicate frame yields a phash distance
+            # ~0, far below the boundary threshold, so it can never be a scene
+            # boundary. Skip the heavy compute_phash and keep prev_hash as the
+            # run baseline (a real spike is never gray-static, so none is missed).
+            curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+            if _frame_is_static(prev_skip_gray[0], curr_gray):
+                if on_progress and total_range > 0:
+                    on_progress((ts - start_seconds) / total_range)
+                return None
+            prev_skip_gray[0] = curr_gray
             curr_hash = compute_phash(pixels)
             if prev_hash[0] is not None:
                 dist = int(curr_hash - prev_hash[0])

--- a/tests/screenspace/test_static_gating.py
+++ b/tests/screenspace/test_static_gating.py
@@ -1,0 +1,209 @@
+"""Static-frame gating parity + savings for the expensive scans.
+
+Each scan that gained a cheap gray-diff pre-gate (flow, inactivity, boundaries
+phash path, template) is exercised two ways on the same frozen-then-changing
+frame sequence:
+
+* **gate on** — the real code path.
+* **gate off** — ``_frame_is_static`` monkeypatched to always return False,
+  reproducing the pre-gate behaviour.
+
+The gate must be *result-equivalent* (same spans/events/rows) while invoking the
+expensive per-frame op (Farneback / phash / matchTemplate) strictly fewer times.
+"""
+
+import cv2
+import numpy as np
+
+import screenspace
+import screenspace_primitives
+import screenspace_scans
+from _ss_helpers import _make_icon, _make_icon_frame
+
+_REGION = {"x": 0, "y": 0, "w": 60, "h": 60}
+
+
+def _disable_gate(monkeypatch):
+    monkeypatch.setattr(screenspace_scans, "_frame_is_static", lambda prev, curr: False)
+
+
+def _feed_region(monkeypatch, sequence):
+    """Patch the region-frame scan driver to replay ``[(ts, frame), ...]``."""
+
+    def fake_scan(video_path, region, interval, callback, **kwargs):
+        for ts, frame in sequence:
+            if callback(ts, frame.copy()) is False:
+                break
+
+    monkeypatch.setattr(screenspace_scans, "scan_video_frames", fake_scan)
+    monkeypatch.setattr(screenspace_scans, "_probe_video_meta", lambda p: (30.0, 10.0))
+
+
+def _feed_full(monkeypatch, sequence):
+    """Patch the full-frame scan driver to replay ``[(ts, frame), ...]``."""
+
+    def fake_scan(video_path, interval, callback, **kwargs):
+        for ts, frame in sequence:
+            if callback(ts, frame.copy()) is False:
+                break
+
+    monkeypatch.setattr(screenspace_scans, "scan_video_full_frames", fake_scan)
+    monkeypatch.setattr(screenspace_scans, "_probe_video_meta", lambda p: (30.0, 10.0))
+
+
+class TestFlowStaticGate:
+    def _run(self, monkeypatch, gate_on):
+        # g0/g1 differ maximally: g0->g1 is real motion, repeats are static.
+        g0 = np.zeros((60, 60, 3), dtype=np.uint8)
+        g1 = np.full((60, 60, 3), 255, dtype=np.uint8)
+        seq = [(0.0, g0), (1.0, g0), (2.0, g1), (3.0, g1)]
+
+        calls = [0]
+
+        def counting_flow(prev, curr, return_grid=False):
+            calls[0] += 1
+            return {
+                "magnitude": float(np.mean(cv2.absdiff(prev, curr))),
+                "angle": 0.0,
+                "flow_grid": [],
+            }
+
+        _feed_region(monkeypatch, seq)
+        monkeypatch.setattr(screenspace_scans, "compute_optical_flow", counting_flow)
+        if not gate_on:
+            _disable_gate(monkeypatch)
+
+        results = screenspace.scan_flow(
+            "/fake.mp4", _REGION, magnitude_threshold=5.0, interval_seconds=1.0
+        )
+        return results, calls[0]
+
+    def test_parity_and_fewer_farneback_calls(self, monkeypatch):
+        on_results, on_calls = self._run(monkeypatch, gate_on=True)
+        off_results, off_calls = self._run(monkeypatch, gate_on=False)
+
+        assert on_results == off_results
+        assert len(on_results) == 1  # single motion event at the g0->g1 transition
+        assert on_results[0]["timestamp"] == 2.0
+        assert on_calls < off_calls
+        assert on_calls == 1 and off_calls == 3
+
+
+class TestInactivityStaticGate:
+    def _run(self, monkeypatch, gate_on):
+        frame = np.full((60, 60, 3), 128, dtype=np.uint8)
+        seq = [(float(i), frame) for i in range(5)]
+
+        calls = [0]
+        real_phash = screenspace_primitives.compute_phash
+
+        def counting_phash(px):
+            calls[0] += 1
+            return real_phash(px)
+
+        _feed_region(monkeypatch, seq)
+        monkeypatch.setattr(screenspace_scans, "compute_phash", counting_phash)
+        if not gate_on:
+            _disable_gate(monkeypatch)
+
+        results = screenspace.scan_inactivity(
+            "/fake.mp4", _REGION, threshold=15, min_duration=2.0, interval_seconds=1.0
+        )
+        return results, calls[0]
+
+    def test_parity_and_fewer_phash_calls(self, monkeypatch):
+        on_results, on_calls = self._run(monkeypatch, gate_on=True)
+        off_results, off_calls = self._run(monkeypatch, gate_on=False)
+
+        assert on_results == off_results
+        assert len(on_results) == 1
+        assert on_results[0]["start"] == 0.0 and on_results[0]["end"] == 4.0
+        assert on_results[0]["avg_distance"] == 0.0
+        assert on_calls < off_calls
+        assert on_calls == 1 and off_calls == 5  # gate skips phash on 4 frozen frames
+
+
+class TestBoundariesStaticGate:
+    def _run(self, monkeypatch, gate_on):
+        a = np.random.RandomState(1).randint(0, 256, (60, 60, 3)).astype(np.uint8)
+        b = np.random.RandomState(2).randint(0, 256, (60, 60, 3)).astype(np.uint8)
+        seq = [(0.0, a), (1.0, a.copy()), (2.0, b)]
+
+        calls = [0]
+        real_phash = screenspace_primitives.compute_phash
+
+        def counting_phash(px):
+            calls[0] += 1
+            return real_phash(px)
+
+        _feed_full(monkeypatch, seq)
+        monkeypatch.setattr(screenspace_scans, "compute_phash", counting_phash)
+        if not gate_on:
+            _disable_gate(monkeypatch)
+
+        results = screenspace.scan_boundaries(
+            "/fake.mp4",
+            _REGION,
+            threshold=10,
+            min_gap=0.1,
+            interval_seconds=1.0,
+            metric="phash",
+        )
+        return results, calls[0]
+
+    def test_parity_and_fewer_phash_calls(self, monkeypatch):
+        on_results, on_calls = self._run(monkeypatch, gate_on=True)
+        off_results, off_calls = self._run(monkeypatch, gate_on=False)
+
+        assert on_results == off_results
+        assert len(on_results) == 1  # one boundary at the a->b cut
+        assert on_results[0]["timestamp"] == 2.0
+        assert on_calls < off_calls
+        assert on_calls == 2 and off_calls == 3  # gate skips phash on the frozen frame
+
+
+class TestTemplateStaticGate:
+    def _run(self, monkeypatch, gate_on):
+        matched = _make_icon_frame(400, 200, [(100, 50, 40)])
+        blank = np.full((200, 400, 3), 200, dtype=np.uint8)
+        seq = [
+            (0.0, matched),
+            (1.0, matched.copy()),
+            (2.0, matched.copy()),
+            (3.0, blank),
+        ]
+        template = _make_icon(40)
+
+        calls = [0]
+        real_match = screenspace_primitives._match_template_prepared
+
+        def counting_match(*args, **kwargs):
+            calls[0] += 1
+            return real_match(*args, **kwargs)
+
+        _feed_full(monkeypatch, seq)
+        monkeypatch.setattr(
+            screenspace_scans, "_match_template_prepared", counting_match
+        )
+        if not gate_on:
+            _disable_gate(monkeypatch)
+
+        results = screenspace.scan_template(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 400, "h": 200},
+            template,
+            threshold=0.70,
+        )
+        return results, calls[0]
+
+    def test_carry_preserves_rows_and_fewer_match_calls(self, monkeypatch):
+        on_results, on_calls = self._run(monkeypatch, gate_on=True)
+        off_results, off_calls = self._run(monkeypatch, gate_on=False)
+
+        # Carried rows must be identical to freshly-matched rows, so the
+        # per-frame detection never flickers across a frozen run.
+        assert on_results == off_results
+        assert [r["timestamp"] for r in on_results] == [0.0, 1.0, 2.0]
+        assert all(r["match_count"] == 1 for r in on_results)
+        assert on_calls < off_calls
+        assert on_calls == 2 and off_calls == 4  # 2 frozen frames carried, not matched

--- a/tests/screenspace/test_text_numbers.py
+++ b/tests/screenspace/test_text_numbers.py
@@ -435,9 +435,10 @@ class TestConsecutiveBuffer:
 
 def test_static_skip_uses_config():
     """The static-frame-skip sites reference the config constant, not a 2.0
-    literal. scan_text/scan_numbers share the _is_static_skip helper (in
-    screenspace_primitives); similarity and scene apply the threshold inline (in
-    screenspace_scans)."""
+    literal. scan_text/scan_numbers share the _is_static_skip helper and
+    similarity/flow/inactivity/boundaries/template share the _frame_is_static
+    predicate (both in screenspace_primitives); scan_scene applies the threshold
+    inline (in screenspace_scans)."""
     src = Path(screenspace_primitives.__file__).read_text(encoding="utf-8")
     src += Path(screenspace_scans.__file__).read_text(encoding="utf-8")
     assert src.count("config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD") >= 3


### PR DESCRIPTION
## Summary

Wire a shared `_frame_is_static` gray-diff pre-gate into the Screenspace scans whose per-frame op dwarfs the gate — flow skips Farneback, inactivity and the boundaries phash path skip perceptual hashing, and template carries the last result so frozen-frame detections don't flicker — while `scan_similarity`'s inline skip is refactored onto the same helper. `color` and `changes` are deliberately left alone (their per-frame cost ≈ the gate, and `changes` already computes the same diff).

## Test plan

- [x] `tests/screenspace/test_static_gating.py` — proves result-parity vs a gate-disabled baseline plus strictly fewer expensive-op calls per scan
- [x] Full Screenspace suite, `test_packaging`, ruff (format + lint), and ty all green
- [ ] Not browser-verified: real Inactivity/Motion/Boundaries scans on footage with static stretches (expected faster, identical results)