### PR TITLE
test(server): monkeypatch module globals in Screenspace/Workflows API fixtures

### DIFF
--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1,6 +1,7 @@
 """Tests for Screenspace server API endpoints."""
 
 import os
+from collections import OrderedDict
 
 import numpy as np
 import pytest
@@ -20,23 +21,34 @@ def client(tmp_path, monkeypatch):
     app.register_blueprint(screenspace_server.screenspace_bp, url_prefix="/screenspace")
 
     monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
-    screenspace_server._manifest = {
-        "regions": {},
-        "tasks": [],
-        "events": [],
-        "stashes": [],
-        "per_participant": {},
-        "pins": {},
-    }
-    screenspace_server._participants = [
-        {"id": "P01", "video_paths": ["/tmp/test_P01.mp4"], "has_video": False},
-        {"id": "P02", "video_paths": ["/tmp/test_P02.mp4"], "has_video": False},
-    ]
-    screenspace_server._output_dir = str(tmp_path)
-    screenspace_server._worker = screenspace.ScreenspaceWorker()
-    # Module-level calibration/preview caches persist across tests; reset them.
-    screenspace_server._decoded_frame_cache.clear()
-    screenspace_server._pin_ocr_cache.clear()
+    # Seed module globals via monkeypatch so they auto-restore on teardown —
+    # otherwise a later test that reads these globals without the fixture would
+    # inherit this test's state (matters under random ordering).
+    monkeypatch.setattr(
+        screenspace_server,
+        "_manifest",
+        {
+            "regions": {},
+            "tasks": [],
+            "events": [],
+            "stashes": [],
+            "per_participant": {},
+            "pins": {},
+        },
+    )
+    monkeypatch.setattr(
+        screenspace_server,
+        "_participants",
+        [
+            {"id": "P01", "video_paths": ["/tmp/test_P01.mp4"], "has_video": False},
+            {"id": "P02", "video_paths": ["/tmp/test_P02.mp4"], "has_video": False},
+        ],
+    )
+    monkeypatch.setattr(screenspace_server, "_output_dir", str(tmp_path))
+    monkeypatch.setattr(screenspace_server, "_worker", screenspace.ScreenspaceWorker())
+    # Fresh module-level calibration/preview caches per test (auto-restored).
+    monkeypatch.setattr(screenspace_server, "_decoded_frame_cache", OrderedDict())
+    monkeypatch.setattr(screenspace_server, "_pin_ocr_cache", OrderedDict())
 
     monkeypatch.setattr(
         screenspace,
@@ -48,6 +60,9 @@ def client(tmp_path, monkeypatch):
 
     with app.test_client() as c:
         yield c
+    # Cancel any debounced manifest write armed during the test so a stray Timer
+    # doesn't fire _do_persist into torn-down state after the fixture exits.
+    screenspace_server._cancel_pending_persist_timer()
 
 
 @pytest.fixture

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -25,18 +25,23 @@ def wf_client(tmp_path, monkeypatch):
     app = Flask(__name__)
     app.register_blueprint(workflows_server.workflows_bp, url_prefix="/workflows")
 
-    workflows_server._manifest = workflows.empty_workflows_manifest()
-    workflows_server._input_dir = str(tmp_path)
-    workflows_server._sheet_context = None
-    workflows_server._worksheet = None
+    # Seed module globals via monkeypatch so they auto-restore on teardown —
+    # otherwise a later test that reads these globals without the fixture would
+    # inherit this test's state (matters under random ordering).
+    monkeypatch.setattr(
+        workflows_server, "_manifest", workflows.empty_workflows_manifest()
+    )
+    monkeypatch.setattr(workflows_server, "_input_dir", str(tmp_path))
+    monkeypatch.setattr(workflows_server, "_sheet_context", None)
+    monkeypatch.setattr(workflows_server, "_worksheet", None)
     # Reset run state so runners/SSE clients never leak across tests.
-    workflows_server._runs = {}
-    workflows_server._sse_clients = []
-    workflows_server._batches = {}
-    workflows_server._batch_sse_clients = []
+    monkeypatch.setattr(workflows_server, "_runs", {})
+    monkeypatch.setattr(workflows_server, "_sse_clients", [])
+    monkeypatch.setattr(workflows_server, "_batches", {})
+    monkeypatch.setattr(workflows_server, "_batch_sse_clients", [])
     # Reset watch-dir trigger state (P6) so seen pids never leak across tests.
-    workflows_server._watch_seen = set()
-    workflows_server._watch_pending = {}
+    monkeypatch.setattr(workflows_server, "_watch_seen", set())
+    monkeypatch.setattr(workflows_server, "_watch_pending", {})
     # Sandbox save_workflows_manifest's write into tmp (it targets the output dir).
     monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
 


### PR DESCRIPTION
## Summary

The `client`/`wf_client` API-test fixtures seeded server module globals by direct assignment, which teardown never undoes — leaking state onto `screenspace_server`/`workflows_server` for later tests that read those globals without the fixture (a green→red flake under `pytest-randomly`). This routes every global through `monkeypatch.setattr` (mirroring `tr_client`), swaps the in-place cache `.clear()` for a fresh `OrderedDict` via `setattr`, and cancels the debounced persist timer on Screenspace fixture teardown so a stray `Timer` can't fire `_do_persist` into torn-down state.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite, 1838 passed
- [x] Affected + reference API suites under random ordering (seeds 1/42/1234) all green
- [x] ruff format + lint + `ty check` clean