### PR TITLE
perf(transcripts): route vtt + embed subtitle through corrected-segments cache

### DIFF
--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1196,6 +1196,34 @@ def test_corrected_segments_cached_and_invalidated_on_correction(
     assert seg["corrected"] is True
 
 
+def test_vtt_shares_corrected_segments_cache(tr_client, monkeypatch):
+    """api_vtt routes through the memoized cache, so a second request for the
+    same participant does not recompute corrections."""
+    calls = {"n": 0}
+    real_apply = transcripts.apply_corrections
+
+    def _counting_apply(segments, corrections):
+        calls["n"] += 1
+        return real_apply(segments, corrections)
+
+    monkeypatch.setattr(transcripts, "apply_corrections", _counting_apply)
+    transcripts_server._bump_corrections_version()  # start from a cold cache
+    transcripts_server._manifest["source_transcripts"]["P01"] = {
+        "segments": [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "teh cat"}],
+    }
+    transcripts_server._manifest["corrections"] = [{"from": "teh", "to": "the"}]
+
+    r1 = tr_client.get("/transcripts/api/vtt/P01")
+    assert r1.status_code == 200
+    assert "the cat" in r1.get_data(as_text=True)
+    assert calls["n"] == 1
+
+    # Second request hits the cache — no recompute.
+    r2 = tr_client.get("/transcripts/api/vtt/P01")
+    assert r2.status_code == 200
+    assert calls["n"] == 1
+
+
 def test_persist_keeps_corrected_cache_for_unchanged_transcription(
     tr_client, monkeypatch
 ):

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -444,7 +444,9 @@ def api_vtt(participant: str) -> FlaskResponse:
         source_file = entry.get("source_file", "")
         model = entry.get("model", "")
 
-    corrected = transcripts.apply_corrections(segments_snapshot, corrections_snapshot)
+    corrected = _corrected_segments(
+        participant, segments_snapshot, corrections_snapshot
+    )
     result = transcripts.TranscriptResult(
         segments=corrected,
         language=language,
@@ -508,7 +510,9 @@ def _embed_subtitle_for_participant(
         }
     video_path = video_paths[0]
 
-    corrected = transcripts.apply_corrections(segments_snapshot, corrections_snapshot)
+    corrected = _corrected_segments(
+        participant, segments_snapshot, corrections_snapshot
+    )
     result = transcripts.TranscriptResult(
         segments=corrected,
         language=language,


### PR DESCRIPTION
## Summary

`api_vtt` and `_embed_subtitle_for_participant` called `transcripts.apply_corrections()` directly — recompiling the correction regex set per request and bypassing the memoized `_corrected_segments()` cache that the mark poll path and `api_transcript` already share. Both now route through that cache, so every correction read sits on one version-invalidated path. These are cold paths (VTT `<track>` load / rare user-triggered ffmpeg mux), so this is a consistency cleanup, not the hot-path win the original review implied — the poll path (`_resolve_mark`) was already fixed in #530.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — full suite green; adds `test_vtt_shares_corrected_segments_cache` asserting a second `/api/vtt` request does not recompute corrections.
- [x] `ruff format --check`, `ruff check`, `ty check` all pass.