### PR TITLE
fix(server): block sheet swap during viewer/gallery builds

### DIFF
--- a/server.py
+++ b/server.py
@@ -454,13 +454,21 @@ def _mark_intake_active(active: bool) -> None:
 
 
 def _generation_busy() -> bool:
-    """Return True while any clip, reel, or intake generation is in flight.
+    """Return True while any clip, reel, timeline-viewer, gallery, or intake
+    generation is in flight.
 
-    Consulted before a sheet swap so generated lists are not rebound under
-    an active stream.
+    Consulted before a sheet swap so generated lists/manifest are not rebound
+    under an active build (e.g. a timeline-viewer build would otherwise append
+    old-sheet artifacts into the new sheet's freshly-rebound list/manifest).
     """
     with _busy_lock:
-        return _generate_in_progress or _reel_in_progress or _intake_active > 0
+        return (
+            _generate_in_progress
+            or _reel_in_progress
+            or _timeline_viewer_in_progress
+            or _gallery_in_progress
+            or _intake_active > 0
+        )
 
 
 @contextmanager

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -427,6 +427,30 @@ def test_spreadsheets_open_rejected_during_intake(client, monkeypatch):
     assert resp.get_json()["ok"] is False
 
 
+def test_spreadsheets_open_rejected_during_timeline_viewer(client, monkeypatch):
+    """A timeline-viewer build blocks a spreadsheet switch: it appends into the
+    shared generated list/manifest, so a swap mid-build would rebind those under
+    it and mix old-sheet artifacts into the new sheet."""
+    monkeypatch.setattr(server, "_timeline_viewer_in_progress", True)
+    resp = client.post(
+        "/api/spreadsheets/open",
+        json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
+    )
+    assert resp.status_code == 409
+    assert resp.get_json()["ok"] is False
+
+
+def test_spreadsheets_open_rejected_during_gallery(client, monkeypatch):
+    """A gallery build also blocks a spreadsheet switch."""
+    monkeypatch.setattr(server, "_gallery_in_progress", True)
+    resp = client.post(
+        "/api/spreadsheets/open",
+        json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
+    )
+    assert resp.status_code == 409
+    assert resp.get_json()["ok"] is False
+
+
 def test_spreadsheets_close_rejected_during_reel(client, monkeypatch):
     """Closing the spreadsheet is rejected with 409 while a reel build runs."""
     monkeypatch.setattr(server, "_reel_in_progress", True)


### PR DESCRIPTION
## Summary

`_generation_busy()` guards the runtime sheet-swap endpoints (`/api/spreadsheets/open`, `/api/spreadsheets/close`) but only checked the `generate`/`reel`/`intake` slots, not the `timeline_viewer` or `gallery` single-job slots — so a swap accepted mid-build let `_swap_worksheet` rebind the shared generated lists/manifest while a running timeline-viewer build appended old-sheet artifacts into the new sheet's list/manifest. It now consults all four single-job slots plus intake.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite green, incl. two new guard tests (`_during_timeline_viewer`, `_during_gallery`)
- [x] `ruff format` + `ruff check` + `ty check` clean