### PR TITLE
fix: derive severity/detector constants from canonical sources

### DIFF
--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -37,10 +37,10 @@
   // ---- Screenspace Intake ----
 
   var INTAKE_DETECTOR_COLORS = DETECTOR_COLORS;
-  var INTAKE_DETECTORS = [
-    "multitool", "color", "change", "similarity", "text",
-    "numbers", "timelapse", "template", "flow", "scene", "inactivity",
-  ];
+  // Ordered detector list for the intake filter chips — copied from utils.js's
+  // canonical `_DETECTOR_TYPES` (includes `boundary`) so a new detector automatically
+  // gets a chip instead of being silently un-filterable.
+  var INTAKE_DETECTORS = _DETECTOR_TYPES.slice();
 
   function setTabDot(elId, on) {
     var el = document.getElementById(elId);

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -1270,6 +1270,11 @@ def sort_clips_by_severity(clips: list[ClipRecord]) -> None:
 
 # ---- Highlights reel scoring ----
 
+# Largest friction magnitude in the severity scale (critical = -4 → 4), used to
+# normalize highlight severity scores into 0-1. Derived from config so the scale
+# can't drift from the canonical severity labels.
+_MAX_SEVERITY_MAGNITUDE = -min(config.SEVERITY_LABEL_TO_NUMERIC.values())
+
 
 def _clip_duration_seconds(clip: Any) -> float:
     """Estimate a clip's total duration in seconds from its raw cell value."""
@@ -1294,10 +1299,10 @@ def _clip_highlight_score(clip: Any, lowered_filenames: Sequence[str]) -> float:
     artifact), and keyword annotation, weighted by config constants.
     ``lowered_filenames`` must already be lowercased by the caller.
     """
-    # Severity: map to 0-1 range
-    severity_scores = {"critical": 1.0, "high": 0.75, "medium": 0.5, "low": 0.25}
+    # Severity: friction magnitude normalized to 0-1 (positive/neutral labels score 0).
     sev_label = clip.get("severity", "").strip().lower()
-    sev = severity_scores.get(sev_label, 0.0)
+    numeric = config.SEVERITY_LABEL_TO_NUMERIC.get(sev_label, 0)
+    sev = max(0, -numeric) / _MAX_SEVERITY_MAGNITUDE
 
     # Uniqueness: 1.0 if no matching artifact exists
     study = (clip.get("study") or "").lower()


### PR DESCRIPTION
## Summary

Fix two hand-copied constants that had drifted from their canonical sources (the exact failure the "No duplicated constants" rule guards against).

- `spreadsheet.py` `_clip_highlight_score` hardcoded a 4-label severity scale; now derived from `config.SEVERITY_LABEL_TO_NUMERIC` via a `_MAX_SEVERITY_MAGNITUDE` constant, with byte-identical output for every reachable label.
- `studio-intake.js` `INTAKE_DETECTORS` copied `utils.js`'s `_DETECTOR_TYPES` minus `boundary`, so boundary clusters never got a filter chip; now `_DETECTOR_TYPES.slice()`, so any detector is filterable.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` — all pass
- [x] Full `pytest` suite green (highlights/truncate, shared-constants, satellite-wiring, studio-frontend-source)
- [x] `node --check assets/web/studio-intake.js`
- [ ] ⚠️ Not browser-checked: open Studio → Screenspace Intake with a boundary detector cluster and confirm a `boundary` filter chip appears and filters correctly