### PR TITLE
refactor(screenspace): drop legacy video_path→video_paths shim in worker

### DIFF
--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -214,13 +214,7 @@ class ScreenspaceWorker:
         with self._lock:
             for t in tasks:
                 if t.get("id"):
-                    restored = copy.deepcopy(t)
-                    # Tasks now carry ``video_paths`` (multi-video timeline); a
-                    # task persisted before that change has only ``video_path``.
-                    # Normalize on load so resume()/_dispatch never KeyError on it.
-                    if not restored.get("video_paths") and restored.get("video_path"):
-                        restored["video_paths"] = [restored["video_path"]]
-                    self._tasks[t["id"]] = restored
+                    self._tasks[t["id"]] = copy.deepcopy(t)
 
     def stop(self) -> None:
         """Signal the worker thread to stop."""

--- a/tests/test_multi_video.py
+++ b/tests/test_multi_video.py
@@ -983,22 +983,6 @@ def test_screenspace_dispatch_single_video_unchanged(monkeypatch):
 # ---- Review-fix regressions ----
 
 
-def test_screenspace_restore_tasks_normalizes_legacy_video_path():
-    import screenspace
-
-    worker = screenspace.ScreenspaceWorker()
-    # A task persisted before the video_paths change carries only video_path.
-    worker.restore_tasks(
-        [{"id": "ss_old", "video_path": "/in/legacy.mp4", "status": "paused"}]
-    )
-    assert worker._tasks["ss_old"]["video_paths"] == ["/in/legacy.mp4"]
-    # A current task keeps its list untouched.
-    worker.restore_tasks(
-        [{"id": "ss_new", "video_paths": ["/in/a.mp4", "/in/b.mp4"], "status": "done"}]
-    )
-    assert worker._tasks["ss_new"]["video_paths"] == ["/in/a.mp4", "/in/b.mp4"]
-
-
 def test_ss_cli_resolves_all_parts(monkeypatch, tmp_path):
     import cli
 


### PR DESCRIPTION
## Summary

Removes the backwards-compatibility shim in `ScreenspaceWorker.restore_tasks()` that normalized the old singular `video_path` task key into `video_paths` — a legacy-manifest reader that violated the project's "no backwards-compatibility layers" hard rule. `create_task()` always emits `video_paths` and every worker read uses it, so the shim was dead for the current shape; the test that only exercised the legacy path is dropped too.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 1837 passed
- [x] `uv run ruff format --check` / `ruff check` / `uv run ty check` — all clean