### PR TITLE
style(web): humanize frontend copy

### DIFF
--- a/assets/web/composer.html
+++ b/assets/web/composer.html
@@ -76,7 +76,7 @@
           <span class="co-btn-icon co-icon-cursor" aria-hidden="true"></span>
         </button>
         <button id="coToolText" class="co-tool-btn" type="button"
-                data-tool="text" title="Add text (T) — click the video to place">
+                data-tool="text" title="Add text (T). Click the video to place">
           <span class="co-btn-icon co-icon-text" aria-hidden="true"></span>
         </button>
         <button id="coToolDraw" class="co-tool-btn" type="button"
@@ -84,7 +84,7 @@
           <span class="co-btn-icon co-icon-draw" aria-hidden="true"></span>
         </button>
         <button id="coToolErase" class="co-tool-btn" type="button"
-                data-tool="erase" title="Eraser (E) — click or drag over annotations">
+                data-tool="erase" title="Eraser (E). Click or drag over annotations">
           <span class="co-btn-icon co-icon-erase" aria-hidden="true"></span>
         </button>
         <span class="co-toolbar-sep"></span>
@@ -154,7 +154,7 @@
         <span class="co-btn-icon co-icon-in" aria-hidden="true"></span>In
       </button>
       <button id="coSetOutBtn" class="btn btn-small btn-icon" type="button" disabled
-              title="Set out point — commits the cut (O)">
+              title="Set out point to commit the cut (O)">
         <span class="co-btn-icon co-icon-out" aria-hidden="true"></span>Out
       </button>
       <span id="coPendingInfo" class="co-pending-info" aria-live="polite"></span>

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -355,7 +355,7 @@
     var info = qs("#coPendingInfo");
     info.textContent = state.pendingIn === null
       ? ""
-      : "In: " + formatTime(state.pendingIn, { decimals: 1 }) + " — press O";
+      : "In: " + formatTime(state.pendingIn, { decimals: 1 }) + ", press O";
   }
 
   function setInPoint() {
@@ -574,7 +574,7 @@
     var end = state.playhead;
     if (end < start) { var tmp = start; start = end; end = tmp; }
     if (end - start < 0.2) {
-      showToast("Cut too short — move the playhead past the in point");
+      showToast("Cut too short. Move the playhead past the in point.");
       return;
     }
     applyCreate({ participant: state.participant, start: start, end: end })

--- a/assets/web/overview-convergence.js
+++ b/assets/web/overview-convergence.js
@@ -729,7 +729,7 @@
 
     if (cvState.events.length === 0) {
       var empty = el("div", "cv-empty-state");
-      empty.textContent = "No events loaded yet — add intake or load a multi-participant sheet to see convergence.";
+      empty.textContent = "No events loaded yet. Add intake or load a multi-participant sheet to see convergence.";
       container.appendChild(empty);
       return;
     }
@@ -890,7 +890,7 @@
     if (btn) {
       btn.classList.toggle("is-stale", stale);
       btn.title = stale
-        ? "New upstream data available — click to refresh"
+        ? "New upstream data available. Click to refresh"
         : "Re-fetch upstream data and recompute convergence";
     }
   }

--- a/assets/web/overview-map.js
+++ b/assets/web/overview-map.js
@@ -1797,7 +1797,7 @@
     if (data.participants.length < 3) {
       showNotice("Only " + data.participants.length + " participant" +
         (data.participants.length === 1 ? "" : "s") +
-        " so far — 3+ make the similarity layout meaningful.");
+        " so far: 3+ make the similarity layout meaningful.");
     } else {
       els.notice.classList.add("hidden");
     }
@@ -1850,13 +1850,13 @@
     }
     els.empty.classList.add("hidden");
     if (!window.THREE) {
-      showNotice("Three.js failed to load — the map cannot render.");
+      showNotice("Three.js failed to load. The map cannot render.");
       return;
     }
     if (data.participants.length < 3) {
       showNotice("Only " + data.participants.length + " participant" +
         (data.participants.length === 1 ? "" : "s") +
-        " so far — 3+ make the similarity layout meaningful.");
+        " so far: 3+ make the similarity layout meaningful.");
     }
 
     state.stats = computeStats(data.matrix, data.columns.length);
@@ -2251,7 +2251,7 @@
     }
     var pid = state.data.participants[idx];
     var rank = state.order.indexOf(idx) + 1;
-    var tip = pid + " — unusualness " +
+    var tip = pid + " · unusualness " +
       state.scores[idx].toFixed(2) + " (#" + rank + ")";
     var cj = colorByIndex();
     if (cj >= 0) {
@@ -2510,7 +2510,7 @@
       {
         key: "showAnchors",
         label: "Shared anchors",
-        hint: "Observation categories and detectors as anchor nodes, placed amid the participants exhibiting them — shows why dots cluster",
+        hint: "Observation categories and detectors as anchor nodes, placed amid the participants exhibiting them; shows why dots cluster",
         apply: setAnchorsVisible,
       },
       {
@@ -2835,7 +2835,7 @@
       ["x", "y", "z"].forEach(function (dim, c) {
         var j = axisFeatureIndex(dim);
         var dt = document.createElement("dt");
-        dt.textContent = axisNames[c] + " — " +
+        dt.textContent = axisNames[c] + ": " +
           (j >= 0 ? state.data.columns[j].label : "(unset)");
         dl.appendChild(dt);
       });
@@ -2853,7 +2853,7 @@
         .sort(function (a, b) { return Math.abs(b.v) - Math.abs(a.v); })
         .slice(0, 3);
       var dt = document.createElement("dt");
-      dt.textContent = axisNames[c] + " — " +
+      dt.textContent = axisNames[c] + ": " +
         Math.round(state.variance[c] * 100) + "% of variance";
       var dd = document.createElement("dd");
       loadings.forEach(function (l, li) {
@@ -3001,7 +3001,7 @@
       muteBtn.type = "button";
       muteBtn.className = "map-feature-mute";
       muteBtn.textContent = "✕";
-      muteBtn.title = "Mute this feature — exclude it from similarity, " +
+      muteBtn.title = "Mute this feature: exclude it from similarity, " +
         "outlier scores, and the layout (restore from the sidebar)";
       muteBtn.addEventListener("click", (function (key) {
         return function () { setFeatureMuted(key, true); };

--- a/assets/web/overview.html
+++ b/assets/web/overview.html
@@ -49,7 +49,7 @@
   <main id="mapShell">
     <aside id="mapSidebar" aria-label="Similarity lens and outliers">
       <div class="map-sidebar-header">Similarity lens</div>
-      <p class="map-hint">Weight what “similar” means. Sliders re-layout the
+      <p class="map-hint">Weight what "similar" means. Sliders re-layout the
         space instantly.</p>
       <div id="mapWeights" class="map-weights"></div>
 
@@ -107,7 +107,7 @@
 
       <div class="map-sidebar-header">Most unusual</div>
       <p class="map-hint">Distance from the cohort centroid across all
-        weighted signals — not just the visible projection.</p>
+        weighted signals, not just the visible projection.</p>
       <ol id="mapOutliers" class="map-outlier-list"></ol>
 
       <details class="map-axis-legend">

--- a/assets/web/screenspace-calibration.js
+++ b/assets/web/screenspace-calibration.js
@@ -64,11 +64,11 @@
     inactivity: { sliderId: "paramInactThresh", invert: true, drawLine: true, compare: "le" },
     color: {
       sliderId: null, rangeMin: 0, rangeMax: 1, invert: false, drawLine: false,
-      rowNote: "Tolerance ≠ confidence — read the gap between green and red dots.",
+      rowNote: "Tolerance ≠ confidence. Read the gap between green and red dots.",
     },
     scene: {
       sliderId: null, rangeMin: 0, rangeMax: 1, invert: false, drawLine: false,
-      rowNote: "Per-scene thresholds — dot colour is pass/fail; hover for the matched scene.",
+      rowNote: "Per-scene thresholds. Dot colour is pass/fail; hover for the matched scene.",
     },
   };
 
@@ -253,9 +253,9 @@
         if (suggestion.mode === "gap") {
           applyTip = "Set the threshold midway between your positives and negatives (gap " + _calFmtVal(suggestion.margin, step) + ").";
         } else if (suggestion.mode === "positives") {
-          applyTip = "Set the threshold at the edge of your positives — pin a negative to widen the margin.";
+          applyTip = "Set the threshold at the edge of your positives. Pin a negative to widen the margin.";
         } else {
-          applyTip = "Set the threshold just past your negatives — pin a positive to widen the margin.";
+          applyTip = "Set the threshold just past your negatives. Pin a positive to widen the margin.";
         }
         applyBadge.setAttribute("data-tooltip", applyTip);
         (function (sid, val, sl) {
@@ -301,7 +301,7 @@
     if (applyBadge) track.appendChild(applyBadge);
     var note = (!axis.drawLine && axis.rowNote) ? axis.rowNote : null;
     if (suggestion && !suggestion.separated) {
-      note = "Positive and negative scores overlap — no clean threshold (check the region or tool).";
+      note = "Positive and negative scores overlap. No clean threshold (check the region or tool).";
     } else if (narrowGap) {
       note = "No step-aligned threshold separates these pins (gap narrower than the slider step, or outside its range).";
     }

--- a/assets/web/screenspace-model-view.js
+++ b/assets/web/screenspace-model-view.js
@@ -42,7 +42,7 @@
     similarity: "Gray-blurred region (≤256 px); reference appears once captured.",
     text: "Grayscale region fed to OCR.",
     numbers: "Grayscale region fed to OCR.",
-    timelapse: "Region crop — FFmpeg encodes this unmodified.",
+    timelapse: "Region crop. FFmpeg encodes this unmodified.",
     template: "Gray-blurred frame, template, and normalized match heatmap.",
     flow: "Prev + current gray frames with dense optical-flow vectors.",
     scene: "Region (≤128 px), Canny edges, and 8-bin hue histogram.",

--- a/assets/web/screenspace-multitool-params.js
+++ b/assets/web/screenspace-multitool-params.js
@@ -595,8 +595,8 @@
         var current = (step.logic || "AND").toUpperCase();
         opBtn.classList.add(current === "NOT" ? "is-not" : "is-and");
         opBtn.title = current === "NOT"
-          ? "NOT — frame rejected if this matches (click to switch to AND)"
-          : "AND — frame must also match (click to switch to NOT)";
+          ? "NOT: frame rejected if this matches (click to switch to AND)"
+          : "AND: frame must also match (click to switch to NOT)";
         opBtn.appendChild(el("span", "multitool-operator-icon"));
         (function (capturedIdx) {
           opBtn.addEventListener("click", function (e) {
@@ -607,8 +607,8 @@
             opBtn.classList.toggle("is-not", next === "NOT");
             opBtn.classList.toggle("is-and", next === "AND");
             opBtn.title = next === "NOT"
-              ? "NOT — frame rejected if this matches (click to switch to AND)"
-              : "AND — frame must also match (click to switch to NOT)";
+              ? "NOT: frame rejected if this matches (click to switch to AND)"
+              : "AND: frame must also match (click to switch to NOT)";
             refreshCalibration({ debounce: true });
           });
         })(idx);
@@ -646,8 +646,8 @@
 
         function setOffsetTitle(active) {
           offBtn.title = active
-            ? "Offset window on — match within a time window of the previous step's frame (not evaluated in calibration; click to disable)"
-            : "Offset — match within a time window relative to the previous step";
+            ? "Offset window on: match within a time window of the previous step's frame (not evaluated in calibration; click to disable)"
+            : "Offset: match within a time window relative to the previous step";
         }
         setOffsetTitle(offActive);
 

--- a/assets/web/screenspace-overlay-interaction.js
+++ b/assets/web/screenspace-overlay-interaction.js
@@ -261,8 +261,8 @@
     var verb = { add: "Added to", subtract: "Subtracted from", intersect: "Intersected" }[op];
     if (!contours.length || contoursArea(contours) < 64) {
       showToast(savedRegion
-        ? "Nothing would remain of '" + name + "' — not applied"
-        : "Nothing would remain — not applied");
+        ? "Nothing would remain of '" + name + "', so this was not applied"
+        : "Nothing would remain, so this was not applied");
       return;
     }
     if (savedRegion) {
@@ -276,7 +276,7 @@
       ? { x: rect.x, y: rect.y, w: rect.w, h: rect.h }
       : pendingShapedRegion(contours, "combo");
     if (!updated) {
-      showToast("Nothing would remain — not applied");
+      showToast("Nothing would remain, so this was not applied");
       return;
     }
     state.pendingRegion = updated;
@@ -322,7 +322,7 @@
         // Drop the draw silently for click-without-drag (zero size), but
         // surface a hint when the user actually dragged a too-small box —
         // otherwise the picker just snaps closed with no feedback.
-        showToast("Region too small — drag a larger area");
+        showToast("Region too small. Drag a larger area");
       }
       flushOverlayRender();
       updateRegionButtons();
@@ -369,7 +369,7 @@
         if (simplified.length >= 3 && polygonArea(simplified) >= 8) {
           applyRegionCombine(combine, { contours: [simplified] });
         } else if (pts.length > 2) {
-          showToast("Shape too small — draw a larger area");
+          showToast("Shape too small. Draw a larger area");
         }
         flushOverlayRender();
         updateRegionButtons();
@@ -379,7 +379,7 @@
       if (pending) {
         state.pendingRegion = pending;
       } else if (pts.length > 2) {
-        showToast("Shape too small — draw a larger area");
+        showToast("Shape too small. Draw a larger area");
       }
       flushOverlayRender();
       updateRegionButtons();
@@ -477,12 +477,12 @@
         if (contour && contour.length >= 3 && polygonArea(contour) >= 8) {
           applyRegionCombine(combine, { contours: [contour] });
         } else {
-          showToast("No contiguous area found — adjust tolerance and try again");
+          showToast("No contiguous area found. Adjust tolerance and try again");
         }
       } else {
         var pending = contour ? pendingShapedRegion([contour], "wand") : null;
         if (pending) state.pendingRegion = pending;
-        else showToast("No contiguous area found — adjust tolerance and try again");
+        else showToast("No contiguous area found. Adjust tolerance and try again");
       }
       flushOverlayRender();
       updateRegionButtons();

--- a/assets/web/screenspace-results.js
+++ b/assets/web/screenspace-results.js
@@ -285,7 +285,7 @@
         renderResults(); // surface freshly-loaded events (histogram, excluded toggle, rows)
         if (!evts.length) {
           showToast(task.status === "running"
-            ? "No events to exclude yet — analysis still running"
+            ? "No events to exclude yet. Analysis still running"
             : "No events to exclude");
           return;
         }

--- a/assets/web/screenspace-tasks.js
+++ b/assets/web/screenspace-tasks.js
@@ -1208,7 +1208,7 @@
         state.eventSource = null;
         if (!state.sseFellBack) {
           state.sseFellBack = true;
-          showToast("Live updates interrupted — falling back to polling");
+          showToast("Live updates interrupted. Falling back to polling");
         }
         startPolling();
       },

--- a/assets/web/screenspace-utils.js
+++ b/assets/web/screenspace-utils.js
@@ -137,7 +137,7 @@ function formatMultitoolStepParams(step) {
 // Readout for a color tool's presence min-area control: percentage plus an
 // approximate pixel count when the analysed region's area is known.
 function _formatMinAreaReadout(pct, area) {
-  if (!(pct > 0)) return "Any presence — no minimum size";
+  if (!(pct > 0)) return "Any presence (no minimum size)";
   var txt = pct + "%";
   if (area && area > 0) {
     var px = Math.max(1, Math.round((pct / 100) * area));

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -81,9 +81,9 @@
       <div id="regionBar">
         <div id="regionChipsScroll"><div id="regionChips"></div></div>
         <div id="regionActions">
-          <button id="toolRectBtn" class="region-toggle-btn active" title="Rectangle — drag to select"></button>
-          <button id="toolLassoBtn" class="region-toggle-btn" title="Lasso — draw a freehand shape"></button>
-          <button id="toolWandBtn" class="region-toggle-btn" title="Magic wand — click a similar-colored area"></button>
+          <button id="toolRectBtn" class="region-toggle-btn active" title="Rectangle: drag to select"></button>
+          <button id="toolLassoBtn" class="region-toggle-btn" title="Lasso: draw a freehand shape"></button>
+          <button id="toolWandBtn" class="region-toggle-btn" title="Magic wand: click a similar-colored area"></button>
           <span id="wandToleranceWrap" class="wand-tolerance hidden">
             <input id="wandToleranceInput" type="range" min="4" max="120" step="1" value="32" title="Wand color tolerance">
             <span id="wandToleranceValue">32</span>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -55,9 +55,9 @@
   // you pick before the fuzzy compare — see _normalize_ocr_text in
   // screenspace.py. Off sits in the middle: digit→letter | off | letter→digit.
   var NORMALIZE_MODES = [
-    { mode: "letters", icon: "language", desc: "Fold digits→letters before matching (0→o, 1→l, 5→s) — for word targets OCR may read as digits" },
+    { mode: "letters", icon: "language", desc: "Fold digits to letters before matching (0→o, 1→l, 5→s). For word targets that OCR may read as digits" },
     { mode: "off", icon: "no-symbol", desc: "No character folding" },
-    { mode: "digits", icon: "hashtag", desc: "Fold letters→digits before matching (O→0, l→1, S→5) — for number targets OCR may read as letters" },
+    { mode: "digits", icon: "hashtag", desc: "Fold letters to digits before matching (O→0, l→1, S→5). For number targets that OCR may read as letters" },
   ];
 
   function _normalizeMode(mode) {
@@ -858,30 +858,30 @@
       "Region":           "Which screen region this step analyzes",
     },
     color: {
-      "Tolerance":        "How far from the target color still counts — widen to catch more shades, tighten to be stricter",
+      "Tolerance":        "How far from the target color still counts. Widen to catch more shades, tighten to be stricter",
       "Hex color":        "Target color in hex notation",
       "Mode":             "Average matches the region's mean colour; Presence fires when the target colour appears anywhere in the region (per-pixel)",
       "Min area %":       "Presence mode only: the minimum share of region pixels that must match before an event fires. 0% = any presence detected (no minimum size); raise it to ignore stray noise pixels. The readout shows the approximate pixel count for the current region.",
     },
     change: {
-      "Threshold":        "How much of the region must change to trigger — raise it to ignore minor flicker",
+      "Threshold":        "How much of the region must change to trigger. Raise it to ignore minor flicker",
       "Noise Thr.":       "Ignore changes below this pixel intensity",
       "Noise":            "Ignore changes below this pixel intensity",
       "Consecutive":      "Require this many consecutive sampled frames to match before an event fires (suppresses single-frame flicker; reports the run's median time)",
     },
     similarity: {
       "Reference":        "Capture the frame you want later frames to match against",
-      "Threshold":        "How close a frame must look to the reference — lower it to allow looser matches",
+      "Threshold":        "How close a frame must look to the reference. Lower it to allow looser matches",
     },
     text: {
       "Search text":      "Exact or partial text to find on screen",
       "Search":           "Exact or partial text to find on screen",
-      "Fuzzy Thr.":       "How closely the text must match (1.0 = exact) — lower it to tolerate more misreads",
-      "Fuzzy":            "How closely the text must match (1.0 = exact) — lower it to tolerate more misreads",
+      "Fuzzy Thr.":       "How closely the text must match (1.0 = exact). Lower it to tolerate more misreads",
+      "Fuzzy":            "How closely the text must match (1.0 = exact). Lower it to tolerate more misreads",
       "Min OCR conf.":    "Drop OCR readings below this confidence before fuzzy matching (raise to suppress noisy misreads)",
       "Min OCR":          "Drop OCR readings below this confidence before fuzzy matching (raise to suppress noisy misreads)",
       "Enhance ROI":      "Upscale small/low-contrast crops and apply CLAHE before OCR (slower; helps tiny HUD text)",
-      "Normalize":        "Fold easily-confused glyphs before matching: digit→letter, off, or letter→digit. Pick the side matching what your search target is (letters vs digits).",
+      "Normalize":        "Fold easily-confused glyphs before matching: digits to letters, off, or letters to digits. Pick the side that matches your search target (letters vs digits).",
       "Language":         "OCR language for text recognition",
       "Consecutive":      "Require this many consecutive sampled frames to match before an event fires (suppresses single-frame flicker; reports the run's median time)",
     },
@@ -904,17 +904,17 @@
     },
     template: {
       "Template":         "Capture or upload the picture to search for anywhere on screen",
-      "Threshold":        "How closely the picture must match — lower it to allow looser matches",
+      "Threshold":        "How closely the picture must match. Lower it to allow looser matches",
     },
     flow: {
-      "Magnitude":        "Minimum movement strength to count — raise it to ignore small or slow motion",
+      "Magnitude":        "Minimum movement strength to count. Raise it to ignore small or slow motion",
       "Consecutive":      "Require this many consecutive sampled frames to match before an event fires (suppresses single-frame flicker; reports the run's median time)",
     },
     scene: {
       "Add Scene":        "Capture and name each screen you want to recognize",
     },
     inactivity: {
-      "Sensitivity":      "How little movement still counts as idle — raise it to treat more frames as still",
+      "Sensitivity":      "How little movement still counts as idle. Raise it to treat more frames as still",
       "Min duration (s)": "Seconds of stillness required before a stall is reported",
     },
     boundary: {
@@ -1167,7 +1167,7 @@
     var disabled = !hasVideo || atCap;
     posBtn.disabled = disabled;
     negBtn.disabled = disabled;
-    var capNote = atCap ? " — limit reached (" + state.maxPins + ")" : "";
+    var capNote = atCap ? ". Limit reached (" + state.maxPins + ")" : "";
     posBtn.title = "Pin this frame as a positive (condition is true here)" + capNote;
     negBtn.title = "Pin this frame as a negative (condition must not fire here)" + capNote;
   }
@@ -2262,18 +2262,18 @@
   // ---- Tool info tooltip ----
 
   var TOOL_INFO = {
-    multitool: "Combines several tools so a frame only matches when it passes every step — e.g. a red health bar AND the word 'DEAD'. Add at least two steps; a step can also be set to exclude (match only when it does NOT apply). Get each tool working on its own first, then chain them here to pin down precise moments.",
+    multitool: "Combines several tools so a frame only matches when it passes every step. For example, a red health bar AND the word 'DEAD'. Add at least two steps; a step can also be set to exclude (match only when it does NOT apply). Get each tool working on its own first, then chain them here to pin down precise moments.",
     color: "Finds frames where the average color of your region matches a color you pick. Draw a small region over a solid-colored element and sample its color; widen Tolerance to catch more shades, tighten it to be stricter. Good for color-coded elements like a health bar or status light. To find a specific icon or picture instead, use Template.",
-    change: "Flags frames where the picture inside your region differs from a moment earlier — sudden changes like a screen transition, a pop-up appearing, or a loading screen finishing. Raise the Threshold if it fires on every small flicker. Unlike Flow (which measures movement) it reacts to any difference; unlike Boundary it watches only the region you draw, not the whole screen.",
-    similarity: "Capture one reference frame, then this finds every later frame that looks almost identical — a strict, pixel-for-pixel match that's sensitive to lighting and layout shifts. Lower the Threshold to allow looser matches. Use it to catch when one exact state returns (a specific dialog or menu). For 'which screen are we on' across several screens that vary, use Scene instead.",
+    change: "Flags frames where the picture inside your region differs from a moment earlier: sudden changes such as a screen transition, a pop-up appearing, or a loading screen finishing. Raise the Threshold if it fires on every small flicker. Unlike Flow (which measures movement) it reacts to any difference; unlike Boundary it watches only the region you draw, not the whole screen.",
+    similarity: "Capture one reference frame, then this finds every later frame that looks almost identical: a strict, pixel-for-pixel match that's sensitive to lighting and layout shifts. Lower the Threshold to allow looser matches. Use it to catch when one exact state returns (a specific dialog or menu). For 'which screen are we on' across several screens that vary, use Scene instead.",
     text: "Reads on-screen text in your region (OCR) and flags frames matching your search words, allowing for small misreads. Draw a tight region around the text; raise the OCR confidence if you get false hits. Good for catching specific labels, error messages, or button text. To compare on-screen numbers (e.g. score over 1000), use Numbers.",
-    numbers: "Reads a number from your region (OCR) and flags frames where it meets a rule you set — equals, greater than, less than, or within a range. Draw a tight region around just the number, then pick the operator and target value. Great for scores, timers, lives, or any changing count. For words rather than numbers, use Text.",
-    timelapse: "Produces one sped-up video or GIF of your region over the time range you choose — a fast way to skim a long session. Unlike every other tool it doesn't mark individual moments on the timeline; it outputs a single clip. Set the speed, and optionally sample every N seconds for a shorter file.",
-    template: "Capture or upload a small reference image, then this looks for that exact picture anywhere on screen — not just inside a region. Ideal for finding an icon, button, or logo wherever it appears. Lower the Threshold to allow looser matches. Unlike Color (which matches an average shade) it matches the picture itself; unlike Similarity it searches the whole frame, not one region.",
-    flow: "Detects movement inside your region — a character running, an animation playing, activity in one corner. Raise the strength threshold to ignore small or slow motion. Unlike Change (which fires on any pixel difference, including flicker) Flow responds only to real movement, so it stays steadier on noisy footage.",
-    scene: "Capture and label several reference screens, then this tags each frame with whichever one it most resembles — building a timeline of which screen is showing (title, map, level, pause menu…). It tolerates lighting and minor changes better than Similarity, and handles many screens at once where Similarity matches just one. Lower the Threshold if frames go untagged.",
+    numbers: "Reads a number from your region (OCR) and flags frames where it meets a rule you set: equals, greater than, less than, or within a range. Draw a tight region around just the number, then pick the operator and target value. Great for scores, timers, lives, or any changing count. For words rather than numbers, use Text.",
+    timelapse: "Produces one sped-up video or GIF of your region over the time range you choose: a fast way to skim a long session. Unlike every other tool it doesn't mark individual moments on the timeline; it outputs a single clip. Set the speed, and optionally sample every N seconds for a shorter file.",
+    template: "Capture or upload a small reference image, then this looks for that exact picture anywhere on screen, not just inside a region. Ideal for finding an icon, button, or logo wherever it appears. Lower the Threshold to allow looser matches. Unlike Color (which matches an average shade) it matches the picture itself; unlike Similarity it searches the whole frame, not one region.",
+    flow: "Detects movement inside your region: a character running, an animation playing, or activity in one corner. Raise the strength threshold to ignore small or slow motion. Unlike Change (which fires on any pixel difference, including flicker) Flow responds only to real movement, so it stays steadier on noisy footage.",
+    scene: "Capture and label several reference screens, then this tags each frame with whichever one it most resembles. This builds a timeline of which screen is showing (title, map, level, pause menu). It tolerates lighting and minor changes better than Similarity, and handles many screens at once where Similarity matches just one. Lower the Threshold if frames go untagged.",
     inactivity: "Finds stretches where your region barely changes for a while — loading screens, frozen states, or a player standing idle. It's the opposite of Change: it fires when nothing happens, not when something does. Set the minimum duration so brief pauses are ignored and only real stalls are reported.",
-    boundary: "Scans the whole screen for period transitions — menu → gameplay, a level loading, a loading screen ending. Metric: Auto (recommended) uses a content fingerprint and only marks a change that holds for a moment and is backed by a hard cut, so camera motion and brief overlays don't fragment one continuous period; pHash is the simpler 'any big frame-to-frame jump' detector. Sensitivity tunes the hard-cut threshold; Min gap avoids clustered markers during fast action. After scanning, near-identical periods are merged and transient blips dissolved. These are orientation markers, not clip candidates; unlike Scene it doesn't label the screens — only marks where they change."
+    boundary: "Scans the whole screen for period transitions: menu to gameplay, a level loading, a loading screen ending. Metric: Auto (recommended) uses a content fingerprint and only marks a change that holds for a moment and is backed by a hard cut, so camera motion and brief overlays don't fragment one continuous period; pHash is the simpler 'any big frame-to-frame jump' detector. Sensitivity tunes the hard-cut threshold; Min gap avoids clustered markers during fast action. After scanning, near-identical periods are merged and transient blips dissolved. These are orientation markers, not clip candidates; unlike Scene, it doesn't label the screens; it only marks where they change."
   };
 
   var _toolInfoPinned = false;
@@ -3061,7 +3061,7 @@
     // calibrationGreen is only ever true after a green evaluation, which
     // implies pins exist.
     if (!btn.disabled && state.calibrationGreen) {
-      btn.setAttribute("data-tooltip", "Calibrated — pins satisfied");
+      btn.setAttribute("data-tooltip", "Calibrated: pins satisfied");
     }
   }
 

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -482,7 +482,7 @@
         }
       } else {
         hint.appendChild(
-          el("span", "settings-prompt-hint-label", "Sent verbatim — no placeholders."),
+          el("span", "settings-prompt-hint-label", "Sent verbatim (no placeholders)."),
         );
       }
       controlDiv.appendChild(hint);

--- a/assets/web/start-overlay.html
+++ b/assets/web/start-overlay.html
@@ -142,7 +142,7 @@
             </div>
 
             <div data-tabpanel="none" class="sheet-panel sheet-panel--none" hidden>
-              You can still use <strong>Screenspace</strong> and <strong>Transcripts</strong> — both work on the source videos directly, no spreadsheet required.
+              You can still use <strong>Screenspace</strong> and <strong>Transcripts</strong>. Both work directly on the source videos and need no spreadsheet.
             </div>
           </div>
         </div>

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -793,7 +793,7 @@
       }
       if (Date.now() > state.googlePollDeadline) {
         state.googlePollTimer = null;
-        renderGoogleConnectCTA(false, "Sign-in timed out — try again.");
+        renderGoogleConnectCTA(false, "Sign-in timed out. Try again.");
         return;
       }
       state.googlePollTimer = setTimeout(pollGoogleAuthOnce, GOOGLE_POLL_INTERVAL_MS);

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -535,7 +535,7 @@
           var trimBadge = el("button", "intake-trim-badge");
           trimBadge.innerHTML = '<span class="cg-icon cg-icon--scissors"></span>';
           trimBadge.type = "button";
-          trimBadge.title = "Trimmed in Composer — click to view the trimmed version";
+          trimBadge.title = "Trimmed in Composer. Click to view the trimmed version";
           trimBadge.setAttribute("aria-label", "Show trimmed version in Composer Intake");
           trimBadge.addEventListener("click", function (ev) {
             ev.stopPropagation();
@@ -1306,7 +1306,7 @@
     buildIntakeDensityTimeline(CO_INTAKE, filtered);
 
     if (filtered.length === 0) {
-      container.innerHTML = '<div class="drop-target-empty">Composer cuts will appear here — set in/out pairs on the Composer page</div>';
+      container.innerHTML = '<div class="drop-target-empty">Composer cuts will appear here. Set in/out pairs on the Composer page</div>';
       return;
     }
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -514,8 +514,8 @@
     btn.type = "button";
     btn.title = active
       ? state.sortDir === "asc"
-        ? "Sorted ascending — click for descending"
-        : "Sorted descending — click to clear"
+        ? "Sorted ascending. Click for descending"
+        : "Sorted descending. Click to clear"
       : "Sort by this column";
     btn.innerHTML = '<span class="cg-icon cg-icon--' + iconName + '"></span>';
     btn.addEventListener("click", function (ev) {
@@ -1095,7 +1095,7 @@
             loading.classList.add("is-empty");
             var caption = document.createElement("div");
             caption.className = "sheet-empty-caption";
-            var prefix = document.createTextNode("No spreadsheet loaded — click ");
+            var prefix = document.createTextNode("No spreadsheet loaded. Click ");
             var icon = document.createElement("span");
             icon.className = "sheet-empty-caption-icon";
             icon.setAttribute("aria-hidden", "true");
@@ -2725,7 +2725,7 @@
       var trimBadge = el("button", "intake-trim-badge");
       trimBadge.innerHTML = iconHTML("scissors");
       trimBadge.type = "button";
-      trimBadge.title = "Trimmed in Composer — click to view the trimmed version";
+      trimBadge.title = "Trimmed in Composer. Click to view the trimmed version";
       trimBadge.setAttribute("aria-label", "Show trimmed version in Composer Intake");
       trimBadge.addEventListener("click", function (ev) {
         ev.stopPropagation();
@@ -2844,7 +2844,7 @@
     areaSel: "#stashedArtifactsArea",
     listSel: "#stashedArtifactsList",
     dragSource: "artifact-stash",
-    emptyHint: "Stash artifacts to keep them aside — drag, or use the Stash button.",
+    emptyHint: "Stash artifacts to keep them aside. Drag them here or use the Stash button.",
     queueKey: "artifactQueue",
     isLocked: isArtifactQueueLocked,
     renderQueue: renderArtifactQueue,

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -853,15 +853,15 @@
         // friction) from "summary done, friction not run" (the friction button is
         // enabled) so the copy points at the step the user can actually take.
         statusEl.textContent = depMet
-          ? "Programmatic scores shown — run friction analysis for AI-refined moments."
-          : "Programmatic scores shown — run Summary for AI-refined moments.";
+          ? "Programmatic scores shown. Run friction analysis for AI-refined moments."
+          : "Programmatic scores shown. Run Summary for AI-refined moments.";
       } else if (llmFailed) {
         statusEl.textContent =
-          "Moment detection failed — model unavailable" +
+          "Moment detection failed: model unavailable" +
           (fd.model ? " (tried " + fd.model + ")" : "") +
           ". Showing programmatic scores; re-run with an installed model.";
       } else if (fd.stale) {
-        statusEl.textContent = "Stale — segments edited since last run" +
+        statusEl.textContent = "Stale: segments edited since last run" +
           (fd.model ? " · " + fd.model : "");
       } else {
         statusEl.textContent = "Computed " + _friendlyTimeAgo(fd.computed_at) +
@@ -908,7 +908,7 @@
     qs("#frictionEmpty").classList.remove("hidden");
     qs("#frictionEmptyHint").textContent = _frictionDepMet()
       ? "Run the analysis to surface moments of likely friction."
-      : "Requires a summary first — run Summary, then friction.";
+      : "Requires a summary first. Run Summary, then friction.";
     _renderFrictionHeader();
     updateFrictionStaleDot();
   }
@@ -1106,7 +1106,7 @@
           ? "Run friction analysis to surface AI-refined moments."
           : "Run Summary to surface AI-refined friction moments.";
       } else if (fd.llm_ok === false) {
-        msg = "Moment detection failed — re-run with an installed Ollama model.";
+        msg = "Moment detection failed. Re-run with an installed Ollama model.";
       } else if (fd.moments && fd.moments.length) {
         msg = "No moments match the current filter.";
       } else {

--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -348,7 +348,7 @@
       var opts = '<option value="">Default</option>';
       models.forEach(function (m) {
         if (m.selected) defaultName = m.name;
-        var label = m.name + (m.cached === false ? " — not downloaded" : "");
+        var label = m.name + (m.cached === false ? " (not downloaded)" : "");
         opts += '<option value="' + escapeHtml(m.name) + '">' + escapeHtml(label) + '</option>';
       });
       modelSelect.innerHTML = opts;

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -462,7 +462,7 @@
     var snippet = (seg.text || "").trim().slice(0, 80);
     if ((seg.text || "").length > 80) snippet += "…";
     var extraCount = (seg.marks && seg.marks.length > 1) ? (seg.marks.length - 1) : 0;
-    var label = mark && mark.label ? " — " + mark.label : "";
+    var label = mark && mark.label ? " · " + mark.label : "";
     tip.textContent = "";
     var catSpan = el("span", "tr-tooltip-cat", cat.label);
     // Set color via property API rather than string-interpolating into a

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -94,7 +94,7 @@
         </button>
         <button id="tabBtnFriction" type="button" class="panel-tab" role="tab" aria-selected="false" data-tab="friction">
           <span class="panel-tab-icon friction-icon"></span><span class="panel-tab-label">Friction</span>
-          <span id="frictionStaleDot" class="panel-tab-dot hidden" title="Stale — re-run friction"></span>
+          <span id="frictionStaleDot" class="panel-tab-dot hidden" title="Stale. Re-run friction"></span>
         </button>
       </div>
 
@@ -137,7 +137,7 @@
         <div id="frictionGenerating" class="friction-generating hidden">Analyzing friction&hellip;</div>
         <div id="frictionContent" class="friction-content hidden">
           <div id="frictionStaleBanner" class="agent-stale-banner hidden">
-            <span class="agent-stale-banner-text">Segments were edited since this analysis ran — results may be out of date.</span>
+            <span class="agent-stale-banner-text">Segments were edited since this analysis ran. Results may be out of date.</span>
             <button id="frictionStaleRerun" type="button" class="btn btn-small">Re-run</button>
           </div>
           <div id="frictionStats" class="friction-stats"></div>

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -136,7 +136,7 @@
     var now = state.xrefErrors.screenspace || state.xrefErrors.studio;
     if (now && !prev && !state.xrefErrorToastShown) {
       state.xrefErrorToastShown = true;
-      showToast("Cross-references unavailable — is Screenspace/Studio running?");
+      showToast("Cross-references unavailable. Is Screenspace/Studio running?");
     }
     if (!now) state.xrefErrorToastShown = false;
     updateStatusIndicator();
@@ -2394,7 +2394,7 @@
           if (st.total > 0) {
             var pct = Math.max(0, Math.min(100, Math.round((st.completed / st.total) * 100)));
             barFill.style.width = pct + "%";
-            progressText.textContent = (st.status || "Downloading") + " — " + pct + "%";
+            progressText.textContent = (st.status || "Downloading") + ": " + pct + "%";
           } else {
             progressText.textContent = st.status || "Working…";
           }

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -819,7 +819,7 @@
       var p = empty.querySelector("p");
       if (p) {
         p.textContent = hasOtherOutputs
-          ? "No timeline clips for this run — see the outputs above."
+          ? "No timeline clips for this run. See the outputs above."
           : "No artifacts were generated for this run.";
       }
       empty.classList.remove("hidden");

--- a/assets/web/workflows-stashes.js
+++ b/assets/web/workflows-stashes.js
@@ -71,7 +71,7 @@
     var stashes = state.stashes || [];
     if (!stashes.length) {
       list.appendChild(
-        el("div", "wf-stash-empty", "No stashes yet — select nodes, then Stash them.")
+        el("div", "wf-stash-empty", "No stashes yet. Select nodes, then Stash them.")
       );
       return;
     }
@@ -88,7 +88,7 @@
     item.dataset.stashId = stash.id;
     item.draggable = true;
     item.title = stash.builtin
-      ? "Built-in recipe — drag or click to add to the canvas"
+      ? "Built-in recipe. Drag or click to add to the canvas"
       : "Drag or click to add to the canvas";
 
     item.appendChild(el("span", "wf-stash-label", stash.name));

--- a/assets/web/workflows.html
+++ b/assets/web/workflows.html
@@ -130,11 +130,11 @@
       <details class="wf-type-legend">
         <summary>Port types</summary>
         <ul class="wf-type-legend-list">
-          <li><span class="wf-type-swatch" data-type-family="temporal"></span>Temporal — clips, events, segments, ranges</li>
-          <li><span class="wf-type-swatch" data-type-family="insight"></span>Insight — transcript, summary, citations, friction</li>
-          <li><span class="wf-type-swatch" data-type-family="source"></span>Source — video, participant, region</li>
-          <li><span class="wf-type-swatch" data-type-family="output"></span>Output — artifacts, manifest, viewer</li>
-          <li><span class="wf-type-swatch" data-type-family="value"></span>Value — scalar, number, string</li>
+          <li><span class="wf-type-swatch" data-type-family="temporal"></span>Temporal: clips, events, segments, ranges</li>
+          <li><span class="wf-type-swatch" data-type-family="insight"></span>Insight: transcript, summary, citations, friction</li>
+          <li><span class="wf-type-swatch" data-type-family="source"></span>Source: video, participant, region</li>
+          <li><span class="wf-type-swatch" data-type-family="output"></span>Output: artifacts, manifest, viewer</li>
+          <li><span class="wf-type-swatch" data-type-family="value"></span>Value: scalar, number, string</li>
         </ul>
       </details>
     </aside>

--- a/assets/web/workflows.js
+++ b/assets/web/workflows.js
@@ -125,7 +125,7 @@
       var req = "Requires " + ((node.requires || []).join(", ") || "context");
       item.setAttribute(
         "data-tooltip",
-        node.description ? node.description + " — " + req : req,
+        node.description ? node.description + ". " + req : req,
       );
     }
     return item;
@@ -496,7 +496,7 @@
     var other = armedBlueprint();
     if (armed) {
       btn.title =
-        "Watching the input folder — new videos auto-run this blueprint. Click to stop.";
+        "Watching the input folder. New videos auto-run this blueprint. Click to stop.";
     } else if (other) {
       btn.title =
         "Auto-run is armed on “" +

--- a/config.py
+++ b/config.py
@@ -477,7 +477,7 @@ Format your response exactly as:
 2: NONE
 Write NONE if no segments clearly support a claim."""
 OLLAMA_FRICTION_SYSTEM: str = (
-    "You analyze UX research session transcripts for moments of friction — "
+    "You analyze UX research session transcripts for moments of friction: "
     "points where the participant struggled, hesitated, got confused, or showed "
     "frustration. You respond with a JSON array only."
 )
@@ -570,7 +570,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "OLLAMA_SUMMARY_MODEL": "Ollama model used for transcript summaries, citation linking, and friction detection.",
     "OLLAMA_FRICTION_MODEL": "Ollama model for friction-moment detection. Leave as 'Same as summary model' to reuse the summary model, or pick a different installed model.",
     "OLLAMA_BASE_URL": "Base URL of the local Ollama server.",
-    "OLLAMA_SUMMARY_PROMPT": "Prompt that generates each session summary. Keep the {text} placeholder — the transcript is inserted there.",
+    "OLLAMA_SUMMARY_PROMPT": "Prompt that generates each session summary. Keep the {text} placeholder. The transcript is inserted there.",
     "OLLAMA_CITATIONS_SYSTEM": "System instruction that frames the citation agent's behavior. Sent verbatim; no placeholders.",
     "OLLAMA_CITATIONS_PROMPT": "Prompt that links summary claims to transcript segments. Keep the {claims} and {transcript} placeholders.",
     "OLLAMA_FRICTION_SYSTEM": "System instruction that frames the friction agent's behavior. Sent verbatim; no placeholders.",
@@ -584,9 +584,9 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "SCREENSPACE_OCR_MIN_CONFIDENCE": "Default minimum EasyOCR per-detection confidence for Text/Numbers tasks. Raise to suppress noisy OCR misreads; lower if real hits are being dropped. Per-task slider overrides this default.",
     "SCREENSPACE_RESTORE_MARKERS_ON_EDIT": "When editing a task, restore the In/Out timeline markers to the range it was originally run with. Disable to keep your current markers in place when iterating across different parts of the timeline.",
     "SCREENSPACE_SHOW_CONFIDENCE_HISTOGRAM": "Show a confidence-distribution histogram above the Results list (for tools that have confidence scores). Lets you see where detections cluster before moving the certainty cutoff. Off by default.",
-    "SCREENSPACE_GENERATE_TEMPLATE_HEATMAP": "Generate detection heatmaps (static image plus accumulation and rolling-window animations) for Template tasks. Disable to skip heatmap generation when you don't need it — useful on long videos where it adds processing time.",
+    "SCREENSPACE_GENERATE_TEMPLATE_HEATMAP": "Generate detection heatmaps (static image plus accumulation and rolling-window animations) for Template tasks. Disable to skip heatmap generation when you don't need it. Useful on long videos where it adds processing time.",
     "SCREENSPACE_GENERATE_FLOW_HEATMAP": "Generate motion heatmaps (static image plus accumulation animation) for Flow tasks. Disable to skip heatmap generation when you don't need it.",
-    "SCREENSPACE_GENERATE_CHANGE_HEATMAP": "Generate change heatmaps (static image plus accumulation and rolling-window animations) for Change tasks. Disable to skip heatmap generation when you don't need it — useful on long videos where it adds processing time.",
+    "SCREENSPACE_GENERATE_CHANGE_HEATMAP": "Generate change heatmaps (static image plus accumulation and rolling-window animations) for Change tasks. Disable to skip heatmap generation when you don't need it. Useful on long videos where it adds processing time.",
     "SCREENSPACE_BOUNDARY_MERGE_THRESHOLD": "Boundary post-processing (Scene/Hybrid metrics): merge two periods whose content is at least this similar, removing the boundary between them. Higher = merge more aggressively (fewer boundaries); lower = keep more. Below the firing sensitivity by design.",
     "SCREENSPACE_BOUNDARY_TYPE_THRESHOLD": "Boundary scene labeling (Scene/Hybrid metrics): distinct scenes closer than this are grouped into one 'type', labeled Scene A1, A2, … (same letter, different number). Looser than the merge threshold. Higher = group more scenes per type; lower = more distinct type letters.",
     "SCREENSPACE_BOUNDARY_RELATIVE_PRUNE_ENABLED": "Boundary post-processing (Scene/Hybrid metrics): after merging, drop boundaries far weaker than the session's typical scene change. Adapts to each recording instead of a fixed threshold; disable to keep every detected boundary.",

--- a/workflows.py
+++ b/workflows.py
@@ -702,7 +702,7 @@ NODE_TYPES: dict[str, NodeType] = {
     "gate_collection": {
         "id": "gate_collection",
         "label": "Threshold Gate",
-        "description": "Measure events, clips, or segments and gate downstream nodes on the result — Measure + Gate in one node.",
+        "description": "Measure events, clips, or segments and gate downstream nodes on the result (Measure + Gate in one node).",
         "domain": "control",
         "category": "Control",
         "inputs": [
@@ -1085,7 +1085,7 @@ for _ss_tool in _SS_DETECTOR_SPECS:
 NODE_TYPES["detect"] = {
     "id": "detect",
     "label": "Detect",
-    "description": "Detect a region condition (text, colour, motion, numbers, …) — pick the detector.",
+    "description": "Detect a region condition (text, colour, motion, numbers). Pick the detector.",
     "domain": "screenspace",
     "category": "Screenspace",
     "inputs": [
@@ -1580,7 +1580,7 @@ def _exec_summarize(
     transcript = inputs.get("transcript") or {}
     segments = transcript.get("segments") or []
     if not ollama_client.is_available():
-        return {"summary": "", "__note__": "Ollama not available — summary skipped"}
+        return {"summary": "", "__note__": "Ollama not available. Summary skipped"}
     summary = thinking_agents.summarize_transcript(
         segments, model=params.get("model") or None, cancel_event=ctx.cancel_event
     )
@@ -1597,7 +1597,7 @@ def _exec_citations(
     seg_val = inputs.get("segments") or {}
     segments = seg_val.get("segments") or []
     if not ollama_client.is_available():
-        return {"citations": [], "__note__": "Ollama not available — citations skipped"}
+        return {"citations": [], "__note__": "Ollama not available. Citations skipped"}
     cites = thinking_agents.find_citations(
         summary,
         segments,
@@ -1618,7 +1618,7 @@ def _exec_friction(
     segments = seg_val.get("segments") or []
     summary = str(inputs.get("summary") or "")
     if not ollama_client.is_available():
-        return {"friction": [], "__note__": "Ollama not available — friction skipped"}
+        return {"friction": [], "__note__": "Ollama not available. Friction skipped"}
     scored = friction.score_segments(segments)
     candidates = friction.select_candidates(scored)
     moments = thinking_agents.find_friction_moments(
@@ -2037,7 +2037,7 @@ def _exec_make_clips(
     if not records:
         return {
             "artifacts": {"artifacts": [], "study": study, "count": 0},
-            "__note__": "No clips to render — wire clips, a time range, or a video",
+            "__note__": "No clips to render. Wire clips, a time range, or a video",
         }
     pad_pre, pad_post, max_duration = _artifact_padding_params(params)
     count, artifacts = pipeline.process_clips(
@@ -2217,7 +2217,7 @@ def _exec_heatmap(
     paths = list(src.get("video_paths") or [])
     if not results or not paths or style not in ("template", "flow", "change"):
         note = (
-            "No detector results — wire a matching template/flow/change detector"
+            "No detector results. Wire a matching template/flow/change detector"
             if not results
             else "No video for the heatmap"
         )
@@ -3615,7 +3615,7 @@ class WorkflowRunner:
                         utils.warning_print(
                             f"workflow adapter {out_type}->{in_type} failed: {exc}"
                         )
-                        notes.append(f"Couldn't convert {out_type} → {in_type}")
+                        notes.append(f"Couldn't convert {out_type} to {in_type}")
                         value = None
             inputs[to_port] = value
         return inputs, notes


### PR DESCRIPTION
## Summary

Copy-editing pass over the web UIs to remove AI-writing tells from user-facing strings, one commit per frontend. The tone was already plain, so this is almost entirely replacing em/en dashes used mid-sentence with periods/colons/commas/parentheses, plus a few prose arrows (`→`), rhetorical rule-of-three fixes, subjectless fragments, and one curly-quote pair. No behavior changes.

- Frontends: `start-overlay`, `viewer`/gallery, `composer`, `studio`, `transcripts`, `overview`, `screenspace` (the `TOOL_INFO` + `PARAM_DESCRIPTIONS` registries), `workflows` (incl. `workflows.py` node descriptions/result notes), and settings/shared (`settings-modal.js` + `config.py` settings help and the friction system prompt).
- Deliberately preserved: legitimate typography (year/time/`A–Z` ranges), empty-value `—` glyphs, glyph-map arrows (`0→o`), pipeline-flow recipe names (`A → B → C`), the nested-quote Run tooltip, genuine enumerations, and the `{text}`/`{summary}` agent-prompt placeholders.

## Test plan

- [x] `node --check` on every changed `.js`
- [x] `uv run ruff format --check` + `ruff check` (clean; `config.py`/`workflows.py` touched)
- [x] Full suite green — `uv run --extra dev pytest -c tests/pytest.ini`
- [x] Agent-prompt placeholder tokens verified intact (`test_studio_api.py` derives `placeholders` from them)
- [ ] ⚠️ Not browser-checked. Worth a quick eyeball of the Screenspace tool-info popovers + parameter hints, the Overview Map explain panel, and the Settings modal (Agent prompts group).