### PR TITLE
perf(web): defer main-page script loading

### DIFF
--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -321,25 +321,25 @@
   <div id="toolInfoTooltip" class="tool-info-tooltip hidden"></div>
 
   <!-- Deps order: utils → screenspace leaf helpers → chrome → settings → page script -->
-  <script src="utils.js"></script>
-  <script src="motion.js"></script>
-  <script src="screenspace-utils.js"></script>
-  <script src="export-actions.js"></script>
-  <script src="topnav.js"></script>
-  <script src="start-overlay.js"></script>
-  <script src="dev-token-tweak.js" data-dev-only></script>
-  <script src="color-picker.js"></script>
-  <script src="settings-modal.js"></script>
-  <script src="video-controls.js"></script>
-  <script src="screenspace.js"></script>
-  <script src="screenspace-model-view.js"></script>
-  <script src="screenspace-overlay-interaction.js"></script>
-  <script src="screenspace-overlay.js"></script>
-  <script src="screenspace-timeline.js"></script>
-  <script src="screenspace-tasks.js"></script>
-  <script src="screenspace-multitool-params.js"></script>
-  <script src="screenspace-calibration.js"></script>
-  <script src="screenspace-color.js"></script>
-  <script src="screenspace-results.js"></script>
+  <script src="utils.js" defer></script>
+  <script src="motion.js" defer></script>
+  <script src="screenspace-utils.js" defer></script>
+  <script src="export-actions.js" defer></script>
+  <script src="topnav.js" defer></script>
+  <script src="start-overlay.js" defer></script>
+  <script src="dev-token-tweak.js" defer data-dev-only></script>
+  <script src="color-picker.js" defer></script>
+  <script src="settings-modal.js" defer></script>
+  <script src="video-controls.js" defer></script>
+  <script src="screenspace.js" defer></script>
+  <script src="screenspace-model-view.js" defer></script>
+  <script src="screenspace-overlay-interaction.js" defer></script>
+  <script src="screenspace-overlay.js" defer></script>
+  <script src="screenspace-timeline.js" defer></script>
+  <script src="screenspace-tasks.js" defer></script>
+  <script src="screenspace-multitool-params.js" defer></script>
+  <script src="screenspace-calibration.js" defer></script>
+  <script src="screenspace-color.js" defer></script>
+  <script src="screenspace-results.js" defer></script>
 </body>
 </html>

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -291,23 +291,23 @@
   <div id="trIntakeTooltip" class="tr-intake-tooltip hidden"></div>
   <div id="toast" class="toast hidden"></div>
   <!-- Deps: utils → primitives → chrome → settings → studio hub → satellites (intake) + panels -->
-  <script src="utils.js"></script>
-  <script src="motion.js"></script>
-  <script src="card-scrubber.js"></script>
-  <script src="primitives.js"></script>
-  <script src="export-actions.js"></script>
-  <script src="topnav.js"></script>
-  <script src="start-overlay.js"></script>
-  <script src="dev-token-tweak.js" data-dev-only></script>
-  <script src="color-picker.js"></script>
-  <script src="settings-modal.js"></script>
-  <script src="intake-cluster.js"></script>
-  <script src="studio.js"></script>
-  <script src="studio-scrubber.js"></script>
-  <script src="studio-trim.js"></script>
-  <script src="studio-generate.js"></script>
-  <script src="studio-intake.js"></script>
-  <script src="convergence.js"></script>
-  <script src="metadata.js"></script>
+  <script src="utils.js" defer></script>
+  <script src="motion.js" defer></script>
+  <script src="card-scrubber.js" defer></script>
+  <script src="primitives.js" defer></script>
+  <script src="export-actions.js" defer></script>
+  <script src="topnav.js" defer></script>
+  <script src="start-overlay.js" defer></script>
+  <script src="dev-token-tweak.js" defer data-dev-only></script>
+  <script src="color-picker.js" defer></script>
+  <script src="settings-modal.js" defer></script>
+  <script src="intake-cluster.js" defer></script>
+  <script src="studio.js" defer></script>
+  <script src="studio-scrubber.js" defer></script>
+  <script src="studio-trim.js" defer></script>
+  <script src="studio-generate.js" defer></script>
+  <script src="studio-intake.js" defer></script>
+  <script src="convergence.js" defer></script>
+  <script src="metadata.js" defer></script>
 </body>
 </html>

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -230,19 +230,19 @@
   <div id="toast" class="toast hidden"></div>
 
   <!-- Deps order: utils → chrome → settings → page hub → transcripts-*.js satellites -->
-  <script src="utils.js"></script>
-  <script src="export-actions.js"></script>
-  <script src="topnav.js"></script>
-  <script src="start-overlay.js"></script>
-  <script src="dev-token-tweak.js" data-dev-only></script>
-  <script src="color-picker.js"></script>
-  <script src="settings-modal.js"></script>
-  <script src="video-controls.js"></script>
-  <script src="transcripts.js"></script>
-  <script src="transcripts-corrections.js"></script>
-  <script src="transcripts-search.js"></script>
-  <script src="transcripts-video.js"></script>
-  <script src="transcripts-pills.js"></script>
-  <script src="transcripts-agents.js"></script>
+  <script src="utils.js" defer></script>
+  <script src="export-actions.js" defer></script>
+  <script src="topnav.js" defer></script>
+  <script src="start-overlay.js" defer></script>
+  <script src="dev-token-tweak.js" defer data-dev-only></script>
+  <script src="color-picker.js" defer></script>
+  <script src="settings-modal.js" defer></script>
+  <script src="video-controls.js" defer></script>
+  <script src="transcripts.js" defer></script>
+  <script src="transcripts-corrections.js" defer></script>
+  <script src="transcripts-search.js" defer></script>
+  <script src="transcripts-video.js" defer></script>
+  <script src="transcripts-pills.js" defer></script>
+  <script src="transcripts-agents.js" defer></script>
 </body>
 </html>

--- a/assets/web/workflows.html
+++ b/assets/web/workflows.html
@@ -195,19 +195,19 @@
   <!-- Deps order: utils → chrome → settings → page hub → workflows-*.js satellites.
        Satellites load after the hub; -nodes before -canvas (the canvas reaches
        the nodes renderer via WF.* late-binding either way). -->
-  <script src="utils.js"></script>
-  <script src="export-actions.js"></script>
-  <script src="topnav.js"></script>
-  <script src="start-overlay.js"></script>
-  <script src="dev-token-tweak.js" data-dev-only></script>
-  <script src="color-picker.js"></script>
-  <script src="settings-modal.js"></script>
-  <script src="workflows.js"></script>
-  <script src="workflows-nodes.js"></script>
-  <script src="workflows-canvas.js"></script>
-  <script src="workflows-wires.js"></script>
-  <script src="workflows-runs.js"></script>
-  <script src="workflows-stashes.js"></script>
-  <script src="workflows-validate.js"></script>
+  <script src="utils.js" defer></script>
+  <script src="export-actions.js" defer></script>
+  <script src="topnav.js" defer></script>
+  <script src="start-overlay.js" defer></script>
+  <script src="dev-token-tweak.js" defer data-dev-only></script>
+  <script src="color-picker.js" defer></script>
+  <script src="settings-modal.js" defer></script>
+  <script src="workflows.js" defer></script>
+  <script src="workflows-nodes.js" defer></script>
+  <script src="workflows-canvas.js" defer></script>
+  <script src="workflows-wires.js" defer></script>
+  <script src="workflows-runs.js" defer></script>
+  <script src="workflows-stashes.js" defer></script>
+  <script src="workflows-validate.js" defer></script>
 </body>
 </html>

--- a/tests/test_motion_wiring.py
+++ b/tests/test_motion_wiring.py
@@ -43,7 +43,7 @@ def test_motion_wiggle_is_tunable():
 def test_motion_loaded_after_utils_on_both_pages():
     for page in ("screenspace.html", "studio.html"):
         html = (_WEB / page).read_text(encoding="utf-8")
-        assert '<script src="motion.js"></script>' in html, (
+        assert '<script src="motion.js" defer></script>' in html, (
             f"{page} must load motion.js"
         )
         # motion.js provides window.ClipgenMotion; it must load after utils.js and

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -225,7 +225,7 @@ def test_studio_card_scrubber_wiring():
 
     html = STUDIO_HTML.read_text(encoding="utf-8")
     assert '<link rel="stylesheet" href="card-scrubber.css">' in html
-    assert '<script src="card-scrubber.js"></script>' in html
+    assert '<script src="card-scrubber.js" defer></script>' in html
 
 
 def test_studio_card_scrubber_gates_on_thumbnail_and_prefetches():


### PR DESCRIPTION
## Summary

Add `defer` to every end-of-body `<script>` tag on the four main pages — Studio, Screenspace, Transcripts, and Workflows — so the browser fetches all ~18–20 scripts in parallel during parse and executes them in source order before `DOMContentLoaded`, improving time-to-interactive. This mirrors the pattern `viewer.html`/`gallery.html` already use; dependency order is preserved because `defer` keeps source-order execution.

## Test plan

- [x] `/check`: ruff format + lint clean; full pytest suite passes (updated two static tag-string assertions in `test_motion_wiring.py` and `test_studio_frontend_source.py` to the `defer` form)
- [ ] ⚠️ UI not browser-checked — load each page and confirm it renders/behaves with a clean console
