### PR TITLE
perf(transcripts): skip offscreen segment-row layout via content-visibility

### DIFF
--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1204,6 +1204,12 @@ body {
   border-left: 3px solid transparent;
   cursor: pointer;
   transition: background var(--duration-fast), border-color var(--duration-fast);
+  /* Let the browser skip layout/paint for offscreen rows. `auto` remembers each
+     row's real rendered height (rows vary with wrapped text) so the scrollbar and
+     scrollToSegment()'s getBoundingClientRect math stay accurate on re-scroll;
+     the 2.25rem fallback only applies before a row's first render. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 2.25rem;
 }
 
 .segment-row:hover {


### PR DESCRIPTION
## Summary

Add `content-visibility: auto` + `contain-intrinsic-size: auto 2.25rem` to `.segment-row` in `assets/web/transcripts.css` so the browser skips layout/paint for offscreen transcript rows — previously a long transcript (hundreds of rows × thousands of per-word spans) laid out the entire list on first paint and on every restyle (friction-heatmap toggle, segment activation). Mirrors the timeline viewer's `.artifact-card`; uses the `auto` last-remembered-size keyword because rows vary in height with wrapped text, keeping `scrollToSegment()`'s `getBoundingClientRect` math accurate on re-scroll.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` — 1853 passed
- [x] `ruff format --check`, `ruff check`, `ty check` — all pass
- [ ] ⚠️ Browser-check pending (repo rule: no headless browsers): confirm transcript renders/scrolls fully, active-segment auto-follow still scrolls into view, and friction-heatmap toggle still recolors rows