### PR TITLE
perf: lazy-load gspread off the CLI startup path

### DIFF
--- a/clipgen.py
+++ b/clipgen.py
@@ -18,8 +18,6 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
-import gspread
-
 import config
 import files
 import google_api
@@ -152,6 +150,8 @@ _STANDARD_MODES = {
 
 def _open_worksheet(open_callable: Callable[[], Any], error_context: str) -> Any | None:
     """Try to open a worksheet via a callable; catch gspread errors and print a consistent message."""
+    import gspread
+
     try:
         return google_api.get_worksheet(open_callable())
     except (
@@ -282,6 +282,8 @@ def _handle_spreadsheet_command(
 
 def select_spreadsheet(gspread_client: Any, doc_list: list[str]) -> Any:
     """Interactive spreadsheet selection. Returns the selected worksheet."""
+    import gspread
+
     if utils.NO_INPUT_MODE:
         utils.error_print(
             "Spreadsheet selection requires -s in non-interactive mode.",
@@ -1140,6 +1142,8 @@ def _dispatch_interactive_mode(
 
 def run_interactive_mode(worksheet: Any, gspread_client: Any = None) -> None:
     """Execute interactive mode - main processing loop."""
+    import gspread
+
     if utils.NO_INPUT_MODE:
         utils.error_print(
             "No CLI mode flag provided; cannot enter interactive mode under --no-input.",

--- a/files.py
+++ b/files.py
@@ -7,8 +7,6 @@ import threading
 import unicodedata
 from pathlib import Path
 
-import gspread
-
 import config
 import utils
 from utils import ClipRecord
@@ -276,7 +274,7 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
     utils.debug_print("Will attempt to split the cell contents")
 
     # Get cell reference for error messages
-    cell_ref = gspread.utils.rowcol_to_a1(clip["cell"].row, clip["cell"].col)
+    cell_ref = utils.safe_cell_a1(clip["cell"].row, clip["cell"].col)
 
     # Parse inline annotations (e.g. !key), then parse timestamps from cleaned value.
     cleaned_cell_value, segment_annotations, cell_annotations = (

--- a/google_api.py
+++ b/google_api.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 """Google Sheets API integration for clipgen."""
 
+from __future__ import annotations
+
 import time
 
 from collections.abc import Callable
-from typing import Any, TypeVar
-
-import gspread
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import config
 import utils
+
+if TYPE_CHECKING:
+    import gspread
 
 _T = TypeVar("_T")
 
@@ -25,6 +28,8 @@ def _is_transient_api_error(exc: gspread.exceptions.APIError) -> bool:
 
 def _call_with_api_retry(fn: Callable[[], _T], operation: str) -> _T:
     """Call *fn*, retrying on transient Google API errors with exponential backoff."""
+    import gspread
+
     max_retries = config.GOOGLE_API_MAX_RETRIES
     for attempt in range(max_retries + 1):
         try:
@@ -54,6 +59,8 @@ def get_worksheet(spreadsheet: gspread.Spreadsheet) -> gspread.Worksheet:
     Returns:
         A gspread Worksheet object
     """
+    import gspread
+
     # Get all worksheet titles from the spreadsheet
     worksheets = spreadsheet.worksheets()
     worksheet_titles = [ws.title for ws in worksheets]

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -44,8 +44,6 @@ from dataclasses import dataclass
 from collections.abc import Sequence
 from typing import Any, NamedTuple
 
-import gspread
-
 import config
 import google_api
 import utils
@@ -579,6 +577,10 @@ def _make_clip_record(
     - category: Category label from the same row (category column).
     'times' is added later when timestamps are resolved to [start, end] ranges.
     """
+    # Lazy import: keeps gspread (and its heavy google.auth/cryptography chain)
+    # off the CLI startup path; only spreadsheet parsing needs the Cell type.
+    import gspread
+
     # Excel cells may yield numbers, datetimes, or None; gspread always returns
     # strings. Coerce here so downstream timestamp parsing (which calls .lower())
     # never sees a non-string.
@@ -696,13 +698,11 @@ def get_line_timestamps(ctx: SheetContext, line_index: int) -> list[ClipRecord]:
                     f"Timestamp at R{issue['cell'].row - 1},C{issue['cell'].col - 1} -> '{issue['cell'].value}'"
                 )
                 utils.debug_print(
-                    f"Actual cell at address {gspread.utils.rowcol_to_a1(issue['cell'].row, issue['cell'].col)}"
+                    f"Actual cell at address {utils.safe_cell_a1(issue['cell'].row, issue['cell'].col)}"
                 )
                 clips.append(issue)
                 display_value = value.replace("\n", " ")
-                cell_addr = gspread.utils.rowcol_to_a1(
-                    issue["cell"].row, issue["cell"].col
-                )
+                cell_addr = utils.safe_cell_a1(issue["cell"].row, issue["cell"].col)
                 utils.verbose_print(
                     f"+ Found timestamp: {display_value} at address {cell_addr}"
                 )
@@ -1145,7 +1145,7 @@ def generate_participant_timestamps(
         issue = _make_clip_record(ctx, row_idx, col_idx, cell_value)
         clips.append(issue)
         display_value = cell_value.replace("\n", " ")
-        cell_addr = gspread.utils.rowcol_to_a1(issue["cell"].row, issue["cell"].col)
+        cell_addr = utils.safe_cell_a1(issue["cell"].row, issue["cell"].col)
         utils.verbose_print(
             f"+ Found timestamp: {display_value} at row {row_idx + 1} ({cell_addr})"
         )
@@ -1219,7 +1219,7 @@ def generate_cell_timestamps(
             )
         clips.append(issue)
         display_value = cell_value.replace("\n", " ")
-        cell_addr = gspread.utils.rowcol_to_a1(issue["cell"].row, issue["cell"].col)
+        cell_addr = utils.safe_cell_a1(issue["cell"].row, issue["cell"].col)
         utils.verbose_print(
             f"+ Found timestamp: {display_value} at cell {participant_id}.{row_number} ({cell_addr})"
         )


### PR DESCRIPTION
## Summary

`gspread` (~105 ms warm, more cold via `google.auth`/`cryptography`'s Rust bindings) was imported at module top level in `clipgen.py`, `spreadsheet.py`, `google_api.py`, and `files.py`, so `cli.py`'s `import clipgen` paid it on **every** invocation — `--help`, `--regenerate`, Excel-only `-s`, and all server launches, none of which touch Google Sheets at startup. This defers it to the functions that actually parse sheets, roughly halving warm `--help` (~0.17 s → ~0.08 s) with no behavior change.

- `files.py`: sole `rowcol_to_a1` use → existing lazy `utils.safe_cell_a1()`; import dropped.
- `spreadsheet.py`: four `rowcol_to_a1` calls → `utils.safe_cell_a1()`; `gspread` lazy-imported inside `_make_clip_record` (the only `Cell` constructor).
- `google_api.py`: `from __future__ import annotations` + `TYPE_CHECKING` import so signature annotations stop evaluating at import; lazy-import in the two runtime-use functions.
- `clipgen.py`: lazy-import in the three exception-handling functions.

## Test plan

- [x] Import isolation: `gspread` absent from `sys.modules` after importing `cli`/`clipgen`/`spreadsheet`/`files`/`google_api`.
- [x] `ruff format` + `ruff check` clean; `ty` clean on the four modules.
- [x] Full suite: 1853 passed.
- [x] Warm `--help` timing measured ~0.17 s → ~0.08 s; `gspread.cell.Cell` construction still works via the lazy path.