### PR TITLE
style(workflows): add icons to New/Delete/Clean up/Stash toolbar buttons

### DIFF
--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -277,6 +277,41 @@ body[data-frontend="workflows"] {
   -webkit-mask-image: url("icons/arrows-pointing-out.svg");
 }
 
+/* Leading glyph for text toolbar buttons (icon + label), sm-sized like the
+   trigger so it reads lighter than the md-sized icon-only buttons above. */
+.wf-label-icon {
+  display: inline-block;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
+  background-color: currentColor;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-position: center;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+}
+
+.wf-new-icon {
+  mask-image: url("icons/plus.svg");
+  -webkit-mask-image: url("icons/plus.svg");
+}
+
+.wf-delete-icon {
+  mask-image: url("icons/trash.svg");
+  -webkit-mask-image: url("icons/trash.svg");
+}
+
+.wf-cleanup-icon {
+  mask-image: url("icons/rectangle-group.svg");
+  -webkit-mask-image: url("icons/rectangle-group.svg");
+}
+
+.wf-stash-icon {
+  mask-image: url("icons/archive-box-arrow-down.svg");
+  -webkit-mask-image: url("icons/archive-box-arrow-down.svg");
+}
+
 /* ---- Save-status indicator ---- */
 
 .wf-save-status {

--- a/assets/web/workflows.html
+++ b/assets/web/workflows.html
@@ -33,8 +33,12 @@
     <!-- Debounced-autosave status: "Saving…" while the timer is armed, "Saved"
          once the PUT resolves, "Save failed" on error (hub setSaveStatus). -->
     <span id="wfSaveStatus" class="wf-save-status" aria-live="polite"></span>
-    <button id="wfNewBlueprint" class="btn btn-small" type="button" disabled>New</button>
-    <button id="wfDeleteBlueprint" class="btn btn-small" type="button" disabled>Delete</button>
+    <button id="wfNewBlueprint" class="btn btn-small btn-icon" type="button" disabled>
+      <span class="wf-label-icon wf-new-icon" aria-hidden="true"></span>New
+    </button>
+    <button id="wfDeleteBlueprint" class="btn btn-small btn-icon" type="button" disabled>
+      <span class="wf-label-icon wf-delete-icon" aria-hidden="true"></span>Delete
+    </button>
     <!-- Blueprint JSON import/export live in the TopNav Quick Actions menu;
          this hidden input is triggered by the "Import blueprint JSON" item. -->
     <input id="wfImportFile" type="file" accept="application/json,.json" hidden />
@@ -48,14 +52,18 @@
             aria-label="Redo" title="Redo (⌘⇧Z)">
       <span class="wf-btn-icon wf-redo-icon" aria-hidden="true"></span>
     </button>
-    <button id="wfCleanUp" class="btn btn-small" type="button" disabled
-            title="Auto-arrange the nodes">Clean up</button>
+    <button id="wfCleanUp" class="btn btn-small btn-icon" type="button" disabled
+            title="Auto-arrange the nodes">
+      <span class="wf-label-icon wf-cleanup-icon" aria-hidden="true"></span>Clean up
+    </button>
     <button id="wfFitView" class="btn btn-small wf-icon-btn" type="button" disabled
             aria-label="Fit to view" title="Fit all nodes in view (F)">
       <span class="wf-btn-icon wf-fit-icon" aria-hidden="true"></span>
     </button>
-    <button id="wfSaveStash" class="btn btn-small" type="button" disabled
-            title="Save the selected nodes as a reusable stash">Stash selection</button>
+    <button id="wfSaveStash" class="btn btn-small btn-icon" type="button" disabled
+            title="Save the selected nodes as a reusable stash">
+      <span class="wf-label-icon wf-stash-icon" aria-hidden="true"></span>Stash selection
+    </button>
     <div class="wf-run-split">
       <button id="wfRunBtn" class="btn btn-small btn-primary" type="button" disabled
               title="Run this workflow (set a Video Source to “All participants” to fan out)">Run</button>


### PR DESCRIPTION
## Summary

Give the four secondary text-only buttons in the Workflows top toolbar a leading Heroicon so the toolbar reads consistently with the already-iconed actions (Undo, Redo, Fit, Shortcuts, Auto-run). Uses the existing `mask-image`-on-a-`<span>` convention — `plus` (New), `trash` (Delete), `rectangle-group` (Clean up), `archive-box-arrow-down` (Stash selection) — via a new sm-sized `.wf-label-icon` base. Primary Run/Stop CTAs stay text-only; no JS or behavior changes.

## Test plan

- [x] `pytest -c tests/pytest.ini` — 1925 passed (HTML/CSS-only, no Python touched)
- [ ] ⚠️ UI not browser-checked: confirm each glyph sits left of its label, inherits text color, and disabled/hover states still dim correctly