### PR TITLE
fix(studio): smooth bottom-panel hide animation

### DIFF
--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -667,11 +667,11 @@ body.bottom-collapsed #panelDivider .divider-handle {
   background: var(--color-accent);
 }
 
-/* When the page boots with a persisted collapse state, no inline max-height is
+/* When the page boots with a persisted collapse state, no inline height is
  * set on #bottomPanel — without this rule the panel reverts to its natural
  * content height (toolbars + ghost text), which reads as "half collapsed". */
 body.bottom-collapsed:not(.bottom-animating) #bottomPanel {
-  max-height: 0;
+  height: 0;
 }
 
 body.bottom-animating #dropAreas,
@@ -1098,7 +1098,7 @@ body.dragging .ts-cell:hover {
 #bottomPanel {
   flex-shrink: 0;
   width: 100%;
-  transition: max-height var(--duration-normal) ease;
+  transition: height var(--duration-normal) ease;
   overflow: hidden;
 }
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1953,36 +1953,40 @@
 
     if (state.bottomCollapsed) {
       // --- Restore ---
+      // Animate `height` between concrete pixel endpoints (0 → bottomH); the box
+      // is never `auto` mid-flight, so the reveal tracks linearly. Mirrors the
+      // Screenspace panel.
       state.bottomCollapsed = false;
       document.body.classList.add("bottom-animating");
-      // Animate maxHeight from 0 to the persisted bottomH; afterwards drop the
-      // inline maxHeight so the explicit `height` style takes over.
-      bottom.style.maxHeight = "0px";
-      bottom.offsetHeight; // reflow at 0
       document.body.classList.remove("bottom-collapsed");
-      bottom.style.maxHeight = state.bottomH + "px";
+      bottom.style.height = "0px";
+      bottom.offsetHeight; // reflow — pin the start frame
       bottom.style.height = state.bottomH + "px";
 
       onCollapseTransitionEnd(bottom, function () {
         document.body.classList.remove("bottom-animating");
-        bottom.style.maxHeight = "";
         bottom._transitioning = false;
         persistBottomHeight();
       });
     } else {
       // --- Collapse ---
+      // Pin the current pixel height, then animate `height` to 0. Keeping the box
+      // height definite the whole way (never clearing to `auto`) is what avoids
+      // the mid-animation hitch.
       state.bottomCollapsed = true;
-      document.body.classList.add("bottom-animating");
       var currentH = bottom.offsetHeight;
-      bottom.style.maxHeight = currentH + "px";
+      document.body.classList.add("bottom-animating");
+      bottom.style.height = currentH + "px";
+      bottom.offsetHeight; // reflow — pin the start frame
       document.body.classList.add("bottom-collapsed");
-      bottom.offsetHeight; // reflow
-      bottom.style.maxHeight = "0px";
-      bottom.style.height = "";
+      bottom.style.height = "0px";
 
       onCollapseTransitionEnd(bottom, function () {
         bottom._transitioning = false;
         document.body.classList.remove("bottom-animating");
+        // Drop the inline height so the collapsed CSS (height: 0) governs the
+        // rest state.
+        bottom.style.height = "";
         persistBottomHeight();
       });
     }
@@ -1997,7 +2001,7 @@
       cb();
     }
     function handler(e) {
-      if (e.target === el && e.propertyName === "max-height") done();
+      if (e.target === el && e.propertyName === "height") done();
     }
     el.addEventListener("transitionend", handler);
     setTimeout(done, 400);


### PR DESCRIPTION
## Summary

The Studio Artifacts/Reels panel (`#bottomPanel`) hitched mid-slide when hiding: the collapse animated `max-height` while clearing inline `height` to `auto`, so the box snapped to its smaller content height and nothing moved until `max-height` dropped below it. Collapse/restore now animate `height` between concrete pixel endpoints (never `auto`), mirroring the smooth Screenspace panel and Studio's own divider-drag sizing model.

## Test plan

- [x] `ruff format --check`, `ruff check`, full `pytest` suite green (CSS/JS-only change; pre-existing unrelated ty diagnostic in `tests/test_workflows_runner.py` left as-is)
- [x] Hide via **V** hotkey and divider double-click is buttery smooth end-to-end; show unchanged; reload-while-collapsed and divider-resize-then-toggle verified in-browser by maintainer