### PR TITLE
fix(web): cover topnav under modals and blur the artifact log backdrop

### DIFF
--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -192,6 +192,7 @@
     _root.style.setProperty("--veil-alpha", "0");
 
     _root.classList.remove("hidden");
+    document.body.classList.add("modal-open");
 
     // Next frame: build in the backdrop blur and slide/scale the panel.
     requestAnimationFrame(function () {
@@ -213,6 +214,9 @@
     if (_closeTimer) clearTimeout(_closeTimer);
     _closeTimer = setTimeout(function () {
       if (_root) _root.classList.add("hidden");
+      // Clear the topnav gate only once the veil is gone, so the bar stays
+      // covered through the fade-out.
+      document.body.classList.remove("modal-open");
       _closeTimer = null;
     }, EXIT_MS);
   }

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -2406,18 +2406,44 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
 #logOverlay {
   position: fixed;
   inset: 0;
-  background: var(--color-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal);
+  /* Animated backdrop blur + dark veil, driven by these custom props from
+   * openLog/closeLog. Mirrors .settings-overlay / .start-overlay. */
+  --host-blur: 0px;
+  --veil-alpha: 0;
+}
+
+#logOverlay::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 10, 11, var(--veil-alpha));
+  backdrop-filter: blur(var(--host-blur)) saturate(0.9);
+  -webkit-backdrop-filter: blur(var(--host-blur)) saturate(0.9);
+  transition:
+    background 460ms cubic-bezier(.22, 1, .36, 1),
+    backdrop-filter 460ms cubic-bezier(.22, 1, .36, 1),
+    -webkit-backdrop-filter 460ms cubic-bezier(.22, 1, .36, 1);
+  pointer-events: none;
 }
 
 #logOverlay.hidden {
   display: none;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  #logOverlay::before {
+    transition: none;
+  }
+}
+
 .log-panel {
+  /* Positioned so it paints above the absolutely-positioned #logOverlay::before
+   * veil (mirrors .settings-panel); otherwise the veil dims/blurs the dialog. */
+  position: relative;
   background: var(--color-surface);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-panel-border);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -4082,18 +4082,51 @@
 
   // ---- Artifact log ----
 
+  // Backdrop veil animation, mirroring the shared Settings modal.
+  var LOG_BLUR_PX = 12;
+  var LOG_VEIL_ALPHA = 0.45;
+  var LOG_EXIT_MS = 360;
+  var _logCloseTimer = null;
+
   function openLog() {
     var overlay = qs("#logOverlay");
     var wasHidden = overlay.classList.contains("hidden");
+    if (_logCloseTimer) {
+      clearTimeout(_logCloseTimer);
+      _logCloseTimer = null;
+    }
+    overlay.style.setProperty("--host-blur", "0px");
+    overlay.style.setProperty("--veil-alpha", "0");
     overlay.classList.remove("hidden");
+    document.body.classList.add("modal-open");
     openModalTrap(overlay, closeLog);
+    // Next frame: build in the backdrop blur + dark veil.
+    requestAnimationFrame(function () {
+      overlay.style.setProperty("--host-blur", LOG_BLUR_PX + "px");
+      overlay.style.setProperty("--veil-alpha", String(LOG_VEIL_ALPHA));
+    });
     popOverlayCardIn(qs(".log-panel"), wasHidden);
     renderLog();
   }
 
   function closeLog() {
-    closeModalTrap(qs("#logOverlay"));
-    qs("#logOverlay").classList.add("hidden");
+    var overlay = qs("#logOverlay");
+    overlay.style.setProperty("--host-blur", "0px");
+    overlay.style.setProperty("--veil-alpha", "0");
+    // Animate the card out alongside the veil fade (pop exits in 150ms, well
+    // inside LOG_EXIT_MS); animateIn on the next open supersedes the held state.
+    var card = qs(".log-panel");
+    if (card && window.ClipgenMotion) ClipgenMotion.animateOut(card, "pop");
+    // Release the focus trap + topnav gate only once the overlay actually hides,
+    // so focus stays trapped in the dialog through the fade (not restored to the
+    // trigger while the veil is still visible). Matches Settings' timing.
+    if (_logCloseTimer) clearTimeout(_logCloseTimer);
+    _logCloseTimer = setTimeout(function () {
+      closeModalTrap(overlay);
+      overlay.classList.add("hidden");
+      document.body.classList.remove("modal-open");
+      _logCloseTimer = null;
+    }, LOG_EXIT_MS);
   }
 
   function renderLog() {

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -46,6 +46,16 @@ body.dragging .topnav {
   background: var(--bg);
 }
 
+/* While a full-screen modal veil is up (Settings, Artifact Log), drop the glass
+ * bar's own backdrop-filter so the overlay's veil composites over it — otherwise
+ * the topnav's own blur promotes it to a crisp glass layer that reads through
+ * the veil. Gate: body.modal-open, set by those modals' open/close. Keeps the
+ * translucent bg (unlike body.dragging) so the veil dims the bar. */
+body.modal-open .topnav {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
 .topnav-left,
 .topnav-right {
   flex: 1 1 0;


### PR DESCRIPTION
## Summary

Two related UX fixes to the shared web chrome. The Settings modal and Artifact Log now set a `body.modal-open` gate that drops the topnav's own `backdrop-filter`, so the overlay veil covers the bar instead of it reading through as crisp glass (mirroring the Start overlay). The Artifact Log also gains the same animated `--host-blur`/`--veil-alpha` backdrop veil the Settings/Start overlays use — fading in on open and out on close, with `.log-panel` popping in/out via ClipgenMotion, made `position: relative` so it paints above the veil, and its focus-trap release deferred until the overlay actually hides.

## Test plan

- [x] `/check` green — ruff format + lint, ty, 1884 tests pass
- [x] `node --check` on `studio.js` / `settings-modal.js`
- [x] Browser-verified: topnav dims under Settings/Log, log backdrop blurs in and card fades out in sync