### PR TITLE
chore: remove dead insights interactive mode

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -76,8 +76,6 @@ MODE_ALIASES = {
     "regenerate": "regenerate",
     "gv": "gallery",
     "gallery": "gallery",
-    "in": "insights",
-    "insights": "insights",
     "st": "studio",
     "studio": "studio",
     "ss": "screenspace",
@@ -1035,15 +1033,6 @@ def _dispatch_interactive_mode(
     if mode == "gallery":
         _run_gallery_mode_interactive()
         return None
-    if mode == "insights":
-        import server
-
-        server.start_combined_server(
-            worksheet=worksheet,
-            default_page="insights",
-            gspread_client=gspread_client,
-        )
-        return None
     if mode == "studio":
         import server
 
@@ -1169,7 +1158,7 @@ def run_interactive_mode(worksheet: Any, gspread_client: Any = None) -> None:
             input_mode = utils.read_user_input(
                 "\nEnter mode or input directly:\n"
                 "  Tools: (s)creen, (g)if, (re)el, (rl) reel-late, (rg) regenerate, (se)ttings \n"
-                "  Front: (st) studio, (in) insights, (ss) screenspace, (tr)anscripts, (br)owse \n"
+                "  Front: (st) studio, (ss) screenspace, (tr)anscripts, (br)owse \n"
                 "  Packs: (v)iewer, (tv) timeline-viewer, (gv) gallery, (ex)port \n"
                 "  Modes: (b)atch, (r)ange, (c)ategory, (l)ine, (ce)ll, (p)articipant, (k)eyword, (sv) severity \n"
                 '  Or enter mixed selectors directly: e.g. 5, P01.11, 13-16, "Observations"\n>> '

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -31,7 +31,6 @@ def _ss_args(**overrides):
         "manifest": False,
         "regenerate": False,
         "studio": False,
-        "insights": False,
         "screenspace": False,
         "transcripts": False,
         "timeline_viewer": False,

--- a/tests/test_cli_thinking_agents_args.py
+++ b/tests/test_cli_thinking_agents_args.py
@@ -30,7 +30,6 @@ def _agent_args(**overrides):
         "manifest": False,
         "regenerate": False,
         "studio": False,
-        "insights": False,
         "screenspace": False,
         "transcripts": False,
         "timeline_viewer": False,


### PR DESCRIPTION
## Summary

The interactive menu advertised `(in) insights` and dispatched to `default_page="insights"`, but the Insights feature was already fully removed (no blueprint, route, or page), so selecting it opened a 404. This strips the leftover `MODE_ALIASES` entries, the dispatch branch, and the menu label in `clipgen.py`, plus two stale `insights` keys in CLI arg-mock test fixtures.

## Test plan

- [x] `ruff format` + `ruff check` + `ty check` clean
- [x] Affected CLI arg tests and the broader CLI/mode/interactive suite (385 tests) pass
- [x] `grep` confirms no `insights` mode references remain (unrelated `insight` severity/category label untouched)