### PR TITLE
fix: resolve bug-hunt findings across worker resume, timestamp parsing, and web UI

### DIFF
--- a/assets/web/overview-metadata.js
+++ b/assets/web/overview-metadata.js
@@ -1239,7 +1239,6 @@
       });
     }
     var table = P.createCoverageMatrix({ rows: rows });
-    table.classList.add("md-coverage-table-host");
     // Click participant cell → drill down
     table.addEventListener("click", function (ev) {
       var td = ev.target.closest && ev.target.closest("td.cg-cov-td-left");

--- a/assets/web/screenspace-results.js
+++ b/assets/web/screenspace-results.js
@@ -590,7 +590,7 @@
       applyIconMask(fIcon, "chevron-double-right", "/screenspace/icons/");
       fastLabel.appendChild(fIcon);
       fastLabel.appendChild(document.createTextNode("Fast scan results"));
-      var rerunBtn = el("button", "ss-btn ss-btn-sm fast-scan-rerun-btn", "Re-Run Normal");
+      var rerunBtn = el("button", "btn btn-small fast-scan-rerun-btn", "Re-Run Normal");
       (function (t) {
         rerunBtn.addEventListener("click", function () {
           var params = {};

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1306,7 +1306,7 @@
         togglePinPolarity(pin.id);
       });
       meta.appendChild(dot);
-      var time = el("span", "pin-tray-time");
+      var time = el("span", "");
       time.textContent = formatTime(pin.timestamp, { decimals: 1 });
       meta.appendChild(time);
       if (pin.stale) {

--- a/assets/web/studio-trim.js
+++ b/assets/web/studio-trim.js
@@ -145,8 +145,8 @@
 
     // Row 2 — in / out points (drag each; click to type).
     var rowInOut = el("div", "trim-row trim-row-inout");
-    var inVal = el("span", "trim-time trim-time-in", formatTime(item.start));
-    var outVal = el("span", "trim-time trim-time-out", formatTime(item.end));
+    var inVal = el("span", "trim-time", formatTime(item.start));
+    var outVal = el("span", "trim-time", formatTime(item.end));
     inVal.title = "Drag to move the in-point · click to type";
     outVal.title = "Drag to move the out-point · click to type";
     rowInOut.appendChild(inVal);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -529,7 +529,7 @@
   function sortableHeaderTh(thClass, label, column) {
     var th = el("th", thClass);
     var inner = el("div", "col-header-inner");
-    inner.appendChild(el("span", "col-header-label", label));
+    inner.appendChild(el("span", "", label));
     inner.appendChild(buildSortButton(column));
     th.appendChild(inner);
     return th;

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -978,7 +978,7 @@
     cats.forEach(function (c) {
       var chip = document.createElement("span");
       chip.className = "friction-chip";
-      var lab = el("span", "friction-chip-label", c.label);
+      var lab = el("span", "", c.label);
       var cnt = el("span", "friction-chip-count", String(byCat[c.key] || 0));
       chip.appendChild(lab);
       chip.appendChild(cnt);

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -665,6 +665,15 @@ body[data-frontend="workflows"] {
   flex-direction: row-reverse;
 }
 
+/* Port name / "gate" text — truncate instead of widening the node card
+   (font + colour inherit from .wf-port). */
+.wf-port-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Connector anchor — drag from a dot to another dot to wire a typed edge.
    Coloured by data type (--wf-port-color, set per type below); hollow when open,
    filled when wired (.wf-port-connected). */

--- a/composer_server.py
+++ b/composer_server.py
@@ -602,7 +602,11 @@ def _render_annotation_overlay(
 
 # One export at a time is plenty for a single-user tool; the cancel event
 # terminates the in-flight ffmpeg via run_ffmpeg_process's cancel_flag.
+# _export_busy enforces the single-export assumption the shared event relies
+# on: without it, a second export's clear() would un-cancel the first, and one
+# cancel POST would abort both in-flight encodes.
 _export_cancel = threading.Event()
+_export_busy = threading.Lock()
 
 # Bound on the ffmpeg filter graph: one overlay input per visibility window.
 MAX_OVERLAY_WINDOWS = 20
@@ -995,13 +999,23 @@ def _run_overlay_export(data: dict[str, Any], *, gif: bool) -> Any:
 @composer_bp.route("/api/export/burn", methods=["POST"])
 def api_export_burn() -> Any:
     """Burn annotations into a video span (seek-first; span-only encode)."""
-    return _run_overlay_export(request.get_json(silent=True) or {}, gif=False)
+    if not _export_busy.acquire(blocking=False):
+        return err("An export is already running", 409)
+    try:
+        return _run_overlay_export(request.get_json(silent=True) or {}, gif=False)
+    finally:
+        _export_busy.release()
 
 
 @composer_bp.route("/api/export/gif", methods=["POST"])
 def api_export_gif() -> Any:
     """Burn annotations into an animated GIF of the span."""
-    return _run_overlay_export(request.get_json(silent=True) or {}, gif=True)
+    if not _export_busy.acquire(blocking=False):
+        return err("An export is already running", 409)
+    try:
+        return _run_overlay_export(request.get_json(silent=True) or {}, gif=True)
+    finally:
+        _export_busy.release()
 
 
 # ---- State init ----

--- a/excel_io.py
+++ b/excel_io.py
@@ -40,6 +40,10 @@ def _cell_to_str(v: Any) -> str:
         h, rem = divmod(total, 3600)
         m, s = divmod(rem, 60)
         return f"{h:02d}:{m:02d}:{s:02d}"
+    if isinstance(v, float) and v.is_integer():
+        # openpyxl often stores whole numbers as floats; gspread returns the
+        # displayed value ("5"), not the repr ("5.0").
+        return str(int(v))
     return str(v)
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1979,8 +1979,15 @@ def _regenerate_reel(
                 {
                     "idx": len(tasks),
                     "source_path": source_path,
-                    "start_ts": utils.seconds_to_timestamp(int(local_start)),
-                    "end_ts": utils.seconds_to_timestamp(int(local_end)),
+                    # Match _local_timestamp's rounding + force_hours so a
+                    # regenerated segment reproduces the original cut instead
+                    # of truncating up to ~1s off it.
+                    "start_ts": utils.seconds_to_timestamp(
+                        int(round(local_start)), force_hours=True
+                    ),
+                    "end_ts": utils.seconds_to_timestamp(
+                        int(round(local_end)), force_hours=True
+                    ),
                 }
             )
 

--- a/screenspace_primitives.py
+++ b/screenspace_primitives.py
@@ -403,6 +403,10 @@ def average_color_hsv(
     Returns:
         Dict with keys ``h`` (0-180), ``s`` (0-255), ``v`` (0-255).
     """
+    if region_pixels.size == 0:
+        # A region cropped fully off-frame: np.mean on the empty crop would
+        # yield NaN (same guard as color_present).
+        return {"h": 0.0, "s": 0.0, "v": 0.0}
     h, w = region_pixels.shape[:2]
     if h > 64 or w > 64:
         new_w, new_h = min(w, 64), min(h, 64)

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -399,7 +399,16 @@ class ScreenspaceWorker:
                     end = timeline[-1][1] + timeline[-1][2]
                 else:
                     _, end = _probe_video_meta(task["video_paths"][0])
-            resume_at = start + progress * (end - start)
+            # ``progress`` is a GLOBAL fraction of the original scan range
+            # (mapped via _progress_offset/_progress_scale in _on_progress),
+            # but ``start`` is the CURRENT segment start — already advanced by
+            # any previous resume. Convert back to the current segment's local
+            # fraction before projecting, or a 2nd+ resume overshoots the true
+            # stop point and skips frames.
+            prev_offset = task.get("_progress_offset", 0.0)
+            prev_scale = task.get("_progress_scale", 1.0)
+            local = max(0.0, min(1.0, (progress - prev_offset) / prev_scale))
+            resume_at = start + local * (end - start)
 
             with self._lock:
                 task["_partial_results"] = list(task.get("result") or [])
@@ -676,6 +685,14 @@ class ScreenspaceWorker:
                 if t:
                     if t.get("_paused_flag"):
                         t["status"] = TASK_STATUS_PAUSED
+                        # ``result`` holds only THIS invocation's detections;
+                        # prepend the pre-pause carry-over (like the completed
+                        # branch below) or a pause on a resumed scan drops the
+                        # earlier results for good — the next resume re-seeds
+                        # _partial_results from t["result"].
+                        partial = t.get("_partial_results")
+                        if partial and isinstance(result, list):
+                            result = partial + result
                         t["result"] = result
                     elif t.get("_cancelled") and not t.get("parameters", {}).get(
                         "detect_first"

--- a/tests/screenspace/test_worker.py
+++ b/tests/screenspace/test_worker.py
@@ -386,6 +386,89 @@ class TestScreenspaceWorker:
         assert t["parameters"]["start_seconds"] == 55.0  # 10 + 0.5*(100-10)
         assert t.get("_partial_results") == [{"timestamp": 5.0}]
 
+    def test_second_resume_uses_segment_local_progress(self):
+        # task["progress"] is a GLOBAL fraction, but start_seconds was already
+        # advanced by the first resume. A second resume must convert back to
+        # the current segment's local fraction — projecting the global
+        # fraction onto the shortened segment overshoots the true stop point
+        # and silently skips frames.
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "color",
+            "P01",
+            "s.mp4",
+            ["/v.mp4"],
+            "r",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+            parameters={"start_seconds": 0.0, "end_seconds": 100.0},
+        )
+        worker.enqueue(task)
+        tid = task["id"]
+        with worker._lock:
+            worker._tasks[tid]["status"] = screenspace.TASK_STATUS_PAUSED
+            worker._tasks[tid]["progress"] = 0.5
+            worker._tasks[tid]["result"] = [{"timestamp": 5.0}]
+        worker.resume()
+        with worker._lock:
+            t = worker._tasks[tid]
+            assert t["parameters"]["start_seconds"] == 50.0
+            # Simulate the resumed scan pausing again at global progress 0.75
+            # — halfway through the [50, 100] segment — with one more result.
+            t["status"] = screenspace.TASK_STATUS_PAUSED
+            t["progress"] = 0.75
+            t["result"] = [{"timestamp": 5.0}, {"timestamp": 60.0}]
+        worker.resume()
+        with worker._lock:
+            t = worker._tasks[tid]
+            assert t["parameters"]["start_seconds"] == 75.0  # not 87.5
+            assert t["_partial_results"] == [
+                {"timestamp": 5.0},
+                {"timestamp": 60.0},
+            ]
+
+    def test_pause_after_resume_preserves_earlier_results(self, monkeypatch):
+        # The paused branch of _execute_task must prepend _partial_results
+        # like the completed branch does — otherwise pausing a resumed scan
+        # permanently drops the results found before the first pause.
+        def pausing_dispatch(self, task, on_progress, cancel_flag, on_result=None):
+            with self._lock:
+                self._tasks[task["id"]]["_paused_flag"] = True
+            return [{"timestamp": 60.0}]
+
+        monkeypatch.setattr(
+            screenspace.ScreenspaceWorker, "_dispatch", pausing_dispatch
+        )
+        worker = screenspace.ScreenspaceWorker()
+        task = screenspace.create_task(
+            "color",
+            "P01",
+            "s.mp4",
+            ["/v.mp4"],
+            "r",
+            {"x": 0, "y": 0, "w": 1, "h": 1},
+            parameters={"start_seconds": 0.0, "end_seconds": 100.0},
+        )
+        worker.enqueue(task)
+        with worker._lock:
+            t = worker._tasks[task["id"]]
+            t["status"] = screenspace.TASK_STATUS_PAUSED
+            t["progress"] = 0.5
+            t["result"] = [{"timestamp": 5.0}]
+        worker.resume()  # seeds _partial_results and re-enqueues
+        worker.start()
+        try:
+            for _ in range(100):
+                t = worker.get_task(task["id"])
+                if t and t["status"] == screenspace.TASK_STATUS_PAUSED:
+                    break
+                time.sleep(0.05)
+            with worker._lock:
+                t = worker._tasks[task["id"]]
+                assert t["status"] == screenspace.TASK_STATUS_PAUSED
+                assert t["result"] == [{"timestamp": 5.0}, {"timestamp": 60.0}]
+        finally:
+            worker.stop()
+
 
 class TestWorkerParallel:
     def test_two_tasks_run_concurrently(self, monkeypatch):

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -477,6 +477,24 @@ def test_annotated_burn_within_part_keeps_single_pass_fast_path(
     assert resp["artifact"]["sourceVideo"] == "study_P01-1.mp4"
 
 
+def test_ffmpeg_exports_rejected_while_another_export_runs(co_client):
+    # _export_cancel is a single shared Event; the busy lock enforces the
+    # one-export-at-a-time assumption it relies on. Without it a second
+    # export's clear() would un-cancel the first, and one cancel POST would
+    # abort both in-flight encodes.
+    assert composer_server._export_busy.acquire(blocking=False)
+    try:
+        for route in ("burn", "gif"):
+            resp = co_client.post(
+                f"/composer/api/export/{route}",
+                json={"participant": "P01", "start": 2.0, "end": 5.0},
+            )
+            assert resp.status_code == 409
+            assert resp.get_json()["ok"] is False
+    finally:
+        composer_server._export_busy.release()
+
+
 def test_combined_app_registers_composer(tmp_path, monkeypatch):
     import server
     import start_settings

--- a/tests/test_titlecards.py
+++ b/tests/test_titlecards.py
@@ -60,6 +60,15 @@ def test_build_titlecard_frame_uses_black_background_when_no_asset(
     assert "drawtext=text='No asset'" in joined
 
 
+def test_build_drawtext_filter_disables_expansion():
+    # "%" survives sanitize_filename; with drawtext's default expansion=normal
+    # a "%{" in the description would trigger text expansion and error the
+    # encode. The filter must render the text literally.
+    filt = titlecards._build_drawtext_filter("Progress 50%{pts}")
+    assert ":expansion=none" in filt
+    assert "Progress 50%{pts}" in filt
+
+
 def test_wrap_clip_with_cards_respects_disabled_flag(monkeypatch, make_clip):
     clip = make_clip()
 

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -48,6 +48,7 @@ def tr_client(tmp_path, monkeypatch):
     # Fresh corrected-segments cache + merged-task set per test (auto-restored).
     monkeypatch.setattr(transcripts_server, "_corrected_cache", {})
     monkeypatch.setattr(transcripts_server, "_merged_task_ids", set())
+    monkeypatch.setattr(transcripts_server, "_pending_chain_pids", [])
 
     monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: [])
 
@@ -97,6 +98,47 @@ def test_transcribe_status_slim_and_segments_tail(tr_client):
     ).get_json()
     assert [s["text"] for s in seg["segments"]] == ["1", "2"]
     assert seg["total"] == 3
+
+
+def test_completion_side_effects_survive_debounced_merge_race(tr_client, monkeypatch):
+    """A debounced _do_persist can win _manifest_lock and merge a completed
+    transcription before _on_task_complete runs. The completion side effects —
+    clearing stale agent fields and starting the thinking-agent chain — must
+    still fire (they drain _pending_chain_pids, not the handler's own merge)."""
+    monkeypatch.setattr(transcripts, "save_transcripts_manifest", lambda *a, **k: None)
+    worker = transcripts.TranscriptWorker()
+    task = transcripts.create_transcript_task("P01", ["/v.mp4"])
+    worker.enqueue(task)
+    new_segments = [{"start": 0.0, "end": 1.0, "text": "new words"}]
+    with worker._lock:
+        t = worker._tasks[task["id"]]
+        t["status"] = transcripts.TASK_STATUS_COMPLETED
+        t["result"] = {"segments": new_segments}
+    monkeypatch.setattr(transcripts_server, "_worker", worker)
+
+    # Stale AI output from a previous transcription of the same participant.
+    transcripts_server._manifest["source_transcripts"]["P01"] = {
+        "segments": [{"start": 0.0, "end": 1.0, "text": "old words"}],
+        "summary": "stale summary",
+    }
+
+    chained: list[str] = []
+    monkeypatch.setattr(
+        transcripts_server._orchestrator,
+        "run_chain",
+        lambda pid: chained.append(pid),
+    )
+
+    # The debounce timer fires first and wins the merge...
+    with transcripts_server._manifest_lock:
+        transcripts_server._do_persist()
+    # ...then the worker's completion callback runs.
+    transcripts_server._on_task_complete()
+
+    entry = transcripts_server._manifest["source_transcripts"]["P01"]
+    assert entry["segments"] == new_segments
+    assert "summary" not in entry  # stale output cleared
+    assert chained == ["P01"]  # chain still kicked off
 
 
 def test_participants_includes_video_version(tr_client, tmp_path):

--- a/tests/test_utils_timestamps.py
+++ b/tests/test_utils_timestamps.py
@@ -9,6 +9,19 @@ def test_parse_timestamps_parses_single_and_range():
     assert range_only == [("1:23", "1:45")]
 
 
+def test_parse_timestamps_rejects_half_garbage_dash_ranges():
+    # A dash range must have a valid timestamp on BOTH sides; half-garbage
+    # ranges are skipped like any other unparseable token instead of flowing
+    # to ffmpeg as bogus (start, end) pairs.
+    assert utils.parse_timestamps("1:23-abc") == []
+    assert utils.parse_timestamps("5-10") == []
+    assert utils.parse_timestamps("1:23-1:45-2:00") == []
+    # Valid ranges still parse, including hours and the MM:SS >59-minute form.
+    assert utils.parse_timestamps("1:23-1:45") == [("1:23", "1:45")]
+    assert utils.parse_timestamps("1:02:03-1:04:05") == [("1:02:03", "1:04:05")]
+    assert utils.parse_timestamps("75:00-80:00") == [("75:00", "80:00")]
+
+
 def test_parse_timestamps_parses_multiple_separators_and_ignored_tokens(monkeypatch):
     monkeypatch.setattr(
         utils.config,

--- a/titlecards.py
+++ b/titlecards.py
@@ -104,6 +104,10 @@ def _build_drawtext_filter(text: str) -> str:
     )
     return (
         "drawtext=text='{}'"
+        # The text is static — disable drawtext's %{...} expansion so a
+        # description containing "%" (which sanitize_filename keeps) renders
+        # literally instead of erroring the encode.
+        ":expansion=none"
         ":font=monospace"
         ":fontcolor=white"
         ":fontsize=min(w\\,h)/16"

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -77,6 +77,13 @@ _manifest_lock = threading.Lock()
 # frozen segments over in-memory edits. Re-transcription mints a fresh task id,
 # so its new segments still merge (and win) exactly once.
 _merged_task_ids: set[str] = set()
+# Participants whose transcript was freshly merged but whose completion side
+# effects (clearing stale agent fields + starting the thinking-agent chain)
+# have not run yet. The merge can be reached from either _on_task_complete or
+# a debounced _do_persist — whichever wins _manifest_lock merges the task — so
+# the reaction must drain this queue rather than key off which caller merged.
+# Guarded by _manifest_lock.
+_pending_chain_pids: list[str] = []
 _transcript_model_warming = False
 _transcript_model_warming_lock = threading.Lock()
 # Thinking-agent orchestrator. Owns per-agent in-flight, cancel-event, and
@@ -1560,6 +1567,9 @@ def _merge_completed_results_locked() -> list[str]:
             _merged_task_ids.add(task["id"])
             merged_pids.append(pid)
     _manifest["tasks"] = _worker.get_all_tasks()
+    # Queue the completion side effects for _on_task_complete no matter which
+    # caller performed the merge (a debounced _do_persist can win the race).
+    _pending_chain_pids.extend(merged_pids)
     if merged_pids:
         # Each task merges exactly once, so a non-empty merged_pids means a
         # participant's segments were just (re)placed — invalidate the
@@ -1607,9 +1617,13 @@ def _on_task_complete() -> None:
     """
     with _manifest_lock:
         # Merge first so next_eligible() sees the freshly completed segments.
-        # merged_pids are the participants with a *new* transcript this call —
-        # both first transcription and re-transcription (a new task id).
-        merged_pids = _merge_completed_results_locked()
+        # A debounced _do_persist may already have merged this task; either
+        # way the freshly merged participants (first transcription and
+        # re-transcription alike — a new task id) sit in _pending_chain_pids,
+        # so drain that instead of trusting this call's own merge return.
+        _merge_completed_results_locked()
+        merged_pids = list(dict.fromkeys(_pending_chain_pids))
+        _pending_chain_pids.clear()
         src = _manifest.get("source_transcripts", {})
         for pid in merged_pids:
             entry = src.get(pid)
@@ -1623,7 +1637,7 @@ def _on_task_complete() -> None:
 
     # run_chain -> next_eligible/run_agent re-acquire _manifest_lock, so this
     # must run OUTSIDE the block above (the lock is non-reentrant).
-    for pid in dict.fromkeys(merged_pids):
+    for pid in merged_pids:
         _orchestrator.run_chain(pid)
 
     _persist_manifest()
@@ -1903,6 +1917,7 @@ def _init_transcripts_state(
     _input_dir = str(utils.get_effective_input_dir())
     _manifest = transcripts.load_transcripts_manifest()
     _merged_task_ids.clear()
+    _pending_chain_pids.clear()
 
     _participants = []
     study_name = ""

--- a/utils.py
+++ b/utils.py
@@ -1232,11 +1232,20 @@ def _parse_single_timestamp_token(token: str) -> tuple[str, str] | None:
     if token == "":
         return None
     # Dash range: "start-end". Require a digit before the dash so we don't
-    # treat a leading dash (e.g. "-5") or non-time dash as a range.
+    # treat a leading dash (e.g. "-5") or non-time dash as a range, and require
+    # both halves to be real timestamps so half-garbage ranges ("1:23-abc",
+    # "5-10", "1:23-1:45-2:00") are reported as skipped here instead of
+    # failing deep in ffmpeg with the clip silently dropped.
     if "-" in token:
         dash_pos = token.find("-")
         if dash_pos > 0 and token[dash_pos - 1].isdigit():
-            return (token[:dash_pos], token[dash_pos + 1 :])
+            start_time = token[:dash_pos]
+            end_time = token[dash_pos + 1 :]
+            if (
+                timestamp_to_seconds(start_time) is not None
+                and timestamp_to_seconds(end_time) is not None
+            ):
+                return (start_time, end_time)
         return None
     # Single timestamp with colon: use as start and add default duration for end.
     # Require a digit before the first colon so we only match time-like strings.


### PR DESCRIPTION
## Summary

Systematic bug hunt across the backend, frontend, and core pipeline; every finding was verified against the source before fixing. Eight functional bugs plus small consistency/dead-CSS cleanups:

- **screenspace_worker**: a 2nd+ pause→resume projected the *global* progress fraction onto an already-advanced `start_seconds`, resuming past the true stop point and silently skipping frames; and the paused branch of `_execute_task` dropped pre-pause `_partial_results` for good. Both fixed to mirror the completed-branch math/carry-over.
- **transcripts_server**: if a debounced `_do_persist` won `_manifest_lock` and merged a completed transcription first, `_on_task_complete` saw no merged pids — stale summaries stayed attached and the agent chain never ran. Both merge callers now queue pids in `_pending_chain_pids`; the completion handler drains it.
- **utils**: dash-range timestamps now validate both halves — `1:23-abc`, `5-10`, `1:23-1:45-2:00` are reported as skipped instead of failing deep in ffmpeg with the clip silently dropped.
- **titlecards**: `drawtext` gets `expansion=none` so `%`/`%{` in descriptions renders literally instead of erroring the encode.
- **composer_server**: a busy lock enforces the one-export-at-a-time assumption behind the shared `_export_cancel` event (concurrent burn/GIF now 409s instead of stomping the other export's cancel state).
- **pipeline**: reel-regeneration pre-flight rounds and forces hours like the primary cut path (was truncating up to ~1s).
- **screenspace_primitives / excel_io**: empty-region guard in `average_color_hsv` (NaN); integral floats stringify as `"5"` to match gspread.
- **web**: unstyled fast-scan "Re-Run Normal" button (nonexistent `ss-btn` classes → `btn btn-small`), missing `.wf-port-label` rule, five dead CSS class names removed.

## Test plan

- [x] Regression tests added for each Tier-1 fix: two-cycle pause/resume math + pause-preserves-partials (`tests/screenspace/test_worker.py`), debounce-vs-completion merge race (`tests/test_transcripts_api.py`), half-garbage dash ranges (`tests/test_utils_timestamps.py`), `expansion=none` (`tests/test_titlecards.py`), export busy guard (`tests/test_composer_server.py`)
- [x] `ruff format` + `ruff check` clean
- [x] `ty check` clean
- [x] Full suite passes (`uv run --extra dev pytest -c tests/pytest.ini`)
- [x] Browser-checked: eyeball the Screenspace fast-scan "Re-Run Normal" button and a Workflows node's port labels