### PR TITLE
refactor(transcripts): move <think>-stripping out of ollama transport into thinking_agents

### DIFF
--- a/ollama_client.py
+++ b/ollama_client.py
@@ -20,7 +20,6 @@ Key functions:
 """
 
 import json
-import re
 import shutil
 import socket
 import subprocess
@@ -48,7 +47,6 @@ _START_TIMEOUT = 10  # seconds to wait for server to become available after star
 # starts; this bounds a stalled connection without aborting a healthy pull.
 _PULL_TIMEOUT = 300  # seconds
 _CANCEL_WATCHER_POLL = 1.0  # seconds; bounds abort latency during long quiet stretches
-_THINK_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
 
 # Serializes _start_server() calls so two threads hitting connection-refused at
 # the same time don't both spawn `ollama serve`.
@@ -356,9 +354,7 @@ def _do_generate(
 
     if cancel_event is not None and cancel_event.is_set():
         return None
-    text = "".join(parts)
-    # Strip <think>...</think> blocks produced by reasoning models (e.g. qwen3.5)
-    text = _THINK_RE.sub("", text).strip()
+    text = "".join(parts).strip()
     if not text:
         utils.warning_print(
             f"Ollama returned empty response (model: {body.get('model')})"

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -152,26 +152,17 @@ class TestGenerate:
         assert result == "Hello world"
 
     @patch("ollama_client.urllib.request.urlopen")
-    def test_strips_think_tags_from_concatenated_response(self, mock_urlopen):
+    def test_returns_think_tags_verbatim(self, mock_urlopen):
+        # Transport is pure: <think> stripping is a response-parsing concern that
+        # lives in thinking_agents, so generate() must pass reasoning blocks through
+        # untouched (only trims surrounding whitespace).
         lines = _ndjson_lines(
             {"response": "<think>Let me think...</think>", "done": False},
             {"response": "\n\nHere is the summary.", "done": True},
         )
         mock_urlopen.return_value = _make_streaming_resp(lines)
         result = ollama_client.generate("test prompt")
-        assert result == "Here is the summary."
-
-    @patch("ollama_client.urllib.request.urlopen")
-    def test_returns_none_when_only_think_tags(self, mock_urlopen):
-        lines = _ndjson_lines(
-            {
-                "response": "<think>Thinking but producing nothing.</think>",
-                "done": True,
-            },
-        )
-        mock_urlopen.return_value = _make_streaming_resp(lines)
-        result = ollama_client.generate("test prompt")
-        assert result is None
+        assert result == "<think>Let me think...</think>\n\nHere is the summary."
 
     @patch("ollama_client.urllib.request.urlopen")
     def test_returns_none_on_empty_stream(self, mock_urlopen):

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -140,6 +140,29 @@ class TestSummarizeTranscript:
         assert result is None
 
     @patch("thinking_agents.ollama_client.generate")
+    def test_strips_think_block_from_result(self, mock_generate):
+        # Transport now returns raw text; the summary agent owns <think> stripping.
+        mock_generate.return_value = "<think>reasoning</think>\n\nActual summary."
+        segments = [
+            {
+                "text": "A sufficiently long segment of text for the minimum length check."
+            },
+        ]
+        result = thinking_agents.summarize_transcript(segments)
+        assert result == "Actual summary."
+
+    @patch("thinking_agents.ollama_client.generate")
+    def test_returns_none_when_only_think_block(self, mock_generate):
+        mock_generate.return_value = "<think>Thinking but producing nothing.</think>"
+        segments = [
+            {
+                "text": "A sufficiently long segment of text for the minimum length check."
+            },
+        ]
+        result = thinking_agents.summarize_transcript(segments)
+        assert result is None
+
+    @patch("thinking_agents.ollama_client.generate")
     def test_passes_model_override(self, mock_generate):
         mock_generate.return_value = "ok"
         segments = [

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -90,6 +90,23 @@ class Agent(TypedDict):
 
 
 # ---------------------------------------------------------------------------
+# Shared response helpers
+# ---------------------------------------------------------------------------
+
+_THINK_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
+
+
+def _strip_think(text: str) -> str:
+    """Remove <think>...</think> reasoning blocks a model may emit despite think=False.
+
+    Reasoning models sometimes emit chain-of-thought scaffolding even when asked
+    not to; stripping it is response parsing, so every agent cleans its own raw
+    completion here rather than relying on the transport layer.
+    """
+    return _THINK_RE.sub("", text).strip()
+
+
+# ---------------------------------------------------------------------------
 # Summary agent (Pass 1)
 # ---------------------------------------------------------------------------
 
@@ -147,7 +164,10 @@ def summarize_transcript(
         on_token=on_token,
     )
     if result:
-        utils.verbose_print(f"Summary generated ({len(result)} chars)")
+        result = _strip_think(result)
+    if not result:
+        return None
+    utils.verbose_print(f"Summary generated ({len(result)} chars)")
     return result
 
 
@@ -329,7 +349,7 @@ def find_citations(
 
     parsed: dict[int, list[dict[str, Any]]] = {}
     if response:
-        parsed = _parse_citation_response(response, segments)
+        parsed = _parse_citation_response(_strip_think(response), segments)
 
     citations: list[dict[str, Any]] = []
     for i, sentence in enumerate(sentences):
@@ -373,7 +393,7 @@ def _extract_json_array(text: str) -> list[Any]:
     """
     if not text:
         return []
-    cleaned = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    cleaned = _strip_think(text)
 
     fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", cleaned, re.DOTALL)
     if fence:


### PR DESCRIPTION
## Summary

`ollama_client` is documented as pure transport, yet `_do_generate()` was stripping `<think>…</think>` reasoning blocks — a response-parsing concern `thinking_agents` already duplicated in `_extract_json_array()`. This gives `thinking_agents` sole ownership via a shared `_strip_think()` helper (applied in the summary, citations, and friction paths), so `ollama_client.generate()` now returns raw model text verbatim. The summary agent strips and returns `None` on think-only responses, preserving prior behavior; the now-unused `import re` was dropped from `ollama_client.py`.

## Test plan

- [x] `ruff format --check`, `ruff check`, `ty check` — all clean
- [x] Full suite green; repointed the two transport think-tests at verbatim passthrough and added summary-level strip coverage in `test_thinking_agents.py`