### PR TITLE
perf(screenspace): version-gate the events poll to skip unchanged ticks

### DIFF
--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -67,7 +67,13 @@
   // ("active this tick") keeps createPoller at the fast cadence; falsy lets it back
   // off. Replaces the former pollIntakeStatus + pollIntakeEvents pair.
   function pollScreenspaceIntake() {
-    return apiGet("../screenspace/api/intake-poll?excluded=false")
+    // Echo the last-seen events version so the server can skip the events
+    // payload (deep-copy + sanitize + ship) when nothing changed this tick.
+    var url = "../screenspace/api/intake-poll?excluded=false";
+    if (state._intakeEventsVersion != null) {
+      url += "&events_version=" + state._intakeEventsVersion;
+    }
+    return apiGet(url)
       .then(function (data) {
         if (!data || !data.ok) {
           setIntakeDot(false);
@@ -76,7 +82,13 @@
         var status = data.status || {};
         var dotOn = !!status.running || (status.worker_alive && !!status.queued);
         setIntakeDot(dotOn);
-        var eventsChanged = applyIntakeEvents(data.events || []);
+        if (data.events_version != null) {
+          state._intakeEventsVersion = data.events_version;
+        }
+        // events omitted => unchanged since our cursor; keep current view.
+        var eventsChanged = data.events_unchanged
+          ? false
+          : applyIntakeEvents(data.events || []);
         return dotOn || eventsChanged;
       })
       .catch(function () {

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -186,6 +186,17 @@ _pin_ocr_cache_lock = threading.Lock()
 _sse_notify, _sse_stream, _sse_clients = make_sse_channel()
 _manifest_lock = threading.Lock()
 
+# Monotonic counter bumped (under _manifest_lock) on every _manifest["events"]
+# mutation — append via drain and per-event exclude/include. The poll routes
+# echo it so an unchanged tick short-circuits the deep-copy + sanitize + ship.
+_events_version = 0
+
+
+def _bump_events_version() -> None:
+    """Mark manifest events changed. Caller must hold _manifest_lock."""
+    global _events_version
+    _events_version += 1
+
 
 def _notify_sse_clients(event_type: str = "update") -> None:
     """Broadcast a task-state change to every connected SSE client.
@@ -2154,11 +2165,10 @@ def api_tasks_results(task_id: str) -> FlaskResponse:
 # ---- Events CRUD ----
 
 
-def _filtered_events(args: Any) -> list[dict[str, Any]]:
-    """Deep-copy manifest events and apply the standard excluded/participant/
-    task_id query filters. Shared by /api/events and /api/intake-poll."""
-    with _manifest_lock:
-        events = copy.deepcopy(_manifest.get("events", []))
+def _apply_event_filters(
+    events: list[dict[str, Any]], args: Any
+) -> list[dict[str, Any]]:
+    """Apply the standard excluded/participant/task_id query filters (pure)."""
     excluded_filter = args.get("excluded")
     if excluded_filter == "false":
         events = [e for e in events if not e.get("excluded")]
@@ -2173,10 +2183,48 @@ def _filtered_events(args: Any) -> list[dict[str, Any]]:
     return events
 
 
+def _events_payload(
+    args: Any, client_version: int | None
+) -> tuple[int, list[dict[str, Any]] | None]:
+    """Version-aware events snapshot for the poll routes.
+
+    Reads the events-version and deep-copies under a single lock acquisition (so
+    a concurrent bump can't slip between the two). Returns ``(current_version,
+    events)``; ``events`` is ``None`` — meaning "unchanged, skip the payload" —
+    only when the caller passed a ``client_version`` equal to the current one.
+    """
+    with _manifest_lock:
+        current = _events_version
+        if client_version is not None and client_version == current:
+            return current, None
+        events = copy.deepcopy(_manifest.get("events", []))
+    return current, utils.sanitize_floats(_apply_event_filters(events, args))
+
+
+def _client_events_version(args: Any) -> int | None:
+    """Parse the optional ``events_version`` poll cursor; ``None`` if absent/bad."""
+    raw = args.get("events_version")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 @screenspace_bp.route("/api/events")
 def api_events_list() -> FlaskResponse:
-    """List events with optional filtering."""
-    return ok(events=utils.sanitize_floats(_filtered_events(request.args)))
+    """List events with optional filtering.
+
+    ``?events_version=N`` short-circuits: when N matches the current events
+    version, returns ``events_unchanged`` with no payload. Omit for the full list.
+    """
+    version, events = _events_payload(
+        request.args, _client_events_version(request.args)
+    )
+    if events is None:
+        return ok(events_version=version, events_unchanged=True)
+    return ok(events_version=version, events=events)
 
 
 @screenspace_bp.route("/api/intake-poll")
@@ -2185,7 +2233,8 @@ def api_intake_poll() -> FlaskResponse:
 
     Collapses the Studio intake client's separate /api/tasks and /api/events
     polls into a single request. Both reads are the same slim, in-memory ones
-    those routes do (no results, no disk I/O)."""
+    those routes do (no results, no disk I/O). ``?events_version=N`` skips the
+    events payload when nothing changed since the client's last tick."""
     tasks = [
         _clean_task(t)
         for t in (_worker.get_all_tasks(include_results=False) if _worker else [])
@@ -2193,10 +2242,13 @@ def api_intake_poll() -> FlaskResponse:
     running = any(t.get("status") == "running" for t in tasks)
     queued = any(t.get("status") == "queued" for t in tasks)
     alive = _worker.is_alive if _worker else False
-    return ok(
-        status={"running": running, "worker_alive": alive, "queued": queued},
-        events=utils.sanitize_floats(_filtered_events(request.args)),
+    status = {"running": running, "worker_alive": alive, "queued": queued}
+    version, events = _events_payload(
+        request.args, _client_events_version(request.args)
     )
+    if events is None:
+        return ok(status=status, events_version=version, events_unchanged=True)
+    return ok(status=status, events_version=version, events=events)
 
 
 @screenspace_bp.route("/api/export/events")
@@ -2256,6 +2308,7 @@ def api_event_exclude(event_id: str) -> FlaskResponse:
         for e in _manifest.get("events", []):
             if e["id"] == event_id:
                 e["excluded"] = True
+                _bump_events_version()
                 _do_persist(drain_events=False)
                 return ok()
     return err("Event not found", 404)
@@ -2268,6 +2321,7 @@ def api_event_include(event_id: str) -> FlaskResponse:
         for e in _manifest.get("events", []):
             if e["id"] == event_id:
                 e["excluded"] = False
+                _bump_events_version()
                 _do_persist(drain_events=False)
                 return ok()
     return err("Event not found", 404)
@@ -2286,6 +2340,8 @@ def api_events_bulk_exclude() -> FlaskResponse:
             if e["id"] in ids:
                 e["excluded"] = True
                 count += 1
+        if count:
+            _bump_events_version()
         _do_persist(drain_events=False)
     return ok(updated=count)
 
@@ -2303,6 +2359,8 @@ def api_events_bulk_include() -> FlaskResponse:
             if e["id"] in ids:
                 e["excluded"] = False
                 count += 1
+        if count:
+            _bump_events_version()
         _do_persist(drain_events=False)
     return ok(updated=count)
 
@@ -2601,6 +2659,7 @@ def _do_persist(*, drain_events: bool = True) -> None:
         new_events = _worker.drain_new_events()
         if new_events:
             _manifest.setdefault("events", []).extend(new_events)
+            _bump_events_version()
     tasks = _worker.get_all_tasks() if _worker else _manifest.get("tasks", [])
     _manifest["tasks"] = tasks
     screenspace.save_screenspace_manifest(

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -44,6 +44,7 @@ def client(tmp_path, monkeypatch):
             {"id": "P02", "video_paths": ["/tmp/test_P02.mp4"], "has_video": False},
         ],
     )
+    monkeypatch.setattr(screenspace_server, "_events_version", 0)
     monkeypatch.setattr(screenspace_server, "_output_dir", str(tmp_path))
     monkeypatch.setattr(screenspace_server, "_worker", screenspace.ScreenspaceWorker())
     # Fresh module-level calibration/preview caches per test (auto-restored).
@@ -1915,6 +1916,80 @@ def test_intake_poll_combines_status_and_events(client):
     assert isinstance(data["status"]["worker_alive"], bool)
     # excluded=false drops ev_2, same as /api/events.
     assert [e["id"] for e in data["events"]] == ["ev_1"]
+
+
+def test_events_poll_reports_version(client):
+    """Poll responses carry an events_version cursor for the client to echo."""
+    screenspace_server._manifest["events"] = [_sample_event("ev_1")]
+    for path in ("/screenspace/api/events", "/screenspace/api/intake-poll"):
+        data = client.get(path).get_json()
+        assert data["ok"] is True
+        assert isinstance(data["events_version"], int)
+        assert "events" in data
+
+
+def test_events_poll_short_circuits_unchanged(client):
+    """Re-polling with the current events_version skips the payload."""
+    screenspace_server._manifest["events"] = [_sample_event("ev_1")]
+    first = client.get("/screenspace/api/intake-poll?excluded=false").get_json()
+    version = first["events_version"]
+    assert "events" in first
+
+    second = client.get(
+        f"/screenspace/api/intake-poll?excluded=false&events_version={version}"
+    ).get_json()
+    assert second["ok"] is True
+    assert second["events_unchanged"] is True
+    assert "events" not in second
+    # Status is still reported on the unchanged tick.
+    assert "status" in second
+    assert second["events_version"] == version
+
+
+def test_events_poll_resends_after_exclude(client):
+    """Toggling an event bumps the version so the next poll re-sends events."""
+    screenspace_server._manifest["events"] = [_sample_event("ev_1")]
+    version = client.get("/screenspace/api/events").get_json()["events_version"]
+
+    assert client.put("/screenspace/api/events/ev_1/exclude").status_code == 200
+
+    data = client.get(f"/screenspace/api/events?events_version={version}").get_json()
+    assert data.get("events_unchanged") is not True
+    assert data["events_version"] != version
+    assert data["events"][0]["excluded"] is True
+
+
+def test_events_poll_resends_after_bulk_toggle(client):
+    """Bulk exclude/include also bumps the version off the client's cursor."""
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1"),
+        _sample_event("ev_2"),
+    ]
+    version = client.get("/screenspace/api/events").get_json()["events_version"]
+    client.put("/screenspace/api/events/bulk-exclude", json={"ids": ["ev_1"]})
+    data = client.get(f"/screenspace/api/events?events_version={version}").get_json()
+    assert data.get("events_unchanged") is not True
+    assert data["events_version"] != version
+
+
+def test_events_list_without_version_returns_full(client):
+    """Omitting events_version always returns the full filtered list (back-compat)."""
+    screenspace_server._manifest["events"] = [
+        _sample_event("ev_1"),
+        _sample_event("ev_2", excluded=True),
+    ]
+    data = client.get("/screenspace/api/events").get_json()
+    assert "events_unchanged" not in data
+    assert len(data["events"]) == 2
+
+
+def test_events_poll_bad_version_returns_full(client):
+    """A non-integer events_version is ignored (treated as no cursor)."""
+    screenspace_server._manifest["events"] = [_sample_event("ev_1")]
+    data = client.get("/screenspace/api/events?events_version=bogus").get_json()
+    assert data["ok"] is True
+    assert "events" in data
+    assert "events_unchanged" not in data
 
 
 def test_event_exclude(client):


### PR DESCRIPTION
## Summary

The Studio intake/events poll deep-copied, sanitized, and shipped the entire events list every tick (the client `JSON.stringify`'d it just to dirty-check) — worst during an active scan when the list is largest and the poller is pinned fast. This adds a monotonic `_events_version`, bumped on every manifest-events mutation (drain-append plus single/bulk exclude/include), that the poll routes echo so an unchanged tick short-circuits to a tiny `events_unchanged` response and the client skips re-render. Events are mutated in place (exclude flips `excluded` on existing events), so a plain append-only `?since=N` cursor would miss those flips — the version counter is the correct primitive.

## Test plan

- [x] `/check` green: ruff format + lint, ty, full suite (1859 passed)
- [x] New tests: version reported, unchanged short-circuit, resend after exclude/bulk-toggle, no-version full-list back-compat, bad-version ignored
- [ ] ⚠️ Not browser-checked: intake tab during a live Screenspace scan (events still stream, exclude/include still reflect immediately; poll responses tiny between detections)