### PR TITLE
fix(screenspace): freeze paused task's elapsed timer

### DIFF
--- a/assets/web/screenspace-tasks.js
+++ b/assets/web/screenspace-tasks.js
@@ -947,6 +947,14 @@
     return task.status === "running" || task.status === "paused";
   }
 
+  function taskIsTerminal(task) {
+    return (
+      task.status === "completed" ||
+      task.status === "failed" ||
+      task.status === "cancelled"
+    );
+  }
+
   // The task-card status line. Progress is NOT part of renderTaskList's rebuild
   // gate (that would rebuild the whole list ~2/s to move a bar); instead this
   // text + the progress fill are refreshed in place by tickTaskProgress. Kept
@@ -1001,6 +1009,9 @@
       t.start(isNaN(seed) ? undefined : seed);
       _etaTrackers[task.id] = t;
     }
+    // Freeze the elapsed clock while paused; resume folds the paused span out.
+    if (task.status === "paused") t.pause();
+    else t.resume();
     var prog = task.status === "paused" ? 0 : task.progress;
     var e = t.update(prog);
     var label = formatDuration(e.elapsedSec);
@@ -1010,13 +1021,16 @@
   }
 
   function tickEtas() {
-    // Prune trackers for tasks that are gone or no longer active.
-    var activeIds = {};
+    // Prune trackers only for tasks that are gone or terminal. A resumed task
+    // dips through "queued" (not active) on its way back to running; keeping the
+    // tracker across that gap preserves its paused-time accumulator so elapsed
+    // doesn't re-count the paused span after resume.
+    var keepIds = {};
     state.tasks.forEach(function (t) {
-      if (taskIsActive(t)) activeIds[t.id] = true;
+      if (!taskIsTerminal(t)) keepIds[t.id] = true;
     });
     Object.keys(_etaTrackers).forEach(function (id) {
-      if (!activeIds[id]) delete _etaTrackers[id];
+      if (!keepIds[id]) delete _etaTrackers[id];
     });
     // Refresh the visible eta spans in place (no list re-render).
     var spans = document.querySelectorAll("#taskList [data-task-eta]");

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -432,6 +432,11 @@ var estimateRemainingSec = function (elapsedSec, progress) {
 // elapsedSec only — remainingSec stays null. Returns a plain object (not a class,
 // per project convention) closing over the start timestamp and an EMA of the raw
 // estimate to damp jitter.
+//
+// pause()/resume() are opt-in: elapsed freezes while paused and continues afterward,
+// with the paused span excluded from elapsed. Callers that never call pause() see the
+// original continuous wall-clock behavior (so e.g. the Transcripts timers are
+// unaffected).
 var createEtaTracker = function (opts) {
   opts = opts || {};
   var emaAlpha = opts.emaAlpha != null ? opts.emaAlpha : 0.3;
@@ -439,17 +444,34 @@ var createEtaTracker = function (opts) {
   var minElapsed = opts.minElapsed != null ? opts.minElapsed : 3;
   var startMs = null;
   var ema = null;
+  var pausedMs = 0; // total ms spent paused across completed pause spans
+  var pausedAt = null; // epoch (ms) the current pause began, else null
   return {
     // Idempotent: repeated calls keep the original start so elapsed never resets.
     // Pass an explicit epoch (ms) to seed from a known start (e.g. reattach).
     start: function (nowMs) {
       if (startMs == null) startMs = nowMs != null ? nowMs : Date.now();
     },
+    // Freeze elapsed at the pause instant. Idempotent — safe to call every tick.
+    pause: function (nowMs) {
+      if (pausedAt == null) pausedAt = nowMs != null ? nowMs : Date.now();
+    },
+    // Resume ticking, folding the just-ended pause span into pausedMs. No-op when
+    // not paused.
+    resume: function (nowMs) {
+      if (pausedAt != null) {
+        pausedMs += (nowMs != null ? nowMs : Date.now()) - pausedAt;
+        pausedAt = null;
+      }
+    },
     // Returns { elapsedSec, remainingSec } — remainingSec is null until the
     // progress/elapsed gates open, then an EMA-smoothed, rounded estimate.
     update: function (progress) {
       if (startMs == null) startMs = Date.now();
-      var elapsedSec = (Date.now() - startMs) / 1000;
+      // While paused, "now" holds at pausedAt (the current pause isn't in pausedMs
+      // yet), so elapsed freezes; after resume() it continues seamlessly.
+      var now = pausedAt != null ? pausedAt : Date.now();
+      var elapsedSec = (now - startMs - pausedMs) / 1000;
       var raw = estimateRemainingSec(elapsedSec, progress);
       var remainingSec = null;
       if (raw != null && progress >= minProgress && elapsedSec >= minElapsed) {
@@ -462,6 +484,8 @@ var createEtaTracker = function (opts) {
     reset: function () {
       startMs = null;
       ema = null;
+      pausedMs = 0;
+      pausedAt = null;
     },
   };
 };


### PR DESCRIPTION
## Summary

A paused Screenspace task's elapsed clock kept counting because it was pure frontend wall-clock time. `createEtaTracker` now has opt-in `pause()`/`resume()` that excludes the paused span from elapsed, driven by `task.status` in `taskEtaLabel`; the eta tracker is also kept alive across the brief `queued` dip on resume so elapsed doesn't re-count the pause. Transcripts/agent timers never pause, so they're unaffected.

## Test plan

- [x] `node --check` on both edited JS files
- [x] Full `pytest` suite passes (incl. frontend/satellite wiring tests)
- [x] Manual browser check: pause a running scan → elapsed freezes and "~X left" hides; resume → elapsed continues without jumping; Transcripts timers still tick. ⚠️ not browser-verified