### PR TITLE
fix(overview): pause map replay and cancel render frame on tab deactivate

### DIFF
--- a/assets/web/overview-map.js
+++ b/assets/web/overview-map.js
@@ -84,6 +84,7 @@
   };
 
   var renderPending = false;
+  var renderRaf = 0;
   var lerp = { active: false, from: null, to: null, start: 0 };
 
   var els = {};
@@ -1562,8 +1563,9 @@
   function requestRender() {
     if (renderPending || !three.renderer) return;
     renderPending = true;
-    requestAnimationFrame(function () {
+    renderRaf = requestAnimationFrame(function () {
       renderPending = false;
+      renderRaf = 0;
       three.renderer.render(three.scene, three.camera);
       updateLabels();
     });
@@ -2090,7 +2092,23 @@
     requestRender();
   }
 
+  function mapDeactivate() {
+    // Pause the free-running replay sweep. Its rAF loop guards on replay.playing,
+    // and setReplayPlaying(false) also resyncs the Play/Pause button + scrub UI.
+    if (replay.playing) setReplayPlaying(false);
+    // Cancel any queued on-demand render — no point painting a hidden canvas.
+    if (renderRaf) {
+      cancelAnimationFrame(renderRaf);
+      renderRaf = 0;
+      renderPending = false;
+    }
+    // Clear the transient hover tooltip; the drill-down drawer + selection persist
+    // so returning to the tab keeps the user's context.
+    if (els.tooltip) els.tooltip.classList.add("hidden");
+    state.hovered = -1;
+  }
+
   window.ClipgenOverview.mapActivate = mapActivate;
-  window.ClipgenOverview.mapDeactivate = function () {};
+  window.ClipgenOverview.mapDeactivate = mapDeactivate;
   window.ClipgenOverview.mapResize = onResize;
 })();


### PR DESCRIPTION
## Summary

Give the Overview Map tab's `mapDeactivate` a real body instead of an empty no-op: it pauses the free-running session-replay `requestAnimationFrame` sweep (which previously kept animating a hidden canvas), `cancelAnimationFrame`s the pending on-demand render frame, and clears the transient hover tooltip. The drill-down drawer and participant selection are intentionally preserved so returning to the tab keeps the user's context.

## Test plan

- [x] `node --check assets/web/overview-map.js`
- [x] `tests/test_overview_frontend_source.py` + `tests/test_frontend_satellite_wiring.py` green; full suite 2031 passed; ruff format/lint + ty clean
- [x] Manual: replay stops (button resets to "Play") and tooltip clears on tab switch; drawer + selection persist on return