### PR TITLE
fix: harden the wand scrub, audio mixing, and keyboard panel focus

### DIFF
--- a/assets/web/hotkeys.js
+++ b/assets/web/hotkeys.js
@@ -261,6 +261,39 @@
     return parts.join("+");
   }
 
+  // Fallback combo for a *bare* digit binding on a layout whose number row is
+  // shifted: on AZERTY the physical Digit1 produces e.key "&", so "1" would
+  // never match and the digit shortcuts (Studio preview tabs, Screenspace tool
+  // selection, transcript mark categories) would be unreachable. The DigitN
+  // codes are layout-stable. Returned as a *second* lookup key rather than
+  // replacing the primary name, so combos that legitimately are "&" still work.
+  // Alt/AltGr is excluded: on ISO layouts that is how punctuation is typed, and
+  // there the produced character — not the physical key — is the combo.
+  function codeDigitCombo(e) {
+    if (e.altKey || e.shiftKey) return null; // shifted digits: see normalizeEvent
+    if (!/^Digit[0-9]$/.test(e.code)) return null;
+    var digit = e.code.charAt(5);
+    if (e.key === digit) return null; // already matched as produced
+    var parts = [];
+    if (IS_MAC ? e.metaKey : e.ctrlKey) parts.push("Mod");
+    if (IS_MAC && e.ctrlKey) parts.push("Ctrl");
+    parts.push(digit);
+    return parts.join("+");
+  }
+
+  // The token keydown stored as `baseKey`, recomputed from a keyup. Shifted
+  // digits and , / . normalize from e.code on keydown (their e.key is the
+  // layout symbol: "!" / "<" / ";"), so keyup has to agree or onRelease never
+  // fires and the entry leaks in _held — later firing on an unrelated keyup
+  // whose e.key happens to equal the stored token.
+  function keyupBaseKey(e) {
+    if (e.key === " " || e.key === "Spacebar") return "SPACE";
+    if (/^Digit[0-9]$/.test(e.code)) return e.code.charAt(5);
+    if (e.code === "Comma") return ",";
+    if (e.code === "Period") return ".";
+    return (e.key || "").length === 1 ? e.key.toUpperCase() : e.key;
+  }
+
   var _MAC_MODS = { Mod: "⌘", Ctrl: "⌃", Alt: "⌥", Shift: "⇧" };
   var _PC_MODS = { Mod: "Ctrl", Ctrl: "Ctrl", Alt: "Alt", Shift: "Shift" };
   var _KEY_GLYPHS = {
@@ -500,7 +533,12 @@
     var combo = normalizeEvent(e);
     if (!combo) return;
     var ids = _comboIndex[combo];
-    if (!ids) return;
+    if (!ids) {
+      var byCode = codeDigitCombo(e);
+      if (byCode) ids = _comboIndex[byCode];
+      if (!ids) return;
+      combo = byCode;
+    }
     var typing = isTypingTarget(e.target);
     for (var n = 0; n < ids.length; n++) {
       var atts = _attachments[ids[n]] || [];
@@ -530,14 +568,7 @@
       disarmHints();
     }
     if (!_held.length) return;
-    // Normalize to the combo token the keydown stored as baseKey — Space's
-    // e.key is " ", which would never match "SPACE" without this.
-    var key =
-      e.key === " " || e.key === "Spacebar"
-        ? "SPACE"
-        : (e.key || "").length === 1
-          ? e.key.toUpperCase()
-          : e.key;
+    var key = keyupBaseKey(e);
     var remaining = [];
     for (var n = 0; n < _held.length; n++) {
       if (_held[n].baseKey === key) _held[n].attachment.onRelease(e);

--- a/assets/web/screenspace-overlay-interaction.js
+++ b/assets/web/screenspace-overlay-interaction.js
@@ -191,7 +191,9 @@
     body.canvas_width = canvas.width;
     body.canvas_height = canvas.height;
     if (region.description) body.description = region.description;
-    apiPost("api/regions", body)
+    // Returns the request promise (it always resolves — the catch below swallows
+    // failures) so callers can serialize successive saves of the same region.
+    return apiPost("api/regions", body)
       .then(function (data) {
         if (!data.ok) {
           showToast(data.error || "Failed to update region");
@@ -228,29 +230,13 @@
     return { x: x, y: y, w: w, h: h, points: contours, shape: shape };
   }
 
-  // Boolean-edit the active region — or, when none is saved-and-active, the
-  // unsaved pending region — with a freshly drawn shape (shift = add, alt =
-  // subtract, shift+alt = intersect — the selection modifiers users know from
-  // Photoshop). `shape` is {rect} or {contours} in canvas pixels. A saved
-  // region round-trips through the server; a pending region is edited in place
-  // and stays unsaved until it's named via the modal.
-  function applyRegionCombine(op, shape) {
+  var COMBINE_VERBS = { add: "Added to", subtract: "Subtracted from", intersect: "Intersected" };
+
+  // Rasterize base ∪/∖/∩ shape and trace it back to contours, or null when
+  // nothing meaningful survives.
+  function combineToContours(baseShape, shape, op) {
     var overlay = qs("#overlayCanvas");
-    if (!overlay.width || !overlay.height) return;
-    var name = state.activeRegion;
-    var savedRegion = name && state.regions[name] ? state.regions[name] : null;
-    var pending = savedRegion ? null : state.pendingRegion;
-    var baseShape = null;
-    if (savedRegion) {
-      baseShape = regionShapeAbs(savedRegion);
-    } else if (pending) {
-      // Pending contours are already canvas-pixel absolute (unlike a saved
-      // region's bbox-relative points, which regionShapeAbs() denormalizes).
-      baseShape = pending.points && pending.points.length > 0
-        ? { contours: pending.points }
-        : { rect: { x: pending.x, y: pending.y, w: pending.w, h: pending.h } };
-    }
-    if (!baseShape) return;
+    if (!overlay.width || !overlay.height) return null;
     var w = overlay.width, h = overlay.height;
     var mask = rasterizeShapesMask([baseShape], w, h);
     combineShapeMasks(mask, rasterizeShapesMask([shape], w, h), op);
@@ -258,23 +244,65 @@
     var s = w / displayW;
     // Drop <8px² specks, then simplify toward the server's 400-vertex cap.
     var contours = simplifyContours(maskToContours(mask, w, h, 8), 2 * s, 400);
-    var verb = { add: "Added to", subtract: "Subtracted from", intersect: "Intersected" }[op];
-    if (!contours.length || contoursArea(contours) < 64) {
-      showToast(savedRegion
-        ? "Nothing would remain of '" + name + "', so this was not applied"
-        : "Nothing would remain, so this was not applied");
+    if (!contours.length || contoursArea(contours) < 64) return null;
+    return contours;
+  }
+
+  // Pending edits to a saved region are serialized per region name. The base
+  // geometry is read from state.regions[name], which is only updated when the
+  // POST resolves — so two combines fired inside one round-trip (an easy
+  // sub-second double shift+wand scrub) would both read the *pre-edit* base and
+  // the second would silently overwrite the first, after the user saw a success
+  // toast for both. Chaining makes the second read the first's saved result.
+  var _regionCombineChain = {};
+
+  // Boolean-edit the active region — or, when none is saved-and-active, the
+  // unsaved pending region — with a freshly drawn shape (shift = add, alt =
+  // subtract, shift+alt = intersect — the selection modifiers users know from
+  // Photoshop). `shape` is {rect} or {contours} in canvas pixels. A saved
+  // region round-trips through the server; a pending region is edited in place
+  // and stays unsaved until it's named via the modal.
+  function applyRegionCombine(op, shape) {
+    var name = state.activeRegion;
+    if (name && state.regions[name]) {
+      var run = function () { return combineIntoRegion(op, shape, name); };
+      var prev = _regionCombineChain[name];
+      _regionCombineChain[name] = prev ? prev.then(run) : run();
       return;
     }
-    if (savedRegion) {
-      saveRegionShape(name, contours, verb + " region '" + name + "'");
-      return;
+    combineIntoPending(op, shape);
+  }
+
+  function combineIntoRegion(op, shape, name) {
+    // Re-read at run time: an earlier queued combine may have replaced it, and
+    // the region can be deleted while this one waits its turn.
+    var region = state.regions[name];
+    if (!region) return Promise.resolve();
+    var contours = combineToContours(regionShapeAbs(region), shape, op);
+    if (!contours) {
+      showToast("Nothing would remain of '" + name + "', so this was not applied");
+      return Promise.resolve();
     }
-    // Pending region: update in place, no server round-trip. Collapse to a
-    // plain rect when the result is axis-aligned (parity with saveRegionShape).
-    var rect = contoursToAxisRect(contours, 2);
-    var updated = rect
-      ? { x: rect.x, y: rect.y, w: rect.w, h: rect.h }
-      : pendingShapedRegion(contours, "combo");
+    return saveRegionShape(name, contours, COMBINE_VERBS[op] + " region '" + name + "'");
+  }
+
+  function combineIntoPending(op, shape) {
+    var pending = state.pendingRegion;
+    if (!pending) return;
+    // Pending contours are already canvas-pixel absolute (unlike a saved
+    // region's bbox-relative points, which regionShapeAbs() denormalizes).
+    var baseShape = pending.points && pending.points.length > 0
+      ? { contours: pending.points }
+      : { rect: { x: pending.x, y: pending.y, w: pending.w, h: pending.h } };
+    var contours = combineToContours(baseShape, shape, op);
+    // Update in place, no server round-trip. Collapse to a plain rect when the
+    // result is axis-aligned (parity with saveRegionShape).
+    var rect = contours ? contoursToAxisRect(contours, 2) : null;
+    var updated = !contours
+      ? null
+      : rect
+        ? { x: rect.x, y: rect.y, w: rect.w, h: rect.h }
+        : pendingShapedRegion(contours, "combo");
     if (!updated) {
       showToast("Nothing would remain, so this was not applied");
       return;
@@ -282,7 +310,7 @@
     state.pendingRegion = updated;
     renderOverlay();
     updateRegionButtons();
-    showToast(verb + " region");
+    showToast(COMBINE_VERBS[op] + " region");
   }
 
   // ---- Overlay interaction state machine ----
@@ -418,13 +446,23 @@
 
     function beginWandDrag(e, pos, s, combine) {
       var frameCanvas = qs("#frameCanvas");
-      if (!frameCanvas || !frameCanvas.width) return;
+      // Gate on the loaded image, not on frameCanvas.width: a <canvas> with no
+      // width/height attributes reports the 300x150 default, so a width check
+      // never fires and the wand would flood the blank placeholder into a bogus
+      // full-canvas region. The caller already cleared the pending/active
+      // region, so repaint before bailing or the buttons and selection go stale.
+      if (!frameCanvas || !state.frameImage) {
+        flushOverlayRender();
+        renderRegionChips();
+        updateRegionButtons();
+        return;
+      }
       var w = frameCanvas.width, h = frameCanvas.height;
       _wandFrame = {
         data: frameCanvas.getContext("2d").getImageData(0, 0, w, h).data,
         w: w, h: h, seedX: pos.x, seedY: pos.y, s: s,
       };
-      // seedX/seedY/scale/headX are for the painter's drag chrome (anchor dot,
+      // seedX/seedY/headOffsetPx are for the painter's drag chrome (anchor dot,
       // track, head dot) — it can't see the module-local _wandFrame.
       state.wandDragging = {
         startClientX: e.clientX,
@@ -434,9 +472,13 @@
         previewPoints: null,
         seedX: pos.x,
         seedY: pos.y,
-        scale: s,
-        headX: pos.x,
+        headOffsetPx: 0,
       };
+      // The scrub is horizontal, so advertise ew-resize — on the *overlay*, not
+      // just the body: #overlayCanvas has its own `cursor: crosshair` rule and
+      // the hover pass writes an inline cursor, both of which beat an inherited
+      // body cursor for the whole drag (which happens over the canvas).
+      overlay.style.cursor = "ew-resize";
       document.body.style.cursor = "ew-resize";
       document.body.style.userSelect = "none";
       computeWandPreview();
@@ -455,8 +497,12 @@
       // Track head follows the *clamped* tolerance, not the raw cursor, so the
       // painted track stops growing once the scrub saturates at min/max —
       // hitting the end of the range is visible instead of running off-screen.
+      // Stored as a CSS-pixel offset rather than a canvas-pixel x so the painter
+      // maps it with the *live* canvas scale: toggling a side panel or resizing
+      // the window mid-drag changes that ratio, and a scale captured at press
+      // would detach the head dot from the cursor.
       var wd = state.wandDragging;
-      wd.headX = wd.seedX + ((tol - wd.startTolerance) / WAND_SCRUB_SENSITIVITY) * wd.scale;
+      wd.headOffsetPx = (tol - wd.startTolerance) / WAND_SCRUB_SENSITIVITY;
       state.wandTolerance = tol;
       inp.value = String(tol);
       qs("#wandToleranceValue").textContent = String(tol);
@@ -465,6 +511,8 @@
 
     function endWandDrag() {
       if (_wandRaf) { cancelAnimationFrame(_wandRaf); _wandRaf = 0; }
+      // The hover pass re-establishes the overlay cursor on the next move.
+      overlay.style.cursor = "";
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
       _wandFrame = null;
@@ -506,6 +554,11 @@
       flushOverlayRender();
       updateRegionButtons();
     }
+    // Published here rather than in the export block at the bottom because the
+    // whole wand cluster is scoped to initRegionDrawing. The hub's Escape
+    // cascade and the frame loader both need to abort a live scrub, and only
+    // this path releases the cached full-frame ImageData (~33 MB at 4K).
+    SS.cancelWandDrag = cancelWandDrag;
 
     overlay.addEventListener("mousedown", function (e) {
       if (e.button !== 0) return;
@@ -699,6 +752,11 @@
 
     overlay.addEventListener("mouseup", function (e) {
       if (state.pipetteActive) return;
+      // Mirror mousedown's `e.button !== 0` guard. Without it, right-clicking
+      // (or a middle / back-forward click) mid-drag commits the gesture while
+      // the left button is still held — the region lands at whatever tolerance
+      // happened to be current, under the open context menu.
+      if (e.button !== 0) return;
       if (state.wandDragging) { commitWandDrag(); return; }
       if (state.draggingTemplate) {
         _cachedOverlayRect = null;
@@ -734,9 +792,23 @@
       finishDrawingRegion(e);
     });
 
+    // Cancel a live scrub when the press can no longer be released normally:
+    // the pointer left the window and came back up, focus moved to another app
+    // (both would otherwise leave `wandDragging` set forever — the document
+    // mousemove branch below returns unconditionally, so every later move would
+    // keep re-flooding and every other drag mode would be dead), or a context
+    // menu opened mid-drag.
+    window.addEventListener("blur", cancelWandDrag);
+    overlay.addEventListener("contextmenu", cancelWandDrag);
+
     // Document-level listeners so drag/resize continues outside the canvas
     document.addEventListener("mousemove", function (e) {
-      if (state.wandDragging) { updateWandDragFromEvent(e); return; }
+      if (state.wandDragging) {
+        // No button held: the mouseup happened somewhere we never saw it.
+        if (e.buttons === 0) cancelWandDrag();
+        else updateWandDragFromEvent(e);
+        return;
+      }
       if (state.drawingLasso) {
         var lassoRect = _cachedOverlayRect || overlay.getBoundingClientRect();
         var lassoPos = canvasCoords(overlay, e, lassoRect);
@@ -777,6 +849,7 @@
     });
 
     document.addEventListener("mouseup", function (e) {
+      if (e.button !== 0) return; // see the overlay mouseup guard above
       if (state.wandDragging) { commitWandDrag(); return; }
       if (finishDrawingLasso()) return;
       if (finishDrawingRegion(e)) return;

--- a/assets/web/screenspace-overlay.js
+++ b/assets/web/screenspace-overlay.js
@@ -200,14 +200,18 @@
       // would have zero visual response. The anchor marks where the press
       // landed, the horizontal track shows how far the tolerance scrub has
       // travelled, and the readout rides the head next to the pointer.
-      var dragged = Math.abs(wd.headX - wd.seedX) >= 2 * s;
+      // headOffsetPx is the scrub distance in CSS pixels; mapping it here with
+      // the live `s` keeps the head under the cursor even when a panel toggle
+      // or window resize changes the canvas-to-display ratio mid-drag.
+      var headX = wd.seedX + wd.headOffsetPx * s;
+      var dragged = Math.abs(headX - wd.seedX) >= 2 * s;
       if (dragged) {
         ctx.strokeStyle = hexToRgba(wcol, 0.55);
         ctx.lineWidth = 1 * s;
         ctx.setLineDash([3 * s, 3 * s]);
         ctx.beginPath();
         ctx.moveTo(wd.seedX, wd.seedY);
-        ctx.lineTo(wd.headX, wd.seedY);
+        ctx.lineTo(headX, wd.seedY);
         ctx.stroke();
         ctx.setLineDash([]);
       }
@@ -217,11 +221,23 @@
       ctx.fillStyle = wcol;
       ctx.beginPath(); ctx.arc(wd.seedX, wd.seedY, 2.5 * s, 0, Math.PI * 2); ctx.fill(); ctx.stroke();
       if (dragged) {
-        ctx.beginPath(); ctx.arc(wd.headX, wd.seedY, 2 * s, 0, Math.PI * 2); ctx.fill(); ctx.stroke();
+        ctx.beginPath(); ctx.arc(headX, wd.seedY, 2 * s, 0, Math.PI * 2); ctx.fill(); ctx.stroke();
       }
       ctx.font = Math.round(11 * s) + "px " + getThemeColors().fontMono;
       ctx.fillStyle = "rgba(255,255,255,0.9)";
-      ctx.fillText("tol " + wd.tolerance, wd.headX + Math.round(6 * s), wd.seedY - Math.round(8 * s));
+      // Ride the head, but flip to its left when scrubbing leftward (otherwise
+      // the readout sits on top of the track and anchor dot) and clamp to the
+      // canvas so a seed near an edge doesn't push it out of frame.
+      var wlabel = "tol " + wd.tolerance;
+      var wpad = Math.round(6 * s);
+      var wlw = ctx.measureText(wlabel).width;
+      var wlx = headX >= wd.seedX ? headX + wpad : headX - wpad - wlw;
+      var wmargin = Math.round(2 * s);
+      ctx.fillText(
+        wlabel,
+        clamp(wlx, wmargin, Math.max(wmargin, canvas.width - wlw - wmargin)),
+        clamp(wd.seedY - Math.round(8 * s), Math.round(11 * s), canvas.height - wmargin)
+      );
     }
 
     // Pending (unsaved) region

--- a/assets/web/screenspace-tasks.js
+++ b/assets/web/screenspace-tasks.js
@@ -953,6 +953,10 @@
     container.innerHTML = "";
     container.appendChild(frag);
     container.scrollTop = prevScrollTop;
+    // The rebuild drops the painted keyboard cursor, and sortTasks() above may
+    // have moved the focused card (a task finishing re-sorts the list), so
+    // re-anchor by task id rather than leaving the user to re-target Shift+3.
+    if (SS.ssRefreshNav) SS.ssRefreshNav();
     updateResultsCrumb();
   }
 

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -182,8 +182,12 @@
     // panel. focusCursor indexes ssNavItems(focusRegion). navEditing is true
     // while a text control (notes / a param input) holds real focus for typing.
     // pickerCursor (>= 0) indexes into an open run-picker dropdown's options.
+    // focusAnchor identifies the focused item so a list that re-renders (the
+    // poller rebuilds #taskList wholesale, and a finishing task re-sorts it)
+    // can restore the cursor to the same row, not the old index.
     focusRegion: "video",
     focusCursor: 0,
+    focusAnchor: null,
     navEditing: false,
     pickerCursor: -1,
     referenceTimestamp: null,
@@ -3954,8 +3958,36 @@
     var cur = items[state.focusCursor];
     if (cur) {
       cur.classList.add("ss-nav-cursor");
+      state.focusAnchor = ssNavKey(cur);
       if (cur.scrollIntoView) cur.scrollIntoView({ block: "nearest" });
     }
+  }
+
+  // Stable identity for a nav item, where it has one. Index alone is not enough
+  // for the task queue: it is rebuilt from scratch on every poll and re-sorted
+  // when a task finishes, so the old index points at a different task.
+  function ssNavKey(item) {
+    if (!item) return null;
+    if (item.dataset && item.dataset.taskId) return "task:" + item.dataset.taskId;
+    if (item.id) return "id:" + item.id;
+    return null;
+  }
+
+  // Re-anchor and repaint after a region's list was rebuilt wholesale. Without
+  // this the painted cursor is simply gone (innerHTML = "") and the user has to
+  // re-target the panel with Shift+N.
+  function ssRefreshNav() {
+    if (state.focusRegion === "video") return;
+    var items = ssNavItems(state.focusRegion);
+    // Nothing to land on: leave focusRegion alone — ssNavFocused hands the
+    // arrows back to the video on the next keypress.
+    if (!items.length) return;
+    if (state.focusAnchor) {
+      for (var i = 0; i < items.length; i++) {
+        if (ssNavKey(items[i]) === state.focusAnchor) { state.focusCursor = i; break; }
+      }
+    }
+    ssPaintNav();
   }
 
   function ssSetFocusRegion(region) {
@@ -3963,9 +3995,31 @@
     state.focusRegion = region;
     state.navEditing = false;
     state.pickerCursor = -1;
+    state.focusAnchor = null;
     if (region === "video") { ssClearNavPaint(); return; }
     state.focusCursor = 0;
     ssPaintNav();
+  }
+
+  // Mouse and keyboard focus must not disagree. Once the user starts clicking,
+  // the arrows belong to whatever they clicked: landing on an item of the
+  // focused region moves the cursor there, anything else (the video, another
+  // panel, a toolbar) hands the arrows back to the video for transport seeking.
+  // Without this the region stays focused as long as its panel is merely
+  // visible, so arrows keep roving a list the user has clicked away from and
+  // seeking looks broken until they think to press Escape.
+  function ssSyncFocusToClick(e) {
+    if (state.focusRegion === "video" || state.navEditing) return;
+    if (ssInPicker()) return; // an open dropdown owns its own click handling
+    var items = ssNavItems(state.focusRegion);
+    for (var i = 0; i < items.length; i++) {
+      if (items[i] === e.target || items[i].contains(e.target)) {
+        state.focusCursor = i;
+        ssPaintNav();
+        return;
+      }
+    }
+    ssSetFocusRegion("video");
   }
 
   // Shift+N: reveal the target panel, then land the cursor in it. Declines
@@ -4221,6 +4275,11 @@
         handler: function () { ssNavActivate(); },
       },
     ]);
+
+    // Capture phase: page click handlers re-render panels (a task card switches
+    // the right-pane tab), so read the click against the *current* DOM before
+    // they run.
+    document.addEventListener("mousedown", ssSyncFocusToClick, true);
 
     // Back-out cascade: leave the notes editor, then return panel focus to the
     // video, then an open run-picker dropdown, then the active pointer
@@ -4928,5 +4987,7 @@
   SS.togglePinTrayVisibility = togglePinTrayVisibility;
   SS.clearAllPins = clearAllPins;
   SS.updatePinButtons = updatePinButtons;
+  // Satellites call this after rebuilding a nav region's list wholesale.
+  SS.ssRefreshNav = ssRefreshNav;
 
 })();

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1531,6 +1531,12 @@
     var img = new Image();
     img.onload = function () {
       if (frameRequestVersion !== _frameRequestVersion || participantId !== state.selectedParticipant) return;
+      // The wand traces a pixel snapshot of the *outgoing* frame and the canvas
+      // may be resized below, so a scrub that is somehow still live here would
+      // commit a contour in the old frame's pixel space. The transport hotkeys
+      // are gated during a drag; this covers every other path into a reload
+      // (participant switch, timeline click, playback tick).
+      cancelWandDrag();
       state.frameImage = img;
       state.frameLoading = false;
       qs("#frameEmpty").classList.add("hidden");
@@ -1785,6 +1791,7 @@
   function updateRegionButtons() { return SS.updateRegionButtons && SS.updateRegionButtons.apply(null, arguments); }
   function hideRegionNameModal() { return SS.hideRegionNameModal && SS.hideRegionNameModal.apply(null, arguments); }
   function invalidateOverlayRect() { return SS.invalidateOverlayRect && SS.invalidateOverlayRect.apply(null, arguments); }
+  function cancelWandDrag() { return SS.cancelWandDrag && SS.cancelWandDrag.apply(null, arguments); }
 
   // ---- Region stashing ----
 
@@ -3123,6 +3130,17 @@
       if (el.type === "checkbox") {
         if (el.checked === saved) return;
         el.checked = saved;
+      } else if (el.type === "hidden" && el.parentNode
+                 && el.parentNode.classList.contains("cg-segtrack")) {
+        // A segmented capsule's value lives in a hidden input, but the visible
+        // state (thumb position, .active segment) is CSS driven off the track
+        // element — writing el.value alone restores the value behind a control
+        // still showing the rebuilt default, and the scan then runs a mode the
+        // UI denies. applyColorMode/applyNormalizeMode also re-apply the
+        // value-dependent row visibility.
+        if (el.value === String(saved)) return;
+        if (id === "paramColorMode") applyColorMode(id, saved);
+        else segTrackSetValue(el.parentNode, saved);
       } else {
         if (el.value === String(saved)) return;
         el.value = saved;
@@ -3803,8 +3821,21 @@
   // suppress the arrow handlers. The lone exception is the notes textarea, which
   // takes real focus for editing (Enter to edit, Escape to step back out).
 
+  // True while a panel owns the arrows. A focused panel can go dark without ever
+  // passing through Escape — clicking a task card switches the right-pane tab,
+  // and the info / bottom panels have their own collapse controls — and its rows
+  // survive in the DOM behind the hidden container. Left unchecked the arrows
+  // stay claimed (and preventDefault'ed) by an invisible cursor and video
+  // seeking silently dies, so an empty region hands focus back to the video.
+  function ssNavFocused() {
+    if (state.focusRegion === "video") return false;
+    if (ssNavItems(state.focusRegion).length) return true;
+    ssSetFocusRegion("video");
+    return false;
+  }
+
   function ssVideoFocused() {
-    return state.focusRegion === "video";
+    return !ssNavFocused();
   }
 
   function ssElVisible(elm) {
@@ -3824,7 +3855,18 @@
   }
 
   // Ordered, currently-visible items the arrows walk in each region.
+  //
+  // The visibility filter is load-bearing, not cosmetic: `.hidden` is
+  // `display: none`, so a panel can go dark while its rows stay in the DOM
+  // (switching the right-pane tab hides the task queue, the info and bottom
+  // panels have their own collapse controls). Returning those would paint the
+  // cursor on an invisible row and keep the arrows claimed — see ssNavFocused.
   function ssNavItems(region) {
+    // slice: the task/results branches return a NodeList, which has no .filter.
+    return Array.prototype.slice.call(_ssNavItemsRaw(region)).filter(ssElVisible);
+  }
+
+  function _ssNavItemsRaw(region) {
     if (region === "sidebar") {
       var items = [];
       var notes = qs("#ssInfoNotes");
@@ -4075,10 +4117,21 @@
     }
   }
 
+  // A live pointer drag owns the frame: the wand caches the frame's pixels at
+  // press and traces the release against that snapshot, so letting a
+  // frame-changing key through mid-drag would commit a region drawn from a frame
+  // that is no longer on screen. (Arrow seeks are already gated on
+  // ssVideoFocused; play/pause and the ,/. frame steps were not gated at all,
+  // and during a mouse drag document.activeElement is <body>, so they dispatch.)
+  function noPointerDrag() {
+    return !state.wandDragging && !state.drawingLasso && !state.drawingRegion;
+  }
+
   function initKeyboard() {
     window.ClipgenHotkeys.register([
       {
         id: "transport.playPause",
+        when: noPointerDrag,
         handler: function () {
           if (state.videoPlaying) pauseVideo();
           else playVideo();
@@ -4091,8 +4144,8 @@
       // works regardless of focus.
       { id: "transport.seekBack", when: ssVideoFocused, handler: function () { _seekBy(-SEEK_STEP); } },
       { id: "transport.seekFwd", when: ssVideoFocused, handler: function () { _seekBy(SEEK_STEP); } },
-      { id: "transport.stepBack", handler: function () { _seekBy(-FRAME_STEP); } },
-      { id: "transport.stepFwd", handler: function () { _seekBy(FRAME_STEP); } },
+      { id: "transport.stepBack", when: noPointerDrag, handler: function () { _seekBy(-FRAME_STEP); } },
+      { id: "transport.stepFwd", when: noPointerDrag, handler: function () { _seekBy(FRAME_STEP); } },
       // Shift+arrow mirrors the ,/. fine step so the 1 s / 5 s pair is discoverable
       // from the arrow keys alone (screenspace-scoped to avoid Composer's Shift+arrow).
       { id: "screenspace.stepBackFine", when: ssVideoFocused, handler: function () { _seekBy(-FRAME_STEP); } },
@@ -4153,7 +4206,7 @@
       },
       {
         id: "screenspace.nav",
-        when: function () { return state.focusRegion !== "video"; },
+        when: ssNavFocused,
         handler: function (e, combo) {
           if (combo === "ArrowUp") ssNavMove(-1);
           else if (combo === "ArrowDown") ssNavMove(1);
@@ -4164,7 +4217,7 @@
       {
         id: "screenspace.navActivate",
         repeat: false,
-        when: function () { return state.focusRegion !== "video"; },
+        when: ssNavFocused,
         handler: function () { ssNavActivate(); },
       },
     ]);
@@ -4215,15 +4268,11 @@
         document.body.style.userSelect = "";
         renderOverlay();
       } else if (state.wandDragging) {
-        // Abort an in-progress wand scrub. It never sets pendingRegion until
-        // release, so nulling the state is a complete cancel; the satellite's
-        // cached frame ImageData is only read while wandDragging is truthy.
-        state.wandDragging = null;
-        invalidateOverlayRect();
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-        renderOverlay();
-        updateRegionButtons();
+        // Abort an in-progress wand scrub. Route through the satellite rather
+        // than nulling the state here: only its cancel path releases the cached
+        // full-frame ImageData (~8 MB at 1080p, ~33 MB at 4K) and drops the
+        // pending re-flood RAF.
+        cancelWandDrag();
       } else if (state.drawingRegion || state.drawingLasso) {
         state.drawingRegion = null;
         state.drawingLasso = null;

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1102,6 +1102,13 @@ body.dragging .ts-cell:hover {
   overflow: hidden;
 }
 
+/* The divider drag writes `height` every frame, so the collapse transition
+ * above has to be off for the duration or the panel lags behind the cursor.
+ * Toggled by initBottomPanelDivider's onDragStart/onDragEnd. */
+body.panel-dragging #bottomPanel {
+  transition: none;
+}
+
 /* Two-column split: ARTIFACTS | REEL — matches the prototype's bottom strip
  * anatomy (full-bleed, hairline divider between columns). */
 #bottomColumns {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1930,6 +1930,16 @@
         state.bottomH = h;
         applyBottomHeight();
       },
+      // #bottomPanel carries a `transition: height` for the collapse animation,
+      // and the drag writes that same property every frame — without suppressing
+      // it the panel eases ~250 ms behind the cursor and keeps sliding after
+      // mouseup. Mirrors Screenspace's body.panel-dragging handling.
+      onDragStart: function () {
+        document.body.classList.add("panel-dragging");
+      },
+      onDragEnd: function () {
+        document.body.classList.remove("panel-dragging");
+      },
       getBounds: function () {
         // Reserve at least MIN_UPPER for the sheet pane.
         var header = qs("#studioSubheader");

--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -174,6 +174,12 @@
     var fresh = buildPillOptions(p, s);
     fresh.setAttribute("data-pid", pid);
     floating.parentNode.replaceChild(fresh, floating);
+    // The whole pane node is swapped, so a painted keyboard cursor goes with it
+    // while state.pillOptionsCursor stays set — and the arrows are still claimed
+    // by _pillMenuActive, so it would look like nothing has focus until the next
+    // keypress. This poll fires most often while a transcription is running,
+    // which is exactly when the dropdown is likely open.
+    pillNavPaint();
   }
 
   function buildPillWrap(p, taskByPid) {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -701,13 +701,18 @@
     // Set video source. ?v=<mtime_ns> mirrors the screenspace cache-bust so
     // a re-encoded or replaced source file invalidates the browser HTTP cache
     // instead of relying on send_from_directory's Last-Modified revalidation.
+    // Reset the audio-track layout to single-track, which tears down the
+    // previous participant's mix. Outside the has_video branch on purpose:
+    // selecting a participant *without* video must also drop the mix, or its
+    // orphaned <audio> elements keep playing, the <video> stays force-muted, and
+    // the volume popover goes on showing the previous participant's sliders.
+    state.audioTracks = [];
+    if (state.audioPanel) state.audioPanel.refresh();
+
     if (p.has_video) {
       // Lazily probe the audio-track layout for the volume popover's caption +
-      // per-track mixer. Reset to single-track now (tears down the previous
-      // participant's mix), then reconfigure once the layout arrives. Guarded by
+      // per-track mixer, then reconfigure once the layout arrives. Guarded by
       // participantReqVer so a stale response can't overwrite the current tracks.
-      state.audioTracks = [];
-      if (state.audioPanel) state.audioPanel.refresh();
       (function (ver) {
         apiGet("api/audio-info/" + encodeURIComponent(pid))
           .then(function (data) {

--- a/assets/web/video-controls.js
+++ b/assets/web/video-controls.js
@@ -106,6 +106,11 @@
     var mixRunning = false;    // per-track <audio> elements confirmed playing
     var lastSig = null;        // track-set signature so refresh() is idempotent
     var retryHandler = null;   // one-shot gesture listener re-arming a blocked mix
+    // Bumped by teardownMulti (which every mode switch goes through). A
+    // discarded track element can still deliver a queued "error" after the next
+    // participant's mix is built, and that must not tear the new mix down —
+    // each track's error handler captures the generation it was created in.
+    var mixGeneration = 0;
 
     // ---- Single-track path: lazy video -> gain -> destination (commit 1) ----
     var videoSrcNode = null;
@@ -151,14 +156,25 @@
 
     function resumeCtx() {
       var ctx = audioContext();
-      if (ctx && ctx.state === "suspended" && ctx.resume) ctx.resume();
+      if (!ctx || ctx.state !== "suspended" || !ctx.resume) return;
+      var p = ctx.resume();
+      // resume() is async and can settle after the elements' play() promises.
+      // onMixStarted bails while the context is still suspended, so re-run it
+      // here once the graph is genuinely audible.
+      if (p && p.then) {
+        p.then(function () {
+          if (multiActive && !mixRunning && !video.paused) onMixStarted();
+        }, function () {});
+      }
     }
 
     function teardownMulti() {
       disarmRetry();
+      mixGeneration++;
       for (var i = 0; i < trackNodes.length; i++) {
         var t = trackNodes[i];
         try { t.el.pause(); } catch (e) {}
+        if (t.onError) t.el.removeEventListener("error", t.onError);
         try { t.el.removeAttribute("src"); t.el.load(); } catch (e2) {}
         try { t.src.disconnect(); } catch (e3) {}
         try { t.gain.disconnect(); } catch (e4) {}
@@ -170,9 +186,13 @@
       mixRunning = false;
     }
 
-    function bailToSingle() {
+    function bailToSingle(gen) {
       // Something went wrong loading a track — never leave the user with a muted
       // video and no sound. Drop the mix and play the video's own default track.
+      // Ignore a track that already belongs to a torn-down mix: its error can
+      // land after the *next* participant's mix is up, and tearing that one down
+      // would silently cost them per-track mixing until another switch.
+      if (gen !== mixGeneration) return;
       teardownMulti();
       lastSig = "single";
       video.muted = muted;
@@ -192,6 +212,7 @@
         masterGain.connect(ctx.destination);
       } catch (e) { enterSingle(); return; }
       trackPercents = [];
+      var gen = mixGeneration;
       for (var i = 0; i < tracks.length; i++) {
         var url = safeTrackUrl(tracks[i].index);
         if (!url) { teardownMulti(); enterSingle(); return; }
@@ -203,14 +224,17 @@
         el.webkitPreservesPitch = true;
         el.src = url;
         el.className = "cg-audiotrack";
-        el.addEventListener("error", bailToSingle);
+        var onError = (function (g0) {
+          return function () { bailToSingle(g0); };
+        })(gen);
+        el.addEventListener("error", onError);
         try {
           var src = ctx.createMediaElementSource(el);
           var g = ctx.createGain();
           g.gain.value = 1;
           src.connect(g);
           g.connect(masterGain);
-          trackNodes.push({ el: el, gain: g, src: src, index: tracks[i].index });
+          trackNodes.push({ el: el, gain: g, src: src, index: tracks[i].index, onError: onError });
           trackPercents.push(100);
           document.body.appendChild(el);
           el.load();
@@ -275,6 +299,13 @@
     }
     function onMixStarted() {
       if (!multiActive) return;
+      // Element playback and AudioContext.resume() are gated independently, so
+      // the tracks can "play" into a still-suspended context — routing the mix
+      // nowhere. Muting the <video> at that point leaves *total* silence with
+      // no retry armed, recoverable only by a manual pause→play. Treat it like
+      // a blocked start instead; resumeCtx re-runs this once the graph is live.
+      var ctx = audioContext();
+      if (!ctx || ctx.state !== "running") { armRetry(); return; }
       disarmRetry();
       mixRunning = true;
       applyMute(); // now silence the <video> — the mix has taken over its audio
@@ -450,7 +481,8 @@
             var tr = tracks[idx] || {};
             var name = tr.label || ("Track " + (idx + 1));
             rowsContainer.appendChild(
-              makeRow(name, trackPercents[idx] || 100, resumeCtx, function (v) {
+              // == null, not ||: 0% is a valid (fully attenuated) track.
+              makeRow(name, trackPercents[idx] == null ? 100 : trackPercents[idx], resumeCtx, function (v) {
                 setTrackGain(idx, v);
               })
             );

--- a/tests/test_hotkeys_frontend_source.py
+++ b/tests/test_hotkeys_frontend_source.py
@@ -77,6 +77,28 @@ def test_keyup_only_in_dispatcher():
     )
 
 
+def test_keyup_normalizes_shifted_digits_and_punctuation_by_code():
+    """onRelease depends on keydown and keyup agreeing on the base token.
+
+    Keydown derives it from ``e.code`` for shifted digits and , / . because
+    their ``e.key`` is a layout-dependent symbol ("!" / "<" / ";"). If keyup
+    normalized from ``e.key`` alone the two would never match: onRelease would
+    never fire and the entry would leak in ``_held``, later firing on an
+    unrelated keyup whose ``e.key`` happened to equal the stored token.
+    """
+    match = re.search(
+        r"function keyupBaseKey\(e\) \{(.+?)\n  \}", HOTKEYS_SRC, re.DOTALL
+    )
+    assert match, "keyupBaseKey not found in hotkeys.js"
+    body = match.group(1)
+    assert "Digit" in body and "e.code.charAt(5)" in body, (
+        "keyupBaseKey must map physical DigitN codes back to their digit"
+    )
+    assert '"Comma"' in body and '"Period"' in body, (
+        "keyupBaseKey must map the physical Comma/Period codes"
+    )
+
+
 def _parse_literal(name: str):
     match = re.search(
         r"var\s+" + re.escape(name) + r"\s*=\s*(\[.+?\n  \]);",

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1,5 +1,8 @@
 import json
+import os
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 import config
@@ -288,6 +291,78 @@ def test_extract_audio_track_failure_returns_none(monkeypatch, tmp_path):
 
 def test_extract_audio_track_file_not_found():
     assert video.extract_audio_track("/nonexistent/missing.mp4", 0) is None
+
+
+def test_extract_audio_track_concurrent_calls_run_ffmpeg_once(monkeypatch, tmp_path):
+    """Two threads racing on the same track must not both invoke ffmpeg.
+
+    Without the per-key lock both would write the same deterministic .partial
+    path with -y and one would rename a half-written file into the cache, which
+    is then served for the source's whole mtime lifetime.
+    """
+    src = tmp_path / "v.mp4"
+    src.write_bytes(b"x")
+    monkeypatch.setattr(config, "DEBUGGING", False)
+    monkeypatch.setattr(video.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    calls: list[list[str]] = []
+    tmp_names: list[str] = []
+    started = threading.Event()
+    calls_lock = threading.Lock()
+
+    def _run(cmd, **_kw):
+        with calls_lock:
+            calls.append(cmd)
+            tmp_names.append(Path(cmd[-1]).name)
+        started.set()
+        time.sleep(0.05)  # hold the lock long enough for the racer to pile up
+        Path(cmd[-1]).write_bytes(b"audio")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(video.subprocess, "run", _run)
+
+    results: list[Path | None] = []
+    results_lock = threading.Lock()
+
+    def _extract():
+        out = video.extract_audio_track(str(src), 0)
+        with results_lock:
+            results.append(out)
+
+    threads = [threading.Thread(target=_extract) for _ in range(2)]
+    threads[0].start()
+    started.wait(timeout=5)
+    threads[1].start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert len(calls) == 1, "second caller should have used the cached result"
+    assert len(results) == 2
+    assert results[0] == results[1]
+    assert results[0] is not None and results[0].read_bytes() == b"audio"
+    # Scratch paths are per-caller, so even a different track of the same file
+    # can never collide on one .partial name.
+    assert ".partial." in tmp_names[0]
+
+
+def test_extract_audio_track_prunes_superseded_extractions(monkeypatch, tmp_path):
+    """A re-encoded source keys a new cache file; the old mtime's must go."""
+    src = tmp_path / "v.mp4"
+    src.write_bytes(b"x")
+    _stub_ffmpeg_writes_output(monkeypatch, tmp_path)
+
+    first = video.extract_audio_track(str(src), 0)
+    assert first is not None and first.is_file()
+
+    # Rewrite the source so mtime_ns (and therefore the cache key) changes.
+    time.sleep(0.01)
+    src.write_bytes(b"xy")
+    os.utime(src, ns=(time.time_ns(), time.time_ns()))
+
+    second = video.extract_audio_track(str(src), 0)
+    assert second is not None and second.is_file()
+    assert second != first
+    assert not first.exists(), "superseded extraction should be pruned"
 
 
 # -- probe_max_keyframe_gap tests --

--- a/video.py
+++ b/video.py
@@ -1597,6 +1597,42 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
     return result
 
 
+# Per-(file, index) locks for extract_audio_track. Two requests for the same
+# track are routine (a re-select tears the <audio> element down and re-requests
+# it; range requests can arrive on a second connection), and the Flask server is
+# threaded, so without this two ffmpeg processes would race on one output path.
+_audio_track_locks: dict[tuple[str, int], threading.Lock] = {}
+_audio_track_locks_guard = threading.Lock()
+
+
+def _audio_track_lock(resolved: str, audio_index: int) -> threading.Lock:
+    key = (resolved, audio_index)
+    with _audio_track_locks_guard:
+        lock = _audio_track_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _audio_track_locks[key] = lock
+        return lock
+
+
+def _prune_stale_audio_tracks(cache_dir: Path, digest: str, keep_mtime_ns: int) -> None:
+    """Drop this source's extractions from earlier mtimes.
+
+    Every re-encode of a source yields a fresh ``mtime_ns`` filename, so without
+    this the superseded tracks accumulate forever — and the directory does not
+    use ``config.TEMP_ARTIFACT_PREFIX``, so the normal temp cleanup never reaps
+    it either.
+    """
+    prefix = f"{digest}_{keep_mtime_ns}_"
+    try:
+        entries = list(cache_dir.glob(f"{digest}_*"))
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.name.startswith(prefix):
+            _delete_quietly(entry)
+
+
 def extract_audio_track(filepath: str, audio_index: int) -> Path | None:
     """Demux one audio stream (``0:a:<audio_index>``) to a standalone, seekable
     ``.m4a`` for the browser's per-track mixer.
@@ -1626,39 +1662,61 @@ def extract_audio_track(filepath: str, audio_index: int) -> Path | None:
         cache_dir.mkdir(parents=True, exist_ok=True)
     except OSError:
         return None
-    tmp_path = out_path.with_suffix(".partial.m4a")
-    # +faststart relocates the moov atom to the front so the browser can stream
-    # and seek the track smoothly (a tail moov forces buffering stalls → pops).
-    base = [
-        "ffmpeg",
-        "-y",
-        "-i",
-        filepath,
-        "-map",
-        f"0:a:{audio_index}",
-        "-vn",
-        "-movflags",
-        "+faststart",
-    ]
-    # Try a stream copy first (instant for AAC), then an AAC re-encode for
-    # codecs that can't be copied into an MP4/M4A container (Opus, PCM, …).
-    for codec_args in (["-c:a", "copy"], ["-c:a", "aac", "-b:a", "160k"]):
-        try:
-            subprocess.run(
-                base + codec_args + [str(tmp_path)],
-                check=True,
-                capture_output=True,
-            )
-        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-            _delete_quietly(tmp_path)
-            continue
-        try:
-            tmp_path.replace(out_path)
-        except OSError:
-            _delete_quietly(tmp_path)
-            return None
-        return out_path
-    return None
+
+    with _audio_track_lock(resolved, audio_index):
+        # Re-check: another thread may have finished while we waited on the lock.
+        if out_path.is_file() and out_path.stat().st_size > 0:
+            return out_path
+        # Unique per caller so a concurrent extraction of a *different* track of
+        # the same file can never share a scratch path either.
+        tmp_path = (
+            cache_dir
+            / f"{out_path.stem}.partial.{os.getpid()}.{threading.get_ident()}.m4a"
+        )
+        # +faststart relocates the moov atom to the front so the browser can
+        # stream and seek the track smoothly (a tail moov forces buffering
+        # stalls → pops).
+        base = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            filepath,
+            "-map",
+            f"0:a:{audio_index}",
+            "-vn",
+            "-movflags",
+            "+faststart",
+        ]
+        # Try a stream copy first (instant for AAC), then an AAC re-encode for
+        # codecs that can't be copied into an MP4/M4A container (Opus, PCM, …).
+        for codec_args in (["-c:a", "copy"], ["-c:a", "aac", "-b:a", "160k"]):
+            try:
+                subprocess.run(
+                    base + codec_args + [str(tmp_path)],
+                    check=True,
+                    capture_output=True,
+                    # Generous: the copy path is near-instant but the AAC
+                    # re-encode fallback runs the length of a long session
+                    # recording. Bounded all the same, so a wedged ffmpeg can't
+                    # pin this request thread (and every waiter on the lock).
+                    timeout=300,
+                )
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+                FileNotFoundError,
+                OSError,
+            ):
+                _delete_quietly(tmp_path)
+                continue
+            try:
+                tmp_path.replace(out_path)
+            except OSError:
+                _delete_quietly(tmp_path)
+                return None
+            _prune_stale_audio_tracks(cache_dir, digest, mtime_ns)
+            return out_path
+        return None
 
 
 def _delete_quietly(path: Path) -> None:


### PR DESCRIPTION
## Summary

A bug-fix pass over the five most recent feature commits (#624–#628), which merged without follow-ups. Three clusters: the **magic-wand scrub** (a release the page never sees left the drag live and armed a phantom region; Escape leaked the cached full-frame `ImageData`; `,`/`.`/Space changed the frame mid-drag; back-to-back boolean combines silently overwrote each other), **audio mixing** (`extract_audio_track` raced on a deterministic `.partial` path under `ffmpeg -y`, renaming truncated files into a cache only checked for "exists and non-empty"; a discarded track's `error` could tear down the *next* participant's mix; the `<video>` could be muted into a still-suspended `AudioContext`), and **keyboard focus** (`.cg-segtrack` params restored their value behind a control still showing the rebuilt default, so Color ran in presence mode under a UI reading average; panel focus ignored mouse clicks and lost its cursor whenever the task list rebuilt). Also: the Studio divider drag no longer rubber-bands behind the cursor, and bare-digit hotkeys fall back to the physical `DigitN` code so they work on layouts with a shifted number row.

## Test plan

- [x] `/check` green — ruff format + lint, ty, full suite
- [x] New tests: `extract_audio_track` concurrency + cache pruning; `keyupBaseKey` source assertion
- [x] Browser-tested manually across Screenspace, Studio and Transcripts
- [ ] Results-list keyboard cursor is **not** re-anchored across full rebuilds (task queue only) — its render has several exit points and its rows carry no stable identity