### PR TITLE
perf: close 6 hot-path redundancies flagged in code review

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2887,13 +2887,15 @@
       img.draggable = false;
       img.style.zIndex = String(picks.length - idx);
       img.style.transform = "translate(" + (idx * 2) + "px, " + (-idx * 2) + "px)";
-      // Route through the throttled/cached thumb queue instead of loading all
-      // 3×N frames eagerly; drop the img on failure (hue-tinted backing shows).
-      // picks[] already guarantees participant/start are present (see key above).
+      // Append before enqueuing: ssEnqueueThumbCustom runs synchronously into
+      // ssProcessQueue, which skips (and the error path no-ops on) any img that
+      // isn't in the DOM yet. Route through the throttled/cached thumb queue
+      // instead of loading all 3×N frames eagerly; drop the img on failure
+      // (hue-tinted backing shows). picks[] guarantees participant/start (see key).
+      icon.appendChild(img);
       ssEnqueueThumbCustom(img, item.participant, item.start, function () {
         if (img.parentNode) img.parentNode.removeChild(img);
       });
-      icon.appendChild(img);
     });
 
     return icon;

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2887,8 +2887,10 @@
       img.draggable = false;
       img.style.zIndex = String(picks.length - idx);
       img.style.transform = "translate(" + (idx * 2) + "px, " + (-idx * 2) + "px)";
-      img.src = ssThumbUrl(item.participant, item.start);
-      img.addEventListener("error", function () {
+      // Route through the throttled/cached thumb queue instead of loading all
+      // 3×N frames eagerly; drop the img on failure (hue-tinted backing shows).
+      // picks[] already guarantees participant/start are present (see key above).
+      ssEnqueueThumbCustom(img, item.participant, item.start, function () {
         if (img.parentNode) img.parentNode.removeChild(img);
       });
       icon.appendChild(img);
@@ -4291,11 +4293,13 @@
           })
           .catch(function () {
             _ssThumbCache[entry.url] = "error";
-            if (entry.img.parentNode) {
-              entry.img.remove();
-              entry.thumbEl.appendChild(el("span", "", "\u2715"));
-              entry.cardEl.classList.add("queue-card-error");
-            }
+            if (!entry.img.parentNode) return;
+            // Entries may carry a custom error handler (e.g. the stash-folder
+            // icon just drops the img); otherwise fall back to the queue-card UI.
+            if (entry.onError) { entry.onError(entry); return; }
+            entry.img.remove();
+            entry.thumbEl.appendChild(el("span", "", "\u2715"));
+            entry.cardEl.classList.add("queue-card-error");
           })
           .then(function () {
             _ssThumbActive--;
@@ -4316,6 +4320,19 @@
       return;
     }
     _ssThumbQueue.push({ img: img, cardEl: cardEl, thumbEl: thumbEl, url: url });
+    ssProcessQueue();
+  }
+
+  // Enqueue a thumbnail with a custom error handler, for surfaces where the
+  // default .queue-card error UI (✕ badge + error class) doesn't apply — e.g.
+  // the stacked stash-folder icon, which just removes the failed img. Shares
+  // the same throttle (_SS_THUMB_MAX) and object-URL cache as ssEnqueueThumb.
+  function ssEnqueueThumbCustom(img, participant, timestamp, onError) {
+    var url = ssThumbUrl(participant, timestamp);
+    var cached = _ssThumbCache[url];
+    if (cached && cached !== "error") { img.src = cached; return; }
+    if (cached === "error") { if (onError) onError({ img: img }); return; }
+    _ssThumbQueue.push({ img: img, url: url, onError: onError });
     ssProcessQueue();
   }
 

--- a/data_export.py
+++ b/data_export.py
@@ -421,6 +421,27 @@ def write_export_bundle(output_dir: Path | None = None) -> list[Path]:
     base = Path(output_dir) if output_dir else Path(utils.get_effective_output_dir())
     written: list[Path] = []
     summaries: list[str] = []
+    # Several surfaces share a manifest (e.g. transcripts + friction_moments +
+    # friction_segments all read the transcripts manifest), so read+parse each
+    # file at most once per export. ``None`` records a missing/unreadable file.
+    manifest_cache: dict[str, dict[str, Any] | None] = {}
+
+    def _load_manifest(manifest_filename: str) -> dict[str, Any] | None:
+        if manifest_filename in manifest_cache:
+            return manifest_cache[manifest_filename]
+        manifest_path = base / manifest_filename
+        parsed: dict[str, Any] | None = None
+        if manifest_path.is_file():
+            try:
+                parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as err:
+                utils.warning_print(
+                    f"Skipping {manifest_filename}: could not read manifest.",
+                    [f"Error: {err}"],
+                )
+                parsed = None
+        manifest_cache[manifest_filename] = parsed
+        return parsed
 
     progress = utils.create_progress_bar()
 
@@ -430,16 +451,8 @@ def write_export_bundle(output_dir: Path | None = None) -> list[Path]:
         manifest_filename: str,
         preferred_cols: tuple[str, ...],
     ) -> None:
-        manifest_path = base / manifest_filename
-        if not manifest_path.is_file():
-            return
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as err:
-            utils.warning_print(
-                f"Skipping {manifest_filename}: could not read manifest.",
-                [f"Error: {err}"],
-            )
+        manifest = _load_manifest(manifest_filename)
+        if manifest is None:
             return
         records = builder(manifest)
         if not records:

--- a/files.py
+++ b/files.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import threading
 import unicodedata
 from pathlib import Path
 
@@ -11,6 +12,14 @@ import gspread
 import config
 import utils
 from utils import ClipRecord
+
+# Per-template high-water counter so a batch of same-named reservations doesn't
+# re-probe 0,1,2,… from scratch each call (which is O(n²) syscalls). Keyed on
+# (directory, base, extension); only ever advances, so released slots leave
+# harmless gaps but uniqueness is preserved. Guarded because get_unique_filename
+# runs inside the clip ThreadPoolExecutor.
+_unique_high_water: dict[tuple[str, str, str], int] = {}
+_unique_high_water_lock = threading.Lock()
 
 
 def _safe_truncate(text: str, max_chars: int) -> str:
@@ -73,7 +82,14 @@ def get_unique_filename(filename: str, file_format: str | None = None) -> str:
         truncated_base = _safe_truncate(base, max_base - len(suffix))
         return directory / (truncated_base + suffix + file_extension)
 
-    counter = 0
+    key = (str(directory), base, file_extension)
+    with _unique_high_water_lock:
+        counter = _unique_high_water.get(key, 0)
+
+    def _record_high_water(used: int) -> None:
+        with _unique_high_water_lock:
+            _unique_high_water[key] = max(_unique_high_water.get(key, 0), used + 1)
+
     while True:
         candidate = _candidate(counter)
         try:
@@ -88,9 +104,11 @@ def get_unique_filename(filename: str, file_format: str | None = None) -> str:
             while candidate.is_file():
                 counter += 1
                 candidate = _candidate(counter)
+            _record_high_water(counter)
             return str(candidate)
         else:
             os.close(fd)
+            _record_high_water(counter)
             return str(candidate)
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1669,7 +1669,9 @@ def regenerate_from_manifest(
 
     def _regenerate_reel_threadsafe(reel: dict[str, Any]) -> bool:
         local_missing: set[str] = set()
-        ok = _regenerate_reel(reel, local_missing)
+        # parallel=False: reels already run concurrently here, so cutting each
+        # reel's components sequentially avoids nested CPU oversubscription.
+        ok = _regenerate_reel(reel, local_missing, parallel=False)
         if local_missing:
             with missing_lock:
                 missing_videos.update(local_missing)
@@ -1746,7 +1748,9 @@ def regenerate_from_manifest(
                             : config.PROGRESS_DESCRIPTION_LENGTH
                         ],
                     )
-                    if _regenerate_reel(reel, missing_videos):
+                    # parallel=True: no reel-level pool here (single or <2 reels),
+                    # so a single large reel parallelizes its own segment cuts.
+                    if _regenerate_reel(reel, missing_videos, parallel=True):
                         generated += 1
                     progress.update(task, advance=1)
     elif parallel_media:
@@ -1789,7 +1793,9 @@ def regenerate_from_manifest(
             generated += sum(1 for ok in reel_results if ok)
         else:
             for reel in reel_list:
-                if _regenerate_reel(reel, missing_videos):
+                # parallel=True: no reel-level pool here (single or <2 reels), so
+                # a single large reel parallelizes its own segment cuts.
+                if _regenerate_reel(reel, missing_videos, parallel=True):
                     generated += 1
     else:
         for artifact in media:
@@ -1816,7 +1822,9 @@ def regenerate_from_manifest(
             generated += sum(1 for ok in reel_results if ok)
         else:
             for reel in reel_list:
-                if _regenerate_reel(reel, missing_videos):
+                # parallel=True: no reel-level pool here (single or <2 reels), so
+                # a single large reel parallelizes its own segment cuts.
+                if _regenerate_reel(reel, missing_videos, parallel=True):
                     generated += 1
 
     if missing_videos:
@@ -1943,64 +1951,99 @@ def _regenerate_single_artifact(
         return False
 
 
-def _regenerate_reel(reel: dict[str, Any], missing_videos: set[str]) -> bool:
-    """Regenerate a reel from its manifest entry by cutting components then concatenating."""
+def _regenerate_reel(
+    reel: dict[str, Any], missing_videos: set[str], parallel: bool = False
+) -> bool:
+    """Regenerate a reel from its manifest entry by cutting components then concatenating.
+
+    A boundary-spanning component carries a ``parts`` list; each part is a
+    separate cut and the parts simply become consecutive entries. Single-segment
+    components cut directly from their mapped sub-video using local offsets. Any
+    missing source or failed cut aborts the whole reel (matching the
+    multipart-clip path) rather than silently producing a shorter reel.
+
+    When *parallel* is True (a single large reel being regenerated on its own),
+    the independent segment cuts run through a ThreadPoolExecutor, mirroring the
+    fresh-build reel path. Callers that already parallelize *across* reels pass
+    ``parallel=False`` so the two levels don't oversubscribe the CPU.
+    """
     components = reel.get("components", [])
     if not components:
         return False
 
-    temp_paths: list[str] = []
-
-    def _cleanup() -> None:
-        for p in temp_paths:
-            try:
-                Path(p).unlink(missing_ok=True)
-            except OSError:
-                pass
-
+    # Pre-flight: flatten segments into an ordered task list and validate every
+    # source up front (cheap stat calls, single-threaded) before spending any
+    # ffmpeg time. A missing source aborts the whole reel without reserving or
+    # cutting anything.
+    tasks: list[dict[str, Any]] = []
     for comp in components:
-        # A boundary-spanning component carries a ``parts`` list; each part is a
-        # separate cut. Since a reel is a concatenation, the parts simply become
-        # consecutive entries in the temp list. Single-segment components cut
-        # directly from their mapped sub-video using local offsets. Any missing
-        # source or failed cut aborts the whole reel (matching the multipart-clip
-        # path) rather than silently producing a shorter reel.
-        segments = comp.get("parts") or [comp]
-        for segment in segments:
+        for segment in comp.get("parts") or [comp]:
             source = segment.get("sourceVideo", "")
             source_path = str(utils.resolve_input_path(source))
             if not Path(source_path).is_file():
                 if source_path not in missing_videos:
                     missing_videos.add(source_path)
                     utils.warning_print(f"Source video not found: '{source}'")
-                _cleanup()
                 return False
-
             local_start = segment.get("localStart", segment.get("start", 0))
             local_end = segment.get("localEnd", segment.get("end", 0))
-            start_ts = utils.seconds_to_timestamp(int(local_start))
-            end_ts = utils.seconds_to_timestamp(int(local_end))
-            out_name = files.get_unique_filename(
-                f"_reel_part_{len(temp_paths) + 1}{config.FILEFORMAT}"
+            tasks.append(
+                {
+                    "idx": len(tasks),
+                    "source_path": source_path,
+                    "start_ts": utils.seconds_to_timestamp(int(local_start)),
+                    "end_ts": utils.seconds_to_timestamp(int(local_end)),
+                }
             )
-            if video.run_ffmpeg(
-                input_file=source_path,
-                output_file=out_name,
-                start_pos=start_ts,
-                end_pos=end_ts,
-                reencode=config.REENCODING,
-            ):
-                temp_paths.append(out_name)
-            else:
-                files.release_reservation(out_name)
-                _cleanup()
-                return False
 
-    if not temp_paths:
+    if not tasks:
+        return False
+
+    def _cut_segment(task: dict[str, Any]) -> tuple[int, str, bool]:
+        """Reserve a part name and cut one segment; returns (idx, path, ok)."""
+        out_name = files.get_unique_filename(
+            f"_reel_part_{task['idx'] + 1}{config.FILEFORMAT}"
+        )
+        ok = video.run_ffmpeg(
+            input_file=task["source_path"],
+            output_file=out_name,
+            start_pos=task["start_ts"],
+            end_pos=task["end_ts"],
+            reencode=config.REENCODING,
+        )
+        return (task["idx"], out_name, ok)
+
+    workers = _resolve_clip_workers()
+    cut_results: dict[int, tuple[str, bool]] = {}
+    if parallel and len(tasks) >= 2 and workers >= 2:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            for future in concurrent.futures.as_completed(
+                [pool.submit(_cut_segment, t) for t in tasks]
+            ):
+                idx, out_name, ok = future.result()
+                cut_results[idx] = (out_name, ok)
+    else:
+        for t in tasks:
+            idx, out_name, ok = _cut_segment(t)
+            cut_results[idx] = (out_name, ok)
+
+    # Reassemble in concat order regardless of completion order.
+    ordered = [cut_results[t["idx"]] for t in tasks]
+    all_names = [name for name, _ok in ordered]
+
+    def _cleanup() -> None:
+        for p in all_names:
+            try:
+                Path(p).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    if not all(ok for _name, ok in ordered):
+        _cleanup()  # any failed cut aborts the whole reel
         return False
 
     output_file = str(utils.resolve_output_path(reel.get("file", "reel.mp4")))
-    ok = video.concatenate_clips(temp_paths, output_file, reencode_on_fail=True)
+    ok = video.concatenate_clips(all_names, output_file, reencode_on_fail=True)
 
     _cleanup()
     return ok

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -62,6 +62,20 @@ def test_get_unique_filename_truncates_long_names(monkeypatch, tmp_path):
     assert result2 != result1
 
 
+def test_get_unique_filename_sequential_same_name_batch(monkeypatch, tmp_path):
+    """A batch of same-named reservations yields name, name-1, name-2, … with no
+    duplicates — and the per-template high-water counter keeps it O(n)."""
+    monkeypatch.setattr(files.config, "OUTPUT_DIR", str(tmp_path), raising=False)
+
+    results = [files.get_unique_filename("clip.mp4") for _ in range(5)]
+    names = [Path(p).name for p in results]
+
+    assert names == ["clip.mp4", "clip-1.mp4", "clip-2.mp4", "clip-3.mp4", "clip-4.mp4"]
+    assert len(set(results)) == len(results)
+    for path in results:
+        assert Path(path).is_file()  # each reserved as a placeholder
+
+
 def test_get_unique_filename_reserves_distinct_paths_under_threads(
     monkeypatch, tmp_path
 ):

--- a/tests/test_utils_timestamps.py
+++ b/tests/test_utils_timestamps.py
@@ -16,12 +16,19 @@ def test_parse_timestamps_parses_multiple_separators_and_ignored_tokens(monkeypa
         {"x"},
         raising=False,
     )
-    value = "00:10-00:20, 00:30; 00:40 + x"
-    parsed = utils.parse_timestamps(value)
-    assert len(parsed) == 3
-    assert parsed[0] == ("00:10", "00:20")
-    assert parsed[1][0] == "00:30"
-    assert parsed[2][0] == "00:40"
+    # get_ignored_timestamp_tokens() is @functools.cache; clear it so the
+    # monkeypatched config value is read, and clear again at the end so the
+    # cached set can't leak to later tests.
+    utils.get_ignored_timestamp_tokens.cache_clear()
+    try:
+        value = "00:10-00:20, 00:30; 00:40 + x"
+        parsed = utils.parse_timestamps(value)
+        assert len(parsed) == 3
+        assert parsed[0] == ("00:10", "00:20")
+        assert parsed[1][0] == "00:30"
+        assert parsed[2][0] == "00:40"
+    finally:
+        utils.get_ignored_timestamp_tokens.cache_clear()
 
 
 def test_timestamp_to_seconds_valid_and_invalid():

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -976,10 +976,11 @@ def _resolve_mark(
     entry = src.get(pid, {})
     segments = entry.get("segments", [])
     if 0 <= idx < len(segments):
-        raw_seg = segments[idx]
         corrections = _manifest.get("corrections", [])
-        corrected = transcripts.apply_corrections([raw_seg], corrections)
-        seg = corrected[0]
+        # Correct the whole participant list once (memoized by corrections
+        # version) instead of recompiling the regex set per mark.
+        corrected = _corrected_segments(pid, segments, corrections)
+        seg = corrected[idx]
         return {
             **mark,
             "valid": True,

--- a/utils.py
+++ b/utils.py
@@ -1152,6 +1152,7 @@ def _clean_timestamp_token(token: str) -> str:
     return token.strip().rstrip(",").rstrip("-").replace(".", ":")
 
 
+@functools.cache
 def get_ignored_timestamp_tokens() -> set[str]:
     """Return configured ignored non-timestamp tokens in normalized form."""
     configured_tokens = getattr(config, "IGNORED_TIMESTAMP_TOKENS", set())


### PR DESCRIPTION
## Summary

Closes six independent hot-path redundancies flagged in code review, each mirroring a pattern already in the codebase:
- `perf(pipeline)`: `_regenerate_reel` cuts a single large reel's components through a `ThreadPoolExecutor` (across-reels pool stays sequential to avoid oversubscription).
- `perf(transcripts)`: `_resolve_mark` reuses the memoized `_corrected_segments` cache instead of recompiling correction regexes per mark.
- `perf(utils)`: `@functools.cache` on `get_ignored_timestamp_tokens` (mirrors its cached sibling).
- `perf(files)`: per-template high-water counter turns `get_unique_filename` same-name batches from O(n²) to O(n) syscalls.
- `perf(studio)`: stash folder thumbnails go through the throttled/cached lazy queue instead of firing 3×N eager requests (plus a `fix` so the img is in the DOM before enqueuing).
- `perf(export)`: `write_export_bundle` parses each manifest once instead of up to 3×.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` clean (ty's pre-existing test-import diagnostics unaffected)
- [x] Full suite green (1838 passed), incl. a new `get_unique_filename` batch test and `node --check` on `studio.js`
- [ ] ⚠️ Stash thumbnail rendering not browser-verified (no-headless-browser rule) — confirm stacked thumbnails render and frame requests throttle to 3 concurrent
