### PR TITLE
fix(server): quiet PR #529 combined intake-poll access-log spam

### DIFF
--- a/server.py
+++ b/server.py
@@ -3763,6 +3763,8 @@ _QUIET_POLL_PATHS: frozenset[str] = frozenset(
     {
         "/screenspace/api/tasks",
         "/screenspace/api/events",
+        "/screenspace/api/intake-poll",
+        "/transcripts/api/intake-poll",
         "/transcripts/api/marks",
         "/transcripts/api/transcribe/status",
         "/transcripts/api/transcribe/model-status",


### PR DESCRIPTION
## Summary

PR #529 added the combined `/screenspace/api/intake-poll` and `/transcripts/api/intake-poll` endpoints that `studio-intake.js` polls every tick, but did not add them to `_QUIET_POLL_PATHS` in `server.py`, so each successful poll spammed two access-log lines — defeating the suppression. This adds both paths to the set (query strings are already stripped before matching; 4xx/5xx and `VERBOSITY >= VERBOSE` still log).

## Test plan

- [x] `/check` green: ruff format + lint, ty, full suite (1838 passed)
- [ ] Manual: run `--studio`, watch the console — the two `GET …/api/intake-poll` lines no longer appear