### PR TITLE
fix(studio): reflect changed default formats in the artifact dropdown

### DIFF
--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1120,12 +1120,14 @@
             loading.appendChild(caption);
           }
           clipgenApplyConfig(data.config);
+          updateArtifactFormatLabels();
           state.sheetData = data;
           refreshMetadataIfActive();
           return;
         }
         state.sheetData = data;
         clipgenApplyConfig(data.config);
+        updateArtifactFormatLabels();
         // Restore persisted sidebar filter selections before the first render so
         // the grid and sidebar paint already-filtered (activeFunction first so
         // the fn range stays enabled).
@@ -4200,7 +4202,36 @@
     return null;
   }
 
+  // Rewrite the #artifactFormat option labels so the "(.ext)" suffix reflects
+  // the current output-format settings (FILEFORMAT/SCREENSHOT_FORMAT/GIF_FORMAT).
+  // Prefers state.settingsData (fresh after a save) and falls back to
+  // CLIPGEN_CONFIG (initial load, before the settings modal has been opened).
+  // The option `value`s (clip/screen/gif) are stable and untouched.
+  function _formatExt(name, fallback) {
+    var s = _findSetting(name);
+    return s && s.value ? s.value : fallback;
+  }
+
+  function updateArtifactFormatLabels() {
+    var sel = qs("#artifactFormat");
+    if (!sel) return;
+    var bases = { clip: "Clip", screen: "Screenshot", gif: "GIF" };
+    var exts = {
+      clip: _formatExt("FILEFORMAT", CLIPGEN_CONFIG.clipFormat),
+      screen: _formatExt("SCREENSHOT_FORMAT", CLIPGEN_CONFIG.screenshotFormat),
+      gif: _formatExt("GIF_FORMAT", CLIPGEN_CONFIG.gifFormat),
+    };
+    for (var i = 0; i < sel.options.length; i++) {
+      var opt = sel.options[i];
+      var base = bases[opt.value];
+      if (base && exts[opt.value]) {
+        opt.textContent = base + " (" + exts[opt.value] + ")";
+      }
+    }
+  }
+
   function syncInlineControls() {
+    updateArtifactFormatLabels();
     if (!state.settingsData) return;
     var tcEnabled = _findSetting("TITLECARDS_ENABLED");
     var tcDuration = _findSetting("TITLECARD_DURATION_SECONDS");

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -58,6 +58,9 @@ var CLIPGEN_CONFIG = {
   convergenceSources: ["sheet", "screenspace", "transcript"],
   cardScrubberSpriteCols: 5,
   cardScrubberSpriteRows: 5,
+  clipFormat: ".mp4",
+  screenshotFormat: ".png",
+  gifFormat: ".gif",
 };
 
 var clipgenApplyConfig = function (payload) {
@@ -103,6 +106,15 @@ var clipgenApplyConfig = function (payload) {
   }
   if (typeof payload.cardScrubberSpriteRows === "number") {
     CLIPGEN_CONFIG.cardScrubberSpriteRows = payload.cardScrubberSpriteRows;
+  }
+  if (typeof payload.clipFormat === "string") {
+    CLIPGEN_CONFIG.clipFormat = payload.clipFormat;
+  }
+  if (typeof payload.screenshotFormat === "string") {
+    CLIPGEN_CONFIG.screenshotFormat = payload.screenshotFormat;
+  }
+  if (typeof payload.gifFormat === "string") {
+    CLIPGEN_CONFIG.gifFormat = payload.gifFormat;
   }
 };
 

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -106,6 +106,9 @@ def test_clipgen_config_defaults_match_python():
     assert js_config["convergenceSources"] == py_config["convergenceSources"]
     assert js_config["cardScrubberSpriteCols"] == py_config["cardScrubberSpriteCols"]
     assert js_config["cardScrubberSpriteRows"] == py_config["cardScrubberSpriteRows"]
+    assert js_config["clipFormat"] == py_config["clipFormat"]
+    assert js_config["screenshotFormat"] == py_config["screenshotFormat"]
+    assert js_config["gifFormat"] == py_config["gifFormat"]
 
 
 def test_get_frontend_config_shape():
@@ -126,6 +129,9 @@ def test_get_frontend_config_shape():
         "convergenceSources",
         "cardScrubberSpriteCols",
         "cardScrubberSpriteRows",
+        "clipFormat",
+        "screenshotFormat",
+        "gifFormat",
     }
     assert isinstance(cfg["defaultDuration"], int)
     assert cfg["defaultDuration"] == config.DEFAULT_DURATION_SECONDS
@@ -166,6 +172,9 @@ def test_get_frontend_config_shape():
     assert cfg["convergenceSources"] == list(config.CONVERGENCE_SOURCES)
     assert cfg["cardScrubberSpriteCols"] == config.STUDIO_SCRUBBER_SPRITE_COLS
     assert cfg["cardScrubberSpriteRows"] == config.STUDIO_SCRUBBER_SPRITE_ROWS
+    assert cfg["clipFormat"] == config.FILEFORMAT
+    assert cfg["screenshotFormat"] == config.SCREENSHOT_FORMAT
+    assert cfg["gifFormat"] == config.GIF_FORMAT
 
 
 def test_severity_css_class_mapping():

--- a/utils.py
+++ b/utils.py
@@ -889,6 +889,9 @@ def get_frontend_config() -> dict[str, Any]:
         "convergenceSources": list(config.CONVERGENCE_SOURCES),
         "cardScrubberSpriteCols": config.STUDIO_SCRUBBER_SPRITE_COLS,
         "cardScrubberSpriteRows": config.STUDIO_SCRUBBER_SPRITE_ROWS,
+        "clipFormat": config.FILEFORMAT,
+        "screenshotFormat": config.SCREENSHOT_FORMAT,
+        "gifFormat": config.GIF_FORMAT,
     }
 
 


### PR DESCRIPTION
## Summary

The Studio artifacts toolbar dropdown (`#artifactFormat`) hardcoded its extension labels (`.mp4`/`.png`/`.gif`) in `studio.html` and never re-read the `FILEFORMAT`/`SCREENSHOT_FORMAT`/`GIF_FORMAT` settings, so the label lied about the output extension after a settings change (generated files were already correct via `pipeline.py`'s `extension_map` — this was display-only). The three extensions now flow through `utils.get_frontend_config()` → `CLIPGEN_CONFIG`, and `updateArtifactFormatLabels()` rebuilds each `(.ext)` suffix from `state.settingsData` (fresh after save/reset) with a `CLIPGEN_CONFIG` fallback, wired into `syncInlineControls()` and both sheet-data load paths; the option `value`s (`clip`/`screen`/`gif`) are untouched.

## Test plan

- [x] `pytest -c tests/pytest.ini` (full suite) — green, incl. extended `tests/test_shared_constants.py` for the new config keys
- [x] `ruff format --check`, `ruff check`, `ty check` — clean
- [x] Browser-checked: verify the dropdown shows the persisted extensions on load (with and without a sheet) and updates live after changing the formats in Settings (save/reset), no reload needed