### PR TITLE
fix(screenspace): use mean-absdiff static-frame skip in scan_scene

### DIFF
--- a/screenspace_primitives.py
+++ b/screenspace_primitives.py
@@ -139,7 +139,7 @@ def _frame_is_static(prev_gray: np.ndarray | None, curr_gray: np.ndarray) -> boo
     predicate with no consecutive-buffer/progress side effects, so callers apply
     whatever skip semantics fit their scan (reset a motion run, extend a span,
     skip a per-frame op, or carry the last result). Shared by scan_similarity,
-    scan_flow, scan_inactivity, scan_boundaries, and scan_template.
+    scan_flow, scan_inactivity, scan_boundaries, scan_scene, and scan_template.
     """
     if prev_gray is None:
         return False

--- a/screenspace_scans.py
+++ b/screenspace_scans.py
@@ -957,16 +957,12 @@ def scan_scene(
         if cancel_flag and cancel_flag():
             return False
 
-        # Static-frame skip (same pattern as similarity scan)
-        curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY).astype(np.float32)
-        if prev_skip_gray[0] is not None:
-            if (
-                abs(float(np.mean(curr_gray)) - float(np.mean(prev_skip_gray[0])))
-                < config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD
-            ):
-                if on_progress and total_range > 0:
-                    on_progress((ts - start_seconds) / total_range)
-                return None
+        # Static-frame skip
+        curr_gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+        if _frame_is_static(prev_skip_gray[0], curr_gray):
+            if on_progress and total_range > 0:
+                on_progress((ts - start_seconds) / total_range)
+            return None
         prev_skip_gray[0] = curr_gray
 
         fp = compute_scene_fingerprint(pixels)

--- a/tests/screenspace/test_text_numbers.py
+++ b/tests/screenspace/test_text_numbers.py
@@ -452,12 +452,14 @@ class TestConsecutiveBuffer:
 def test_static_skip_uses_config():
     """The static-frame-skip sites reference the config constant, not a 2.0
     literal. scan_text/scan_numbers share the _is_static_skip helper and
-    similarity/flow/inactivity/boundaries/template share the _frame_is_static
-    predicate (both in screenspace_primitives); scan_scene applies the threshold
-    inline (in screenspace_scans)."""
+    similarity/flow/inactivity/boundaries/scene/template share the
+    _frame_is_static predicate (both in screenspace_primitives)."""
     src = Path(screenspace_primitives.__file__).read_text(encoding="utf-8")
     src += Path(screenspace_scans.__file__).read_text(encoding="utf-8")
-    assert src.count("config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD") >= 3
+    # Both shared helpers (_is_static_skip, _frame_is_static) live in
+    # screenspace_primitives and reference the constant; every scan routes
+    # through one of them rather than inlining the threshold.
+    assert src.count("config.SCREENSPACE_STATIC_FRAME_SKIP_THRESHOLD") >= 2
     assert "< 2.0" not in src
 
 


### PR DESCRIPTION
## Summary

`scan_scene` skipped frames using `abs(mean(curr) - mean(prev))` — the absolute difference of frame grayscale *means* — which collapses each frame to a single average-luminance scalar, so two visually different frames with equal average luminance (e.g. a dialog swap over the same background) scored ~0 and were silently skipped, missing their scene classification. It now routes the static-frame skip through the shared `_frame_is_static()` predicate (mean of per-pixel absdiff), matching `scan_similarity` and every other scan; the `_frame_is_static` docstring and the static-skip test are updated to match.

## Test plan

- [x] `uv run ruff format --check && uv run ruff check && uv run ty check` — clean
- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 1838 passed