### PR TITLE
refactor(transcripts): generic /api/agent/<key> routes + JS poll factory

### DIFF
--- a/agents/skills/new-thinking-agent/SKILL.md
+++ b/agents/skills/new-thinking-agent/SKILL.md
@@ -1,6 +1,6 @@
 # clipgen-new-thinking-agent — Add an Ollama thinking agent
 
-The orchestrator in `transcripts_server.py` auto-picks up new agents from the `AGENTS` list — no orchestrator edits needed.
+Both the orchestrator **and** the HTTP routes in `transcripts_server.py` auto-pick up new agents from the `AGENTS` list by key — no orchestrator or route edits needed. The frontend touch is a descriptor entry, not new plumbing.
 
 ## Checklist
 
@@ -16,16 +16,37 @@ The orchestrator in `transcripts_server.py` auto-picks up new agents from the `A
      - Respect topological order: dependencies must appear before dependents
      - Set `depends_on` to the `manifest_field` names of agents this one needs
      - Set `manifest_field` to the key that will be written into the transcript entry
+     - Set `on_upstream_change` to `"clear"` (drop the result when an upstream
+       dependency regenerates — the default) or `"stale"` (keep it but flag for a
+       prompted re-run; only the friction shape carries a `stale` flag today, so a
+       new `"stale"` agent also needs a `stale`-flagging path)
 
-3. **UI surfacing (if needed)** (`transcripts_server.py`)
-   - Extend an existing endpoint's response shape, or add a new endpoint
-   - The in-flight check pattern: `_is_generating(participant, agent_key)`
+3. **Backend routes** (`transcripts_server.py`) — **usually nothing**
+   - The generic `/api/agent/<key>/<participant>` routes (poll / `regenerate` /
+     `stop`) cover every agent in `AGENTS` by key, so a new agent needs **no**
+     route edits. The generic poll returns the result under the agent's
+     `manifest_field`, plus a `<dep_field>_generating`/`_started_at` block for
+     any dependents — driven off `depends_on`.
+   - Only add a route for genuinely-unique behavior. Summary is the sole example:
+     its SSE token **stream** (`/api/agent/summary/<pid>/stream`) and user-**edit**
+     PUT are hand-written because only summary streams tokens / is user-editable.
+     A second streaming agent would generalize the `/stream` seam via an `Agent`
+     `streams` flag rather than cloning the route.
 
-4. **Tests** (`tests/test_thinking_agents.py`)
+4. **UI surfacing** (`assets/web/transcripts-agents.js`)
+   - Add an `AGENT_DESCRIPTORS` entry (URL base `api/agent/<key>`, poll interval,
+     optional timeout) plus the agent's render hooks (`onResult`/`onGenerating`/
+     `onEmpty`/`onStale`). The shared `_makeAgentPoll` factory handles the
+     poll/staleness/timeout scaffolding — no new poll/stop plumbing.
+   - Agent run/stop rows in `transcripts-pills.js` build URLs from the agent key
+     (`api/agent/<key>/...`), so a new pill row is data-only too.
+
+5. **Tests** (`tests/test_thinking_agents.py`)
    - Test the `run()` callable with a mock transcript entry
    - Test that the agent appears in `AGENTS` with correct metadata
 
 ## No edits needed
 
-- `transcripts_server.py` orchestrator logic (chain auto-advances)
+- `transcripts_server.py` routes (the generic `/api/agent/<key>/...` routes and
+  orchestrator both key off `AGENTS`; the chain auto-advances)
 - `ollama_client.py` (pure transport layer)

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -12,8 +12,8 @@
  *
  * The ETA trackers + ticker and _updateAgentElapsed live in the hub (shared with
  * the transcription ETA path) and are used here by reference. isSummaryPolling
- * lets the hub poller re-arm the summary poll without reading _summaryPoller
- * directly. Plain utils.js globals (qs/el/escapeHtml/apiGet/apiPost/formatTime/
+ * lets the hub poller re-arm the summary poll without reaching into the
+ * summary descriptor's poller directly. Plain utils.js globals (qs/el/escapeHtml/apiGet/apiPost/formatTime/
  * createPoller/MARK_CATEGORIES/CLIPGEN_CONFIG/...) are reached via the scope chain.
  */
 (function () {
@@ -36,23 +36,144 @@
     _updateAgentElapsed = TS._updateAgentElapsed,
     _currentParticipantHasTranscript = TS._currentParticipantHasTranscript;
 
+  // ---- Thinking-agent plumbing (shared poll factory) ----
+  //
+  // summary / citations / friction all poll the same generic /api/agent/<key>/
+  // endpoints; only the URL base, cadence, and result-handling hooks differ, so
+  // one _makeAgentPoll scaffold drives all three (the "one JS poll factory").
+  // Adding an agent is a descriptor entry + its render hooks — no new poll/stop
+  // plumbing. Summary stays richest (SSE token stream + citation chaining +
+  // inline edit); its extra behavior rides in its hooks and the bespoke run
+  // helpers further down.
+
+  // Hard cap on agent polls (citations + friction). Long Ollama runs on big
+  // transcripts once outlived a shorter timeout, so the result landed in the
+  // manifest after we'd given up and only surfaced on a full reload. Five
+  // minutes covers realistic completion; the server's `generating: false`
+  // stops the poll earlier when the agent finishes or fails sooner. Summary has
+  // no cap — its SSE stream (or 1.2s fallback poll) runs until done.
+  var _AGENT_POLL_TIMEOUT = 300000;
+
+  var AGENT_DESCRIPTORS = {
+    summary: {
+      key: "summary",
+      urlBase: "api/agent/summary",
+      interval: 1200,
+      timeout: null,
+      _poller: null,
+      getResult: function (d) { return d.summary; },
+      onResult: function (pid, d) { _onSummaryResult(pid, d); },
+      onGenerating: function (pid, d) {
+        // Still generating — stream in whatever tokens have arrived. Rebuild the
+        // generating box if a re-render dropped it, then push the partial text.
+        if (!qs("#summaryStream")) {
+          renderSummaryGenerating(d.started_at ? d.started_at * 1000 : undefined);
+        }
+        if (d.partial) _updateSummaryStream(d.partial);
+      },
+      onEmpty: function () { renderSummaryEmpty(); },
+      // Participant switch: just stop — don't paint an empty box into the panel,
+      // which now belongs to a different participant.
+      onStale: function () {},
+    },
+    citations: {
+      key: "citations",
+      urlBase: "api/agent/citations",
+      interval: 3000,
+      timeout: _AGENT_POLL_TIMEOUT,
+      _poller: null,
+      getResult: function (d) { return d.citations; },
+      onResult: function (pid, d) {
+        state.summaryCitations = d.citations;
+        state.citationsGenerating = false;
+        renderCitations();
+      },
+      onEmpty: function () { _clearCitationsStatus(); },
+      onStale: function () { _clearCitationsStatus(); },
+    },
+    friction: {
+      key: "friction",
+      urlBase: "api/agent/friction",
+      interval: 3000,
+      timeout: _AGENT_POLL_TIMEOUT,
+      _poller: null,
+      getResult: function (d) { return d.friction; },
+      onResult: function (pid, d) { _setFrictionData(d.friction); },
+      onEmpty: function () { state.frictionGenerating = false; renderFrictionEmpty(); },
+      onStale: function () { state.frictionGenerating = false; renderFriction(); },
+    },
+  };
+
+  // The one poll scaffold. The version/participant staleness guard + optional
+  // timeout are identical across agents; per-result behavior is the descriptor's
+  // hooks. runImmediately:false so the first poll waits one interval (the
+  // initial render already painted the box). createPoller auto-pauses on hidden
+  // tabs and the endpoints are cheap in-memory reads.
+  function _makeAgentPoll(desc) {
+    return function (pid) {
+      _stopAgentPoll(desc);
+      var started = Date.now();
+      var ver = state.participantReqVer;
+      desc._poller = createPoller(function () {
+        if (ver !== state.participantReqVer ||
+            state.selectedParticipant !== pid ||
+            (desc.timeout && Date.now() - started > desc.timeout)) {
+          _stopAgentPoll(desc);
+          desc.onStale(pid);
+          return;
+        }
+        apiGet(desc.urlBase + "/" + pid).then(function (data) {
+          if (ver !== state.participantReqVer) return;
+          if (data.ok && desc.getResult(data)) {
+            _stopAgentPoll(desc);
+            desc.onResult(pid, data);
+          } else if (data.generating) {
+            if (desc.onGenerating) desc.onGenerating(pid, data);
+          } else {
+            _stopAgentPoll(desc);
+            desc.onEmpty(pid);
+          }
+        }).catch(function () {
+          if (ver !== state.participantReqVer) return;
+          _stopAgentPoll(desc);
+          desc.onEmpty(pid);
+        });
+      }, desc.interval, { runImmediately: false });
+      desc._poller.start();
+    };
+  }
+
+  // Timer-only teardown (mirrors the old per-agent _stop*Poll): does NOT reset
+  // ETA trackers — render*Status/*Generating reset-then-seed, so resetting here
+  // would wipe the seed when a poll restarts.
+  function _stopAgentPoll(desc) {
+    if (desc._poller) {
+      desc._poller.stop();
+      desc._poller = null;
+    }
+  }
+
+  var _startSummaryPoll = _makeAgentPoll(AGENT_DESCRIPTORS.summary);
+  var _startCitationsPoll = _makeAgentPoll(AGENT_DESCRIPTORS.citations);
+  var _startFrictionPoll = _makeAgentPoll(AGENT_DESCRIPTORS.friction);
+
   // ---- AI Summary ----
   //
-  // Two cooperating pollers (createPoller handles):
-  //   _summaryPoller   — runs while the backend is still generating the
-  //                      summary. Stops as soon as a summary lands, or
-  //                      when the user switches participant.
-  //   _citationsPoller — runs after the summary arrives if citations are
-  //                      still being computed (citations depend on summary).
+  // Two cooperating pollers, both built by _makeAgentPoll above:
+  //   AGENT_DESCRIPTORS.summary._poller   — runs while the backend is still
+  //                      generating the summary. Stops as soon as a summary
+  //                      lands, or when the user switches participant.
+  //   AGENT_DESCRIPTORS.citations._poller — runs after the summary arrives if
+  //                      citations are still computing (citations depend on
+  //                      summary).
   // Both are stopped by their own _stop*Poll() helpers; either also stops if
   // `state.selectedParticipant` no longer matches the participant the poll
   // was started for.
 
-  var _summaryPoller = null;
   // SSE token stream: the primary live-update transport while a summary
   // generates — pushes each token as the model emits it (true word-by-word).
-  // _summaryPoller is the fallback used when EventSource is unsupported or the
-  // stream drops mid-run.
+  // The summary poll (AGENT_DESCRIPTORS.summary._poller) is the fallback used
+  // when EventSource is unsupported or the stream drops mid-run.
   var _summaryStream = null;
 
   function loadSummary(pid) {
@@ -67,30 +188,11 @@
       _setAnalysisPanelVisible(true);
     }
 
-    apiGet("api/summary/" + pid).then(function (data) {
+    apiGet(AGENT_DESCRIPTORS.summary.urlBase + "/" + pid).then(function (data) {
       if (ver !== state.participantReqVer) return;
       if (data.ok && data.summary) {
         _stopSummaryPoll();
-        // Clear any citation state carried over from a previous participant
-        // before rendering — renderSummary() reapplies state.summaryCitations,
-        // so stale superscripts would otherwise leak onto this summary.
-        state.summaryCitations = null;
-        state.citationsGenerating = false;
-        renderSummary(data.summary);
-        // Handle citations
-        if (data.citations && data.citations.length > 0) {
-          state.summaryCitations = data.citations;
-          state.citationsGenerating = false;
-          renderCitations();
-        } else if (data.citations_generating) {
-          state.summaryCitations = null;
-          state.citationsGenerating = true;
-          renderCitationsStatus(
-            data.citations_started_at ? data.citations_started_at * 1000 : undefined
-          );
-          _startCitationsPoll(pid);
-          _refreshAgentStateNow();
-        }
+        _onSummaryResult(pid, data);
       } else if (data.generating) {
         renderSummaryGenerating(data.started_at ? data.started_at * 1000 : undefined);
         if (data.partial) _updateSummaryStream(data.partial);
@@ -106,62 +208,30 @@
     });
   }
 
-  function _startSummaryPoll(pid) {
-    _stopSummaryPoll();
-    var ver = state.participantReqVer;
-    // Poll fast (1.2s) while the summary generates so streamed partial text
-    // updates feel live; runImmediately is false so the first poll waits one
-    // interval (the initial render already painted the generating box). The
-    // endpoint is a cheap in-memory read and createPoller auto-pauses on hidden
-    // tabs.
-    _summaryPoller = createPoller(function () {
-      if (ver !== state.participantReqVer || state.selectedParticipant !== pid) {
-        _stopSummaryPoll();
-        return;
-      }
-      apiGet("api/summary/" + pid).then(function (data) {
-        if (ver !== state.participantReqVer) return;
-        if (data.ok && data.summary) {
-          _stopSummaryPoll();
-          // Clear stale citation state before render (see loadSummary).
-          state.summaryCitations = null;
-          state.citationsGenerating = false;
-          renderSummary(data.summary);
-          // Summary just arrived — check citation status
-          if (data.citations && data.citations.length > 0) {
-            state.summaryCitations = data.citations;
-            state.citationsGenerating = false;
-            renderCitations();
-          } else if (data.citations_generating) {
-            state.summaryCitations = null;
-            state.citationsGenerating = true;
-            renderCitationsStatus(
-              data.citations_started_at ? data.citations_started_at * 1000 : undefined
-            );
-            _startCitationsPoll(pid);
-          }
-        } else if (data.generating) {
-          // Still generating — stream in whatever tokens have arrived so far.
-          // Rebuild the generating box if a re-render dropped it (e.g. the
-          // panel was cleared and re-shown), then push the partial text.
-          if (!qs("#summaryStream")) {
-            renderSummaryGenerating(
-              data.started_at ? data.started_at * 1000 : undefined
-            );
-          }
-          if (data.partial) _updateSummaryStream(data.partial);
-        } else {
-          // Generation finished without result — stop polling
-          _stopSummaryPoll();
-          renderSummaryEmpty();
-        }
-      }).catch(function () {
-        if (ver !== state.participantReqVer) return;
-        _stopSummaryPoll();
-        renderSummaryEmpty();
-      });
-    }, 1200, { runImmediately: false });
-    _summaryPoller.start();
+  // Summary landed (via initial load OR the fallback poll's onResult hook):
+  // render it, then — if citations are still generating server-side — surface
+  // their status and start the citations poll. Shared so the loader and the
+  // poll stay in lockstep (the summary poll's descriptor onResult delegates here).
+  function _onSummaryResult(pid, data) {
+    // Clear any citation state carried over from a previous participant before
+    // rendering — renderSummary() reapplies state.summaryCitations, so stale
+    // superscripts would otherwise leak onto this summary.
+    state.summaryCitations = null;
+    state.citationsGenerating = false;
+    renderSummary(data.summary);
+    if (data.citations && data.citations.length > 0) {
+      state.summaryCitations = data.citations;
+      state.citationsGenerating = false;
+      renderCitations();
+    } else if (data.citations_generating) {
+      state.summaryCitations = null;
+      state.citationsGenerating = true;
+      renderCitationsStatus(
+        data.citations_started_at ? data.citations_started_at * 1000 : undefined
+      );
+      _startCitationsPoll(pid);
+      _refreshAgentStateNow();
+    }
   }
 
   // Open the SSE token stream for a generating summary. Falls back to the GET
@@ -171,7 +241,7 @@
   function _startSummaryStream(pid) {
     _stopSummaryPoll(); // clear any prior poller/stream before (re)starting
     var ver = state.participantReqVer;
-    _summaryStream = createSSEStream("api/summary/" + pid + "/stream", {
+    _summaryStream = createSSEStream(AGENT_DESCRIPTORS.summary.urlBase + "/" + pid + "/stream", {
       onMessage: function (data) {
         if (ver !== state.participantReqVer || state.selectedParticipant !== pid) {
           _stopSummaryStream();
@@ -213,10 +283,7 @@
   // existing teardown site (participant switch, clear, cancel, completion)
   // covers both transports without needing to know which one is active.
   function _stopSummaryPoll() {
-    if (_summaryPoller) {
-      _summaryPoller.stop();
-      _summaryPoller = null;
-    }
+    _stopAgentPoll(AGENT_DESCRIPTORS.summary);
     _stopSummaryStream();
   }
 
@@ -398,7 +465,14 @@
 
   // ---- Citation rendering (Pass 2) ----
 
-  var _citationsPoller = null;
+  // Citations cleanup shared by the poll's onEmpty/onStale hooks, the cancel
+  // path, and the regenerate error path: drop the generating flag and remove
+  // the "Finding sources…" status line from the summary panel.
+  function _clearCitationsStatus() {
+    state.citationsGenerating = false;
+    var status = qs("#summaryContent .citations-status");
+    if (status) status.remove();
+  }
 
   function renderCitations() {
     // Remove any existing status text
@@ -470,61 +544,8 @@
     _txEtaTicker.ensure();
   }
 
-  // Hard cap on agent polls (citations and friction). The previous 90 s value
-  // was shorter than some real Ollama runs on long transcripts, so the result
-  // would land in the manifest after we'd given up — and the UI only picked it
-  // up on a full page reload. Five minutes covers realistic completion times;
-  // the server-side `generating: false` signal stops the poll earlier when the
-  // agent finishes (or fails) sooner.
-  var _AGENT_POLL_TIMEOUT = 300000;
-
-  function _startCitationsPoll(pid) {
-    _stopCitationsPoll();
-    var started = Date.now();
-    var ver = state.participantReqVer;
-    // runImmediately is false to match the previous setInterval (first poll after 3s).
-    _citationsPoller = createPoller(function () {
-      if (ver !== state.participantReqVer ||
-          state.selectedParticipant !== pid ||
-          Date.now() - started > _AGENT_POLL_TIMEOUT) {
-        _stopCitationsPoll();
-        state.citationsGenerating = false;
-        var status = qs("#summaryContent .citations-status");
-        if (status) status.remove();
-        return;
-      }
-      apiGet("api/citations/" + pid).then(function (data) {
-        if (ver !== state.participantReqVer) return;
-        if (data.ok && data.citations) {
-          _stopCitationsPoll();
-          state.summaryCitations = data.citations;
-          state.citationsGenerating = false;
-          renderCitations();
-        } else if (!data.generating) {
-          _stopCitationsPoll();
-          state.citationsGenerating = false;
-          var status = qs("#summaryContent .citations-status");
-          if (status) status.remove();
-        }
-      }).catch(function () {
-        if (ver !== state.participantReqVer) return;
-        _stopCitationsPoll();
-        state.citationsGenerating = false;
-        var status = qs("#summaryContent .citations-status");
-        if (status) status.remove();
-      });
-    }, 3000, { runImmediately: false });
-    _citationsPoller.start();
-  }
-
-  // Poller teardown only — does NOT reset _citationsEtaTracker (renderCitationsStatus
-  // resets-then-seeds), mirroring _stopSummaryPoll / _stopFrictionPoll. Resetting
-  // here would wipe the seed when _startCitationsPoll restarts the poll.
   function _stopCitationsPoll() {
-    if (_citationsPoller) {
-      _citationsPoller.stop();
-      _citationsPoller = null;
-    }
+    _stopAgentPoll(AGENT_DESCRIPTORS.citations);
   }
 
   function _stopCitationsRun() {
@@ -533,10 +554,8 @@
     // Citations run after the summary exists, so keep the summary visible and
     // only remove the "Finding sources…" status line.
     _stopCitationsPoll();
-    state.citationsGenerating = false;
-    var status = qs("#summaryContent .citations-status");
-    if (status) status.remove();
-    apiPost("api/citations/" + pid + "/stop", {}).then(function () {
+    _clearCitationsStatus();
+    apiPost(AGENT_DESCRIPTORS.citations.urlBase + "/" + pid + "/stop", {}).then(function () {
       _refreshAgentStateNow();
     }).catch(function () {});
   }
@@ -551,7 +570,7 @@
       state.citationsGenerating = false;
       _stopCitationsPoll();
       renderSummaryGenerating();
-      apiPost("api/summary/" + pid + "/regenerate", {}).then(function (data) {
+      apiPost(AGENT_DESCRIPTORS.summary.urlBase + "/" + pid + "/regenerate", {}).then(function (data) {
         if (data.ok && data.generating) {
           _startSummaryStream(pid);
           _refreshAgentStateNow();
@@ -576,8 +595,8 @@
     // running. Re-sync only after both stops are acknowledged, otherwise the
     // follow-up GET can still see citations in-flight and restart its poll.
     Promise.all([
-      apiPost("api/summary/" + pid + "/stop", {}),
-      apiPost("api/citations/" + pid + "/stop", {}),
+      apiPost(AGENT_DESCRIPTORS.summary.urlBase + "/" + pid + "/stop", {}),
+      apiPost(AGENT_DESCRIPTORS.citations.urlBase + "/" + pid + "/stop", {}),
     ]).then(function () {
       _refreshAgentStateNow();
       loadSummary(pid); // re-sync with backend (mirrors friction's loadFriction)
@@ -617,15 +636,13 @@
         state.citationsGenerating = true;
         renderCitations(); // clear existing links
         renderCitationsStatus();
-        apiPost("api/citations/" + pid + "/regenerate", {}).then(function (data) {
+        apiPost(AGENT_DESCRIPTORS.citations.urlBase + "/" + pid + "/regenerate", {}).then(function (data) {
           if (data.ok && data.generating) {
             _startCitationsPoll(pid);
           }
         }).catch(function () {
           showToast("Failed to regenerate citations");
-          state.citationsGenerating = false;
-          var status = qs("#summaryContent .citations-status");
-          if (status) status.remove();
+          _clearCitationsStatus();
         });
       });
     });
@@ -662,7 +679,7 @@
           showToast("Summary cannot be empty");
           return;
         }
-        apiPut("api/summary/" + pid, { summary: newText }).then(function () {
+        apiPut(AGENT_DESCRIPTORS.summary.urlBase + "/" + pid, { summary: newText }).then(function () {
           state.summaryCitations = null;
           state.citationsGenerating = false;
           _stopCitationsPoll();
@@ -682,8 +699,6 @@
   // top moments; the timeline heatmap + segment tints read the per-segment
   // scores. Generation mirrors summary/citations (poll until done; manual
   // run/cancel bypass the global flag).
-
-  var _frictionPoller = null;
 
   function _currentParticipant() {
     var pid = state.selectedParticipant;
@@ -737,7 +752,7 @@
     state.frictionData = null;
     state.frictionBySegId = {};
     state.frictionGenerating = false;
-    apiGet("api/friction/" + pid).then(function (data) {
+    apiGet(AGENT_DESCRIPTORS.friction.urlBase + "/" + pid).then(function (data) {
       if (ver !== state.participantReqVer) return;
       if (data.ok && data.friction) {
         _setFrictionData(data.friction);
@@ -892,45 +907,8 @@
     dot.classList.toggle("hidden", !(state.frictionData && state.frictionData.stale));
   }
 
-  function _startFrictionPoll(pid) {
-    _stopFrictionPoll();
-    var started = Date.now();
-    var ver = state.participantReqVer;
-    // runImmediately is false to match the previous setInterval (first poll after 3s).
-    _frictionPoller = createPoller(function () {
-      if (ver !== state.participantReqVer ||
-          state.selectedParticipant !== pid ||
-          Date.now() - started > _AGENT_POLL_TIMEOUT) {
-        _stopFrictionPoll();
-        state.frictionGenerating = false;
-        renderFriction();
-        return;
-      }
-      apiGet("api/friction/" + pid).then(function (data) {
-        if (ver !== state.participantReqVer) return;
-        if (data.ok && data.friction) {
-          _stopFrictionPoll();
-          _setFrictionData(data.friction);
-        } else if (!data.generating) {
-          _stopFrictionPoll();
-          state.frictionGenerating = false;
-          renderFrictionEmpty();
-        }
-      }).catch(function () {
-        if (ver !== state.participantReqVer) return;
-        _stopFrictionPoll();
-        state.frictionGenerating = false;
-        renderFrictionEmpty();
-      });
-    }, 3000, { runImmediately: false });
-    _frictionPoller.start();
-  }
-
   function _stopFrictionPoll() {
-    if (_frictionPoller) {
-      _frictionPoller.stop();
-      _frictionPoller = null;
-    }
+    _stopAgentPoll(AGENT_DESCRIPTORS.friction);
   }
 
   function _startFrictionRun() {
@@ -941,7 +919,7 @@
       state.frictionGenerating = true;
       state.frictionStartedAt = null;
       renderFrictionGenerating();
-      apiPost("api/friction/" + pid + "/regenerate", {}).then(function (data) {
+      apiPost(AGENT_DESCRIPTORS.friction.urlBase + "/" + pid + "/regenerate", {}).then(function (data) {
         if (data.ok && data.generating) {
           _startFrictionPoll(pid);
           _refreshAgentStateNow();
@@ -962,7 +940,7 @@
     if (!pid) return;
     _stopFrictionPoll();
     state.frictionGenerating = false;
-    apiPost("api/friction/" + pid + "/stop", {}).then(function () {
+    apiPost(AGENT_DESCRIPTORS.friction.urlBase + "/" + pid + "/stop", {}).then(function () {
       _refreshAgentStateNow();
       loadFriction(pid);
     }).catch(function () {});
@@ -1291,6 +1269,8 @@
   TS._hideFrictionTooltip = _hideFrictionTooltip;
   // True while a summary is being live-tracked by EITHER transport, so the hub's
   // grace-window re-arm doesn't restart the stream out from under itself.
-  TS.isSummaryPolling = function () { return !!(_summaryPoller || _summaryStream); };
+  TS.isSummaryPolling = function () {
+    return !!(AGENT_DESCRIPTORS.summary._poller || _summaryStream);
+  };
 })();
 

--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -425,7 +425,7 @@
       onStart: function () {
         ensureAgentModelInstalled("summary").then(function (ok) {
           if (!ok) return;
-          apiPost("api/summary/" + p.id + "/regenerate", {}).then(function () {
+          apiPost("api/agent/summary/" + p.id + "/regenerate", {}).then(function () {
             _refreshAgentStateNow();
           }).catch(function () {
             showToast("Failed to start summary");
@@ -433,7 +433,7 @@
         });
       },
       onStop: function () {
-        apiPost("api/summary/" + p.id + "/stop", {}).then(function () {
+        apiPost("api/agent/summary/" + p.id + "/stop", {}).then(function () {
           _refreshAgentStateNow();
         }).catch(function () {
           showToast("Failed to stop summary");
@@ -454,7 +454,7 @@
       onStart: function () {
         ensureAgentModelInstalled("citations").then(function (ok) {
           if (!ok) return;
-          apiPost("api/citations/" + p.id + "/regenerate", {}).then(function () {
+          apiPost("api/agent/citations/" + p.id + "/regenerate", {}).then(function () {
             _refreshAgentStateNow();
           }).catch(function () {
             showToast("Failed to start citations");
@@ -462,7 +462,7 @@
         });
       },
       onStop: function () {
-        apiPost("api/citations/" + p.id + "/stop", {}).then(function () {
+        apiPost("api/agent/citations/" + p.id + "/stop", {}).then(function () {
           _refreshAgentStateNow();
         }).catch(function () {
           showToast("Failed to stop citations");
@@ -483,7 +483,7 @@
       onStart: function () {
         ensureAgentModelInstalled("friction").then(function (ok) {
           if (!ok) return;
-          apiPost("api/friction/" + p.id + "/regenerate", {}).then(function () {
+          apiPost("api/agent/friction/" + p.id + "/regenerate", {}).then(function () {
             _refreshAgentStateNow();
             // loadFriction lives in the agents satellite (loads after this one).
             if (state.selectedParticipant === p.id && TS.loadFriction) TS.loadFriction(p.id);
@@ -493,7 +493,7 @@
         });
       },
       onStop: function () {
-        apiPost("api/friction/" + p.id + "/stop", {}).then(function () {
+        apiPost("api/agent/friction/" + p.id + "/stop", {}).then(function () {
           _refreshAgentStateNow();
           if (state.selectedParticipant === p.id && TS.loadFriction) TS.loadFriction(p.id);
         }).catch(function () {

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -399,14 +399,14 @@ def _agent_state_clean():
 
 
 def test_summary_stop_sets_cancel_event(tr_client, _agent_state_clean):
-    """POST /api/summary/<pid>/stop must set the registered event and remove
+    """POST /api/agent/summary/<pid>/stop must set the registered event and remove
     the participant from the in-flight set so the UI flips to idle."""
     pid = "P01"
     evt = threading.Event()
     transcripts_server._orchestrator._in_flight["summary"].add(pid)
     transcripts_server._orchestrator._cancel_events["summary"][pid] = evt
 
-    resp = tr_client.post(f"/transcripts/api/summary/{pid}/stop")
+    resp = tr_client.post(f"/transcripts/api/agent/summary/{pid}/stop")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -416,14 +416,14 @@ def test_summary_stop_sets_cancel_event(tr_client, _agent_state_clean):
 
 
 def test_citations_stop_sets_cancel_event(tr_client, _agent_state_clean):
-    """POST /api/citations/<pid>/stop must set the registered event and
+    """POST /api/agent/citations/<pid>/stop must set the registered event and
     remove the participant from the in-flight set."""
     pid = "P01"
     evt = threading.Event()
     transcripts_server._orchestrator._in_flight["citations"].add(pid)
     transcripts_server._orchestrator._cancel_events["citations"][pid] = evt
 
-    resp = tr_client.post(f"/transcripts/api/citations/{pid}/stop")
+    resp = tr_client.post(f"/transcripts/api/agent/citations/{pid}/stop")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -434,7 +434,7 @@ def test_citations_stop_sets_cancel_event(tr_client, _agent_state_clean):
 
 def test_summary_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
     """When nothing is in flight, /stop is a no-op returning running: False."""
-    resp = tr_client.post("/transcripts/api/summary/P01/stop")
+    resp = tr_client.post("/transcripts/api/agent/summary/P01/stop")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -444,7 +444,7 @@ def test_summary_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
 
 def test_citations_stop_when_not_running_is_noop(tr_client, _agent_state_clean):
     """When nothing is in flight, /stop is a no-op returning running: False."""
-    resp = tr_client.post("/transcripts/api/citations/P01/stop")
+    resp = tr_client.post("/transcripts/api/agent/citations/P01/stop")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -539,7 +539,7 @@ def test_summary_partial_streams_via_sink_and_clears(
     tr_client, _agent_state_clean, monkeypatch
 ):
     """The orchestrator feeds a per-run token sink into the agent; the streamed
-    text is exposed by partial_text() and the GET /api/summary poll while the
+    text is exposed by partial_text() and the GET /api/agent/summary poll while the
     run is in flight, then cleared once the run finishes."""
     orch = transcripts_server._orchestrator
     pid = "P01"
@@ -572,7 +572,7 @@ def test_summary_partial_streams_via_sink_and_clears(
         assert orch.partial_text(pid, "summary") == "Hello world"
 
         # The GET poll surfaces the same partial while generating.
-        resp = tr_client.get(f"/transcripts/api/summary/{pid}")
+        resp = tr_client.get(f"/transcripts/api/agent/summary/{pid}")
         data = resp.get_json()
         assert data["generating"] is True
         assert data["partial"] == "Hello world"
@@ -587,7 +587,7 @@ def test_summary_partial_streams_via_sink_and_clears(
 def test_summary_stream_emits_partial_then_done(
     tr_client, _agent_state_clean, monkeypatch
 ):
-    """GET /api/summary/<pid>/stream yields the accumulated partial text, then a
+    """GET /api/agent/summary/<pid>/stream yields the accumulated partial text, then a
     done event once the run is no longer generating."""
     # Grace window only applies to the not-yet-started race; zero it so a
     # not-generating stream with buffered text returns immediately.
@@ -599,7 +599,7 @@ def test_summary_stream_emits_partial_then_done(
     with orch._partial_lock:
         orch._partial["summary"][pid] = ["Hello", " world"]
 
-    resp = tr_client.get(f"/transcripts/api/summary/{pid}/stream")
+    resp = tr_client.get(f"/transcripts/api/agent/summary/{pid}/stream")
     assert resp.status_code == 200
     assert resp.mimetype == "text/event-stream"
     body = resp.get_data(as_text=True)
@@ -611,7 +611,7 @@ def test_summary_stream_done_when_idle(tr_client, _agent_state_clean, monkeypatc
     """A stream opened when nothing is generating (empty buffer) ends with done
     after the start grace, without emitting a partial."""
     monkeypatch.setattr(transcripts_server, "_SUMMARY_STREAM_START_GRACE", 0)
-    resp = tr_client.get("/transcripts/api/summary/P01/stream")
+    resp = tr_client.get("/transcripts/api/agent/summary/P01/stream")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert '"done": true' in body
@@ -645,7 +645,7 @@ def test_summary_stop_schedules_model_unload(
     transcripts_server._orchestrator._in_flight["summary"].add(pid)
     transcripts_server._orchestrator._cancel_events["summary"][pid] = evt
 
-    tr_client.post(f"/transcripts/api/summary/{pid}/stop")
+    tr_client.post(f"/transcripts/api/agent/summary/{pid}/stop")
 
     model = config.OLLAMA_SUMMARY_MODEL
     assert model in transcripts_server._pending_model_unloads
@@ -661,7 +661,7 @@ def test_citations_stop_schedules_model_unload(
     transcripts_server._orchestrator._in_flight["citations"].add(pid)
     transcripts_server._orchestrator._cancel_events["citations"][pid] = evt
 
-    tr_client.post(f"/transcripts/api/citations/{pid}/stop")
+    tr_client.post(f"/transcripts/api/agent/citations/{pid}/stop")
 
     model = config.OLLAMA_SUMMARY_MODEL
     assert model in transcripts_server._pending_model_unloads
@@ -870,7 +870,7 @@ def _join_orchestrator_threads(orch, timeout=2.0):
 
 def test_friction_get_404_when_absent_and_idle(tr_client, _agent_state_clean):
     _seed_friction_entry()
-    resp = tr_client.get("/transcripts/api/friction/P01")
+    resp = tr_client.get("/transcripts/api/agent/friction/P01")
     assert resp.status_code == 404
     assert resp.get_json()["ok"] is False
 
@@ -878,7 +878,7 @@ def test_friction_get_404_when_absent_and_idle(tr_client, _agent_state_clean):
 def test_friction_get_returns_cached(tr_client, _agent_state_clean):
     fr = {"segments": [], "moments": [], "stats": {}, "stale": False, "model": "m"}
     _seed_friction_entry(friction=fr)
-    resp = tr_client.get("/transcripts/api/friction/P01")
+    resp = tr_client.get("/transcripts/api/agent/friction/P01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -889,7 +889,7 @@ def test_friction_get_returns_cached(tr_client, _agent_state_clean):
 def test_friction_get_generating_when_in_flight(tr_client, _agent_state_clean):
     _seed_friction_entry()
     transcripts_server._orchestrator._in_flight["friction"].add("P01")
-    resp = tr_client.get("/transcripts/api/friction/P01")
+    resp = tr_client.get("/transcripts/api/agent/friction/P01")
     assert resp.status_code == 200
     assert resp.get_json()["generating"] is True
 
@@ -908,7 +908,7 @@ def test_summary_get_generating_includes_started_at(tr_client, _agent_state_clea
         "segments": [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "x"}],
     }
     _claim_slot("summary", "P01", 1000.0)
-    resp = tr_client.get("/transcripts/api/summary/P01")
+    resp = tr_client.get("/transcripts/api/agent/summary/P01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["generating"] is True
@@ -918,7 +918,7 @@ def test_summary_get_generating_includes_started_at(tr_client, _agent_state_clea
 def test_citations_get_generating_includes_started_at(tr_client, _agent_state_clean):
     _seed_friction_entry()  # summary present, no citations yet
     _claim_slot("citations", "P01", 2000.0)
-    resp = tr_client.get("/transcripts/api/citations/P01")
+    resp = tr_client.get("/transcripts/api/agent/citations/P01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["generating"] is True
@@ -930,7 +930,7 @@ def test_summary_get_includes_citations_started_at(tr_client, _agent_state_clean
     citations start rides on the summary response (the only call the UI makes)."""
     _seed_friction_entry()  # summary present, no citations yet
     _claim_slot("citations", "P01", 3000.0)
-    resp = tr_client.get("/transcripts/api/summary/P01")
+    resp = tr_client.get("/transcripts/api/agent/summary/P01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -941,7 +941,7 @@ def test_summary_get_includes_citations_started_at(tr_client, _agent_state_clean
 def test_friction_get_generating_includes_started_at(tr_client, _agent_state_clean):
     _seed_friction_entry()
     _claim_slot("friction", "P01", 4000.0)
-    resp = tr_client.get("/transcripts/api/friction/P01")
+    resp = tr_client.get("/transcripts/api/agent/friction/P01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["generating"] is True
@@ -952,7 +952,7 @@ def test_friction_regenerate_404_without_summary(tr_client, _agent_state_clean):
     transcripts_server._manifest["source_transcripts"]["P01"] = {
         "segments": [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "x"}],
     }
-    resp = tr_client.post("/transcripts/api/friction/P01/regenerate")
+    resp = tr_client.post("/transcripts/api/agent/friction/P01/regenerate")
     assert resp.status_code == 404
 
 
@@ -970,7 +970,7 @@ def test_friction_regenerate_triggers(tr_client, _agent_state_clean, monkeypatch
     assert fr_agent is not None
     monkeypatch.setitem(fr_agent, "run", stub_run)
 
-    resp = tr_client.post("/transcripts/api/friction/P01/regenerate")
+    resp = tr_client.post("/transcripts/api/agent/friction/P01/regenerate")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -985,7 +985,7 @@ def test_friction_regenerate_returns_generating_when_in_flight(
 ):
     _seed_friction_entry(friction={"stale": False})
     transcripts_server._orchestrator._in_flight["friction"].add("P01")
-    resp = tr_client.post("/transcripts/api/friction/P01/regenerate")
+    resp = tr_client.post("/transcripts/api/agent/friction/P01/regenerate")
     assert resp.status_code == 200
     assert resp.get_json()["generating"] is True
     # In-flight short-circuit must not clear the existing friction.
@@ -997,7 +997,7 @@ def test_friction_stop_sets_cancel_event(tr_client, _agent_state_clean):
     evt = threading.Event()
     transcripts_server._orchestrator._in_flight["friction"].add(pid)
     transcripts_server._orchestrator._cancel_events["friction"][pid] = evt
-    resp = tr_client.post(f"/transcripts/api/friction/{pid}/stop")
+    resp = tr_client.post(f"/transcripts/api/agent/friction/{pid}/stop")
     assert resp.status_code == 200
     assert resp.get_json()["running"] is False
     assert evt.is_set()
@@ -1012,10 +1012,30 @@ def test_friction_stop_schedules_model_unload(
     evt = threading.Event()
     transcripts_server._orchestrator._in_flight["friction"].add(pid)
     transcripts_server._orchestrator._cancel_events["friction"][pid] = evt
-    tr_client.post(f"/transcripts/api/friction/{pid}/stop")
+    tr_client.post(f"/transcripts/api/agent/friction/{pid}/stop")
     # Friction inherits the summary model (OLLAMA_FRICTION_MODEL is blank by
     # default), so the unload targets the resolved model.
     assert thinking_agents.friction_model() in transcripts_server._pending_model_unloads
+
+
+def test_agent_get_unknown_key_404(tr_client, _agent_state_clean):
+    """An unrecognized <agent_key> must return a JSON {ok: False} 404 (not Flask's
+    HTML no-match) so the frontend's data.ok/.catch paths behave."""
+    resp = tr_client.get("/transcripts/api/agent/bogus/P01")
+    assert resp.status_code == 404
+    assert resp.get_json()["ok"] is False
+
+
+def test_agent_regenerate_unknown_key_404(tr_client, _agent_state_clean):
+    resp = tr_client.post("/transcripts/api/agent/bogus/P01/regenerate")
+    assert resp.status_code == 404
+    assert resp.get_json()["ok"] is False
+
+
+def test_agent_stop_unknown_key_404(tr_client, _agent_state_clean):
+    resp = tr_client.post("/transcripts/api/agent/bogus/P01/stop")
+    assert resp.status_code == 404
+    assert resp.get_json()["ok"] is False
 
 
 def test_friction_not_eligible_when_disabled(
@@ -1076,7 +1096,7 @@ def test_summary_put_marks_friction_stale(tr_client, _agent_state_clean, monkeyp
         friction={"stale": False},
     )
     resp = tr_client.put(
-        "/transcripts/api/summary/P01", json={"summary": "an edited summary"}
+        "/transcripts/api/agent/summary/P01", json={"summary": "an edited summary"}
     )
     assert resp.status_code == 200
     entry = transcripts_server._manifest["source_transcripts"]["P01"]
@@ -1266,7 +1286,7 @@ def test_citations_regenerate_does_not_run_disabled_friction(
     monkeypatch.setitem(cit_agent, "run", cit_stub)
     monkeypatch.setitem(fr_agent, "run", fr_stub)
 
-    resp = tr_client.post("/transcripts/api/citations/P01/regenerate")
+    resp = tr_client.post("/transcripts/api/agent/citations/P01/regenerate")
     assert resp.status_code == 200
 
     _join_orchestrator_threads(transcripts_server._orchestrator)
@@ -1283,20 +1303,20 @@ def test_summary_regenerate_marks_friction_stale(
     summary feeds the friction prompt), mirroring the summary-edit path."""
     monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
     # Don't spawn real agent threads — we only assert the endpoint's synchronous
-    # manifest mutation.
+    # manifest mutation. The generic regenerate route triggers run_agent directly.
     monkeypatch.setattr(
-        transcripts_server._orchestrator, "run_chain", lambda *a, **k: None
+        transcripts_server._orchestrator, "run_agent", lambda *a, **k: None
     )
     _seed_friction_entry(
         citations=[{"sentence": "s", "refs": []}],
         friction={"stale": False, "moments": []},
     )
 
-    resp = tr_client.post("/transcripts/api/summary/P01/regenerate")
+    resp = tr_client.post("/transcripts/api/agent/summary/P01/regenerate")
     assert resp.status_code == 200
     entry = transcripts_server._manifest["source_transcripts"]["P01"]
     assert entry["friction"]["stale"] is True
-    assert entry["summary"] == ""
+    assert "summary" not in entry  # own field cleared (popped) before re-trigger
     assert "citations" not in entry  # citations invalidated alongside friction
 
 

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -60,6 +60,12 @@ class Agent(TypedDict):
                           can run. Also used to skip Pass 2 when Pass 1 failed.
       thread_name_prefix: Prefix for the daemon thread name (useful for
                           debugging).
+      on_upstream_change: How this agent's result reacts when an upstream
+                          dependency is regenerated: ``"clear"`` drops the
+                          field (the default), ``"stale"`` keeps it but flags
+                          it for a prompted re-run (only the friction shape
+                          carries a ``stale`` flag today). Read generically by
+                          the regenerate route's dependent-invalidation.
       run:                Callable invoked inside the daemon thread. Receives
                           the transcript entry (the ``source_transcripts[pid]``
                           dict), an optional ``threading.Event`` that, when
@@ -79,6 +85,7 @@ class Agent(TypedDict):
     manifest_field: str
     depends_on: list[str]
     thread_name_prefix: str
+    on_upstream_change: str
     run: Callable[..., Any]
 
 
@@ -610,6 +617,7 @@ AGENTS: list[Agent] = [
         manifest_field="summary",
         depends_on=[],
         thread_name_prefix="summary",
+        on_upstream_change="clear",
         run=_run_summary,
     ),
     Agent(
@@ -619,6 +627,7 @@ AGENTS: list[Agent] = [
         manifest_field="citations",
         depends_on=["summary"],
         thread_name_prefix="citations",
+        on_upstream_change="clear",
         run=_run_citations,
     ),
     Agent(
@@ -628,6 +637,7 @@ AGENTS: list[Agent] = [
         manifest_field="friction",
         depends_on=["summary"],
         thread_name_prefix="friction",
+        on_upstream_change="stale",
         run=_run_friction,
     ),
 ]

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -14,13 +14,11 @@ API endpoints (all under /transcripts/):
   GET  /api/vtt/<participant>                     - serve transcript as WebVTT
   POST /api/embed-subtitle/<participant>          - mux participant transcript into a copy of their video
   POST /api/embed-all-subtitles                   - mux every participant's transcript into a subtitled copy of their video
-  GET  /api/summary/<participant>                - AI-generated transcript summary
-  POST /api/summary/<participant>/regenerate    - re-trigger AI summary generation
-  POST /api/summary/<participant>/stop          - flag in-flight summary for discard
-  PUT  /api/summary/<participant>               - save user-edited summary
-  GET  /api/citations/<participant>             - citation refs for summary sentences
-  POST /api/citations/<participant>/regenerate  - re-trigger citation generation
-  POST /api/citations/<participant>/stop        - flag in-flight citations for discard
+  GET  /api/agent/<key>/<participant>            - a thinking agent's result (summary/citations/friction), status, or 404
+  POST /api/agent/<key>/<participant>/regenerate - clear + re-trigger an agent (forces past its enabled config)
+  POST /api/agent/<key>/<participant>/stop       - flag an in-flight agent run for discard
+  GET  /api/agent/summary/<participant>/stream   - SSE token stream of the summary as it generates (summary-only)
+  PUT  /api/agent/summary/<participant>          - save a user-edited summary (summary-only)
   GET  /api/corrections                           - list all study-local corrections
   POST /api/corrections                           - add a correction manually
   DELETE /api/corrections/<id>                    - remove a correction
@@ -174,6 +172,23 @@ def _mark_friction_stale(entry: dict[str, Any]) -> None:
     fr = entry.get("friction")
     if isinstance(fr, dict):
         fr["stale"] = True
+
+
+def _invalidate_dependents(entry: dict[str, Any], agent: thinking_agents.Agent) -> None:
+    """Invalidate every agent whose result depends on *agent*'s field.
+
+    Driven off ``depends_on`` + each dependent's ``on_upstream_change`` so this
+    stays generic: ``"stale"`` keeps the result but flags it for a prompted
+    re-run (friction), ``"clear"`` drops it (citations). Callers must hold
+    ``_manifest_lock``.
+    """
+    for dep in thinking_agents.AGENTS:
+        if agent["manifest_field"] not in dep["depends_on"]:
+            continue
+        if dep.get("on_upstream_change") == "stale":
+            _mark_friction_stale(entry)  # only the friction shape has a stale flag
+        else:
+            entry.pop(dep["manifest_field"], None)
 
 
 def _transcribe_prewarm_setting() -> str:
@@ -597,36 +612,108 @@ def api_embed_all_subtitles() -> FlaskResponse:
     )
 
 
-# ---- AI Summary ----
+# ---- AI thinking agents (summary / citations / friction) ----
+#
+# Three generic routes cover every agent in thinking_agents.AGENTS, keyed by
+# <agent_key>, so appending an Agent needs no new endpoints here. Summary keeps
+# two extra routes below that are genuinely unique to it (the SSE token stream
+# and the user-edit PUT).
 
 
-@transcripts_bp.route("/api/summary/<participant>")
-def api_summary(participant: str) -> FlaskResponse:
-    """Return AI-generated summary, generation status, or 404."""
+@transcripts_bp.route("/api/agent/<agent_key>/<participant>")
+def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
+    """Return an agent's result, its generation status, or 404.
+
+    Success carries the result under the agent's ``manifest_field`` key, so the
+    summary/citations/friction responses keep their historic shape. For every
+    agent that depends on this one, a ``<dep_field>_generating`` flag (and
+    ``<dep_field>_started_at`` when true) is added generically — that is how the
+    summary poll still surfaces citation-generation status to the UI without
+    special-casing it.
+    """
+    agent = thinking_agents.get_agent(agent_key)
+    if agent is None:
+        return jsonify({"ok": False}), 404
+    field = agent["manifest_field"]
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry or not entry.get("summary"):
-            if _orchestrator.is_generating(participant, "summary"):
-                return jsonify(
-                    {
-                        "ok": False,
-                        "generating": True,
-                        "started_at": _orchestrator.started_at(participant, "summary"),
-                        "partial": _orchestrator.partial_text(participant, "summary"),
-                    }
-                )
-            return jsonify({"ok": False}), 404
-        summary = entry["summary"]
-        citations = entry.get("citations")
-    resp: dict[str, Any] = {"ok": True, "summary": summary}
-    if citations:
-        resp["citations"] = citations
-    resp["citations_generating"] = _orchestrator.is_generating(participant, "citations")
-    if resp["citations_generating"]:
-        resp["citations_started_at"] = _orchestrator.started_at(
-            participant, "citations"
+        result = entry.get(field) if entry else None
+    if result:
+        resp: dict[str, Any] = {"ok": True, field: result}
+        for dep in thinking_agents.AGENTS:
+            if field in dep["depends_on"]:
+                dep_field = dep["manifest_field"]
+                generating = _orchestrator.is_generating(participant, dep["key"])
+                resp[f"{dep_field}_generating"] = generating
+                if generating:
+                    resp[f"{dep_field}_started_at"] = _orchestrator.started_at(
+                        participant, dep["key"]
+                    )
+        return jsonify(resp)
+    if _orchestrator.is_generating(participant, agent_key):
+        return jsonify(
+            {
+                "ok": False,
+                "generating": True,
+                "started_at": _orchestrator.started_at(participant, agent_key),
+                "partial": _orchestrator.partial_text(participant, agent_key),
+            }
         )
-    return jsonify(resp)
+    return jsonify({"ok": False}), 404
+
+
+@transcripts_bp.route(
+    "/api/agent/<agent_key>/<participant>/regenerate", methods=["POST"]
+)
+def api_agent_regenerate(agent_key: str, participant: str) -> FlaskResponse:
+    """Clear an agent's result and re-trigger it (bypassing its enabled config).
+
+    Manual trigger: runs even when the agent's enabled config is False so the
+    frontend's per-participant controls can force a run. Requires a transcript
+    and every dependency's result. Regenerating an agent also invalidates its
+    dependents (``_invalidate_dependents``): e.g. regenerating summary clears
+    citations and flags friction stale. ``run_agent`` auto-advances the chain
+    on completion, so downstream enabled agents still run.
+    """
+    agent = thinking_agents.get_agent(agent_key)
+    if agent is None:
+        return jsonify({"ok": False}), 404
+    if _orchestrator.is_generating(participant, agent_key):
+        return ok(generating=True)
+    with _manifest_lock:
+        entry = _manifest.get("source_transcripts", {}).get(participant)
+        if (
+            not entry
+            or not entry.get("segments")
+            or not _agent_dependencies_met(agent, entry)
+        ):
+            return err("No transcript or unmet dependency", 404)
+        entry.pop(agent["manifest_field"], None)
+        _invalidate_dependents(entry, agent)
+    _persist_manifest()
+    _orchestrator.run_agent(agent_key, participant, force=True)
+    return ok(generating=True)
+
+
+@transcripts_bp.route("/api/agent/<agent_key>/<participant>/stop", methods=["POST"])
+def api_agent_stop(agent_key: str, participant: str) -> FlaskResponse:
+    """Abort an in-flight agent run.
+
+    Sets the cancel event so the streaming Ollama call closes its response
+    promptly, freeing the model for another run. The UI flips to idle
+    immediately. After a short delay, the model is unloaded from memory if no
+    new run has started in the meantime.
+    """
+    if thinking_agents.get_agent(agent_key) is None:
+        return jsonify({"ok": False}), 404
+    if _orchestrator.stop(agent_key, participant):
+        model = _agent_model(agent_key)
+        if model:
+            _schedule_model_unload(model)
+    return ok(running=False)
+
+
+# ---- Summary-only routes (SSE token stream + user edit) ----
 
 
 # Server-side cadence for the summary token stream. The agent runs in the
@@ -638,7 +725,7 @@ _SUMMARY_STREAM_TICK = 0.1  # seconds between buffer samples
 _SUMMARY_STREAM_START_GRACE = 2.0  # seconds to wait for the run to claim its slot
 
 
-@transcripts_bp.route("/api/summary/<participant>/stream")
+@transcripts_bp.route("/api/agent/summary/<participant>/stream")
 def api_summary_stream(participant: str) -> FlaskResponse:
     """Stream summary tokens to the browser via SSE as the model produces them.
 
@@ -676,44 +763,7 @@ def api_summary_stream(participant: str) -> FlaskResponse:
     )
 
 
-@transcripts_bp.route("/api/summary/<participant>/regenerate", methods=["POST"])
-def api_summary_regenerate(participant: str) -> FlaskResponse:
-    """Clear existing summary and re-trigger AI generation.
-
-    Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False
-    so the frontend's per-participant controls can force a run.
-    """
-    if _orchestrator.is_generating(participant, "summary"):
-        return ok(generating=True)
-    with _manifest_lock:
-        entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry or not entry.get("segments"):
-            return err("No transcript found", 404)
-        entry["summary"] = ""
-        entry.pop("citations", None)
-        _mark_friction_stale(entry)  # the new summary feeds the friction prompt
-    _persist_manifest()
-    _orchestrator.run_chain(participant, force=True)
-    return ok(generating=True)
-
-
-@transcripts_bp.route("/api/summary/<participant>/stop", methods=["POST"])
-def api_summary_stop(participant: str) -> FlaskResponse:
-    """Abort an in-flight summary run.
-
-    Sets the cancel event so the streaming Ollama call closes its response
-    promptly, freeing the model for another run. The UI flips to idle
-    immediately. After a short delay, the model is unloaded from memory if
-    no new run has started in the meantime.
-    """
-    if _orchestrator.stop("summary", participant):
-        model = _agent_model("summary")
-        if model:
-            _schedule_model_unload(model)
-    return ok(running=False)
-
-
-@transcripts_bp.route("/api/summary/<participant>", methods=["PUT"])
+@transcripts_bp.route("/api/agent/summary/<participant>", methods=["PUT"])
 def api_summary_save(participant: str) -> FlaskResponse:
     """Save a user-edited summary for a participant."""
     data = request.get_json(silent=True)
@@ -728,127 +778,6 @@ def api_summary_save(participant: str) -> FlaskResponse:
         _mark_friction_stale(entry)  # summary text feeds the friction prompt
     _schedule_persist()
     return ok()
-
-
-# ---- Citations ----
-
-
-@transcripts_bp.route("/api/citations/<participant>")
-def api_citations(participant: str) -> FlaskResponse:
-    """Return citation refs for a participant's summary, or generation status."""
-    with _manifest_lock:
-        entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry:
-            return jsonify({"ok": False}), 404
-        citations = entry.get("citations")
-    if citations:
-        return ok(citations=citations)
-    if _orchestrator.is_generating(participant, "citations"):
-        return jsonify(
-            {
-                "ok": False,
-                "generating": True,
-                "started_at": _orchestrator.started_at(participant, "citations"),
-            }
-        )
-    return jsonify({"ok": False}), 404
-
-
-@transcripts_bp.route("/api/citations/<participant>/regenerate", methods=["POST"])
-def api_citations_regenerate(participant: str) -> FlaskResponse:
-    """Clear existing citations and re-trigger citation generation (Pass 2).
-
-    Manual trigger: runs even when config.OLLAMA_SUMMARY_ENABLED is False.
-    """
-    if _orchestrator.is_generating(participant, "citations"):
-        return ok(generating=True)
-    with _manifest_lock:
-        entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry or not entry.get("summary") or not entry.get("segments"):
-            return err("No summary or transcript found", 404)
-        entry.pop("citations", None)
-    _persist_manifest()
-    _orchestrator.run_agent("citations", participant, force=True)
-    return ok(generating=True)
-
-
-@transcripts_bp.route("/api/citations/<participant>/stop", methods=["POST"])
-def api_citations_stop(participant: str) -> FlaskResponse:
-    """Abort an in-flight citations run.
-
-    Sets the cancel event so the streaming Ollama call closes its response
-    promptly, freeing the model for another run. The UI flips to idle
-    immediately. After a short delay, the model is unloaded from memory if
-    no new run has started in the meantime.
-    """
-    if _orchestrator.stop("citations", participant):
-        model = _agent_model("citations")
-        if model:
-            _schedule_model_unload(model)
-    return ok(running=False)
-
-
-# ---- Friction ----
-
-
-@transcripts_bp.route("/api/friction/<participant>")
-def api_friction(participant: str) -> FlaskResponse:
-    """Return friction analysis for a participant, or generation status.
-
-    The returned object carries its own ``stale`` flag (set after segment/summary
-    edits) so the UI can prompt for a re-run without a separate request.
-    """
-    with _manifest_lock:
-        entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry:
-            return jsonify({"ok": False}), 404
-        friction_data = entry.get("friction")
-    if friction_data:
-        return ok(friction=friction_data)
-    if _orchestrator.is_generating(participant, "friction"):
-        return jsonify(
-            {
-                "ok": False,
-                "generating": True,
-                "started_at": _orchestrator.started_at(participant, "friction"),
-            }
-        )
-    return jsonify({"ok": False}), 404
-
-
-@transcripts_bp.route("/api/friction/<participant>/regenerate", methods=["POST"])
-def api_friction_regenerate(participant: str) -> FlaskResponse:
-    """Clear friction and re-trigger analysis (Pass 3).
-
-    Manual trigger: runs even when config.OLLAMA_FRICTION_ENABLED is False so the
-    frontend's per-participant controls can force a run. Requires a summary.
-    """
-    if _orchestrator.is_generating(participant, "friction"):
-        return ok(generating=True)
-    with _manifest_lock:
-        entry = _manifest.get("source_transcripts", {}).get(participant)
-        if not entry or not entry.get("summary") or not entry.get("segments"):
-            return err("No summary or transcript found", 404)
-        entry.pop("friction", None)
-    _persist_manifest()
-    _orchestrator.run_agent("friction", participant, force=True)
-    return ok(generating=True)
-
-
-@transcripts_bp.route("/api/friction/<participant>/stop", methods=["POST"])
-def api_friction_stop(participant: str) -> FlaskResponse:
-    """Abort an in-flight friction run.
-
-    Sets the cancel event so the streaming Ollama call closes its response
-    promptly, freeing the model for another run. The UI flips to idle
-    immediately. After a short delay, the model is unloaded from memory if no new
-    run has started in the meantime.
-    """
-    if _orchestrator.stop("friction", participant):
-        model = _agent_model("friction")
-        if model:
-            _schedule_model_unload(model)
-    return ok(running=False)
 
 
 # ---- Corrections ----


### PR DESCRIPTION
## Summary

Thinking-agent plumbing (summary/citations/friction) was cloned per agent on both server and client, contradicting the "append an `Agent`, no orchestrator edits" contract — this collapses it so the registry claim holds.

- **Backend** (`transcripts_server.py`): nine per-agent handlers → three generic `/api/agent/<key>/<participant>{,/regenerate,/stop}` keyed off `AGENTS`; summary keeps its unique SSE `/stream` + edit `PUT` (re-pathed). Regenerate invalidates dependents generically via a new `on_upstream_change` field (`clear` vs `stale`).
- **Frontend** (`transcripts-agents.js`): one `_makeAgentPoll` factory + `AGENT_DESCRIPTORS` drive all three pollers, every URL flowing through `desc.urlBase`; same-named `_stop*Poll`/`load*` kept for the hub delegators; `transcripts-pills.js` routed to `api/agent/`.
- Tests migrated to the new URLs (+ unknown-agent 404 coverage); `new-thinking-agent` SKILL updated to note new agents need no route edits.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` — clean
- [x] Full suite: **1841 passed** (incl. `test_frontend_satellite_wiring`)
- [x] `node --check` on both touched JS files
- [x] Confirmed via `url_map` that the static `summary` PUT/stream win over the dynamic `<agent_key>` GET
- [ ] ⚠️ Not browser-checked — summary SSE/citation chain, friction run/stop, pills run/stop, and participant-switch mid-generation need a manual UI pass