### PR TITLE
refactor: dedupe timestamp parsing and comma/plus selector splitting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -738,8 +738,9 @@ def parse_cli_mode_args(args: Any) -> CliModeArgs:
     if args.lines:
         try:
             # Support both + and , as separators
-            line_str = args.lines.replace(",", "+")
-            cli_line_numbers = [int(num.strip()) for num in line_str.split("+")]
+            cli_line_numbers = [
+                int(num) for num in utils.split_selector_tokens(args.lines)
+            ]
         except ValueError:
             utils.error_print(
                 f'Invalid line numbers "{args.lines}". Use format: 1+4+5 or 1,4,5'
@@ -991,13 +992,9 @@ def _generate_cli_clips(
         """Parse CLI category string into a list of category names."""
         if not raw:
             return []
-        combined = raw.replace(",", "+")
         seen = set()
         result: list[str] = []
-        for token in combined.split("+"):
-            name = token.strip()
-            if not name:
-                continue
+        for name in utils.split_selector_tokens(raw):
             if name not in seen:
                 seen.add(name)
                 result.append(name)
@@ -1008,11 +1005,10 @@ def _generate_cli_clips(
     def _parse_cli_severities(raw: str | None) -> list[str]:
         if not raw:
             return []
-        combined = raw.replace(",", "+")
         seen = set()
         result: list[str] = []
-        for token in combined.split("+"):
-            name = utils.normalize_severity(token.strip())
+        for token in utils.split_selector_tokens(raw):
+            name = utils.normalize_severity(token)
             if not name:
                 continue
             if name not in seen:
@@ -1024,9 +1020,8 @@ def _generate_cli_clips(
 
     cli_annotation_ids = None
     if isinstance(args.keyword, str):
-        combined = args.keyword.replace(",", "+")
         cli_annotation_ids = [
-            t.strip().lower().lstrip("!") for t in combined.split("+") if t.strip()
+            t.lower().lstrip("!") for t in utils.split_selector_tokens(args.keyword)
         ] or None
 
     # Apply custom highlights duration if specified (e.g. -H 120)

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -294,11 +294,8 @@ def parse_participant_selection(input_str: str) -> list[str]:
     Returns:
         List of participant ID strings (e.g. ['P01', 'P03'])
     """
-    if not input_str or not input_str.strip():
-        return []
     # Support both + and , as separators
-    combined = input_str.replace(",", "+")
-    return [s.strip() for s in combined.split("+") if s.strip()]
+    return utils.split_selector_tokens(input_str)
 
 
 def parse_cell_specifications(cell_input: str) -> list[tuple[str, int]]:
@@ -318,14 +315,9 @@ def parse_cell_specifications(cell_input: str) -> list[tuple[str, int]]:
         ValueError: If format is invalid
     """
     # Support both + and , as separators; normalize to + then split
-    cell_str = cell_input.replace(",", "+")
     specs = []
 
-    for spec in cell_str.split("+"):
-        spec = spec.strip()
-        if not spec:
-            continue
-
+    for spec in utils.split_selector_tokens(cell_input):
         # Exactly one dot: participant_id.row_number (split('.', 1) avoids splitting IDs like P01.02)
         if "." not in spec:
             raise ValueError(

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -309,6 +309,13 @@ class TestParseCitationResponse:
         result = thinking_agents._parse_citation_response(response, segments)
         assert result == {}
 
+    def test_rejects_timestamps_with_seconds_over_59(self):
+        # Timestamps route through the strict utils.timestamp_to_seconds, so a
+        # malformed seconds field (>= 60) is dropped rather than parsed as 75s.
+        segments = self._make_segments([75])
+        result = thinking_agents._parse_citation_response("1: 0:75", segments)
+        assert result == {}
+
     def test_handles_unsorted_segments(self):
         # Segments supplied out of start order; the binary search must still
         # resolve to the correct *original* segment index.

--- a/tests/test_utils_timestamps.py
+++ b/tests/test_utils_timestamps.py
@@ -52,6 +52,17 @@ def test_timestamp_to_seconds_allows_minutes_over_59_in_mmss():
     assert utils.timestamp_to_seconds("1:2:3:4") is None
 
 
+def test_split_selector_tokens_splits_on_comma_and_plus():
+    # Shared helper for CLI/spreadsheet selectors: split on ',' or '+',
+    # strip whitespace, drop empty tokens.
+    assert utils.split_selector_tokens("P01,P02") == ["P01", "P02"]
+    assert utils.split_selector_tokens("P01+P02") == ["P01", "P02"]
+    assert utils.split_selector_tokens("P01 + P02, P03") == ["P01", "P02", "P03"]
+    assert utils.split_selector_tokens("1++2") == ["1", "2"]
+    assert utils.split_selector_tokens("  ,+ ") == []
+    assert utils.split_selector_tokens("") == []
+
+
 def test_seconds_to_timestamp_handles_float_input():
     # Shared helper: a float arg must not crash the int format specs.
     assert utils.seconds_to_timestamp(75.9) == "1:15"

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -201,19 +201,6 @@ def _format_segment_chunk(segments: list[dict[str, Any]], offset: int) -> str:
     return "\n".join(lines)
 
 
-def _timestamp_to_seconds(ts: str) -> float | None:
-    """Parse ``M:SS`` or ``H:MM:SS`` to seconds."""
-    parts = ts.split(":")
-    try:
-        if len(parts) == 2:
-            return int(parts[0]) * 60 + int(parts[1])
-        if len(parts) == 3:
-            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
-    except ValueError:
-        pass
-    return None
-
-
 def _find_closest_segment(
     target_seconds: float,
     sorted_starts: list[float],
@@ -265,7 +252,7 @@ def _parse_citation_response(
             continue
         refs: list[dict[str, Any]] = []
         for ts_match in _TIMESTAMP_RE.finditer(body):
-            ts_seconds = _timestamp_to_seconds(ts_match.group(1))
+            ts_seconds = utils.timestamp_to_seconds(ts_match.group(1))
             if ts_seconds is None:
                 continue
             best_idx = _find_closest_segment(ts_seconds, sorted_starts, sorted_indices)

--- a/transcripts.py
+++ b/transcripts.py
@@ -760,12 +760,7 @@ def _vtt_time_to_seconds(ts: str) -> float:
 
 
 def _md_time_to_seconds(ts: str) -> float:
-    parts = ts.strip().split(":")
-    if len(parts) == 2:
-        return int(parts[0]) * 60 + int(parts[1])
-    if len(parts) == 3:
-        return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
-    return 0.0
+    return utils.timestamp_to_seconds(ts) or 0.0
 
 
 def _parse_srt(text: str, filepath: str) -> TranscriptResult:

--- a/utils.py
+++ b/utils.py
@@ -1147,6 +1147,17 @@ def _split_timestamp_tokens(cell_value: str) -> list[str]:
     )
 
 
+def split_selector_tokens(text: str) -> list[str]:
+    """Split a selector string on ',' or '+' into stripped, non-empty tokens.
+
+    Used by the CLI category/severity/keyword/line selectors and the spreadsheet
+    participant/cell selectors, which all accept comma- or plus-separated lists.
+    """
+    if not text:
+        return []
+    return [tok.strip() for tok in text.replace(",", "+").split("+") if tok.strip()]
+
+
 def _clean_timestamp_token(token: str) -> str:
     """Normalize one token before timestamp parsing."""
     return token.strip().rstrip(",").rstrip("-").replace(".", ":")


### PR DESCRIPTION
## Summary

Collapse two families of copy-pasted parsing logic onto their canonical implementations.

- **Timestamps:** delete the two hand-rolled `M:SS`/`H:MM:SS` parsers (`thinking_agents._timestamp_to_seconds`, `transcripts._md_time_to_seconds`) that duplicated `utils.timestamp_to_seconds` with laxer rules, and route both through the strict canonical parser — so malformed LLM citation timestamps (`seconds >= 60`) now drop instead of parsing. The millisecond-aware SRT/VTT readers are intentionally left alone.
- **Selectors:** extract `utils.split_selector_tokens` and replace six identical comma/plus splits across `cli.py` (line/category/severity/keyword) and `spreadsheet.py` (participant/cell); each call site keeps its own downstream int-cast, dedupe, and normalize.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 1851 passed (added `split_selector_tokens` unit test + a citation `seconds >= 60` rejection test)
- [x] `ruff format` + `ruff check` + `ty check` all green