### PR TITLE
perf(studio): idle-backoff intake pollers + combined status endpoints

### DIFF
--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -51,60 +51,73 @@
 
   // ---- Screenspace intake: poll Screenspace/Transcripts + cluster for Studio ----
 
-  function pollIntakeStatus() {
-    apiGet("../screenspace/api/tasks")
+  function setIntakeDot(on) {
+    if (state._intakeTabDotOn === on) return;
+    state._intakeTabDotOn = on;
+    setTabDot("intakeTabDot", on);
+  }
+
+  function setTrIntakeDot(on) {
+    if (state._trIntakeTabDotOn === on) return;
+    state._trIntakeTabDotOn = on;
+    setTabDot("trIntakeTabDot", on);
+  }
+
+  // Screenspace intake poll: one combined request (../screenspace/api/intake-poll)
+  // for the task-status dot + curation events. Returns a Promise<boolean> — truthy
+  // ("active this tick") keeps createPoller at the fast cadence; falsy lets it back
+  // off. Replaces the former pollIntakeStatus + pollIntakeEvents pair.
+  function pollScreenspaceIntake() {
+    return apiGet("../screenspace/api/intake-poll?excluded=false")
       .then(function (data) {
         if (!data || !data.ok) {
-          state._intakeTabDotOn = false;
-          setTabDot("intakeTabDot", false);
-          return;
+          setIntakeDot(false);
+          return false;
         }
-        var tasks = data.tasks || [];
-        var running = false;
-        var hasQueued = false;
-        for (var i = 0; i < tasks.length; i++) {
-          if (tasks[i].status === "running") { running = true; break; }
-          if (tasks[i].status === "queued") hasQueued = true;
-        }
-        var dotOn = running || (data.worker_alive && hasQueued);
-        if (state._intakeTabDotOn === dotOn) return;
-        state._intakeTabDotOn = dotOn;
-        setTabDot("intakeTabDot", dotOn);
+        var status = data.status || {};
+        var dotOn = !!status.running || (status.worker_alive && !!status.queued);
+        setIntakeDot(dotOn);
+        var eventsChanged = applyIntakeEvents(data.events || []);
+        return dotOn || eventsChanged;
       })
       .catch(function () {
-        state._intakeTabDotOn = false;
-        setTabDot("intakeTabDot", false);
+        setIntakeDot(false);
+        return false;
       });
   }
 
-  function pollTrIntakeStatus() {
-    var statusP = apiGet("../transcripts/api/transcribe/status").catch(function () { return null; });
-    var modelP = apiGet("../transcripts/api/transcribe/model-status").catch(function () { return null; });
-    var partsP = apiGet("../transcripts/api/participants").catch(function () { return null; });
-    Promise.all([statusP, modelP, partsP]).then(function (results) {
-      var status = results[0];
-      var model = results[1];
-      var parts = results[2];
-      var running = false;
-      if (status && status.ok && Array.isArray(status.tasks)) {
-        for (var i = 0; i < status.tasks.length; i++) {
-          if (status.tasks[i].status === "running") { running = true; break; }
+  // Transcript intake poll: one combined request (../transcripts/api/intake-poll)
+  // for the running-state dot + resolved marks. Returns a Promise<boolean> as above.
+  // Replaces the former pollTrIntakeStatus (3-request fan-out) + pollTranscriptIntakeMarks.
+  function pollTranscriptIntake() {
+    return apiGet("../transcripts/api/intake-poll")
+      .then(function (data) {
+        if (!data || !data.ok) {
+          setTrIntakeDot(false);
+          return false;
         }
-      }
-      if (!running && model && model.ok && model.warming) running = true;
-      if (!running && parts && parts.ok && Array.isArray(parts.participants)) {
-        for (var j = 0; j < parts.participants.length; j++) {
-          var agents = parts.participants[j].agents || {};
-          if (agents.summary === "running" || agents.citations === "running") {
-            running = true;
-            break;
-          }
-        }
-      }
-      if (state._trIntakeTabDotOn === running) return;
-      state._trIntakeTabDotOn = running;
-      setTabDot("trIntakeTabDot", running);
-    });
+        var status = data.status || {};
+        var running = !!status.tasks_running || !!status.model_warming || !!status.agents_running;
+        setTrIntakeDot(running);
+        var marksChanged = applyTranscriptMarks(data.marks || {});
+        return running || marksChanged;
+      })
+      .catch(function () {
+        setTrIntakeDot(false);
+        return false;
+      });
+  }
+
+  // On-demand refresh after a user action: wake the adaptive poller so it
+  // refetches now AND resets its idle backoff to the fast cadence. Falls back to
+  // a direct poll if the poller hasn't been created yet (pre-boot).
+  function refreshScreenspaceIntake() {
+    if (state.ssIntakePoller) state.ssIntakePoller.wake();
+    else pollScreenspaceIntake();
+  }
+  function refreshTranscriptIntake() {
+    if (state.trIntakePoller) state.trIntakePoller.wake();
+    else pollTranscriptIntake();
   }
 
   // Events fed into the intake clustering surface. Navigational (boundary)
@@ -124,7 +137,7 @@
 
   // One-click boundary detection: enqueue a full-frame boundary task per
   // participant that has a source video. Progress surfaces through the existing
-  // task poll (intake tab dot) and new boundary events arrive via pollIntakeEvents.
+  // task poll (intake tab dot) and new boundary events arrive via pollScreenspaceIntake.
   function intakeDetectBoundaries(btn) {
     var labelEl = btn ? btn.querySelector("span") : null;
     var origLabel = labelEl ? labelEl.textContent : "";
@@ -151,31 +164,27 @@
       .catch(restore);
   }
 
-  function pollIntakeEvents() {
-    apiGet("../screenspace/api/events?excluded=false")
-      .then(function (data) {
-        if (!data.ok) return;
-        var events = data.events || [];
-        var raw = JSON.stringify(events);
-        if (raw === state._intakeEventsPollRaw) return;
-        state._intakeEventsPollRaw = raw;
-        var hasNew = false;
-        events.forEach(function (ev) {
-          if (!state.intakeSeenIds[ev.id]) {
-            state.intakeSeenIds[ev.id] = "new";
-            hasNew = true;
-          }
-        });
-        state.intakeEvents = events;
-        var threshold = parseInt((qs("#intakeClusterThreshold") || {}).value, 10) || 10;
-        state.intakeClusters = clusterIntakeEvents(intakeClusterSource(), threshold);
-        renderIntake(hasNew);
-        checkConvergenceTabVisibility();
-        refreshMetadataIfActive();
-      })
-      .catch(function (err) {
-        console.warn("[Intake] poll failed:", err);
-      });
+  // Apply the events slice from a Screenspace intake poll. Dirty-checks against
+  // the last raw payload; returns true when it changed (and re-rendered), false
+  // when nothing changed (so the poller can back off).
+  function applyIntakeEvents(events) {
+    var raw = JSON.stringify(events);
+    if (raw === state._intakeEventsPollRaw) return false;
+    state._intakeEventsPollRaw = raw;
+    var hasNew = false;
+    events.forEach(function (ev) {
+      if (!state.intakeSeenIds[ev.id]) {
+        state.intakeSeenIds[ev.id] = "new";
+        hasNew = true;
+      }
+    });
+    state.intakeEvents = events;
+    var threshold = parseInt((qs("#intakeClusterThreshold") || {}).value, 10) || 10;
+    state.intakeClusters = clusterIntakeEvents(intakeClusterSource(), threshold);
+    renderIntake(hasNew);
+    checkConvergenceTabVisibility();
+    refreshMetadataIfActive();
+    return true;
   }
 
   function highlightIntakeCard(idx) {
@@ -447,7 +456,7 @@
     onDismiss: trIntakeDismissCluster,
     onThresholdChange: function () {
       // TR re-polls (the poll re-reads the threshold input itself); ignores arg.
-      pollTranscriptIntakeMarks();
+      refreshTranscriptIntake();
     },
     onCardHover: function (card, idx) {
       var cluster = filteredTranscriptIntakeClusters()[idx];
@@ -459,7 +468,7 @@
       showAllToggle.addEventListener("change", function () {
         state.trIntakeShowAll = this.checked;
         state._trIntakeMarksPollFp = null;
-        pollTranscriptIntakeMarks();
+        refreshTranscriptIntake();
       });
     },
   };
@@ -594,7 +603,7 @@
   function intakeDismissCluster(cluster) {
     var ids = cluster.events.map(function (e) { return e.id; });
     apiPut("../screenspace/api/events/bulk-exclude", { ids: ids })
-      .then(function () { pollIntakeEvents(); })
+      .then(function () { refreshScreenspaceIntake(); })
       .catch(function () {});
   }
 
@@ -784,70 +793,78 @@
     }
   }
 
-  function pollTranscriptIntakeMarks() {
-    apiGet("../transcripts/api/marks")
-      .then(function (data) {
-        if (!data.ok) return;
-        var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value, 10) || 10;
-        if (!state.trIntakeShowAll) {
-          var fp =
-            String(threshold) +
-            "\0" +
-            (data.categories ? JSON.stringify(data.categories) : "") +
-            "\0" +
-            JSON.stringify(data.marks || []);
-          if (fp === state._trIntakeMarksPollFp) return;
-          state._trIntakeMarksPollFp = fp;
-        }
-        if (data.categories) setMarkCategories(data.categories);
-        state.trIntakeMarks = data.marks.filter(function (m) { return m.valid; });
-        state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, threshold);
+  // Apply the marks block ({marks, categories}) from a transcript intake poll.
+  // In default mode a fingerprint dirty-check skips redundant re-renders and
+  // returns false so the poller can back off; returns true when it re-rendered.
+  // In "Show all" mode it always refreshes (via applyTranscriptShowAll, its own
+  // participants+transcripts fan-out) and returns false — backoff there is
+  // governed by the status flags, so the heavy fan-out slows when nothing runs.
+  function applyTranscriptMarks(block) {
+    var marks = block.marks || [];
+    var categories = block.categories;
+    var threshold = parseInt((qs("#trIntakeClusterThreshold") || {}).value, 10) || 10;
+    if (!state.trIntakeShowAll) {
+      var fp =
+        String(threshold) +
+        "\0" +
+        (categories ? JSON.stringify(categories) : "") +
+        "\0" +
+        JSON.stringify(marks);
+      if (fp === state._trIntakeMarksPollFp) return false;
+      state._trIntakeMarksPollFp = fp;
+    }
+    if (categories) setMarkCategories(categories);
+    state.trIntakeMarks = marks.filter(function (m) { return m.valid; });
+    state.trIntakeClusters = clusterTranscriptMarks(state.trIntakeMarks, threshold);
+    if (state.trIntakeShowAll) {
+      applyTranscriptShowAll(threshold);
+      return false;
+    }
+    renderTranscriptIntake();
+    checkConvergenceTabVisibility();
+    refreshMetadataIfActive();
+    return true;
+  }
 
-        // If "Show all" is enabled, also fetch all segments as unmark items
-        if (state.trIntakeShowAll) {
-          apiGet("../transcripts/api/participants")
-            .then(function (pData) {
-              if (!pData.ok) return;
-              var transcribed = pData.participants.filter(function (p) { return p.has_transcript; });
-              var promises = transcribed.map(function (p) {
-                return apiGet("../transcripts/api/transcript/" + p.id);
-              });
-              Promise.all(promises).then(function (results) {
-                var markedIds = {};
-                for (var i = 0; i < state.trIntakeMarks.length; i++) markedIds[state.trIntakeMarks[i].segment_id] = true;
-                var allItems = state.trIntakeMarks.slice();
-                for (var j = 0; j < results.length; j++) {
-                  if (!results[j].ok) continue;
-                  var pid = results[j].participant;
-                  var segs = results[j].segments;
-                  for (var k = 0; k < segs.length; k++) {
-                    if (!markedIds[segs[k].id]) {
-                      allItems.push({
-                        id: null,
-                        segment_id: segs[k].id,
-                        category: null,
-                        label: null,
-                        valid: true,
-                        participant: pid,
-                        start: segs[k].start,
-                        end: segs[k].end,
-                        text: segs[k].text,
-                      });
-                    }
-                  }
-                }
-                state.trIntakeClusters = clusterTranscriptMarks(allItems, threshold);
-                renderTranscriptIntake();
-                checkConvergenceTabVisibility();
-                refreshMetadataIfActive();
-              });
-            })
-            .catch(function () {});
-        } else {
+  // "Show all": append every unmarked segment as a queue item. Its own fan-out
+  // (participants + one transcript fetch each) — user-toggled, not always-on.
+  function applyTranscriptShowAll(threshold) {
+    apiGet("../transcripts/api/participants")
+      .then(function (pData) {
+        if (!pData.ok) return;
+        var transcribed = pData.participants.filter(function (p) { return p.has_transcript; });
+        var promises = transcribed.map(function (p) {
+          return apiGet("../transcripts/api/transcript/" + p.id);
+        });
+        Promise.all(promises).then(function (results) {
+          var markedIds = {};
+          for (var i = 0; i < state.trIntakeMarks.length; i++) markedIds[state.trIntakeMarks[i].segment_id] = true;
+          var allItems = state.trIntakeMarks.slice();
+          for (var j = 0; j < results.length; j++) {
+            if (!results[j].ok) continue;
+            var pid = results[j].participant;
+            var segs = results[j].segments;
+            for (var k = 0; k < segs.length; k++) {
+              if (!markedIds[segs[k].id]) {
+                allItems.push({
+                  id: null,
+                  segment_id: segs[k].id,
+                  category: null,
+                  label: null,
+                  valid: true,
+                  participant: pid,
+                  start: segs[k].start,
+                  end: segs[k].end,
+                  text: segs[k].text,
+                });
+              }
+            }
+          }
+          state.trIntakeClusters = clusterTranscriptMarks(allItems, threshold);
           renderTranscriptIntake();
           checkConvergenceTabVisibility();
           refreshMetadataIfActive();
-        }
+        });
       })
       .catch(function () {});
   }
@@ -962,7 +979,7 @@
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ids: ids }),
     })
-      .then(function () { pollTranscriptIntakeMarks(); })
+      .then(function () { refreshTranscriptIntake(); })
       .catch(function () {});
   }
 
@@ -1002,10 +1019,8 @@
 
   // ---- Published to the hub (window.ClipgenStudio) ----
   STUDIO.initIntake = initIntake;
-  STUDIO.pollIntakeStatus = pollIntakeStatus;
-  STUDIO.pollTrIntakeStatus = pollTrIntakeStatus;
-  STUDIO.pollIntakeEvents = pollIntakeEvents;
-  STUDIO.pollTranscriptIntakeMarks = pollTranscriptIntakeMarks;
+  STUDIO.pollScreenspaceIntake = pollScreenspaceIntake;
+  STUDIO.pollTranscriptIntake = pollTranscriptIntake;
   STUDIO.initTooltipToggle = initTooltipToggle;
   STUDIO.refreshIntakeCardStates = refreshIntakeCardStates;
   STUDIO.renderIntake = renderIntake;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -4353,10 +4353,8 @@
   // Same-named guarded wrappers so bare hub call sites stay unchanged; the real
   // implementations live in studio-intake.js, published onto window.ClipgenStudio.
   function initIntake() { return STUDIO.initIntake && STUDIO.initIntake.apply(null, arguments); }
-  function pollIntakeStatus() { return STUDIO.pollIntakeStatus && STUDIO.pollIntakeStatus.apply(null, arguments); }
-  function pollTrIntakeStatus() { return STUDIO.pollTrIntakeStatus && STUDIO.pollTrIntakeStatus.apply(null, arguments); }
-  function pollIntakeEvents() { return STUDIO.pollIntakeEvents && STUDIO.pollIntakeEvents.apply(null, arguments); }
-  function pollTranscriptIntakeMarks() { return STUDIO.pollTranscriptIntakeMarks && STUDIO.pollTranscriptIntakeMarks.apply(null, arguments); }
+  function pollScreenspaceIntake() { return STUDIO.pollScreenspaceIntake && STUDIO.pollScreenspaceIntake.apply(null, arguments); }
+  function pollTranscriptIntake() { return STUDIO.pollTranscriptIntake && STUDIO.pollTranscriptIntake.apply(null, arguments); }
   function initTooltipToggle() { return STUDIO.initTooltipToggle && STUDIO.initTooltipToggle.apply(null, arguments); }
   function refreshIntakeCardStates() { return STUDIO.refreshIntakeCardStates && STUDIO.refreshIntakeCardStates.apply(null, arguments); }
   function renderIntake() { return STUDIO.renderIntake && STUDIO.renderIntake.apply(null, arguments); }
@@ -4458,14 +4456,16 @@
     initFrontendSwitcher();
     initTopNavActions();
     initIntake();
-    // Live counter polls — intake-status / tr-intake-status (5s) keep the
-    // start-overlay's status pill fresh; intake-events / tr-intake-marks
-    // (10s) keep the sub-tab counter badges live regardless of which
-    // sub-tab is currently visible. createPoller handles visibility-pause.
-    createPoller(pollIntakeStatus, 5000).start();
-    createPoller(pollTrIntakeStatus, 5000).start();
-    createPoller(pollIntakeEvents, 10000).start();
-    createPoller(pollTranscriptIntakeMarks, 10000).start();
+    // Live counter polls — two combined per-domain endpoints, each carrying its
+    // status dot + curation payload, keep the start-overlay pills and sub-tab
+    // badges fresh regardless of which sub-tab is visible. createPoller handles
+    // visibility-pause and (via maxIntervalMs) idle backoff: 5s while work is
+    // active/changing, easing to 30s when everything is quiet. Handles live on
+    // `state` so on-demand user actions can wake() them back to the fast cadence.
+    state.ssIntakePoller = createPoller(pollScreenspaceIntake, 5000, { maxIntervalMs: 30000 });
+    state.trIntakePoller = createPoller(pollTranscriptIntake, 5000, { maxIntervalMs: 30000 });
+    state.ssIntakePoller.start();
+    state.trIntakePoller.start();
     // One-shot job-status fetch on page load picks up any reel/generate
     // build that's still running in the background after the user navigated
     // away to a sibling frontend and back. The poll's own success handler

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -877,36 +877,111 @@ var POLL_INTERVAL = 3000;
 //                                     catch up.
 //   runImmediately  (default true)  — run fn() once on start (and again on
 //                                     resume) before the next interval tick.
+//   maxIntervalMs   (default = intervalMs) — enable idle backoff. When set
+//                                     above intervalMs the loop self-reschedules
+//                                     with setTimeout instead of setInterval:
+//                                     fn's resolved value is an "active this
+//                                     tick" signal — truthy resets to the base
+//                                     interval, falsy backs the delay off toward
+//                                     maxIntervalMs after backoffAfter quiet
+//                                     ticks (e.g. 5s → 10 → 20 → 30, capped).
+//   backoffAfter    (default 3)     — consecutive quiet ticks before backing off.
+//
+// In backoff mode fn may return a value or a Promise; the loop waits for it
+// before scheduling the next tick (so slow polls never overlap). The returned
+// object also gains wake(): snap back to the base cadence and refresh now —
+// call it after a user action so polling both refreshes and speeds back up.
 //
 // fn exceptions are swallowed so a transient error does not kill the loop.
 var createPoller = function (fn, intervalMs, opts) {
   opts = opts || {};
   var pauseWhenHidden = opts.pauseWhenHidden !== false;
   var runImmediately = opts.runImmediately !== false;
+  var maxIntervalMs = opts.maxIntervalMs != null ? opts.maxIntervalMs : intervalMs;
+  var backoffAfter = opts.backoffAfter != null ? opts.backoffAfter : 3;
+  var adaptive = maxIntervalMs > intervalMs;
   var timer = null;
   var visListener = null;
   var wantRunning = false;
+  var currentDelay = intervalMs;
+  var quiet = 0;
+  var inFlight = false;
+  var pendingWake = false;
 
   function safeFn() {
     try { fn(); } catch (_) {}
   }
+  function hidden() {
+    return pauseWhenHidden && typeof document !== "undefined" && document.hidden;
+  }
+  // --- backoff (self-rescheduling) path ---
+  function applySignal(active) {
+    if (active) {
+      quiet = 0;
+      currentDelay = intervalMs;
+    } else {
+      quiet += 1;
+      if (quiet >= backoffAfter && currentDelay < maxIntervalMs) {
+        currentDelay = Math.min(currentDelay * 2, maxIntervalMs);
+      }
+    }
+  }
+  function schedule() {
+    timer = setTimeout(runAdaptive, currentDelay);
+  }
+  function runAdaptive() {
+    timer = null;
+    inFlight = true;
+    var result;
+    try { result = fn(); } catch (_) { result = false; }
+    Promise.resolve(result).then(
+      function (active) { applySignal(!!active); },
+      function () { applySignal(false); }
+    ).then(function () {
+      inFlight = false;
+      if (!wantRunning || hidden()) { pendingWake = false; return; }
+      // A wake() landed mid-flight: that response may predate the user's
+      // mutation, so run one fresh poll now instead of waiting a full tick.
+      if (pendingWake) {
+        pendingWake = false;
+        currentDelay = intervalMs;
+        quiet = 0;
+        runAdaptive();
+        return;
+      }
+      schedule();
+    });
+  }
   function arm() {
-    if (timer != null) return;
-    if (pauseWhenHidden && document.hidden) return;
-    if (runImmediately) safeFn();
-    timer = setInterval(safeFn, intervalMs);
+    if (timer != null || inFlight) return;
+    if (hidden()) return;
+    if (adaptive) {
+      if (runImmediately) runAdaptive(); else schedule();
+    } else {
+      if (runImmediately) safeFn();
+      timer = setInterval(safeFn, intervalMs);
+    }
   }
   function disarm() {
-    if (timer != null) { clearInterval(timer); timer = null; }
+    if (timer != null) {
+      if (adaptive) clearTimeout(timer); else clearInterval(timer);
+      timer = null;
+    }
   }
   function onVisibility() {
     if (!wantRunning) return;
-    if (document.hidden) disarm(); else arm();
+    if (document.hidden) {
+      disarm();
+    } else {
+      if (adaptive) { currentDelay = intervalMs; quiet = 0; }
+      arm();
+    }
   }
   return {
     start: function () {
       if (wantRunning) return;
       wantRunning = true;
+      if (adaptive) { currentDelay = intervalMs; quiet = 0; }
       arm();
       if (pauseWhenHidden && !visListener) {
         visListener = onVisibility;
@@ -919,6 +994,22 @@ var createPoller = function (fn, intervalMs, opts) {
       if (visListener) {
         document.removeEventListener("visibilitychange", visListener);
         visListener = null;
+      }
+    },
+    wake: function () {
+      if (!wantRunning || hidden()) return;
+      if (adaptive) {
+        currentDelay = intervalMs;
+        quiet = 0;
+        // A poll is already running but may predate this action's server-side
+        // effect — queue one fresh poll for when it completes.
+        if (inFlight) { pendingWake = true; return; }
+        disarm();
+        runAdaptive();
+      } else {
+        disarm();
+        safeFn();
+        timer = setInterval(safeFn, intervalMs);
       }
     },
   };

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -2203,23 +2203,49 @@ def api_tasks_results(task_id: str) -> FlaskResponse:
 # ---- Events CRUD ----
 
 
-@screenspace_bp.route("/api/events")
-def api_events_list() -> FlaskResponse:
-    """List events with optional filtering."""
+def _filtered_events(args: Any) -> list[dict[str, Any]]:
+    """Deep-copy manifest events and apply the standard excluded/participant/
+    task_id query filters. Shared by /api/events and /api/intake-poll."""
     with _manifest_lock:
         events = copy.deepcopy(_manifest.get("events", []))
-    excluded_filter = request.args.get("excluded")
+    excluded_filter = args.get("excluded")
     if excluded_filter == "false":
         events = [e for e in events if not e.get("excluded")]
     elif excluded_filter == "true":
         events = [e for e in events if e.get("excluded")]
-    participant = request.args.get("participant")
+    participant = args.get("participant")
     if participant:
         events = [e for e in events if e.get("participant") == participant]
-    task_id = request.args.get("task_id")
+    task_id = args.get("task_id")
     if task_id:
         events = [e for e in events if e.get("task_id") == task_id]
-    return ok(events=utils.sanitize_floats(events))
+    return events
+
+
+@screenspace_bp.route("/api/events")
+def api_events_list() -> FlaskResponse:
+    """List events with optional filtering."""
+    return ok(events=utils.sanitize_floats(_filtered_events(request.args)))
+
+
+@screenspace_bp.route("/api/intake-poll")
+def api_intake_poll() -> FlaskResponse:
+    """Combined Studio-intake poll: task-status booleans + filtered events.
+
+    Collapses the Studio intake client's separate /api/tasks and /api/events
+    polls into a single request. Both reads are the same slim, in-memory ones
+    those routes do (no results, no disk I/O)."""
+    tasks = [
+        _clean_task(t)
+        for t in (_worker.get_all_tasks(include_results=False) if _worker else [])
+    ]
+    running = any(t.get("status") == "running" for t in tasks)
+    queued = any(t.get("status") == "queued" for t in tasks)
+    alive = _worker.is_alive if _worker else False
+    return ok(
+        status={"running": running, "worker_alive": alive, "queued": queued},
+        events=utils.sanitize_floats(_filtered_events(request.args)),
+    )
 
 
 @screenspace_bp.route("/api/export/events")

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1883,6 +1883,25 @@ def test_events_filter_by_task_id(client):
     assert data["events"][0]["task_id"] == "ss_a"
 
 
+def test_intake_poll_combines_status_and_events(client):
+    """/api/intake-poll returns task-status booleans + the same filtered events
+    slice the Studio intake client used to fetch from /api/tasks + /api/events."""
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1"),
+        _sample_event("ev_2", excluded=True),
+    ]
+    resp = client.get("/screenspace/api/intake-poll?excluded=false")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    # No queued/running tasks in a fresh worker.
+    assert data["status"]["running"] is False
+    assert data["status"]["queued"] is False
+    assert isinstance(data["status"]["worker_alive"], bool)
+    # excluded=false drops ev_2, same as /api/events.
+    assert [e["id"] for e in data["events"]] == ["ev_1"]
+
+
 def test_event_exclude(client):
     screenspace_server._manifest["events"] = [_sample_event("ev_1")]
     resp = client.put("/screenspace/api/events/ev_1/exclude")

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1113,6 +1113,52 @@ def test_marks_add_debounces_persist_until_flush(tr_client, monkeypatch):
     assert saved["count"] == 1
 
 
+def test_intake_poll_combines_status_and_marks(tr_client, _agent_state_clean):
+    """/api/intake-poll returns running-state booleans + resolved marks, collapsing
+    the Studio intake client's four transcript polls into one request."""
+    transcripts_server._manifest["source_transcripts"]["P01"] = {
+        "segments": [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "hello"}],
+    }
+    transcripts_server._manifest["marks"] = [
+        {"id": "m1", "segment_id": "P01:0", "category": "friction", "label": None}
+    ]
+    resp = tr_client.get("/transcripts/api/intake-poll")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["status"] == {
+        "tasks_running": False,
+        "model_warming": False,
+        "agents_running": False,
+    }
+    assert data["marks"]["categories"] == config.MARK_CATEGORIES
+    resolved = data["marks"]["marks"]
+    assert len(resolved) == 1
+    assert resolved[0]["segment_id"] == "P01:0"
+    assert resolved[0]["valid"] is True
+
+
+def test_intake_poll_agents_running_without_stat(
+    tr_client, monkeypatch, _agent_state_clean
+):
+    """agents_running is read from the orchestrator's in-memory in-flight set, so the
+    route must never stat() a video file (the expensive part of /api/participants)."""
+    import pathlib
+
+    def _boom(*_a, **_k):
+        raise AssertionError("intake-poll must not stat video files")
+
+    monkeypatch.setattr(pathlib.Path, "stat", _boom)
+    transcripts_server._participants = [
+        {"id": "P01", "video_paths": ["/tmp/study_P01.mp4"], "has_video": True}
+    ]
+    transcripts_server._orchestrator._in_flight["summary"].add("P01")
+
+    resp = tr_client.get("/transcripts/api/intake-poll")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"]["agents_running"] is True
+
+
 def test_corrected_segments_cached_and_invalidated_on_correction(
     tr_client, monkeypatch
 ):

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1058,6 +1058,42 @@ def api_marks_list() -> FlaskResponse:
     )
 
 
+@transcripts_bp.route("/api/intake-poll")
+def api_intake_poll() -> FlaskResponse:
+    """Combined Studio-intake poll: running-state booleans + resolved marks.
+
+    Collapses the Studio intake client's four transcript polls (transcribe
+    status, model-status, participants, marks) into one request. ``agents_running``
+    is read straight from the orchestrator's in-memory in-flight tracking, so —
+    unlike /api/participants — this never stat()s or ffprobe()s a video file."""
+    tasks_running = False
+    if _worker:
+        for t in _worker.get_all_tasks(include_partials=False):
+            if t["status"] == transcripts.TASK_STATUS_RUNNING:
+                tasks_running = True
+                break
+    with _transcript_model_warming_lock:
+        model_warming = _transcript_model_warming
+    agents_running = any(
+        _orchestrator.is_generating(p["id"], "summary")
+        or _orchestrator.is_generating(p["id"], "citations")
+        for p in _participants
+    )
+    # Same resolve path as /api/marks (partial lookup outside _manifest_lock).
+    partial_lookup = _build_partial_lookup()
+    with _manifest_lock:
+        raw_marks = list(_manifest.get("marks", []))
+        resolved = [_resolve_mark(m, partial_lookup) for m in raw_marks]
+    return ok(
+        status={
+            "tasks_running": tasks_running,
+            "model_warming": model_warming,
+            "agents_running": agents_running,
+        },
+        marks={"marks": resolved, "categories": config.MARK_CATEGORIES},
+    )
+
+
 @transcripts_bp.route("/api/marks", methods=["POST"])
 def api_marks_add() -> FlaskResponse:
     """Create marks for one or more segments."""


### PR DESCRIPTION
## Summary

Studio ran four always-on intake pollers (~60 req/min even when idle), one fanning out three parallel transcript requests every 5s — including the expensive per-participant `stat()`/`ffprobe` in `/participants`. This adds opt-in idle backoff to `createPoller` (5s→30s when quiet, plus a `wake()` that snaps back to fast and refreshes after user actions) and collapses the four pollers into two new combined endpoints — `/screenspace/api/intake-poll` and `/transcripts/api/intake-poll` — whose transcript running-state flag reads in-memory state, dropping the video stat from the hot path. Idle traffic falls to ~4 req/min (~90% less) with the status dots and badges still live.

## Test plan

- [x] `pytest` full suite (1827 passed), incl. new endpoint tests asserting the transcripts route works with `Path.stat` monkeypatched to raise
- [x] `ruff format --check`, `ruff check`, `ty check` clean
- [x] Manual browser check: cadence eases to ~30s when idle, dots/badges update on task start/finish, user actions refresh immediately