### PR TITLE
perf: reduce image jank and heatmap-GIF peak memory

### DIFF
--- a/assets/web/convergence.js
+++ b/assets/web/convergence.js
@@ -94,6 +94,7 @@
     if (_cvFramePreviewEl) return _cvFramePreviewEl;
     var wrap = el("div", "cv-frame-preview hidden");
     var img = document.createElement("img");
+    img.decoding = "async";
     img.className = "cv-frame-preview-img";
     img.alt = "";
     wrap.appendChild(img);

--- a/assets/web/gallery.js
+++ b/assets/web/gallery.js
@@ -116,6 +116,7 @@
         card.appendChild(createGalleryLoopVideo(src, altText));
       } else {
         var img = document.createElement("img");
+        img.decoding = "async";
         img.src = src;
         img.alt = altText;
         img.loading = "lazy";
@@ -185,6 +186,7 @@
       content.appendChild(createLoopVideo(src, altText));
     } else {
       var img = document.createElement("img");
+      img.decoding = "async";
       img.src = src;
       img.alt = altText;
       content.appendChild(img);

--- a/assets/web/screenspace-multitool-params.js
+++ b/assets/web/screenspace-multitool-params.js
@@ -270,6 +270,7 @@
       info.innerHTML = "";
       if (step._upload) {
         var thumb = document.createElement("img");
+        thumb.decoding = "async";
         thumb.src = "data:image/png;base64," + step._upload.data;
         thumb.alt = "Uploaded template";
         thumb.title = step._upload.name;

--- a/assets/web/screenspace-results.js
+++ b/assets/web/screenspace-results.js
@@ -644,6 +644,7 @@
       var filename = results.split("/").pop();
       if (ext === "gif") {
         var img = document.createElement("img");
+        img.decoding = "async";
         img.src = "media/" + filename;
         wrapper.appendChild(img);
       } else {
@@ -755,6 +756,7 @@
         var thumb = el("div", "heatmap-thumb");
         var media = el("div", "heatmap-thumb-media");
         var img = document.createElement("img");
+        img.decoding = "async";
         img.src = "media/" + view.src;
         img.alt = view.alt;
         media.appendChild(img);

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1257,6 +1257,7 @@
       item.setAttribute("data-pin-id", pin.id);
 
       var img = document.createElement("img");
+      img.decoding = "async";
       img.className = "pin-tray-thumb";
       img.alt = "";
       img.loading = "lazy";
@@ -2691,6 +2692,7 @@
       }
       var uploadInfo = el("span", "param-value template-upload-info");
       var uploadThumb = document.createElement("img");
+      uploadThumb.decoding = "async";
       uploadThumb.src = "data:image/png;base64," + state.uploadedTemplate.data;
       uploadThumb.alt = "Uploaded template";
       uploadThumb.title = state.uploadedTemplate.name;

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -694,6 +694,7 @@
     var preview = el("div", "card-tile-preview card-tile-preview--" + item.kind);
     if (item.url) {
       var img = document.createElement("img");
+      img.decoding = "async";
       img.src = item.url;
       img.alt = item.label;
       img.loading = "lazy";

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2250,6 +2250,7 @@
     thumb.dataset.start = opts.start;
     thumb.dataset.end = Number(opts.start) + Number(opts.duration);
     var img = document.createElement("img");
+    img.decoding = "async";
     img.alt = "";
     img.draggable = false;
     thumb.appendChild(img);
@@ -2882,6 +2883,7 @@
 
     picks.forEach(function (item, idx) {
       var img = document.createElement("img");
+      img.decoding = "async";
       img.className = "stash-card-icon-img";
       img.alt = "";
       img.draggable = false;

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -121,6 +121,7 @@
         media.src = a.file;
       } else {
         media = document.createElement("img");
+        media.decoding = "async";
         media.src = a.file;
         media.alt = a.description || a.type;
         media.loading = "lazy";
@@ -234,6 +235,7 @@
           }
           _thumbCache[artifact.id] = url;
           var img = document.createElement("img");
+          img.decoding = "async";
           img.src = url;
           img.alt = artifact.description || "";
           mediaEl.classList.remove("thumb-pending");
@@ -384,6 +386,7 @@
       if (!media || media.querySelector("img")) return;
       if (_thumbCache[a.id]) {
         var img = document.createElement("img");
+        img.decoding = "async";
         img.src = _thumbCache[a.id];
         img.alt = a.description || "";
         media.classList.remove("thumb-pending");
@@ -1445,6 +1448,7 @@
       var media = el("div", "artifact-media");
       if (a.type === "screen" || a.type === "gif") {
         var img = document.createElement("img");
+        img.decoding = "async";
         img.src = a.file;
         img.alt = a.description || "";
         img.loading = "lazy";
@@ -1452,6 +1456,7 @@
       } else if (a.type === "clip") {
         if (_thumbCache[a.id]) {
           var cimg = document.createElement("img");
+          cimg.decoding = "async";
           cimg.src = _thumbCache[a.id];
           cimg.alt = a.description || "";
           media.classList.add("thumb-loaded");
@@ -1621,6 +1626,7 @@
 
     if (a.type === "screen") {
       var img = document.createElement("img");
+      img.decoding = "async";
       img.src = a.file;
       img.alt = a.description || "screenshot";
       preview.appendChild(img);
@@ -1629,6 +1635,7 @@
         preview.appendChild(createLoopVideo(a.file, a.description || "gif"));
       } else {
         var gifImg = document.createElement("img");
+        gifImg.decoding = "async";
         gifImg.src = a.file;
         gifImg.alt = a.description || "gif";
         preview.appendChild(gifImg);
@@ -1696,6 +1703,7 @@
 
     if (a.type === "screen") {
       var img = document.createElement("img");
+      img.decoding = "async";
       img.src = a.file;
       img.alt = a.description || "screenshot";
       preview.appendChild(img);
@@ -1708,6 +1716,7 @@
         preview.appendChild(createLoopVideo(a.file, a.description || "gif"));
       } else {
         var gifImg = document.createElement("img");
+        gifImg.decoding = "async";
         gifImg.src = a.file;
         gifImg.alt = a.description || "gif";
         preview.appendChild(gifImg);
@@ -2119,6 +2128,7 @@
 
     if (a.type === "screen") {
       var img = document.createElement("img");
+      img.decoding = "async";
       img.src = a.file;
       img.alt = a.description || "screenshot";
       preview.appendChild(img);
@@ -2127,6 +2137,7 @@
         preview.appendChild(createLoopVideo(a.file, a.description || "gif"));
       } else {
         var gifImg = document.createElement("img");
+        gifImg.decoding = "async";
         gifImg.src = a.file;
         gifImg.alt = a.description || "gif";
         preview.appendChild(gifImg);

--- a/screenspace_heatmap.py
+++ b/screenspace_heatmap.py
@@ -194,28 +194,30 @@ def generate_heatmap_gif(
     if heatmap_type in ("flow", "change"):
         acc_h = acc_w = 256
 
-    # Single pass: accumulate progressively, snapshotting each frame's state.
+    # Pass 1: accumulate everything to find the shared ceiling. Accumulation is
+    # monotonic, so the final cumulative state already carries the global max —
+    # no per-frame snapshots needed to compute it.
     accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
-    snapshots: list[np.ndarray | None] = []
-    for frame_idx in range(num_frames):
-        start_idx, end_idx = _frame_bucket_bounds(frame_idx, len(results), num_frames)
-        for r_idx in range(start_idx, end_idx):
-            _accumulate_heatmap_result(accumulator, results[r_idx], heatmap_type)
-        snapshots.append(accumulator.copy())
-
-    # Monotonic accumulation → the final cumulative state carries the global max.
+    for r in results:
+        _accumulate_heatmap_result(accumulator, r, heatmap_type)
     global_max = float(accumulator.max())
     if global_max == 0:
         return None
 
+    # Pass 2: replay the accumulation bucket-by-bucket, colorizing each frame
+    # inline against that shared max. Only one float32 accumulator is ever
+    # resident, so peak memory is ~one frame instead of all `num_frames`
+    # snapshots at once (~190MB → ~8MB at 1080p). `_heatmap_frame_image` reads
+    # the accumulator without mutating it, so accumulation safely continues.
+    accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
     frames: list[Image.Image] = []
-    for idx in range(num_frames):
-        snap = snapshots[idx]
-        assert snap is not None  # freshly filled above; released only after use
+    for frame_idx in range(num_frames):
+        start_idx, end_idx = _frame_bucket_bounds(frame_idx, len(results), num_frames)
+        for r_idx in range(start_idx, end_idx):
+            _accumulate_heatmap_result(accumulator, results[r_idx], heatmap_type)
         frames.append(
-            _heatmap_frame_image(snap, global_max, heatmap_type, width, height)
+            _heatmap_frame_image(accumulator, global_max, heatmap_type, width, height)
         )
-        snapshots[idx] = None  # release the array once colorized (bound peak memory)
 
     frames[0].save(
         output_path,
@@ -265,24 +267,24 @@ def generate_rolling_heatmap_gif(
                 _accumulate_heatmap_result(acc, results[r_idx], heatmap_type)
         return acc
 
-    # Single pass: build each window once, cache it, and track the shared ceiling.
-    window_accs: list[np.ndarray | None] = [
-        _accumulate_window(i) for i in range(num_frames)
-    ]
-    global_max = max(
-        (float(a.max()) for a in window_accs if a is not None), default=0.0
-    )
+    # Pass 1: build each window once to find the shared ceiling, discarding each
+    # array immediately so only one window is ever resident.
+    global_max = 0.0
+    for i in range(num_frames):
+        global_max = max(global_max, float(_accumulate_window(i).max()))
     if global_max == 0:
         return None
 
+    # Pass 2: rebuild each window and colorize inline against that shared max —
+    # peak memory is ~one window instead of all `num_frames` at once. Windows are
+    # independent, so rebuilding them is cheap relative to holding them all.
     frames: list[Image.Image] = []
     for idx in range(num_frames):
-        acc = window_accs[idx]
-        assert acc is not None  # freshly filled above; released only after use
         frames.append(
-            _heatmap_frame_image(acc, global_max, heatmap_type, width, height)
+            _heatmap_frame_image(
+                _accumulate_window(idx), global_max, heatmap_type, width, height
+            )
         )
-        window_accs[idx] = None  # release once colorized
 
     frames[0].save(
         output_path,


### PR DESCRIPTION
## Summary
Two image-themed performance fixes from code review, one commit each:

- **`perf(web)`** — set `img.decoding = "async"` at all 22 `document.createElement("img")` sites (viewer, gallery, screenspace, studio, settings, convergence) so image decode runs off the main thread, cutting scroll/paint jank alongside the existing `loading="lazy"`. `new Image()` sites are untouched (async is already their default).
- **`perf(screenspace)`** — `generate_heatmap_gif` / `generate_rolling_heatmap_gif` in `screenspace_heatmap.py` no longer hold all `num_frames` full-res float32 snapshots (~190MB at 1080p) before colorizing. A two-pass approach (find shared `global_max`, then replay + colorize inline) caps peak to one accumulator (~8MB). GIF output bytes unchanged.

A third reviewed finding — gallery batch screenshots full-decoding at sparse intervals (`video._batch_extract_screenshots`) — is **deferred to a separate PR**; it needs a keyframe-gap threshold and a benchmark before committing to parallel fast-seeks (they can regress dense grids).

## Test plan
- [x] `ruff format --check`, `ruff check`, `ty check` — all green
- [x] Full `pytest` suite — all green (heatmap-GIF tests unchanged and passing)
- [x] `node --check` on all touched JS
- [ ] ⚠️ UI not browser-checked — `decoding="async"` is invisible-by-design (no-regression); please spot-check viewer grid / gallery / screenspace results