### PR TITLE
refactor(web): consolidate CSS chrome heights, theme toggle, spinners, dark-mode, modal z-index

### DIFF
--- a/assets/web/metadata.css
+++ b/assets/web/metadata.css
@@ -5,7 +5,7 @@
   /* Inner blocks set their own var(--space-3) lateral padding to match
    * Convergence / Intake; no horizontal panel-level inset. The 92px top
    * inset comes from floating-nav scroll-under (TopNav + subheader fixed). */
-  padding: 92px 0 0;
+  padding: var(--chrome-height) 0 0;
 }
 
 /* ---- Header bar ---- */

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -152,38 +152,6 @@ body {
   color: var(--color-text-dim);
 }
 
-/* Theme toggle (matches Studio) */
-
-#themeToggle {
-  position: relative;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
-  flex-shrink: 0;
-}
-
-#themeToggle:hover {
-  background: var(--color-surface);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
-}
-
-#themeToggle:active {
-  transform: scale(0.96);
-}
-
-#themeToggle:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
 /* Main content */
 
 #ssMain {
@@ -192,7 +160,7 @@ body {
   /* Floating-nav scroll-under: TopNav (48px) + subheader (44px) are
    * `position: fixed`. The 92px top inset pushes visible content below
    * chrome; scrolled content slides up *under* the glass. */
-  padding: calc(var(--space-4) + 92px) var(--space-5) var(--space-4);
+  padding: calc(var(--space-4) + var(--chrome-height)) var(--space-5) var(--space-4);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -233,7 +201,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  max-height: calc(100vh - var(--bottom-panel-height) - 92px - var(--space-4) * 2);
+  max-height: calc(100vh - var(--bottom-panel-height) - var(--chrome-height) - var(--space-4) * 2);
   overflow-y: auto;
   /* Left padding makes room for foldable section chevrons that pull
    * themselves outside the info-block content edge via negative margin
@@ -314,7 +282,7 @@ body {
 .ss-info-expand-btn {
   position: fixed;
   left: var(--space-3);
-  top: calc(92px + var(--space-4));
+  top: calc(var(--chrome-height) + var(--space-4));
   z-index: var(--z-float);
 }
 
@@ -3232,10 +3200,6 @@ body.panel-dragging #bottomPanel {
   cursor: grabbing;
 }
 
-@keyframes task-card-spin {
-  to { transform: rotate(360deg); }
-}
-
 .task-card-spinner {
   display: inline-flex;
   align-items: center;
@@ -3253,7 +3217,7 @@ body.panel-dragging #bottomPanel {
   border: 1.5px solid var(--color-border);
   border-top-color: var(--color-accent);
   border-radius: var(--radius-full);
-  animation: task-card-spin 0.7s linear infinite;
+  animation: spin 0.7s linear infinite;
 }
 
 .task-card-pause-icon {
@@ -3793,7 +3757,7 @@ body.panel-dragging #bottomPanel {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: var(--z-dropdown);
+  z-index: var(--z-modal);
 }
 
 .modal-card {
@@ -3959,33 +3923,20 @@ body.panel-dragging #bottomPanel {
   font-size: var(--text-xs);
 }
 
-/* Dark mode — system preference */
-
-/* Dark element overrides — shared dark tokens are in tokens.css */
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .modal-card {
-    background: var(--color-surface-alt);
-  }
-  :root:not([data-theme="light"]) .region-chip.active {
-    background: rgba(255, 255, 255, 0.08);
-  }
-}
-
-html[data-theme="dark"] .modal-card {
+/* Dark mode — page-specific overrides (shared tokens live in tokens.css). Dark
+ * is the default theme, so this single selector matches everything except an
+ * explicit light opt-in. */
+:root:not([data-theme="light"]) .modal-card {
   background: var(--color-surface-alt);
 }
-
-html[data-theme="dark"] .region-chip.active {
+:root:not([data-theme="light"]) .region-chip.active {
   background: rgba(255, 255, 255, 0.08);
 }
-
-html[data-theme="dark"] .run-picker-panel {
+:root:not([data-theme="light"]) .run-picker-panel {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
-
-html[data-theme="dark"] .stash-card-name:hover,
-html[data-theme="dark"] .stash-card-name:focus {
+:root:not([data-theme="light"]) .stash-card-name:hover,
+:root:not([data-theme="light"]) .stash-card-name:focus {
   background: rgba(255, 255, 255, 0.08);
 }
 

--- a/assets/web/settings-modal.css
+++ b/assets/web/settings-modal.css
@@ -11,7 +11,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: var(--z-dropdown);
+  z-index: var(--z-modal);
   /* Backdrop blur + dark veil are animated via these custom props on the
    * overlay root; the ::before pseudo paints them. Mirrors start-overlay. */
   --host-blur: 0px;

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -70,36 +70,6 @@ body {
 
 /* Theme toggle (matches viewer.css) */
 
-#themeToggle {
-  position: relative;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
-  flex-shrink: 0;
-}
-
-#themeToggle:hover {
-  background: var(--color-surface);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
-}
-
-#themeToggle:active {
-  transform: scale(0.96);
-}
-
-#themeToggle:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
 #tooltipToggle {
   position: relative;
   width: 32px;
@@ -191,7 +161,7 @@ body {
 #trIntakePanel,
 #convergencePanel,
 #metadataPanel {
-  padding: 92px 0 var(--space-3);
+  padding: var(--chrome-height) 0 var(--space-3);
 }
 
 /* Sub-tab panels are flex children of #sheetMain. Without explicit
@@ -214,7 +184,7 @@ body {
   flex-direction: column;
   /* Floating-nav scroll-under: 92px top inset clears the fixed chrome strip
    * (TopNav + subheader). */
-  padding: calc(var(--space-3) + 92px) 0 var(--space-3);
+  padding: calc(var(--space-3) + var(--chrome-height)) 0 var(--space-3);
   background: var(--bg);
   border-right: 1px solid var(--hairline);
   overflow-x: hidden;
@@ -525,7 +495,7 @@ body[data-active-tab]:not([data-active-tab="sheet"]) #studioSidebar {
   flex: 1;
   overflow: hidden;
   /* Floating-nav scroll-under: 92px top inset clears the fixed chrome strip. */
-  padding: 92px var(--space-1) 0;
+  padding: var(--chrome-height) var(--space-1) 0;
   display: flex;
   flex-direction: column;
 }
@@ -632,7 +602,7 @@ body[data-active-tab]:not([data-active-tab="sheet"]) #studioSidebar {
    * chrome's own `border-bottom` already supplies the separator, and the
    * extra 1 px shifted the thead's natural position past the sticky target,
    * creating a visible gap below chrome. */
-  padding-top: 92px;
+  padding-top: var(--chrome-height);
 }
 
 #sheetGrid table {
@@ -2401,86 +2371,42 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   animation: spin 0.7s linear infinite;
 }
 
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
 /* ---- Dark mode ---- */
 
-/* OS preference — page-specific dark overrides (shared tokens in tokens.css) */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --color-cell-text: #1e3a5f;
-    --color-cell-valid: #1d4ed8;
-    --color-cell-selected: #334155;
-    --color-cell-hover: var(--color-accent-hover);
-    --color-heatmap: 192, 160, 235;
-  }
-}
-
-/* Manual toggle — page-specific dark overrides */
-html[data-theme="dark"] {
+/* Page-specific dark overrides (shared tokens live in tokens.css). Dark is the
+ * default theme, so a single selector that matches everything except an
+ * explicit light opt-in covers both system-dark and the manual toggle. */
+:root:not([data-theme="light"]) {
   --color-cell-text: #1e3a5f;
   --color-cell-valid: #1d4ed8;
   --color-cell-selected: #334155;
-  --color-heatmap: 192, 160, 235;
   --color-cell-hover: var(--color-accent-hover);
+  --color-heatmap: 192, 160, 235;
 }
 
-/* Dark element overrides (shared by both @media and data-theme via specificity) */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) #sheetGrid .col-participant.header-highlight,
-  :root:not([data-theme="light"]) #sheetGrid .col-row-num-clickable.header-highlight {
-    background-color: var(--color-accent-highlight);
-  }
-  :root:not([data-theme="light"]) .status-card,
-  :root:not([data-theme="light"]) .confirm-card {
-    background: var(--color-surface-alt);
-  }
-  :root:not([data-theme="light"]) .card-gen-overlay {
-    background: rgba(0, 0, 0, 0.45);
-  }
-  :root:not([data-theme="light"]) .queue-card-success {
-    border-color: #4ade80;
-    background: #052e16;
-  }
-  :root:not([data-theme="light"]) .queue-card-fail {
-    border-color: #f87171;
-    background: #451a1a;
-  }
-  :root:not([data-theme="light"]) .stash-card-name-input {
-    background: var(--color-surface-alt);
-  }
-  :root:not([data-theme="light"]) .settings-panel {
-    background: var(--color-surface-alt);
-  }
-}
-
-html[data-theme="dark"] #sheetGrid .col-participant.header-highlight,
-html[data-theme="dark"] #sheetGrid .col-row-num-clickable.header-highlight {
+:root:not([data-theme="light"]) #sheetGrid .col-participant.header-highlight,
+:root:not([data-theme="light"]) #sheetGrid .col-row-num-clickable.header-highlight {
   background-color: var(--color-accent-highlight);
 }
-
-html[data-theme="dark"] .status-card,
-html[data-theme="dark"] .confirm-card {
+:root:not([data-theme="light"]) .status-card,
+:root:not([data-theme="light"]) .confirm-card {
   background: var(--color-surface-alt);
 }
-
-html[data-theme="dark"] .card-gen-overlay {
+:root:not([data-theme="light"]) .card-gen-overlay {
   background: rgba(0, 0, 0, 0.45);
 }
-
-html[data-theme="dark"] .queue-card-success {
+:root:not([data-theme="light"]) .queue-card-success {
   border-color: #4ade80;
   background: #052e16;
 }
-
-html[data-theme="dark"] .queue-card-fail {
+:root:not([data-theme="light"]) .queue-card-fail {
   border-color: #f87171;
   background: #451a1a;
 }
-
-html[data-theme="dark"] .stash-card-name-input {
+:root:not([data-theme="light"]) .stash-card-name-input {
+  background: var(--color-surface-alt);
+}
+:root:not([data-theme="light"]) .settings-panel {
   background: var(--color-surface-alt);
 }
 
@@ -2493,7 +2419,7 @@ html[data-theme="dark"] .stash-card-name-input {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: var(--z-dropdown);
+  z-index: var(--z-modal);
 }
 
 #logOverlay.hidden {

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -249,6 +249,13 @@
   --layout-max-width: 1120px;
   --layout-padding-x: var(--space-5);
 
+  /* Floating chrome — the fixed TopNav + subheader strip. --chrome-height
+   * (48 + 44 = 92px) is the combined offset content clears below both bars. */
+  --topnav-height: 48px;
+  --subheader-height: 44px;
+  --chrome-height: calc(var(--topnav-height) + var(--subheader-height));
+  --subheader-font-size: 12.5px; /* intentional off-scale, between --text-xs/--text-sm */
+
   /* Sidebar widths */
   --sidebar-width-default: 340px;
   --sidebar-width-wide: 420px;
@@ -408,6 +415,11 @@ html[data-theme="light"] .cg-logo {
 }
 @media (prefers-reduced-motion: reduce) {
   .skeleton { animation: none; }
+}
+/* Shared 360° rotation for every page spinner. Pages keep their own duration
+ * on the animated selector and reference this keyframe by name. */
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 /* Cross-reference badge icon (mask-image from assets/icons/) */
 .xref-badge-icon {
@@ -664,17 +676,17 @@ button[data-tooltip]:disabled { pointer-events: auto; cursor: not-allowed; }
 #trSubheader {
   display: flex;
   align-items: center;
-  height: 44px;
-  padding: 0 16px;
+  height: var(--subheader-height);
+  padding: 0 var(--space-4);
   border-bottom: 1px solid var(--border);
   background: color-mix(in oklab, var(--bg) 72%, transparent);
   -webkit-backdrop-filter: blur(14px) saturate(1.4);
   backdrop-filter: blur(14px) saturate(1.4);
-  font-size: 12.5px;
+  font-size: var(--subheader-font-size);
   color: var(--fg-muted);
-  gap: 16px;
+  gap: var(--space-4);
   position: fixed;
-  top: 48px;
+  top: var(--topnav-height);
   left: 0;
   right: 0;
   /* Sits at --z-dropdown so popovers anchored inside a subheader (e.g. the

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -13,7 +13,7 @@
 .topnav {
   display: flex;
   align-items: center;
-  height: 48px;
+  height: var(--topnav-height);
   padding: 0 16px;
   border-bottom: 1px solid var(--border);
   background: color-mix(in oklab, var(--bg) 72%, transparent);
@@ -185,6 +185,7 @@ body.dragging .topnav {
  * Page-level #themeToggle rules are scoped narrowly enough not to fight us.
  * (Standalone gallery/viewer don't load topnav.css and keep their own copies.) */
 .topnav-right #themeToggle {
+  position: relative;
   width: 30px;
   height: 30px;
   padding: 0;
@@ -196,11 +197,19 @@ body.dragging .topnav {
   border-radius: 5px;
   color: var(--fg-muted);
   cursor: pointer;
+  flex-shrink: 0;
   transition: background-color var(--duration-fast), color var(--duration-fast);
 }
 .topnav-right #themeToggle:hover {
   background: var(--bg-hover);
   color: var(--fg);
+}
+.topnav-right #themeToggle:active {
+  transform: scale(0.96);
+}
+.topnav-right #themeToggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Sun/moon icon visuals — shared by every TopNav page (consolidated from the

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -128,36 +128,6 @@ body {
   opacity: 0.4;
 }
 
-#themeToggle {
-  position: relative;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
-  flex-shrink: 0;
-}
-
-#themeToggle:hover {
-  background: var(--color-surface);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
-}
-
-#themeToggle:active {
-  transform: scale(0.96);
-}
-
-#themeToggle:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
 /* Search bar */
 
 #headerSearch {
@@ -1416,7 +1386,7 @@ body {
   /* Floating-nav scroll-under: pinned to viewport, completing the
    * 148px chrome strip below the topnav (48) + subheader (44). */
   position: fixed;
-  top: 92px;
+  top: var(--chrome-height);
   left: 0;
   right: 0;
   z-index: calc(var(--z-dropdown) - 1);
@@ -1553,10 +1523,6 @@ body {
   border-color: color-mix(in srgb, var(--sev-critical) 45%, var(--color-border));
 }
 
-@keyframes pill-spin {
-  to { transform: rotate(360deg); }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .pill-trigger--running .pill-trigger-icon--rest { animation: none; }
   .pill-progress { transition: none; }
@@ -1617,7 +1583,7 @@ body {
 .pill-trigger--idle { color: var(--color-text-dim); }
 
 .pill-trigger--running .pill-trigger-icon--rest {
-  animation: pill-spin 1.2s linear infinite;
+  animation: spin 1.2s linear infinite;
 }
 
 .pill-trigger--running:hover,

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -9,7 +9,6 @@
 
 :root {
   /* Page-local structural dimensions (not shared design tokens). */
-  --wf-topnav-height: 48px; /* matches the fixed .topnav height */
   --wf-panel-width: 16rem;
   --wf-grid-size: 24px; /* dot-grid cell at zoom 1; JS scales it with zoom */
   --wf-node-width: 11rem;
@@ -54,7 +53,7 @@ body[data-frontend="workflows"] {
 #wfShell {
   display: flex;
   height: 100vh;
-  padding-top: var(--wf-topnav-height);
+  padding-top: var(--topnav-height);
   box-sizing: border-box;
 }
 
@@ -168,39 +167,6 @@ body[data-frontend="workflows"] {
 
 #wfDeleteBlueprint {
   margin-left: var(--space-1);
-}
-
-/* Theme toggle (matches Studio / Screenspace) — the TopNav renders the
-   #themeToggle button + sun/moon spans, but each page supplies the icon visuals
-   and the position:relative anchor the absolutely-positioned icons need. */
-#themeToggle {
-  position: relative;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
-  flex-shrink: 0;
-}
-
-#themeToggle:hover {
-  background: var(--color-surface);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
-}
-
-#themeToggle:active {
-  transform: scale(0.96);
-}
-
-#themeToggle:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
 }
 
 /* Run split-button: primary "Run" joined to a caret that opens the more-options
@@ -1120,13 +1086,7 @@ body[data-frontend="workflows"] {
   border-radius: var(--radius-full);
   border: 2px solid var(--border);
   border-top-color: var(--accent);
-  animation: wf-spin 0.8s linear infinite;
-}
-
-@keyframes wf-spin {
-  to {
-    transform: rotate(360deg);
-  }
+  animation: spin 0.8s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1758,7 +1718,7 @@ body[data-frontend="workflows"] {
   background-color: var(--accent);
   mask-image: url("icons/arrow-path.svg");
   -webkit-mask-image: url("icons/arrow-path.svg");
-  animation: wf-spin 0.8s linear infinite;
+  animation: spin 0.8s linear infinite;
 }
 .wf-run-node-icon[data-status="completed"] {
   background-color: var(--severity-positive);

--- a/tests/test_workflows_frontend_source.py
+++ b/tests/test_workflows_frontend_source.py
@@ -592,13 +592,16 @@ def test_run_to_selected_node():
 
 
 def test_theme_toggle_icons_styled():
-    """The sun/moon icon visuals are identical on every TopNav page, so they live
-    once in topnav.css; each page still supplies the #themeToggle button base +
-    position:relative anchor the absolutely-positioned icons hang off of."""
+    """The sun/moon icon visuals AND the #themeToggle button base (including the
+    position:relative anchor the absolutely-positioned icons hang off of) live
+    once in topnav.css; the per-page duplicates were removed."""
     topnav_css = (_WEB / "topnav.css").read_text(encoding="utf-8")
     assert ".theme-icon-sun" in topnav_css
     assert ".theme-icon-moon" in topnav_css
     assert '#themeToggle[data-theme="dark"] .theme-icon-moon' in topnav_css
-    # The absolutely-positioned icons need a positioned button to anchor to.
-    css = WORKFLOWS_CSS.read_text(encoding="utf-8")
-    assert "#themeToggle {" in css
+    # The absolutely-positioned icons need a positioned button to anchor to —
+    # supplied by topnav.css's consolidated .topnav-right #themeToggle block.
+    assert "position: relative;" in topnav_css
+    # Page CSS must NOT re-declare the base block (it was dead code overridden
+    # by topnav.css's higher-specificity rule).
+    assert "#themeToggle {" not in WORKFLOWS_CSS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Move hand-copied CSS values into `tokens.css` as the single source of truth, removing ~250 lines of duplication across 8 stylesheets.

- **Chrome heights** — new `--topnav-height`/`--subheader-height`/`--chrome-height` (48/44/92px) replace ~19 hand-derived literals across 7 files; the `.subheader` block now uses `--space-4` and a `--subheader-font-size` token for its intentional off-scale 12.5px.
- **`#themeToggle`** — `topnav.css` now fully owns the button (adds the `position:relative` icon anchor, `flex-shrink`, `:active`/`:focus-visible`); the four dead per-page base blocks are removed (gallery/viewer keep their own, no topnav.css).
- **Spinners** — one shared `@keyframes spin` replaces four identical keyframes; **dark mode** — the `@media(prefers-color-scheme:dark)` + `html[data-theme="dark"]` twin blocks in studio/screenspace collapse to a single `:root:not([data-theme="light"])` rule (dark is the default theme).
- **Modal z-index fix** — raised screenspace `.modal-overlay`, studio `#logOverlay`, and `.settings-overlay` from `--z-dropdown` to `--z-modal` so they paint above the subheader (which intentionally sits at `--z-dropdown`).

## Test plan

- [x] `/check` green — ruff format + lint, ty, full pytest suite (updated `test_theme_toggle_icons_styled` to the consolidated shape).
- [ ] ⚠️ Not browser-verified: toggle light/dark on Studio/Screenspace/Transcripts/Workflows and confirm chrome alignment, toggle icon crossfade/hover/active/focus, spinners, and that the three modals now paint above the subheader; confirm standalone Gallery/Viewer toggles unchanged.