### PR TITLE
build(ruff): migrate to 0.16 and clear the expanded default rule set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,10 +93,10 @@ jobs:
           python-version: "3.12"
 
       - name: Ruff check
-        run: uvx ruff@0.15.12 check
+        run: uvx ruff@0.16.0 check
 
       - name: Ruff format check
-        run: uvx ruff@0.15.12 format --check
+        run: uvx ruff@0.16.0 format --check
 
   typecheck:
     needs: [gate]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,13 @@ Always use `uv run` instead of `python`. Use `uv add` to add dependencies.
 
 ```python
 {
-    'cell': gspread.Cell,      # Cell with timestamp value (1-based row/col)
-    'desc': str,               # Observation text from Observation column
-    'study': str,              # Normalized study name (filesystem-safe)
-    'participant': str,        # e.g. 'P01', 'G02' from header
-    'category': str,           # Row category (sanitized; empty → 'uncategorized')
-    'severity': str,           # Row severity (normalized label; empty if no Severity column)
-    'times': [(start, end)]    # Added by files.prepare_clip(): list of (start_time, end_time) strings
+    "cell": gspread.Cell,  # Cell with timestamp value (1-based row/col)
+    "desc": str,  # Observation text from Observation column
+    "study": str,  # Normalized study name (filesystem-safe)
+    "participant": str,  # e.g. 'P01', 'G02' from header
+    "category": str,  # Row category (sanitized; empty → 'uncategorized')
+    "severity": str,  # Row severity (normalized label; empty if no Severity column)
+    "times": [(start, end)],  # Set by files.prepare_clip(): (start, end) strings
 }
 ```
 

--- a/agents/CLOUD.md
+++ b/agents/CLOUD.md
@@ -14,7 +14,7 @@ clipgen is a self-contained Python CLI tool with no databases or Docker services
 
 | Task | Command |
 |------|---------|
-| Lint | `uvx ruff check` and `uvx ruff format --check` |
+| Lint | `uvx ruff@0.16.0 check` and `uvx ruff@0.16.0 format --check` (match the CI pin; `pyproject.toml` sets `required-version = ">=0.16.0"`) |
 | Type check | `uvx ty check` |
 | Tests | `uv run --no-sync pytest -c tests/pytest.ini` |
 | Run app (CLI help) | `uv run clipgen.py --help` |

--- a/agents/skills/check/SKILL.md
+++ b/agents/skills/check/SKILL.md
@@ -4,8 +4,8 @@ Run this before every `git commit` to catch formatting, lint, type, and test fai
 
 ## Steps (run in order, stop on first failure)
 
-1. **Format check** — `uv run ruff format --check` on all modified `.py` files.
-   - If any would be reformatted: run `uv run ruff format` on them, then re-check.
+1. **Format check** — `uv run ruff format --check` (covers `.py` **and** Python code blocks in `.md`).
+   - If any file would be reformatted: run `uv run ruff format`, then re-check.
 2. **Lint** — `uv run ruff check --fix`
 3. **Type check** — `uv run ty check`
 4. **Tests** — `uv run --extra dev pytest -c tests/pytest.ini`

--- a/build/render_icons.py
+++ b/build/render_icons.py
@@ -23,6 +23,7 @@ import tempfile
 from pathlib import Path
 
 from PIL import Image, ImageDraw
+import itertools
 
 BG = (10, 10, 10, 255)  # #0a0a0a
 FG = (250, 250, 247, 255)  # #fafaf7
@@ -54,7 +55,7 @@ def render(size: int) -> Image.Image:
         return (offset + x * scale, offset + y * scale)
 
     for corners in PATHS:
-        for a, b in zip(corners, corners[1:]):
+        for a, b in itertools.pairwise(corners):
             x1, y1 = to_canvas(*a)
             x2, y2 = to_canvas(*b)
             left = min(x1, x2) - half

--- a/changelog.py
+++ b/changelog.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Parse ``CHANGELOG.md`` into structured entries for the Start overlay.
 
 Each entry corresponds to a level-2 heading in the form::

--- a/cli.py
+++ b/cli.py
@@ -2500,8 +2500,10 @@ def _run_ss_clips(args: argparse.Namespace) -> None:
         utils.warning_print(
             "No Screenspace events found.",
             [
-                "Run --screenspace (UI) or --ss-task to generate events first, "
-                "or check your input/output directory."
+                (
+                    "Run --screenspace (UI) or --ss-task to generate events first, "
+                    "or check your input/output directory."
+                )
             ],
         )
         return
@@ -2586,8 +2588,10 @@ def _run_transcript_clips(args: argparse.Namespace) -> None:
         utils.warning_print(
             "No transcripts found.",
             [
-                "Run --transcribe (with a clip mode) or --pre-transcribe / --transcripts "
-                "to generate transcripts first."
+                (
+                    "Run --transcribe (with a clip mode) or --pre-transcribe / --transcripts "
+                    "to generate transcripts first."
+                )
             ],
         )
         return
@@ -2735,8 +2739,10 @@ def _run_transcript_mark(args: argparse.Namespace) -> None:
         utils.warning_print(
             "No transcripts found.",
             [
-                "Run --transcribe (with a clip mode) or --pre-transcribe / --transcripts "
-                "to generate transcripts first."
+                (
+                    "Run --transcribe (with a clip mode) or --pre-transcribe / --transcripts "
+                    "to generate transcripts first."
+                )
             ],
         )
         return

--- a/cli.py
+++ b/cli.py
@@ -2303,9 +2303,8 @@ def _filter_transcript_segments(
             attached = marks_by_segment.get(seg_id, [])
             if mark_categories and not attached:
                 continue
-            if needle is not None:
-                if needle not in str(seg.get("text", "")).lower():
-                    continue
+            if needle is not None and needle not in str(seg.get("text", "")).lower():
+                continue
             rows.append((pid, seg, attached))
     return rows
 
@@ -3703,7 +3702,7 @@ def main() -> None:
     gspread_client = None
     if not _is_excel_spreadsheet_arg(getattr(args, "spreadsheet", None)):
         gspread_client = authenticate_google()
-        if gspread_client is None:
+        if gspread_client is None:  # noqa: SIM102 - the comment below belongs to the inner branch
             # Auth failed. CLI mode or an explicit -s argument can't recover
             # interactively — fall back to a sole local .xlsx when possible,
             # else point the user at the Excel option and exit.

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """CLI entry point and argument parsing for clipgen.
 
 Handles command-line argument parsing, CLI mode detection, setup,
@@ -12,9 +11,10 @@ import io
 import os
 import sys
 import uuid
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, NamedTuple
+from typing import Any, NamedTuple
 
 import clipgen
 import config
@@ -1324,7 +1324,7 @@ def _run_pre_transcribe(worksheet: Any, args: Any) -> None:
             "language": result["language"],
             "model": result["model"],
             "source_file": result["source_file"],
-            "transcribed_at": datetime.now(timezone.utc).isoformat(),
+            "transcribed_at": datetime.now(UTC).isoformat(),
         }
         transcribed += 1
 
@@ -2365,8 +2365,7 @@ def _build_clusters_from_ss_events(
             t_out = float(ev.get("time_out", t_in))
         except (TypeError, ValueError):
             continue
-        if t_out < t_in:
-            t_out = t_in
+        t_out = max(t_out, t_in)
         key = (
             ev.get("participant", ""),
             ev.get("source_video", ""),
@@ -2435,8 +2434,7 @@ def _build_clusters_from_transcript_segments(
             e = float(seg.get("end", s))
         except (TypeError, ValueError):
             continue
-        if e < s:
-            e = s
+        e = max(e, s)
         keyed.append((pid, (s, e), idx))
 
     clusters_raw = _cluster_groups(
@@ -2775,7 +2773,7 @@ def _run_transcript_mark(args: argparse.Namespace) -> None:
         return
 
     existing_by_seg = {m["segment_id"]: m for m in marks if m.get("segment_id")}
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     created = 0
     updated = 0
     for sid in seg_id_list:

--- a/clipgen.py
+++ b/clipgen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """clipgen - Video clip generator from Google Sheets timestamps.
 
 This program will help quickly create video snippets from longer video files, based on timestamps in a spreadsheet!
@@ -15,8 +14,9 @@ This script supports full unicode/UTF-8 for international characters in:
 """
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import config
 import files

--- a/composer_server.py
+++ b/composer_server.py
@@ -59,6 +59,7 @@ import pipeline
 import utils
 import video
 from server_utils import MediaCache, err, ok, parse_clip_window
+import itertools
 
 # ---- Module state (initialized by _init_composer_state) ----
 
@@ -1014,7 +1015,7 @@ def _annotation_windows(
         bounds.add(min(end, max(start, a["span"]["end"])))
     ordered = sorted(bounds)
     windows: list[dict[str, Any]] = []
-    for w_start, w_end in zip(ordered, ordered[1:]):
+    for w_start, w_end in itertools.pairwise(ordered):
         if w_end - w_start < 0.01:
             continue
         visible = [

--- a/composer_server.py
+++ b/composer_server.py
@@ -47,7 +47,7 @@ import math
 import os
 import threading
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -242,7 +242,7 @@ def api_cut_create() -> Any:
         "start": start,
         "end": end,
         "label": str(data.get("label", "")),
-        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "createdAt": datetime.now(UTC).isoformat(),
     }
     with _manifest_lock:
         _manifest.setdefault("cuts", []).append(cut)
@@ -503,7 +503,7 @@ def api_annotation_create() -> Any:
         "span": {"start": span[0], "end": span[1]},
         "geometry": geometry,
         "style": _sanitize_annotation_style(data.get("style")),
-        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "createdAt": datetime.now(UTC).isoformat(),
     }
     with _manifest_lock:
         _manifest.setdefault("annotations", []).append(annotation)
@@ -1372,7 +1372,7 @@ def _init_composer_state(
     ``participant_list`` is accepted for parity with the other blueprints' init
     signatures; participants are discovered from the input dir on demand.
     """
-    global _input_dir, _sheet_context, _manifest  # noqa: PLW0603
+    global _input_dir, _sheet_context, _manifest
 
     _input_dir = str(utils.get_effective_input_dir())
     _sheet_context = sheet_context

--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Configuration constants for clipgen.
 
 Sections

--- a/data_export.py
+++ b/data_export.py
@@ -518,8 +518,10 @@ def run_cli_export() -> int:
             "No exports written.",
             [
                 "No manifest files were found in the output directory.",
-                f"Expected one or more of: {config.SCREENSPACE_MANIFEST_FILENAME}, "
-                f"{config.TRANSCRIPTS_MANIFEST_FILENAME}",
+                (
+                    f"Expected one or more of: {config.SCREENSPACE_MANIFEST_FILENAME}, "
+                    f"{config.TRANSCRIPTS_MANIFEST_FILENAME}"
+                ),
             ],
         )
         return 1

--- a/data_export.py
+++ b/data_export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Analysis-ready data export for Screenspace and Transcripts.
 
 Reads the on-disk manifests and produces flat, one-row-per-atomic-unit
@@ -22,9 +21,10 @@ from __future__ import annotations
 import csv
 import io
 import json
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import config
 import utils
@@ -368,7 +368,7 @@ def to_csv(
 def to_json(records: list[dict[str, Any]]) -> str:
     """Serialize records to a JSON string with an export envelope."""
     payload = {
-        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "exported_at": datetime.now(UTC).isoformat(),
         "version": utils.get_version(),
         "records": records,
     }
@@ -528,15 +528,15 @@ def run_cli_export() -> int:
 
 
 __all__ = [
+    "SCREENSPACE_EVENT_COLUMNS",
+    "SCREENSPACE_PIN_COLUMNS",
+    "build_friction_moments",
+    "build_friction_segments",
     "build_screenspace_events",
     "build_screenspace_pins",
     "build_transcript_segments",
-    "build_friction_moments",
-    "build_friction_segments",
+    "run_cli_export",
     "to_csv",
     "to_json",
     "write_export_bundle",
-    "run_cli_export",
-    "SCREENSPACE_EVENT_COLUMNS",
-    "SCREENSPACE_PIN_COLUMNS",
 ]

--- a/excel_io.py
+++ b/excel_io.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Local Excel (.xlsx) support for clipgen.
 
 Provides a sheet adapter that matches the gspread Worksheet interface

--- a/files.py
+++ b/files.py
@@ -301,7 +301,7 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
         config.debug_ic(clip["times"])
 
     # Warn if no valid timestamps were parsed, except cells with only ignored tokens (e.g. "x").
-    if not clip["times"] and utils.has_non_ignored_timestamp_content(
+    if not clip["times"] and utils.has_non_ignored_timestamp_content(  # noqa: SIM102 - the comment below belongs to the inner branch
         cleaned_cell_value
     ):
         # Only show this detailed per-cell warning at verbose verbosity.

--- a/files.py
+++ b/files.py
@@ -221,8 +221,10 @@ def discover_numbered_source_videos(
             f"Numbered source videos for '{prefix}' are non-contiguous "
             f"(found parts {indices}); expected 1..N with no gaps.",
             [
-                "Ignoring the numbered sequence; rename the parts to a gapless "
-                "1..N sequence to enable concatenation.",
+                (
+                    "Ignoring the numbered sequence; rename the parts to a gapless "
+                    "1..N sequence to enable concatenation."
+                ),
             ],
         )
         return []

--- a/files.py
+++ b/files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """File and filename operations for clipgen."""
 
 import os

--- a/friction.py
+++ b/friction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Programmatic friction scorer for clipgen Transcripts.
 
 A cheap, deterministic first pass over transcript segments that flags moments of

--- a/google_api.py
+++ b/google_api.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Google Sheets API integration for clipgen."""
 
 from __future__ import annotations

--- a/interactive.py
+++ b/interactive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Interactive prompt helpers for clipgen.
 
 All user-facing interactive prompts (line selection, range selection, cell
@@ -14,7 +13,8 @@ the caller should re-prompt or abort).
 import shutil
 import sys
 import webbrowser
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import config
 import spreadsheet

--- a/interactive.py
+++ b/interactive.py
@@ -689,7 +689,7 @@ def browse_spreadsheet(sheet: Any, *, process_fn=None) -> None:
             else:
                 utils.info_print("Already at the last row.")
             return True, cur
-        if cmd.startswith("jump ") or cmd.startswith("j "):
+        if cmd.startswith(("jump ", "j ")):
             try:
                 parts = cmd.split()
                 if len(parts) >= 2:

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -340,8 +340,8 @@ def _do_generate(
         if resp is not None:
             try:
                 resp.close()
-            except Exception:
-                pass
+            except OSError:
+                pass  # already-dead socket; nothing to recover
         if watcher is not None:
             watcher.join(timeout=0.5)
         if deadline_exceeded:
@@ -476,8 +476,8 @@ def _do_pull(model: str, on_progress: Callable[[dict[str, Any]], None] | None) -
         if resp is not None:
             try:
                 resp.close()
-            except Exception:
-                pass
+            except OSError:
+                pass  # already-dead socket; nothing to recover
     return succeeded
 
 

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -157,9 +157,7 @@ def _is_connection_refused(exc: Exception) -> bool:
         exc.reason, ConnectionRefusedError
     ):
         return True
-    if isinstance(exc, ConnectionRefusedError):
-        return True
-    return False
+    return isinstance(exc, ConnectionRefusedError)
 
 
 def _ollama_install_guidance_lines() -> list[str]:

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Ollama local LLM transport for clipgen.
 
 A thin, reusable HTTP wrapper around the Ollama REST API. All functions fail
@@ -28,7 +27,8 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import config
 import utils

--- a/overview.py
+++ b/overview.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Overview: per-participant feature matrix + Flask blueprint for /overview/.
 
 Serves the Overview frontend (assets/web/overview.html + the overview-*.js

--- a/pipeline.py
+++ b/pipeline.py
@@ -192,7 +192,6 @@ def _resolve_one_source(
             _best_ratio, best_size, best_path = candidates[0]
             size_gb = best_size / 1_000_000_000
             # Pause progress bar so the prompt is visible and input is rendered
-            global _active_progress
             paused = False
             if _active_progress is not None:
                 _active_progress.stop()
@@ -1106,7 +1105,7 @@ def process_clips(
     skipped_no_times = 0
     skipped_no_video = 0
 
-    global _active_progress, _active_secondary_task
+    global _active_progress
     progress = utils.create_progress_bar()
     if progress:
         _active_progress = progress

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Clip processing pipeline for clipgen.
 
 Reusable functions for generating clips, reels, screenshots, GIFs, and
@@ -20,8 +19,9 @@ import hashlib
 import os
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import config
 import files
@@ -940,7 +940,7 @@ def _embed_transcript_on_artifacts(
             model=entry.get("model", ""),
         )
         transcript_version = entry.get("transcribed_at", "")
-    elif base_video in transcript_cache and transcript_cache[base_video]:
+    elif transcript_cache.get(base_video):
         full_transcript = transcript_cache[base_video]
 
     if not full_transcript:

--- a/pipeline.py
+++ b/pipeline.py
@@ -189,7 +189,7 @@ def _resolve_one_source(
         candidates.sort(key=lambda c: (c[0], c[1]), reverse=True)
 
         if candidates and candidates[0][0] >= 0.7 and not utils.NO_INPUT_MODE:
-            best_ratio, best_size, best_path = candidates[0]
+            _best_ratio, best_size, best_path = candidates[0]
             size_gb = best_size / 1_000_000_000
             # Pause progress bar so the prompt is visible and input is rendered
             global _active_progress
@@ -330,7 +330,7 @@ def _local_timestamp(seconds: float) -> str:
     ``M:SS`` / ``H:MM:SS`` pairs. These strings feed ffmpeg, not the
     spreadsheet, so the explicit hours are harmless.
     """
-    return utils.seconds_to_timestamp(int(round(seconds)), force_hours=True)
+    return utils.seconds_to_timestamp(round(seconds), force_hours=True)
 
 
 def _point_source(
@@ -348,7 +348,7 @@ def _point_source(
         return None
     index, local_start = mapped
     seg_duration = timeline[index][1]
-    remaining = max(1, seg_duration - int(round(local_start)))
+    remaining = max(1, seg_duration - round(local_start))
     return (timeline[index][0], _local_timestamp(local_start), remaining)
 
 
@@ -1655,10 +1655,14 @@ def _process_reel(
             f"Reel aborted: {len(reel_failures)} clip(s) could not be generated.",
             reel_failures
             + [
-                "No reel was written — a partial reel would look complete but "
-                "silently omit these moments.",
-                "Fix the sources (or deselect those clips) and run again; the "
-                "clips that did cut are not reused, so nothing is left stale.",
+                (
+                    "No reel was written — a partial reel would look complete but "
+                    "silently omit these moments."
+                ),
+                (
+                    "Fix the sources (or deselect those clips) and run again; the "
+                    "clips that did cut are not reused, so nothing is left stale."
+                ),
             ],
         )
         return (0, [])
@@ -2082,10 +2086,10 @@ def _regenerate_reel(
                     # regenerated segment reproduces the original cut instead
                     # of truncating up to ~1s off it.
                     "start_ts": utils.seconds_to_timestamp(
-                        int(round(local_start)), force_hours=True
+                        round(local_start), force_hours=True
                     ),
                     "end_ts": utils.seconds_to_timestamp(
-                        int(round(local_end)), force_hours=True
+                        round(local_end), force_hours=True
                     ),
                 }
             )

--- a/plans/archive/FRICTION-PLAN.md
+++ b/plans/archive/FRICTION-PLAN.md
@@ -115,7 +115,9 @@ Phrase patterns, not bare words. Examples (final list refined during implementat
 ```python
 FRICTION_PATTERNS = {
     "hesitation": [
-        r"\bum+\b", r"\buh+\b", r"\berm+\b",
+        r"\bum+\b",
+        r"\buh+\b",
+        r"\berm+\b",
         r"\b(let me (see|think|try))\b",
         r"\b(i (think|guess|mean))\b",
         r"\b(kind of|sort of)\b",
@@ -133,12 +135,16 @@ FRICTION_PATTERNS = {
         r"\bwhy (won't|isn't|can't|does)\b",
     ],
     "surprise": [
-        r"\boh!?\b", r"\bhuh\b", r"\bwait what\b",
-        r"\bno way\b", r"\bwhat the\b",
+        r"\boh!?\b",
+        r"\bhuh\b",
+        r"\bwait what\b",
+        r"\bno way\b",
+        r"\bwhat the\b",
     ],
     "self_correction": [
         r"\bwait[,.]\s*(actually|no)\b",
-        r"\bnever mind\b", r"\bscratch that\b",
+        r"\bnever mind\b",
+        r"\bscratch that\b",
         r"\blet me start over\b",
     ],
     "help_seeking": [
@@ -156,15 +162,17 @@ Patterns are compiled once at module load. Matching is case-insensitive. Word bo
 `Agent` is a **TypedDict** — append a dict literal (not a constructor call):
 
 ```python
-Agent(
-    key="friction",
-    enabled_config_key="OLLAMA_FRICTION_ENABLED",
-    model_config_key="OLLAMA_FRICTION_MODEL",
-    manifest_field="friction",
-    depends_on=["summary"],
-    thread_name_prefix="friction",
-    run=_run_friction,
-),
+(
+    Agent(
+        key="friction",
+        enabled_config_key="OLLAMA_FRICTION_ENABLED",
+        model_config_key="OLLAMA_FRICTION_MODEL",
+        manifest_field="friction",
+        depends_on=["summary"],
+        thread_name_prefix="friction",
+        run=_run_friction,
+    ),
+)
 ```
 
 `_run_friction(entry, cancel_event)`:
@@ -180,9 +188,9 @@ Agent(
 
 ```python
 {
-    "segments": [...],       # per-segment scores from step 2
+    "segments": [...],  # per-segment scores from step 2
     "stats": {...},
-    "moments": [...],        # from LLM
+    "moments": [...],  # from LLM
     "computed_at": "...",
     "model": config.OLLAMA_FRICTION_MODEL,
     "stale": False,

--- a/plans/archive/SCENE-BOUNDARIES-PHASE4-PLAN.md
+++ b/plans/archive/SCENE-BOUNDARIES-PHASE4-PLAN.md
@@ -170,14 +170,24 @@ in Phase 4 — only the data is emitted, as the bridge to the future "Segment la
 ## Config (config.py)
 
 ```python
-SCREENSPACE_BOUNDARY_METRIC: str = "hybrid"               # default algorithm
-SCREENSPACE_BOUNDARY_SCENE_THRESHOLD: float = 0.25        # fingerprint distance (1 − similarity); mirrors scene's 0.75 sim
-SCREENSPACE_BOUNDARY_CONFIRM_WINDOW: int = 2              # samples a shift must persist
-SCREENSPACE_BOUNDARY_SCENE_HASH_DIM: int = 128           # pipe downscale for fingerprinting
-SCREENSPACE_BOUNDARY_MERGE_THRESHOLD: float = 0.15        # post-run: merge periods this similar (exposed in settings)
-SCREENSPACE_BOUNDARY_SHORT_PERIOD_SECONDS: float = 3.0    # post-run: transient-dissolve candidate ceiling
-SCREENSPACE_BOUNDARY_RELATIVE_PRUNE_ENABLED: bool = True  # post-run: session-relative weak-boundary prune (exposed in settings)
-SCREENSPACE_BOUNDARY_RELATIVE_PRUNE_FACTOR: float = 0.5   # drop boundaries below factor × median entry distance
+SCREENSPACE_BOUNDARY_METRIC: str = "hybrid"  # default algorithm
+SCREENSPACE_BOUNDARY_SCENE_THRESHOLD: float = (
+    0.25  # fingerprint distance (1 − similarity); mirrors scene's 0.75 sim
+)
+SCREENSPACE_BOUNDARY_CONFIRM_WINDOW: int = 2  # samples a shift must persist
+SCREENSPACE_BOUNDARY_SCENE_HASH_DIM: int = 128  # pipe downscale for fingerprinting
+SCREENSPACE_BOUNDARY_MERGE_THRESHOLD: float = (
+    0.15  # post-run: merge periods this similar (exposed in settings)
+)
+SCREENSPACE_BOUNDARY_SHORT_PERIOD_SECONDS: float = (
+    3.0  # post-run: transient-dissolve candidate ceiling
+)
+SCREENSPACE_BOUNDARY_RELATIVE_PRUNE_ENABLED: bool = (
+    True  # post-run: session-relative weak-boundary prune (exposed in settings)
+)
+SCREENSPACE_BOUNDARY_RELATIVE_PRUNE_FACTOR: float = (
+    0.5  # drop boundaries below factor × median entry distance
+)
 ```
 
 ### Exposed in the settings modal (per decisions 4 & 5)

--- a/plans/archive/WORKFLOWS-PLAN.md
+++ b/plans/archive/WORKFLOWS-PLAN.md
@@ -105,15 +105,17 @@ carrying typed ports the DAG needs. Each entry:
 
 ```python
 class NodeType(TypedDict):
-    id: str            # "transcribe", "ss_scan", "find_word", "make_clips", "timeline_viewer", "gate"
+    id: str  # "transcribe", "ss_scan", "find_word", "make_clips", "timeline_viewer", "gate"
     label: str
     domain: Literal["artifact", "screenspace", "transcript", "thinking", "control"]
     category: str
-    inputs: list[Port]            # {name, type, optional}
+    inputs: list[Port]  # {name, type, optional}
     outputs: list[Port]
-    params: list[ParamSpec]       # {name, type, default, min/max/choices, label}
+    params: list[ParamSpec]  # {name, type, default, min/max/choices, label}
     requires: list[Literal["sheet", "videoDir"]]
-    execute: Callable[[NodeContext, dict, dict], dict]   # (ctx, inputs, params) -> {out_port: value}
+    execute: Callable[
+        [NodeContext, dict, dict], dict
+    ]  # (ctx, inputs, params) -> {out_port: value}
 ```
 `NodeContext` carries `on_progress(float)`, `cancel_event: threading.Event`, and
 `cancel_flag()->bool` so each executor forwards whichever form its callee wants (scans want
@@ -192,11 +194,22 @@ contract — avoids a backwards `workflows → cli` import) and refactor the two
 (collapses existing duplication):
 
 ```python
-def build_clip_records(*, participant, source_filename, time_ranges: list[tuple[float, float]],
-                       description, category="workflow", study="", severity="",
-                       cell_col=_WORKFLOW_CELL_COL, cell_row_base=0,
-                       cluster_gap=None, pad_pre=0.0, pad_post=0.0,
-                       max_duration=None) -> list[ClipRecord]:
+def build_clip_records(
+    *,
+    participant,
+    source_filename,
+    time_ranges: list[tuple[float, float]],
+    description,
+    category="workflow",
+    study="",
+    severity="",
+    cell_col=_WORKFLOW_CELL_COL,
+    cell_row_base=0,
+    cluster_gap=None,
+    pad_pre=0.0,
+    pad_post=0.0,
+    max_duration=None,
+) -> list[ClipRecord]:
     """Build sheet-free ClipRecords from explicit (start,end) second ranges; pre-fills `times`
     (H:MM:SS) so process_clips runs without a live spreadsheet. cluster_gap merges adjacent ranges."""
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,37 @@ py-modules = [
 [tool.uv]
 required-version = ">=0.11.0"
 
+[tool.ruff]
+# Ruff 0.16 enables ~413 rules by default (up from 59 in 0.15). We run those defaults
+# as-is; the carve-outs below are the only deliberate exceptions. Pinned so a stale
+# local ruff fails loudly instead of quietly disagreeing with CI (tests.yml lint job).
+# `requires-python` above already gives ruff target-version = py312.
+required-version = ">=0.16.0"
+
+[tool.ruff.lint]
+ignore = [
+    # ~50 `except Exception:` handlers at ffmpeg / OCR / worker-thread / HTTP
+    # boundaries. Narrowing them is semantic work, tracked as "Narrow
+    # `except Exception`" in agents/CODE-REVIEW.md. Drop this once that pass lands.
+    "BLE001",
+    # Import sorting. Module import order in the screenspace.py / workflows.py
+    # re-export facades is a deliberate deepest-first DAG (agents/ARCHITECTURE.md).
+    "I001",
+    # Timestamps here are local wall-clock times for video/session metadata, never
+    # cross-timezone instants. Naive datetimes are the correct representation.
+    "DTZ005",
+    "DTZ007",
+    # PEP 695 generic syntax. Plain TypeVars read better in this codebase.
+    "UP047",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Both clusters are test-only, and both are correct test idioms:
+# B018   — bare `resp.data` expressions that intentionally consume a streamed
+#          response so the generator's finally-block runs.
+# RUF012 — mutable class attributes on throwaway test doubles; ClassVar noise.
+"tests/**" = ["B018", "RUF012"]
+
 [tool.coverage.run]
 source = ["."]
 omit = ["tests/*"]

--- a/screenspace.py
+++ b/screenspace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace analysis engine for clipgen.
 
 Thirteen analysis tools (passed as 'type' when creating a task):

--- a/screenspace_frames.py
+++ b/screenspace_frames.py
@@ -189,8 +189,8 @@ def _ffmpeg_pipe_frames(
     # max_dim cap. Skipped at 1.0 so default-config runs are byte-identical
     # to pre-feature behavior.
     if cv_scale > 0 and abs(cv_scale - 1.0) > 1e-6:
-        scaled_w = max(2, int(round(out_w * cv_scale)))
-        scaled_h = max(2, int(round(out_h * cv_scale)))
+        scaled_w = max(2, round(out_w * cv_scale))
+        scaled_h = max(2, round(out_h * cv_scale))
         scaled_w += scaled_w % 2
         scaled_h += scaled_h % 2
         filters.append(f"scale={scaled_w}:{scaled_h}:flags=lanczos")

--- a/screenspace_frames.py
+++ b/screenspace_frames.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace frame extraction (ffmpeg pipe + ffprobe).
 
 The per-frame scan drivers (``scan_video_frames`` / ``scan_video_full_frames``),
@@ -349,7 +348,7 @@ def _scan_via_ffmpeg_pipe(
     _phash_thresh = (fast_opts or {}).get(
         "phash_threshold", config.SCREENSPACE_FAST_SCAN_PHASH_THRESHOLD
     )
-    _prev_phash: list["imagehash.ImageHash | None"] = [None]
+    _prev_phash: list[imagehash.ImageHash | None] = [None]
 
     pipe_region = None if full_frame else region
     # For the pipe, push max_dim downscaling into ffmpeg when phash_skip is off.

--- a/screenspace_frames.py
+++ b/screenspace_frames.py
@@ -62,12 +62,11 @@ def scan_video_frames(
     # Reject zero-dimension regions early so ffmpeg's crop filter doesn't
     # produce empty frames downstream (which would crash cv2.cvtColor /
     # cv2.GaussianBlur with an opaque shape mismatch).
-    if not full_frame and region is not None:
-        if region.get("w", 0) <= 0 or region.get("h", 0) <= 0:
-            utils.warning_print(
-                f"Skipping scan: region has zero width or height ({region})"
-            )
-            return
+    if region is not None and (region.get("w", 0) <= 0 or region.get("h", 0) <= 0):
+        utils.warning_print(
+            f"Skipping scan: region has zero width or height ({region})"
+        )
+        return
     if cv_scale is None:
         cv_scale = config.SCREENSPACE_CV_RESOLUTION_SCALE
 

--- a/screenspace_heatmap.py
+++ b/screenspace_heatmap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace heatmap generation (pure cv2/PIL leaf).
 
 Template-, flow-, change-, and attention-heatmap PNGs plus animated-GIF views:

--- a/screenspace_manifest.py
+++ b/screenspace_manifest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace task + manifest helpers.
 
 Task-status constants, task construction, manifest load/save, result-time
@@ -7,7 +6,7 @@ Imports the confidence extractor from screenspace_tools.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -211,7 +210,7 @@ def create_task(
         "priority": 100,
         "result": None,
         "error": None,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": datetime.now(UTC).isoformat(),
         "completed_at": None,
         "_cancelled": False,
     }

--- a/screenspace_multitool.py
+++ b/screenspace_multitool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace multitool chaining.
 
 Chains multiple tools (each later step only re-checks frames that passed the
@@ -8,7 +7,8 @@ sweep / ffprobe helper from screenspace_frames.
 """
 
 import bisect
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 

--- a/screenspace_ocr.py
+++ b/screenspace_ocr.py
@@ -121,7 +121,7 @@ def _preprocess_for_ocr(pixels: np.ndarray, *, min_height: int = 0) -> np.ndarra
         return pixels
     if h < min_height:
         scale = min_height / float(h)
-        new_w = max(1, int(round(w * scale)))
+        new_w = max(1, round(w * scale))
         pixels = cv2.resize(pixels, (new_w, min_height), interpolation=cv2.INTER_CUBIC)
     gray = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY) if pixels.ndim == 3 else pixels
     clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))

--- a/screenspace_ocr.py
+++ b/screenspace_ocr.py
@@ -321,10 +321,11 @@ def _score_numbers_readings(
         cleaned = text.replace(",", "")
         for match in _NUMBERS_RE.findall(cleaned):
             num = float(match)
-            if _number_matches(num, operator, target_value, range_min, range_max):
-                if matched_number is None or conf > matched_conf:
-                    matched_number = num
-                    matched_conf = conf
+            if _number_matches(num, operator, target_value, range_min, range_max) and (
+                matched_number is None or conf > matched_conf
+            ):
+                matched_number = num
+                matched_conf = conf
     detail: dict[str, Any] = {"confidence": round(matched_conf, 4)}
     if matched_number is not None:
         detail["number_found"] = matched_number

--- a/screenspace_ocr.py
+++ b/screenspace_ocr.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace OCR + numeric helpers.
 
 Pooled EasyOCR readers, region preprocessing, glyph confusion-folding, the
@@ -11,8 +10,9 @@ import math
 import queue
 import re
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any
 
 import cv2
 import numpy as np

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Preprocessing preview generation for the Screenspace "Model view" pane.
 
 Given a frame (and optionally a prev_frame / reference_frame / template_image),
@@ -327,8 +326,7 @@ def _draw_flow_arrows(
             if m < min_mag:
                 continue
             samples.append((cx * coord_scale, cy * coord_scale, fx, fy, m))
-            if m > max_mag:
-                max_mag = m
+            max_mag = max(max_mag, m)
 
     if not samples or max_mag <= 0:
         return
@@ -346,7 +344,7 @@ def _overlay_flow(
     pixels: "np.ndarray",
     prev_frame: "np.ndarray | None",
     region: dict[str, Any] | None,
-    params: dict[str, Any],  # noqa: ARG001 — magnitude param affects threshold display only
+    params: dict[str, Any],  # magnitude param affects threshold display only
 ) -> "np.ndarray | None":
     if prev_frame is None:
         return None
@@ -891,7 +889,7 @@ def _preview_flow(
 def _preview_scene(
     frame: "np.ndarray",
     region: dict[str, Any] | None,
-    params: dict[str, Any],  # noqa: ARG001 — reserved for future scene-ref overlays
+    params: dict[str, Any],  # reserved for future scene-ref overlays
 ) -> "np.ndarray":
     pixels = _clip_region_pixels(frame, region)
     if pixels is None:

--- a/screenspace_preview.py
+++ b/screenspace_preview.py
@@ -311,7 +311,7 @@ def _draw_flow_arrows(
     vis_step_y = step_y * coord_scale
     vis_cell = min(vis_step_x, vis_step_y)
     max_arrow_len = vis_cell * 0.7
-    thickness = max(1, min(2, int(round(vis_cell / 32))))
+    thickness = max(1, min(2, round(vis_cell / 32)))
 
     samples: list[tuple[float, float, float, float, float]] = []
     max_mag = 0.0
@@ -332,9 +332,9 @@ def _draw_flow_arrows(
         return
     arrow_scale = max_arrow_len / max_mag
     for vx, vy, fx, fy, m in samples:
-        sx, sy = int(round(vx)), int(round(vy))
-        ex = int(round(vx + fx * arrow_scale))
-        ey = int(round(vy + fy * arrow_scale))
+        sx, sy = round(vx), round(vy)
+        ex = round(vx + fx * arrow_scale)
+        ey = round(vy + fy * arrow_scale)
         # Color-code by magnitude: slow = blue, fast = red (JET).
         color = _magnitude_color(m / max_mag)
         cv2.arrowedLine(vis, (sx, sy), (ex, ey), color, thickness, tipLength=0.3)
@@ -486,7 +486,7 @@ def _colorize_diff(
 
 def _magnitude_color(t: float) -> tuple[int, int, int]:
     """Map a normalized magnitude in [0, 1] to a BGR color via the diff colormap."""
-    v = int(round(max(0.0, min(1.0, t)) * 255))
+    v = round(max(0.0, min(1.0, t)) * 255)
     bgr = cv2.applyColorMap(np.array([[v]], dtype=np.uint8), _DIFF_COLORMAP)[0, 0]
     return int(bgr[0]), int(bgr[1]), int(bgr[2])
 
@@ -515,7 +515,7 @@ def _fit_width(img: "np.ndarray", target_w: int) -> "np.ndarray":
     if w == target_w:
         return img
     scale = target_w / float(w)
-    new_h = max(1, int(round(h * scale)))
+    new_h = max(1, round(h * scale))
     interp = cv2.INTER_AREA if scale < 1.0 else cv2.INTER_NEAREST
     return cv2.resize(img, (target_w, new_h), interpolation=interp)
 
@@ -523,7 +523,7 @@ def _fit_width(img: "np.ndarray", target_w: int) -> "np.ndarray":
 def _label_panel(img: "np.ndarray", label: str) -> "np.ndarray":
     """Stack a small label strip above an image."""
     img = _gray_to_bgr(img)
-    h, w = img.shape[:2]
+    _h, w = img.shape[:2]
     strip = np.full((_LABEL_HEIGHT, w, 3), 24, dtype=np.uint8)
     cv2.putText(
         strip,
@@ -548,7 +548,7 @@ def _hstack_panels(panels: list["np.ndarray"]) -> "np.ndarray":
         h, w = p.shape[:2]
         if h != target_h:
             scale = target_h / float(h)
-            new_w = max(1, int(round(w * scale)))
+            new_w = max(1, round(w * scale))
             p = cv2.resize(
                 _gray_to_bgr(p), (new_w, target_h), interpolation=cv2.INTER_AREA
             )

--- a/screenspace_primitives.py
+++ b/screenspace_primitives.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace image-analysis primitives (pure cv2/numpy).
 
 Region cropping/denormalization/resolution, HSV color math, frame-diff, SSIM,
@@ -10,7 +9,8 @@ buffer, static-frame skip). No file or ffmpeg I/O lives here.
 import functools
 import math
 import statistics
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import cv2
 
@@ -18,7 +18,7 @@ try:
     # cv2.data.haarcascades is a submodule attribute; ty needs the explicit
     # import. Absent on cv2 builds without the bundled cascade data (the face
     # channel feature-detects it and degrades to a zeros map).
-    import cv2.data  # noqa: F401
+    import cv2.data
 except ImportError:  # pragma: no cover - depends on the installed cv2 build
     pass
 import numpy as np

--- a/screenspace_primitives.py
+++ b/screenspace_primitives.py
@@ -306,10 +306,10 @@ def denormalize_region(
         ``mask_points``/``shape`` passed through for shaped regions.
     """
     out: dict[str, Any] = {
-        "x": int(round(region["x"] * target_w)),
-        "y": int(round(region["y"] * target_h)),
-        "w": int(round(region["w"] * target_w)),
-        "h": int(round(region["h"] * target_h)),
+        "x": round(region["x"] * target_w),
+        "y": round(region["y"] * target_h),
+        "w": round(region["w"] * target_w),
+        "h": round(region["h"] * target_h),
     }
     # Shaped regions: contour vertices are bbox-relative (0-1 of the region's
     # own rect), so they pass through denormalization verbatim. Copying them
@@ -672,8 +672,8 @@ def _scale_template(
     if not (effective > 0 and abs(effective - 1.0) > 1e-6):
         return template, mask
     th, tw = template.shape[:2]
-    nw = max(8, int(round(tw * effective)))
-    nh = max(8, int(round(th * effective)))
+    nw = max(8, round(tw * effective))
+    nh = max(8, round(th * effective))
     interp = cv2.INTER_AREA if effective < 1.0 else cv2.INTER_CUBIC
     scaled_template = cv2.resize(template, (nw, nh), interpolation=interp)
     scaled_mask = (

--- a/screenspace_primitives.py
+++ b/screenspace_primitives.py
@@ -366,7 +366,10 @@ def resolve_region_request(
         raise ValueError(f"Region '{region_name}' not found")
 
     if not isinstance(region_ref, dict):
-        raise ValueError("region_ref must be an object")
+        # ValueError, not TypeError: this resolver's contract is "ValueError means
+        # bad request", and every caller (cli.py, screenspace_server's
+        # _resolve_region_request) catches ValueError to render a hint or a 400.
+        raise ValueError("region_ref must be an object")  # noqa: TRY004
 
     source = str(region_ref.get("source", "")).strip()
 

--- a/screenspace_scans.py
+++ b/screenspace_scans.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace scan workflows (one per analysis tool).
 
 Each scan sweeps a video via the frame-extraction drivers and applies one
@@ -9,7 +8,8 @@ Imports primitives, OCR helpers, and frame extractors from sibling modules.
 """
 
 import subprocess
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import cv2
 import numpy as np
@@ -1037,7 +1037,7 @@ def scan_inactivity(
     vid_fps, vid_duration, end_seconds, total_range = window
 
     results: list[dict[str, Any]] = []
-    prev_hash: list["imagehash.ImageHash | None"] = [None]
+    prev_hash: list[imagehash.ImageHash | None] = [None]
     prev_skip_gray: list[np.ndarray | None] = [None]
     span_start: list[float | None] = [None]
     span_distances: list[list[int]] = [[]]
@@ -1382,7 +1382,7 @@ def scan_boundaries(
     boundary_opts.pop("phash_skip", None)
 
     results: list[dict[str, Any]] = []
-    prev_hash: list["imagehash.ImageHash | None"] = [None]
+    prev_hash: list[imagehash.ImageHash | None] = [None]
     last_boundary_ts: list[float | None] = [None]
     eps = config.SCREENSPACE_BOUNDARY_CONFIDENCE_EPSILON
 

--- a/screenspace_scans.py
+++ b/screenspace_scans.py
@@ -751,10 +751,10 @@ def scan_template(
             inv = scale_back / _cv_scale
             if abs(inv - 1.0) > 1e-6:
                 for m in matches:
-                    m["x"] = int(round(m["x"] * inv))
-                    m["y"] = int(round(m["y"] * inv))
-                    m["w"] = int(round(m["w"] * inv))
-                    m["h"] = int(round(m["h"] * inv))
+                    m["x"] = round(m["x"] * inv)
+                    m["y"] = round(m["y"] * inv)
+                    m["w"] = round(m["w"] * inv)
+                    m["h"] = round(m["h"] * inv)
             # Shaped region: the match itself runs full-frame (as for rects,
             # which don't restrict template search either), but detections
             # whose center falls outside the polygon are dropped. Runs before
@@ -1517,7 +1517,7 @@ def scan_boundaries(
                             {
                                 "start_ts": round(pending["start_ts"], 2),
                                 "pixels": _boundary_rep_pixels(pixels),
-                                "entry_dist": int(round(dist_raw * 100)),
+                                "entry_dist": round(dist_raw * 100),
                                 "entry_conf": conf,
                             }
                         )

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -2687,7 +2687,9 @@ def _validate_scene_references(
     validated_refs = []
     for i, ref_raw in enumerate(scene_refs):
         if not isinstance(ref_raw, dict):
-            raise ValueError(f"{context}scene_references[{i}] must be an object")
+            # ValueError, not TypeError: this validator's contract is that any bad
+            # payload raises ValueError, which the calling route turns into a 400.
+            raise ValueError(f"{context}scene_references[{i}] must be an object")  # noqa: TRY004
         ref_data = cast(dict[str, Any], ref_raw)
         name = str(ref_data.get("name", "")).strip()
         if not name:

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -710,7 +710,7 @@ def api_calibrate() -> FlaskResponse:
     resolved = _find_participant_video_with_mtime(participant)
     if resolved is None:
         return err(f"No video for participant {participant}", 404)
-    video_path, mtime_ns = resolved
+    video_path, _mtime_ns = resolved
 
     props = video.probe_video_properties(video_path)
     resolve_region = _region_coords_resolver(props, all_known_regions)
@@ -1090,10 +1090,10 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
             except ValueError:
                 return err("Invalid region")
             region_coords = {
-                "x": int(round(rx * frame_w)),
-                "y": int(round(ry * frame_h)),
-                "w": int(round(rw * frame_w)),
-                "h": int(round(rh * frame_h)),
+                "x": round(rx * frame_w),
+                "y": round(ry * frame_h),
+                "w": round(rw * frame_w),
+                "h": round(rh * frame_h),
             }
             # Optional shaped-region contours: "u1,v1;u2,v2;..." bbox-relative
             # fractions, multiple contours joined with "|". Malformed values

--- a/screenspace_server.py
+++ b/screenspace_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace Flask blueprint for clipgen.
 
 Registered at /screenspace/ by start_combined_server(). Works with or without a
@@ -60,9 +59,10 @@ import math
 import threading
 import uuid
 from collections import OrderedDict
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, TypeGuard, cast
+from typing import Any, TypeGuard, cast
 
 from flask import Blueprint, Response, jsonify, request, send_file
 
@@ -503,7 +503,7 @@ def api_pins_create(participant: str) -> FlaskResponse:
         "timestamp": round(timestamp, 3),
         "polarity": polarity,
         "label": label,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": datetime.now(UTC).isoformat(),
     }
     with _manifest_lock:
         pins = _participant_pin_list(participant, create=True)
@@ -797,7 +797,7 @@ def api_calibrate() -> FlaskResponse:
                     ocr_reader=ocr_reader,
                 )
             entry.update(score)
-        except Exception as exc:  # noqa: BLE001 - one bad pin must not 500 the batch
+        except Exception as exc:  # one bad pin must not 500 the whole batch
             utils.warning_print(f"Calibration failed for pin {pin.get('id')}: {exc}")
             entry["status"] = "not_evaluable"
         results.append(entry)
@@ -1695,7 +1695,7 @@ def api_stashes_create() -> FlaskResponse:
         stash = {
             "id": "stash_" + uuid.uuid4().hex[:8],
             "name": "Stashed Regions",
-            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "createdAt": datetime.now(UTC).isoformat(),
             "regions": copy.deepcopy(regions),
         }
         _manifest.setdefault("stashes", []).append(stash)
@@ -1934,14 +1934,11 @@ def _coerce_tool_spec(spec: dict[str, Any], tool_type: str, context: str = "") -
     Mutates *spec* in place; raises ``ValueError`` on bad input. *context* prefixes
     error messages (e.g. ``"Step 0: "``). Shared by the task-level and per-step paths.
     """
-    if tool_type == "similarity":
-        spec["reference_timestamp"] = _coerce_float(
-            spec.get("reference_timestamp"),
-            "reference_timestamp",
-            required=True,
-            context=context,
-        )
-    elif tool_type == "template" and not spec.get("template_image_data"):
+    if (
+        tool_type == "similarity"
+        or tool_type == "template"
+        and not spec.get("template_image_data")
+    ):
         spec["reference_timestamp"] = _coerce_float(
             spec.get("reference_timestamp"),
             "reference_timestamp",
@@ -2821,7 +2818,7 @@ def _init_screenspace_state(
 
 def _discover_participant_videos(study_name: str) -> None:
     """Scan input directory for source video files and populate _participants."""
-    global _participants  # noqa: PLW0603
+    global _participants
     _participants = utils.discover_participant_videos(study_name)
 
 

--- a/screenspace_tools.py
+++ b/screenspace_tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace analysis tools (strategy registry) + per-frame dispatch.
 
 The ``AnalysisTool`` base class, one subclass per tool, the ``TOOLS`` registry,
@@ -10,8 +9,9 @@ keep the module graph acyclic.
 """
 
 import math
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, ClassVar
+from typing import Any, ClassVar
 
 import cv2
 import numpy as np

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Screenspace background worker.
 
 A daemon-thread task queue that runs analysis tasks sequentially with
@@ -11,10 +10,11 @@ import copy
 import queue
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import config
 import utils
@@ -759,7 +759,7 @@ class ScreenspaceWorker:
                                 list(t.get("video_paths", [])),
                                 dict(t.get("region_coords", {})),
                             )
-                    t["completed_at"] = datetime.now(timezone.utc).isoformat()
+                    t["completed_at"] = datetime.now(UTC).isoformat()
 
             # Generate heatmaps without holding the lock, then reacquire it to
             # strip the grids and attach the filenames. Safe because the scan has
@@ -803,7 +803,7 @@ class ScreenspaceWorker:
                 if t:
                     t["status"] = TASK_STATUS_FAILED
                     t["error"] = str(exc)
-                    t["completed_at"] = datetime.now(timezone.utc).isoformat()
+                    t["completed_at"] = datetime.now(UTC).isoformat()
         finally:
             # A task dismissed while running was kept in _tasks so its cancel
             # could land; now that the scan has unwound, drop it for good.

--- a/screenspace_worker.py
+++ b/screenspace_worker.py
@@ -615,7 +615,7 @@ class ScreenspaceWorker:
                     except queue.Empty:
                         continue
 
-                    priority, created_at, task_id = item
+                    _priority, _created_at, task_id = item
                     if task_id is _SENTINEL:
                         # Wait for active tasks to finish
                         for drain_tid, f in active.items():

--- a/server.py
+++ b/server.py
@@ -3066,7 +3066,7 @@ def _init_studio_state(worksheet: Any) -> None:
     the HTML, but spreadsheet-dependent routes report ``sheet_loaded: false``
     until a sheet is opened via ``POST /api/spreadsheets/open``.
     """
-    global _worksheet, _sheet_context, _generated_artifacts, _generated_reels
+    global _worksheet, _generated_artifacts, _generated_reels
 
     _load_studio_settings()
     _worksheet = worksheet
@@ -3123,8 +3123,8 @@ def _derive_sheet_meta(worksheet: Any) -> dict[str, str] | None:
                 "label": Path(path).name,
                 "worksheet": getattr(worksheet, "title", ""),
             }
-    except Exception:
-        pass
+    except ImportError:
+        pass  # no excel_io in this build; fall through to the gspread branch
     # gspread Worksheet (or anything quacking like one): use the parent
     # spreadsheet title as both the identifier and the label.
     parent = getattr(worksheet, "spreadsheet", None)
@@ -3161,7 +3161,7 @@ def _swap_worksheet(new_worksheet: Any) -> None:
     import screenspace_server
     import transcripts_server
 
-    global _worksheet, _sheet_context, _generated_artifacts, _generated_reels
+    global _worksheet, _generated_artifacts, _generated_reels
     prev_worksheet = _worksheet
     prev_sheet_context = _sheet_context
     prev_artifacts = _generated_artifacts
@@ -3191,14 +3191,14 @@ def _swap_worksheet(new_worksheet: Any) -> None:
                 sheet_context=_sheet_context,
                 participant_list=_resolve_participants(),
             )
-        except Exception:
+        except Exception:  # noqa: S110 - deliberate, see the comment above
             pass
         try:
             transcripts_server._init_transcripts_state(
                 sheet_context=_sheet_context,
                 participant_list=_resolve_participants(),
             )
-        except Exception:
+        except Exception:  # noqa: S110 - deliberate, see the comment above
             pass
         raise
 

--- a/server.py
+++ b/server.py
@@ -1439,11 +1439,9 @@ def _apply_time_overrides(clips: list[Any], overrides: dict[str, Any]) -> None:
             new_times.append(
                 (
                     utils.seconds_to_timestamp(
-                        int(round(start_sec)), force_hours=needs_hours
+                        round(start_sec), force_hours=needs_hours
                     ),
-                    utils.seconds_to_timestamp(
-                        int(round(end_sec)), force_hours=needs_hours
-                    ),
+                    utils.seconds_to_timestamp(round(end_sec), force_hours=needs_hours),
                 )
             )
         if new_times:
@@ -2355,7 +2353,7 @@ def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str |
         # subset (now at defaults) with the current non-default values of
         # everything else, and let _save_studio_settings drop any keys that
         # equal their default (including the ones we just reset).
-        merged = {name: getattr(config, name) for name in config.STUDIO_SETTINGS.keys()}
+        merged = {name: getattr(config, name) for name in config.STUDIO_SETTINGS}
         _save_studio_settings(merged)
         return applied, None
 
@@ -2630,7 +2628,7 @@ def api_titlecard_delete(name: str) -> FlaskResponse:
             setattr(config, setting, "")
             reset[setting] = ""
     if reset:
-        merged = {n: getattr(config, n) for n in config.STUDIO_SETTINGS.keys()}
+        merged = {n: getattr(config, n) for n in config.STUDIO_SETTINGS}
         _save_studio_settings(merged)
     return ok(reset=reset)
 
@@ -3577,9 +3575,7 @@ def build_combined_app(
                 import clipgen as _clipgen
                 import google_api
 
-                if id_or_path.startswith("http://") or id_or_path.startswith(
-                    "https://"
-                ):
+                if id_or_path.startswith(("http://", "https://")):
                     new_ws = _clipgen.open_spreadsheet_by_url(
                         _google_auth.client, id_or_path, worksheet_name=worksheet
                     )

--- a/server.py
+++ b/server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Combined Flask server for clipgen Studio, Screenspace, Transcripts, and Workflows.
 
 Entry point: start_combined_server(worksheet, port, default_page) registers
@@ -60,11 +59,12 @@ import sys
 import threading
 import time
 import webbrowser
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from collections.abc import Iterator
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from flask import (
     Blueprint,
@@ -95,6 +95,7 @@ from server_utils import (
     parse_clip_window,
     parse_number_arg,
 )
+from datetime import UTC
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -280,7 +281,11 @@ def _try_claim_busy(slot: str) -> bool:
     Returns True on success (caller must call ``_release_busy`` when done) or
     False if another request is already holding the slot.
     """
-    global _generate_in_progress, _reel_in_progress, _timeline_viewer_in_progress, _gallery_in_progress  # noqa: PLW0603
+    global \
+        _generate_in_progress, \
+        _reel_in_progress, \
+        _timeline_viewer_in_progress, \
+        _gallery_in_progress
     with _busy_lock:
         if slot == "generate":
             if _generate_in_progress:
@@ -373,7 +378,11 @@ def _release_busy(slot: str) -> None:
 
     Valid slots: ``'generate'``, ``'reel'``, ``'timeline_viewer'``, ``'gallery'``.
     """
-    global _generate_in_progress, _reel_in_progress, _timeline_viewer_in_progress, _gallery_in_progress  # noqa: PLW0603
+    global \
+        _generate_in_progress, \
+        _reel_in_progress, \
+        _timeline_viewer_in_progress, \
+        _gallery_in_progress
     with _busy_lock:
         if slot == "generate":
             _generate_in_progress = False
@@ -453,7 +462,7 @@ def _increment_intake_done(n: int = 1) -> None:
 
 def _mark_intake_active(active: bool) -> None:
     """Increment/decrement the in-flight intake-stream counter."""
-    global _intake_active  # noqa: PLW0603
+    global _intake_active
     with _busy_lock:
         _intake_active += 1 if active else -1
 
@@ -2176,7 +2185,7 @@ def api_regenerate() -> FlaskResponse:
 def _handle_stash_crud(load_fn: Any, save_fn: Any, id_prefix: str) -> FlaskResponse:
     """Shared create/update/delete logic for stash endpoints."""
     import uuid
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     data = request.get_json(silent=True) or {}
     action = data.get("action", "create")
@@ -2201,7 +2210,7 @@ def _handle_stash_crud(load_fn: Any, save_fn: Any, id_prefix: str) -> FlaskRespo
                 "items": items,
                 "count": len(items),
                 "totalDuration": total_duration,
-                "createdAt": datetime.now(timezone.utc).isoformat(),
+                "createdAt": datetime.now(UTC).isoformat(),
             }
             stashes.append(stash)
             save_fn(stashes)

--- a/server_utils.py
+++ b/server_utils.py
@@ -31,8 +31,9 @@ import math
 import queue
 import threading
 from collections import OrderedDict
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable
+from typing import Any
 
 from flask import Response, jsonify, request
 
@@ -120,7 +121,7 @@ class MediaCache:
     """
 
     def __init__(self, max_entries: int) -> None:
-        self._store: "OrderedDict[tuple, bytes]" = OrderedDict()
+        self._store: OrderedDict[tuple, bytes] = OrderedDict()
         self._max = max_entries
         self._lock = threading.Lock()
         self._inflight: dict[tuple, threading.Lock] = {}
@@ -251,7 +252,7 @@ def make_sse_channel(
 ) -> tuple[
     Callable[..., None],
     Callable[..., Response],
-    list[tuple[Any, "queue.Queue[str]"]],
+    list[tuple[Any, queue.Queue[str]]],
 ]:
     """Build one SSE pub/sub channel; returns ``(notify, stream, clients)``.
 

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -600,7 +600,9 @@ def _make_clip_record(
             str(ctx.sheet_data[participant_row][col_idx] or "")
         )
     timestamp_baseline = ""
-    if ctx.baseline_row_idx is not None:
+    # Kept nested (not collapsed) to match the severity_cell guard below: row
+    # presence and row/col bounds are separate checks in this layer.
+    if ctx.baseline_row_idx is not None:  # noqa: SIM102
         if 0 <= ctx.baseline_row_idx < len(ctx.sheet_data) and col_idx < len(
             ctx.sheet_data[ctx.baseline_row_idx]
         ):
@@ -625,7 +627,7 @@ def _make_clip_record(
     }
     if timestamp_baseline:
         result["timestamp_baseline"] = timestamp_baseline
-    if ctx.filename_row_idx is not None:
+    if ctx.filename_row_idx is not None:  # noqa: SIM102 - see baseline_row_idx above
         if 0 <= ctx.filename_row_idx < len(ctx.sheet_data) and col_idx < len(
             ctx.sheet_data[ctx.filename_row_idx]
         ):

--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Spreadsheet data processing for clipgen.
 
 Expected spreadsheet layout (see README.md for a reference example):
@@ -40,8 +39,8 @@ Clip record (returned by generation functions):
 """
 
 import re
-from dataclasses import dataclass
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 import config

--- a/start_settings.py
+++ b/start_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Persistent first-run / Start overlay settings.
 
 Stores last-used input/output directories and last-used spreadsheet so the
@@ -17,7 +16,7 @@ Settings file location:
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -180,7 +179,7 @@ def record_project_session(
         "input": input_dir,
         "output": output_dir,
         "spreadsheet": spreadsheet if spreadsheet else None,
-        "last_opened": datetime.now(timezone.utc).isoformat(),
+        "last_opened": datetime.now(UTC).isoformat(),
     }
     settings["recent_projects"] = _prepend_dedup(
         settings.get("recent_projects", []),

--- a/tests/_frontend_source.py
+++ b/tests/_frontend_source.py
@@ -30,8 +30,8 @@ def concat_js(prefix: str) -> str:
 
 def strip_comments(src: str) -> str:
     """Drop ``/* */`` blocks and full-line ``//`` comments from a JS source."""
-    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
-    return re.sub(r"^\s*//.*$", "", src, flags=re.M)
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    return re.sub(r"^\s*//.*$", "", src, flags=re.MULTILINE)
 
 
 def assert_es5(src: str, name: str) -> None:

--- a/tests/screenspace/test_color.py
+++ b/tests/screenspace/test_color.py
@@ -73,7 +73,7 @@ class TestResolveRegionRequest:
         assert region["w"] == 1.0
 
     def test_active_ref(self):
-        name, region = screenspace.resolve_region_request(
+        _name, region = screenspace.resolve_region_request(
             "", {"source": "active", "name": "hud"}, self.MANIFEST
         )
         assert region["w"] == 0.5

--- a/tests/screenspace/test_region_mask.py
+++ b/tests/screenspace/test_region_mask.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Shaped-region mask primitives and per-tool masked-statistics behavior."""
 
 import numpy as np

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -483,7 +483,7 @@ def test_select_worksheet_url_skips_drive_listing(monkeypatch):
 def test_single_xlsx_fallback_path_requires_exactly_one(monkeypatch):
     import excel_io
 
-    monkeypatch.setattr(excel_io, "list_excel_in_cwd", lambda: [])
+    monkeypatch.setattr(excel_io, "list_excel_in_cwd", list)
     assert cli._single_xlsx_fallback_path("reason") is None
 
     monkeypatch.setattr(excel_io, "list_excel_in_cwd", lambda: ["a.xlsx", "b.xlsx"])

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -416,9 +416,12 @@ def test_run_cli_mode_dispatch(
     monkeypatch.setattr(clipgen, process_attr, process_fn)
     monkeypatch.setattr(clipgen, "_print_completion_message", completion)
 
-    parsed_defaults = dict(
-        line_numbers=None, range_start=None, range_end=None, cell_specs=None
-    )
+    parsed_defaults = {
+        "line_numbers": None,
+        "range_start": None,
+        "range_end": None,
+        "cell_specs": None,
+    }
     parsed_defaults.update(parsed_kwargs)
 
     cli.run_cli_mode(None, args, cli.CliModeArgs(**parsed_defaults))

--- a/tests/test_cli_event_clip_args.py
+++ b/tests/test_cli_event_clip_args.py
@@ -396,7 +396,6 @@ def test_run_ss_clips_smoke_dispatches_pipeline(monkeypatch):
     def fake_save(artifacts, **kw):
         saved["artifacts"] = artifacts
         saved["mode"] = kw.get("mode")
-        return None
 
     monkeypatch.setattr(viewer, "save_manifest", fake_save)
 
@@ -456,7 +455,6 @@ def test_run_transcript_clips_smoke_dispatches_pipeline(monkeypatch):
     def fake_save(artifacts, **kw):
         saved["artifacts"] = artifacts
         saved["mode"] = kw.get("mode")
-        return None
 
     monkeypatch.setattr(viewer, "save_manifest", fake_save)
 

--- a/tests/test_cli_event_clip_args.py
+++ b/tests/test_cli_event_clip_args.py
@@ -140,13 +140,13 @@ def _ev(**overrides):
     return base
 
 
-_NO_FILTERS = dict(
-    detectors=None,
-    regions=None,
-    participants=None,
-    min_confidence=None,
-    event_type_substr=None,
-)
+_NO_FILTERS = {
+    "detectors": None,
+    "regions": None,
+    "participants": None,
+    "min_confidence": None,
+    "event_type_substr": None,
+}
 
 
 @pytest.mark.parametrize(
@@ -613,15 +613,15 @@ def _mark_manifest():
     "args_overrides,expected_seg_ids",
     [
         (
-            dict(transcript_mark="checkout", transcript_mark_category="insight"),
+            {"transcript_mark": "checkout", "transcript_mark_category": "insight"},
             ["P01:0", "P02:0"],
         ),
         (
-            dict(
-                transcript_mark="checkout",
-                transcript_mark_category="insight",
-                transcript_mark_participant="P01",
-            ),
+            {
+                "transcript_mark": "checkout",
+                "transcript_mark_category": "insight",
+                "transcript_mark_participant": "P01",
+            },
             ["P01:0"],
         ),
     ],

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -10,31 +10,31 @@ import viewer as viewer_mod
 
 
 def _args(**overrides):
-    base = dict(
-        batch=False,
-        lines=None,
-        range=None,
-        category=None,
-        cell=None,
-        participant=None,
-        keyword=False,
-        severity=None,
-        mixed=None,
-        reel=None,
-        chronologic=None,
-        highlights=None,
-        screen=False,
-        gif=False,
-        no_input=False,
-        verbose=False,
-        spreadsheet=None,
-        viewer=False,
-        screenspace=False,
-        transcripts=False,
-        workflows=False,
-        composer=False,
-        overview=False,
-    )
+    base = {
+        "batch": False,
+        "lines": None,
+        "range": None,
+        "category": None,
+        "cell": None,
+        "participant": None,
+        "keyword": False,
+        "severity": None,
+        "mixed": None,
+        "reel": None,
+        "chronologic": None,
+        "highlights": None,
+        "screen": False,
+        "gif": False,
+        "no_input": False,
+        "verbose": False,
+        "spreadsheet": None,
+        "viewer": False,
+        "screenspace": False,
+        "transcripts": False,
+        "workflows": False,
+        "composer": False,
+        "overview": False,
+    }
     base.update(overrides)
     return Namespace(**base)
 

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -560,7 +560,6 @@ def test_ss_task_color_dispatches_and_persists(monkeypatch):
         regions, tasks, events, stashes=None, per_participant=None, pins=None
     ):
         saved_tasks.extend(tasks)
-        return None
 
     monkeypatch.setattr(screenspace, "save_screenspace_manifest", fake_save)
 
@@ -671,7 +670,6 @@ def test_ss_task_attention_forces_full_frame(monkeypatch, capsys):
         regions, tasks, events, stashes=None, per_participant=None, pins=None
     ):
         saved_tasks.extend(tasks)
-        return None
 
     monkeypatch.setattr(screenspace, "save_screenspace_manifest", fake_save)
     monkeypatch.setattr(screenspace, "ScreenspaceWorker", _FakeWorker)
@@ -746,7 +744,6 @@ def _install_ss_stubs(monkeypatch, fake_manifest):
         regions, tasks, events, stashes=None, per_participant=None, pins=None
     ):
         saved_tasks.extend(tasks)
-        return None
 
     monkeypatch.setattr(screenspace, "save_screenspace_manifest", fake_save)
     return saved_tasks

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -227,21 +227,21 @@ def test_ss_build_params_color_average_omits_mode():
     "overrides",
     [
         pytest.param(
-            dict(
-                ss_task=["color", "P01", "button"],
-                ss_target_color="#FF0000",
-                ss_tolerance="20,30,30",
-                ss_threshold=0.85,
-                studio=True,
-            ),
+            {
+                "ss_task": ["color", "P01", "button"],
+                "ss_target_color": "#FF0000",
+                "ss_tolerance": "20,30,30",
+                "ss_threshold": 0.85,
+                "studio": True,
+            },
             id="ss-task-vs-studio",
         ),
         pytest.param(
-            dict(summarize=[], pre_transcribe=["P01"]),
+            {"summarize": [], "pre_transcribe": ["P01"]},
             id="summarize-vs-pre-transcribe",
         ),
         pytest.param(
-            dict(ss_run_task="ss_abc", studio=True), id="ss-run-task-vs-studio"
+            {"ss_run_task": "ss_abc", "studio": True}, id="ss-run-task-vs-studio"
         ),
     ],
 )

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -375,7 +375,7 @@ def test_process_clips_forwards_cancel_flag_to_segments(monkeypatch, make_clip):
 
     monkeypatch.setattr(pipeline, "_process_single_clip_segments", fake_segments)
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     clipgen.process_clips([raw_clip], output_format="clip", cancel_flag=sentinel)
     assert captured["cancel_flag"] is sentinel
 
@@ -435,7 +435,7 @@ def test_process_single_clip_segments_forwards_cancel_to_video(monkeypatch, make
     monkeypatch.setattr(pipeline.video, "extract_gif", fake_gif)
     monkeypatch.setattr(config, "TITLECARDS_ENABLED", False)
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     pipeline._process_single_clip_segments(
         raw_clip, "src.mp4", set(), output_format="clip", cancel_flag=sentinel
     )
@@ -1015,7 +1015,7 @@ def test_process_reel_forwards_cancel_and_titlecard_options_to_segments(
     monkeypatch.setattr(clipgen.video, "concatenate_clips", lambda *_a, **_k: True)
     monkeypatch.setattr(pipeline, "_build_reel_transcript", lambda *_a, **_k: [])
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     clipgen.process_reel(
         [raw_clip],
         output_file="reel.mp4",

--- a/tests/test_command_palette_source.py
+++ b/tests/test_command_palette_source.py
@@ -95,7 +95,7 @@ def test_css_toggle_completeness_and_tokens():
     page stylesheet), sit at --z-overlay, and use no raw z-index."""
     css = PALETTE_CSS.read_text(encoding="utf-8")
     assert re.search(
-        r"^\.cmdp-overlay\.hidden \{\n  display: none !important;", css, re.M
+        r"^\.cmdp-overlay\.hidden \{\n  display: none !important;", css, re.MULTILINE
     )
     assert "z-index: var(--z-overlay);" in css
     assert not re.search(r"z-index: \d", css), "raw z-index in command-palette.css"
@@ -158,7 +158,7 @@ def test_cross_page_deep_links():
     utils_src = (_WEB / "utils.js").read_text(encoding="utf-8")
     assert "var clipgenHashTab = function () {" in utils_src
     tabs_block = src[src.index("var NAV_TABS") : src.index("var PARTICIPANT_PAGES")]
-    for dest in re.findall(r"^    (\w[\w-]*): \[", tabs_block, re.M):
+    for dest in re.findall(r"^    (\w[\w-]*): \[", tabs_block, re.MULTILINE):
         page_src = (_WEB / f"{dest}.js").read_text(encoding="utf-8")
         assert "clipgenHashTab()" in page_src, f"{dest}.js ignores #tab= deep links"
     pages_block = src[src.index("var PARTICIPANT_PAGES") : src.index("var providers")]

--- a/tests/test_command_palette_source.py
+++ b/tests/test_command_palette_source.py
@@ -204,7 +204,7 @@ def test_topnav_exposes_quick_actions_getter():
 def test_all_hubs_register():
     """Each hub contributes a page command set (Composer and Overview have no
     quick actions, so without this they'd only get the built-ins)."""
-    for page, hub_js in HUB_PAGES.items():
+    for hub_js in HUB_PAGES.values():
         src = (_WEB / hub_js).read_text(encoding="utf-8")
         assert "window.ClipgenCommandPalette.register(" in src, (
             f"{hub_js} does not register palette commands"

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -13,10 +13,10 @@ import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
-import composer_server  # noqa: E402
-import config  # noqa: E402
-import utils  # noqa: E402
-import video  # noqa: E402
+import composer_server
+import config
+import utils
+import video
 
 
 @pytest.fixture

--- a/tests/test_friction_agent.py
+++ b/tests/test_friction_agent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the friction thinking agent (thinking_agents friction helpers).
 
 Covers defensive JSON extraction/parsing, candidate formatting, the Ollama-

--- a/tests/test_friction_scorer.py
+++ b/tests/test_friction_scorer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the programmatic friction scorer (friction.py).
 
 Pure deterministic engine — no Ollama, no I/O. Covers phrase matching per

--- a/tests/test_friction_smoke.py
+++ b/tests/test_friction_smoke.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """End-to-end smoke test for the friction pipeline.
 
 Stub Whisper output (segments) flows through the programmatic scorer into the

--- a/tests/test_frontend_satellite_wiring.py
+++ b/tests/test_frontend_satellite_wiring.py
@@ -158,7 +158,7 @@ def _strip(src: str) -> str:
 def _is_iife(src: str) -> bool:
     """True if the file body opens with an IIFE wrapper (isolated scope)."""
     body = re.sub(r'^\s*"use strict";?', "", _strip(src).lstrip()).lstrip()
-    return body.startswith("(function") or body.startswith("(()")
+    return body.startswith(("(function", "(()"))
 
 
 def _param_names(params: str) -> set[str]:

--- a/tests/test_frontend_satellite_wiring.py
+++ b/tests/test_frontend_satellite_wiring.py
@@ -148,7 +148,7 @@ def _strip(src: str) -> str:
     a DOTALL match would let one stray quote/regex literal eat real definitions
     across the whole file.
     """
-    src = re.sub(r"/\*.*?\*/", " ", src, flags=re.S)
+    src = re.sub(r"/\*.*?\*/", " ", src, flags=re.DOTALL)
     src = re.sub(r"(?<!:)//[^\n]*", " ", src)  # keep http:// inside strings intact
     src = re.sub(r'"(?:\\.|[^"\\\n])*"', '""', src)
     src = re.sub(r"'(?:\\.|[^'\\\n])*'", "''", src)
@@ -195,7 +195,9 @@ def _local_defs(src: str) -> set[str]:
 def _top_level_defs(src: str) -> set[str]:
     """File-scope (column-0) defs — the globals a non-IIFE script exposes."""
     return set(
-        re.findall(r"^(?:var|let|const|function)\s+([A-Za-z_$][\w$]*)", src, re.M)
+        re.findall(
+            r"^(?:var|let|const|function)\s+([A-Za-z_$][\w$]*)", src, re.MULTILINE
+        )
     )
 
 

--- a/tests/test_hotkeys_frontend_source.py
+++ b/tests/test_hotkeys_frontend_source.py
@@ -54,9 +54,11 @@ def _js_files():
 def test_document_keydown_allowlist():
     offenders = []
     for path in _js_files():
-        if _DOC_KEYDOWN_RE.search(path.read_text(encoding="utf-8")):
-            if path.name not in KEYDOWN_ALLOWLIST:
-                offenders.append(path.name)
+        if (
+            _DOC_KEYDOWN_RE.search(path.read_text(encoding="utf-8"))
+            and path.name not in KEYDOWN_ALLOWLIST
+        ):
+            offenders.append(path.name)
     assert not offenders, (
         f"Files attach document-level keydown listeners outside the allowlist: "
         f"{offenders}. Register actions via ClipgenHotkeys.register / "

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for ollama_client transport layer.
 
 Agent-specific behavior (summarization, citation linking) lives in
@@ -343,7 +342,7 @@ class _StubOllamaHandler(http.server.BaseHTTPRequestHandler):
                      readline() until shut down.
     """
 
-    def do_POST(self):  # noqa: N802
+    def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
         body_bytes = self.rfile.read(length)
         body = json.loads(body_bytes.decode("utf-8"))

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -197,7 +197,7 @@ def test_session_shape_bins_place_events_and_sum_to_one():
         _ss_row(time_in=1.0, time_out=3.0),
         _ss_row(time_in=98.0, time_out=100.0),
     ]
-    columns, values = overview.build_session_shape_features(rows, {}, bins=4)
+    _columns, values = overview.build_session_shape_features(rows, {}, bins=4)
     p01 = values["P01"]
     ss_bins = [p01[f"shape_ss_bin{i}"] for i in range(4)]
     assert sum(ss_bins) == pytest.approx(1.0, abs=1e-3)

--- a/tests/test_overview_frontend_source.py
+++ b/tests/test_overview_frontend_source.py
@@ -226,7 +226,7 @@ def test_hidden_utility_class_defined():
     Studio that rule came from studio.css — which this page doesn't load.
     Without it the "analysis running"/"data changed" banners render always."""
     css = (_WEB / "overview.css").read_text(encoding="utf-8")
-    assert re.search(r"^\.hidden \{\n  display: none !important;", css, re.M)
+    assert re.search(r"^\.hidden \{\n  display: none !important;", css, re.MULTILINE)
 
 
 def test_es5_discipline_in_overview_sources():

--- a/tests/test_resource_lifecycle.py
+++ b/tests/test_resource_lifecycle.py
@@ -121,7 +121,7 @@ def test_module_level_caches_are_bounded_or_justified():
         if "OrderedDict" in rhs:
             # Require a companion cap constant, e.g. _FRAME_CACHE_MAX.
             cap = name.upper() + "_MAX"
-            if re.search(rf"^{cap}\s*=", src, re.M):
+            if re.search(rf"^{cap}\s*=", src, re.MULTILINE):
                 continue
             offenders.append(f"{mod}:{name} is an OrderedDict with no {cap}")
             continue

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -8,10 +8,10 @@ import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
-import config  # noqa: E402
-import screenspace  # noqa: E402
-import screenspace_preview  # noqa: E402
-import screenspace_server  # noqa: E402
+import config
+import screenspace
+import screenspace_preview
+import screenspace_server
 
 
 @pytest.fixture

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -288,9 +288,9 @@ def test_generate_keyword_timestamps_honors_header_and_segment_annotations(
     coords = {(clip["cell"].row, clip["cell"].col) for clip in clips}
     # Both cells with segment-level !key annotations should be included.
     assert coords == {(3, 2), (4, 3)}
-    segment_indexes = [
+    segment_indexes = next(
         clip.get("selected_segment_indexes") for clip in clips if clip["cell"].col == 3
-    ][0]
+    )
     assert segment_indexes == [0]
 
 

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -12,7 +12,7 @@ import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
-import server_utils  # noqa: E402
+import server_utils
 
 
 @pytest.fixture
@@ -132,6 +132,5 @@ def test_json_endpoint_does_not_swallow_other_exceptions(app):
     def handler():
         raise ValueError("real bug")
 
-    with app.app_context():
-        with pytest.raises(ValueError):
-            handler()
+    with app.app_context(), pytest.raises(ValueError):
+        handler()

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -23,9 +23,9 @@ import pytest
 
 pytest.importorskip("flask")
 
-import config  # noqa: E402
-import server  # noqa: E402
-import start_settings  # noqa: E402
+import config
+import server
+import start_settings
 
 
 @pytest.fixture

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 
 Flask = pytest.importorskip("flask").Flask
-import server  # noqa: E402
+import server
 
 
 def _set_artifacts(monkeypatch, artifacts):
@@ -1322,7 +1322,7 @@ def test_api_timeline_viewer_without_intake(client, monkeypatch):
     monkeypatch.setattr(spreadsheet, "generate_list", lambda *a, **kw: fake_clips)
     monkeypatch.setattr(pipeline, "process_clips", lambda *a, **kw: (1, fake_artifacts))
     monkeypatch.setattr(pipeline, "is_excel_worksheet", lambda ws: False)
-    monkeypatch.setattr(viewer, "load_screenspace_events_for_viewer", lambda: [])
+    monkeypatch.setattr(viewer, "load_screenspace_events_for_viewer", list)
     monkeypatch.setattr(viewer, "finalize_timeline_data", lambda *a, **kw: {"meta": {}})
     monkeypatch.setattr(
         viewer, "generate_timeline_viewer", lambda *a, **kw: "/out/viewer.html"
@@ -1371,7 +1371,7 @@ def test_api_timeline_viewer_with_intake(client, monkeypatch):
         pipeline, "process_clips", lambda *a, **kw: (1, sheet_artifacts)
     )
     monkeypatch.setattr(pipeline, "is_excel_worksheet", lambda ws: False)
-    monkeypatch.setattr(viewer, "load_screenspace_events_for_viewer", lambda: [])
+    monkeypatch.setattr(viewer, "load_screenspace_events_for_viewer", list)
     monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
 
     captured_artifacts = []
@@ -1522,7 +1522,7 @@ def test_api_timeline_viewer_passes_cancel_flag(client, monkeypatch):
     monkeypatch.setattr(spreadsheet, "generate_list", lambda *a, **kw: [{"desc": "x"}])
     monkeypatch.setattr(pipeline, "process_clips", fake_process_clips)
     monkeypatch.setattr(pipeline, "is_excel_worksheet", lambda ws: False)
-    monkeypatch.setattr(viewer, "load_screenspace_events_for_viewer", lambda: [])
+    monkeypatch.setattr(viewer, "load_screenspace_events_for_viewer", list)
     monkeypatch.setattr(viewer, "finalize_timeline_data", lambda *a, **kw: {"meta": {}})
     monkeypatch.setattr(
         viewer, "generate_timeline_viewer", lambda *a, **kw: "/out/viewer.html"
@@ -1859,7 +1859,7 @@ def test_api_gallery_returns_409_when_busy(client, monkeypatch):
 
 
 def test_api_stashes_get_empty(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_stashes", list)
     resp = client.get("/studio/api/stashes")
     assert resp.status_code == 200
     data = resp.get_json()
@@ -1869,7 +1869,7 @@ def test_api_stashes_get_empty(client, monkeypatch):
 
 def test_api_stashes_create(client, monkeypatch):
     saved = []
-    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_stashes", list)
     monkeypatch.setattr(server, "_save_stashes", lambda s: saved.append(s))
 
     items = [
@@ -1906,7 +1906,7 @@ def test_api_stashes_create_default_name(client, monkeypatch):
 
 
 def test_api_stashes_create_empty_items_400(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_stashes", list)
     resp = client.post(
         "/studio/api/stashes",
         json={"action": "create", "items": []},
@@ -1934,7 +1934,7 @@ def test_api_stashes_update_name(client, monkeypatch):
 
 
 def test_api_stashes_update_404(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_stashes", list)
     resp = client.post(
         "/studio/api/stashes",
         json={"action": "update", "id": "stash_nope", "name": "x"},
@@ -1963,7 +1963,7 @@ def test_api_stashes_delete(client, monkeypatch):
 
 
 def test_api_stashes_delete_not_found_404(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_stashes", list)
     resp = client.post(
         "/studio/api/stashes",
         json={"action": "delete", "id": "stash_nope"},
@@ -1972,7 +1972,7 @@ def test_api_stashes_delete_not_found_404(client, monkeypatch):
 
 
 def test_api_stashes_unknown_action_400(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_stashes", list)
     resp = client.post(
         "/studio/api/stashes",
         json={"action": "bogus"},
@@ -1986,7 +1986,7 @@ def test_api_stashes_unknown_action_400(client, monkeypatch):
 
 
 def test_api_artifact_stashes_get_empty(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_artifact_stashes", list)
     resp = client.get("/studio/api/artifact-stashes")
     assert resp.status_code == 200
     data = resp.get_json()
@@ -1996,7 +1996,7 @@ def test_api_artifact_stashes_get_empty(client, monkeypatch):
 
 def test_api_artifact_stashes_create(client, monkeypatch):
     saved = []
-    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_artifact_stashes", list)
     monkeypatch.setattr(server, "_save_artifact_stashes", lambda s: saved.append(s))
 
     items = [
@@ -2035,7 +2035,7 @@ def test_api_artifact_stashes_create_default_name(client, monkeypatch):
 
 
 def test_api_artifact_stashes_create_empty_items_400(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_artifact_stashes", list)
     resp = client.post(
         "/studio/api/artifact-stashes",
         json={"action": "create", "items": []},
@@ -2063,7 +2063,7 @@ def test_api_artifact_stashes_update_name(client, monkeypatch):
 
 
 def test_api_artifact_stashes_update_404(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_artifact_stashes", list)
     resp = client.post(
         "/studio/api/artifact-stashes",
         json={"action": "update", "id": "astash_nope", "name": "x"},
@@ -2092,7 +2092,7 @@ def test_api_artifact_stashes_delete(client, monkeypatch):
 
 
 def test_api_artifact_stashes_delete_not_found_404(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_artifact_stashes", list)
     resp = client.post(
         "/studio/api/artifact-stashes",
         json={"action": "delete", "id": "astash_nope"},
@@ -2101,7 +2101,7 @@ def test_api_artifact_stashes_delete_not_found_404(client, monkeypatch):
 
 
 def test_api_artifact_stashes_unknown_action_400(client, monkeypatch):
-    monkeypatch.setattr(server, "_load_artifact_stashes", lambda: [])
+    monkeypatch.setattr(server, "_load_artifact_stashes", list)
     resp = client.post(
         "/studio/api/artifact-stashes",
         json={"action": "bogus"},

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -6,6 +6,7 @@ import pytest
 
 Flask = pytest.importorskip("flask").Flask
 import server
+import itertools
 
 
 def _set_artifacts(monkeypatch, artifacts):
@@ -1822,7 +1823,7 @@ def test_api_gallery_multi_video_intervals_globally_aligned(
     assert requested[str(b)] == list(range(5, 120, 10))  # 5,15,...,115
     # Global timestamps are evenly spaced by the interval across the boundary.
     globals_ = sorted(art["timestamp"] for art in captured["artifacts"])
-    diffs = {round(hi - lo, 6) for lo, hi in zip(globals_, globals_[1:])}
+    diffs = {round(hi - lo, 6) for lo, hi in itertools.pairwise(globals_)}
     assert diffs == {10.0}
 
 

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for thinking_agents module.
 
 Covers the built-in summary and citation agents plus registry invariants.
@@ -213,7 +212,7 @@ class TestSummarizeTranscript:
     @patch("thinking_agents.ollama_client.generate")
     def test_forwards_on_token_to_generate(self, mock_generate):
         mock_generate.return_value = "ok"
-        sink = lambda _tok: None  # noqa: E731
+        sink = lambda _tok: None
         segments = [
             {
                 "text": "A sufficiently long segment of text for the minimum length check."
@@ -225,7 +224,7 @@ class TestSummarizeTranscript:
     @patch("thinking_agents.ollama_client.generate")
     def test_run_summary_forwards_on_token(self, mock_generate):
         mock_generate.return_value = "ok"
-        sink = lambda _tok: None  # noqa: E731
+        sink = lambda _tok: None
         entry = {
             "segments": [
                 {"text": "A sufficiently long segment of text for the length check."}

--- a/tests/test_tooltip_conventions.py
+++ b/tests/test_tooltip_conventions.py
@@ -98,8 +98,7 @@ def _js_functions(src: str):
     unrelated `card.title` in a different builder.
     """
     parts = re.split(r"\bfunction\b", src)
-    for part in parts[1:]:
-        yield part
+    yield from parts[1:]
 
 
 def test_native_title_is_not_set_on_a_draggable_element():

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -321,7 +321,7 @@ class TestTranscribeVideoWhisperKwargs:
             language = "en"
 
         class FakeModel:
-            def transcribe(self, path: str, **kwargs):  # noqa: ARG002
+            def transcribe(self, path: str, **kwargs):
                 captured.update(kwargs)
                 return iter([FakeSeg()]), FakeInfo()
 
@@ -357,7 +357,7 @@ class TestTranscribeVideoWhisperKwargs:
 
         monkeypatch.setattr(video_mod, "probe_video_properties", _fake_probe)
 
-        def _fail_load(model_name=None):  # noqa: ARG001
+        def _fail_load(model_name=None):
             raise AssertionError("_load_model must not be called when audio is absent")
 
         monkeypatch.setattr(transcripts, "_load_model", _fail_load)
@@ -894,7 +894,7 @@ class TestTranscriptWorker:
                 yield FakeSeg(i)
 
         class FakeModel:
-            def transcribe(self, path, **kwargs):  # noqa: ARG002
+            def transcribe(self, path, **kwargs):
                 return fake_segments(), SimpleNamespace(language="en")
 
         monkeypatch.setattr(transcripts, "_load_model", lambda *_a, **_k: FakeModel())

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -7,12 +7,12 @@ import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
-import config  # noqa: E402
-import thinking_agents  # noqa: E402
-import transcripts  # noqa: E402
-import transcripts_server  # noqa: E402
-import video  # noqa: E402
-import viewer  # noqa: E402
+import config
+import thinking_agents
+import transcripts
+import transcripts_server
+import video
+import viewer
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def tr_client(tmp_path, monkeypatch):
     monkeypatch.setattr(transcripts_server, "_merged_task_ids", set())
     monkeypatch.setattr(transcripts_server, "_pending_chain_pids", [])
 
-    monkeypatch.setattr(viewer, "load_manifest_artifacts", lambda: [])
+    monkeypatch.setattr(viewer, "load_manifest_artifacts", list)
 
     with app.test_client() as c:
         yield c
@@ -559,7 +559,6 @@ def test_orchestrator_stop_then_restart_isolates_run_state(
     def blocking_run_first(snapshot, cancel_event, on_token=None):
         started_first.set()
         release_first.wait(timeout=5)
-        return None
 
     monkeypatch.setitem(summary_agent, "run", blocking_run_first)
 
@@ -584,7 +583,6 @@ def test_orchestrator_stop_then_restart_isolates_run_state(
     def blocking_run_second(snapshot, cancel_event, on_token=None):
         started_second.set()
         release_second.wait(timeout=5)
-        return None
 
     monkeypatch.setitem(summary_agent, "run", blocking_run_second)
     orch.run_agent("summary", pid, force=True)
@@ -638,7 +636,6 @@ def test_summary_partial_streams_via_sink_and_clears(
         on_token(" world")
         streamed.set()
         release.wait(timeout=5)
-        return None  # don't commit; finally releases the slot
 
     monkeypatch.setitem(summary_agent, "run", streaming_run)
 
@@ -1057,7 +1054,6 @@ def test_friction_regenerate_triggers(tr_client, _agent_state_clean, monkeypatch
 
     def stub_run(snapshot, cancel_event, on_token=None):
         done.set()
-        return None
 
     fr_agent = thinking_agents.get_agent("friction")
     assert fr_agent is not None
@@ -1436,7 +1432,6 @@ def test_citations_regenerate_does_not_run_disabled_friction(
 
     def fr_stub(snapshot, cancel_event, on_token=None):
         friction_ran.set()
-        return None
 
     cit_agent = thinking_agents.get_agent("citations")
     fr_agent = thinking_agents.get_agent("friction")
@@ -1517,7 +1512,6 @@ def test_on_task_complete_registers_summary_before_disk_write(
             "summary must be in-flight before the manifest disk write"
         )
         persisted["flag"] = True
-        return None  # avoid touching disk
 
     monkeypatch.setattr(transcripts, "save_transcripts_manifest", _spy_save)
 
@@ -1528,7 +1522,6 @@ def test_on_task_complete_registers_summary_before_disk_write(
     def _blocking_summary(snapshot, cancel_event, on_token=None):
         started.set()
         release.wait(2.0)
-        return None  # don't commit/chain; the finally{} block releases the slot
 
     summary_agent = thinking_agents.get_agent("summary")
     assert summary_agent is not None

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Guard: static element IDs the Transcripts page script toggles must exist.
 
 A missing element makes ``qs("#id")`` return ``null`` and the first

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1296,7 +1296,7 @@ def test_run_ffmpeg_forwards_cancel_flag(monkeypatch):
     captured: list = []
     monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     ok = video.run_ffmpeg(
         "in.mp4", "out.mp4", "00:10", "00:15", reencode=False, cancel_flag=sentinel
     )
@@ -1326,7 +1326,7 @@ def test_enforce_filesize_limit_compresses_and_forwards_cancel_flag(monkeypatch)
 
     monkeypatch.setattr(video, "compress_to_size", _fake_compress)
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     video.enforce_filesize_limit("out.mp4", cancel_flag=sentinel)
     assert captured == [("out.mp4", 50, sentinel)]
 
@@ -1342,7 +1342,7 @@ def test_extract_screenshot_forwards_cancel_flag(monkeypatch):
     captured: list = []
     monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     ok = video.extract_screenshot("in.mp4", "out.png", "00:10", cancel_flag=sentinel)
     assert ok is True
     assert captured == [sentinel]
@@ -1359,7 +1359,7 @@ def test_extract_gif_forwards_cancel_flag(monkeypatch):
     captured: list = []
     monkeypatch.setattr(video, "run_ffmpeg_process", _captured_run_ffmpeg(captured))
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     ok = video.extract_gif("in.mp4", "out.gif", "00:10", 5, cancel_flag=sentinel)
     assert ok is True
     assert captured == [sentinel]
@@ -1377,7 +1377,7 @@ def test_compress_to_size_forwards_cancel_flag_to_both_passes(monkeypatch, tmp_p
     # Stub os.replace and unlink so the test doesn't move/delete real files.
     monkeypatch.setattr(video.os, "replace", lambda *_a, **_kw: None)
 
-    sentinel = lambda: False  # noqa: E731
+    sentinel = lambda: False
     # Target tiny size so compression runs both passes.
     video.compress_to_size(str(big), 0.0001, cancel_flag=sentinel)
     assert captured == [sentinel, sentinel]
@@ -1482,7 +1482,6 @@ def test_batch_extract_screenshots_seeks_only_for_offset_grid(monkeypatch):
 
     def fake_run(command, **_kwargs):
         captured["cmd"] = command
-        return None  # short-circuit fallback; we only inspect the built command
 
     monkeypatch.setattr(video.config, "SCREENSHOT_FORMAT", ".png")
     monkeypatch.setattr(video, "run_ffmpeg_process", fake_run)

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -375,15 +375,7 @@ def test_probe_max_keyframe_gap_uses_max_not_median(monkeypatch, tmp_path):
     # Keyframes at 0, 1, 2, 8 (gaps 1, 1, 6). The max (6.0) is returned — a
     # single long-GOP stretch must not be masked by the surrounding short gaps
     # (median would be 1.0). Interior non-keyframe packets are ignored.
-    csv = "\n".join(
-        [
-            "0.000000,K__",
-            "0.033000,__",
-            "1.000000,K__",
-            "2.000000,K__",
-            "8.000000,K__",
-        ]
-    )
+    csv = "0.000000,K__\n0.033000,__\n1.000000,K__\n2.000000,K__\n8.000000,K__"
     monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: csv)
     assert video.probe_max_keyframe_gap(str(clip)) == 6.0
 
@@ -406,7 +398,7 @@ def test_probe_max_keyframe_gap_single_keyframe_returns_none(monkeypatch, tmp_pa
     clip.write_bytes(b"x")
     # Only one keyframe in the probe window → GOP longer than the window; can't
     # confirm short cadence, so treat as unknown (None → do not skip).
-    csv = "\n".join(["0.000000,K__", "0.033000,__", "1.000000,__"])
+    csv = "0.000000,K__\n0.033000,__\n1.000000,__"
     monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: csv)
     assert video.probe_max_keyframe_gap(str(clip)) is None
 

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -14,10 +14,10 @@ import pytest
 
 Flask = pytest.importorskip("flask").Flask
 
-import config  # noqa: E402
-import utils  # noqa: E402
-import workflows  # noqa: E402
-import workflows_server  # noqa: E402
+import config
+import utils
+import workflows
+import workflows_server
 
 
 @pytest.fixture

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -198,7 +198,7 @@ def _split_summary_sentences(summary: str) -> list[str]:
         line = line.strip()
         if not line:
             continue
-        if line.startswith("- ") or line.startswith("* "):
+        if line.startswith(("- ", "* ")):
             sentences.append(line[2:].strip())
             continue
         parts = re.split(r"(?<=[.!?])\s+", line)

--- a/thinking_agents.py
+++ b/thinking_agents.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Thinking-agent registry for clipgen.
 
 A "thinking agent" is a small, self-contained unit of Ollama-powered reasoning
@@ -25,8 +24,9 @@ import bisect
 import json
 import re
 import threading
-from datetime import datetime, timezone
-from typing import Any, Callable, TypedDict
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any, TypedDict
 
 import config
 import friction
@@ -603,7 +603,7 @@ def _run_friction(
         "segments": scored,
         "moments": moments or [],
         "stats": stats,
-        "computed_at": datetime.now(timezone.utc).isoformat(),
+        "computed_at": datetime.now(UTC).isoformat(),
         "model": model,
         "llm_ok": llm_ok,
         "stale": False,

--- a/titlecards.py
+++ b/titlecards.py
@@ -243,7 +243,12 @@ def _build_card_frame(
     video_out_args = list(_x264_video_args())
     if match_fps:
         # Fixed framerate + timebase so concat-demuxer copy sees consistent cards.
-        video_out_args += ["-r", "%g" % match_fps, "-video_track_timescale", "90000"]
+        video_out_args += [
+            "-r",
+            f"{match_fps:g}",
+            "-video_track_timescale",
+            "90000",
+        ]
 
     ffmpeg_command = [
         "ffmpeg",
@@ -419,7 +424,7 @@ def get_or_build_endcard(
     if config.ENDCARD_IMAGE == config.CARD_IMAGE_COLOR:
         endcard_id = endcard_id + config.ENDCARD_COLOR
     audio_sig = _audio_match_signature(audio_match)
-    fps_sig = ("%g" % match_fps) if match_fps else "nofps"
+    fps_sig = f"{match_fps:g}" if match_fps else "nofps"
     cache_key = f"{resolution}:{duration}:{endcard_id}:{fps_sig}:{audio_sig}"
     with _endcard_lock:
         cached = _endcard_cache.get(cache_key)

--- a/titlecards.py
+++ b/titlecards.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Titlecard and endcard generation for clipgen.
 
 Prepends a short title card (first frame of source video + text overlay) and optionally
@@ -105,7 +104,7 @@ def _build_drawtext_filter(text: str) -> str:
         safe_text.replace("\\", "\\\\").replace(":", "\\:").replace("'", "'\\''")
     )
     return (
-        "drawtext=text='{}'"
+        f"drawtext=text='{safe_text}'"
         # The text is static — disable drawtext's %{...} expansion so a
         # description containing "%" (which sanitize_filename keeps) renders
         # literally instead of erroring the encode.
@@ -116,7 +115,7 @@ def _build_drawtext_filter(text: str) -> str:
         ":x=(w-text_w)/2"
         ":y=(h-text_h)/2"
         ":box=1:boxcolor=black@0.4:boxborderw=10"
-    ).format(safe_text)
+    )
 
 
 def _ffmpeg_color(value: str) -> str:

--- a/transcripts.py
+++ b/transcripts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Transcription support for clipgen via faster-whisper (CTranslate2-based Whisper).
 
 The Whisper model is lazy-loaded on first use and cached at module level for the session.
@@ -45,9 +44,10 @@ import queue
 import re
 import threading
 import uuid
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import config
 import utils
@@ -158,7 +158,7 @@ def _load_model(model_name: str | None = None) -> Any:
     When *model_name* is None, uses ``config.TRANSCRIBE_MODEL``. Passing a
     different name swaps the cached model.
     """
-    global _cached_model, _cached_model_name  # noqa: PLW0603
+    global _cached_model, _cached_model_name
 
     model_name = model_name or config.TRANSCRIBE_MODEL
     if _cached_model is not None and _cached_model_name == model_name:
@@ -373,11 +373,13 @@ def transcribe_timeline(
     out_language = ""
     out_model = ""
     for path, _duration, cumulative in timeline:
-        part_on_segment: Callable[[float, "TranscriptSegment"], None] | None = None
+        part_on_segment: Callable[[float, TranscriptSegment], None] | None = None
         if on_segment is not None:
             inner = on_segment
 
-            def part_on_segment(  # noqa: E731 - small per-part shifter
+            # Small per-part shifter: rebases this part's segment times onto the
+            # stitched timeline via the default-arg captures below.
+            def part_on_segment(
                 end_time: float,
                 segment: "TranscriptSegment",
                 _cum: int = cumulative,
@@ -686,7 +688,7 @@ def _format_markdown(result: TranscriptResult) -> str:
         f"- **Source:** {source_name}",
         f"- **Model:** {result['model']}",
         f"- **Language:** {result['language']}",
-        f"- **Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
+        f"- **Generated:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}",
         "",
         "---",
         "",
@@ -921,7 +923,7 @@ def create_transcript_task(
         "partial_segments": [],
         "result": None,
         "error": None,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": datetime.now(UTC).isoformat(),
         "completed_at": None,
         "_cancelled": False,
     }
@@ -1079,7 +1081,7 @@ class TranscriptWorker:
                 task["status"] = TASK_STATUS_FAILED
                 task["error"] = "No video files — nothing to transcribe."
                 task["partial_segments"] = []
-                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+                task["completed_at"] = datetime.now(UTC).isoformat()
             return
 
         # Multi-video participants form one continuous timeline; transcribe each
@@ -1097,7 +1099,7 @@ class TranscriptWorker:
                     "No audio stream — this video has no audio track to transcribe."
                 )
                 task["partial_segments"] = []
-                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+                task["completed_at"] = datetime.now(UTC).isoformat()
             return
 
         if timeline is not None:
@@ -1144,7 +1146,7 @@ class TranscriptWorker:
                     task["status"] = TASK_STATUS_FAILED
                     task["error"] = "Transcription returned None"
                     task["partial_segments"] = []
-                    task["completed_at"] = datetime.now(timezone.utc).isoformat()
+                    task["completed_at"] = datetime.now(UTC).isoformat()
                 return
 
             with self._lock:
@@ -1156,19 +1158,19 @@ class TranscriptWorker:
                     "language": result["language"],
                     "model": result["model"],
                     "source_file": result["source_file"],
-                    "transcribed_at": datetime.now(timezone.utc).isoformat(),
+                    "transcribed_at": datetime.now(UTC).isoformat(),
                 }
-                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+                task["completed_at"] = datetime.now(UTC).isoformat()
 
         except _TranscriptionCancelled:
             with self._lock:
                 task["status"] = TASK_STATUS_CANCELLED
                 task["partial_segments"] = []
-                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+                task["completed_at"] = datetime.now(UTC).isoformat()
 
         except Exception as exc:
             with self._lock:
                 task["status"] = TASK_STATUS_FAILED
                 task["error"] = str(exc)
                 task["partial_segments"] = []
-                task["completed_at"] = datetime.now(timezone.utc).isoformat()
+                task["completed_at"] = datetime.now(UTC).isoformat()

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -596,23 +596,28 @@ def _embed_subtitle_for_participant(
         str(output_dir / desired_name), file_format=src.suffix
     )
 
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".srt", delete=False, encoding="utf-8"
-    )
+    tmp_path = ""
     try:
-        tmp.write(srt_text)
-        tmp.close()
+        # delete=False + the explicit unlink below: ffmpeg reopens the sidecar by
+        # path once we've closed it, which Windows won't allow while the
+        # NamedTemporaryFile handle is still open.
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".srt", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp_path = tmp.name
+            tmp.write(srt_text)
         ok = video.mux_subtitles(
             str(video_path),
-            tmp.name,
+            tmp_path,
             output_path,
             track_language=language or "und",
         )
     finally:
-        try:
-            os.unlink(tmp.name)
-        except OSError:
-            pass
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     if not ok:
         return {

--- a/transcripts_server.py
+++ b/transcripts_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Transcripts Flask blueprint for clipgen.
 
 Registered at /transcripts/ by start_combined_server(). Works with or without a
@@ -46,7 +45,7 @@ import threading
 import time
 import uuid
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -336,7 +335,7 @@ _corrections_version = 0
 
 def _bump_corrections_version() -> None:
     """Invalidate the corrected-segments cache (corrections or segments changed)."""
-    global _corrections_version  # noqa: PLW0603
+    global _corrections_version
     with _corrected_cache_lock:
         _corrections_version += 1
         _corrected_cache.clear()
@@ -445,7 +444,7 @@ def api_edit_segment(participant: str) -> FlaskResponse:
             "id": f"c_{uuid.uuid4().hex[:8]}",
             "from": original_text,
             "to": new_text,
-            "created": datetime.now(timezone.utc).isoformat(),
+            "created": datetime.now(UTC).isoformat(),
         }
         _manifest.setdefault("corrections", []).append(correction)
         _bump_corrections_version()  # new correction invalidates corrected cache
@@ -908,7 +907,7 @@ def api_corrections_add() -> FlaskResponse:
                 "id": f"c_{uuid.uuid4().hex[:8]}",
                 "from": from_text,
                 "to": to_text,
-                "created": datetime.now(timezone.utc).isoformat(),
+                "created": datetime.now(UTC).isoformat(),
             }
             corrections.append(correction)
 
@@ -1117,7 +1116,7 @@ def api_marks_add() -> FlaskResponse:
     category = data.get("category") or None
     label = data.get("label") or None
     severity = data.get("severity") or None
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
 
     created = []
     with _manifest_lock:
@@ -1305,7 +1304,7 @@ def api_transcribe_warmup() -> FlaskResponse:
             size_mb=_whisper_model_size_mb(model),
         )
 
-    global _transcript_model_warming  # noqa: PLW0603
+    global _transcript_model_warming
 
     with _transcript_model_warming_lock:
         if _transcript_model_warming:
@@ -1315,7 +1314,7 @@ def api_transcribe_warmup() -> FlaskResponse:
         _transcript_model_warming = True
 
     def _run_warmup() -> None:
-        global _transcript_model_warming  # noqa: PLW0603
+        global _transcript_model_warming
         try:
             transcripts.warmup_transcription_model()
         finally:
@@ -1832,9 +1831,7 @@ class AgentOrchestrator:
                 return
             self._in_flight[agent_key].add(participant)
             self._cancel_events[agent_key][participant] = cancel_event
-            self._started_at[agent_key][participant] = datetime.now(
-                timezone.utc
-            ).timestamp()
+            self._started_at[agent_key][participant] = datetime.now(UTC).timestamp()
         with self._partial_lock:
             self._partial[agent_key][participant] = []
 
@@ -1946,7 +1943,7 @@ def _init_transcripts_state(
     Loads manifest, resolves participant video paths, and starts the
     background worker thread.
     """
-    global _manifest, _worker, _input_dir, _participants  # noqa: PLW0603
+    global _manifest, _worker, _input_dir, _participants
 
     _input_dir = str(utils.get_effective_input_dir())
     _manifest = transcripts.load_transcripts_manifest()

--- a/utils.py
+++ b/utils.py
@@ -2057,8 +2057,10 @@ def discover_participant_videos(study_name: str = "") -> list[dict[str, Any]]:
                         f"Numbered source videos for participant '{pid}' are "
                         f"non-contiguous (found parts {indices}); expected 1..N.",
                         [
-                            "Skipping this participant; rename the parts to a "
-                            "gapless 1..N sequence to enable concatenation.",
+                            (
+                                "Skipping this participant; rename the parts to a "
+                                "gapless 1..N sequence to enable concatenation."
+                            ),
                         ],
                     )
                     continue

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utility functions for clipgen."""
 
 import contextlib
@@ -10,10 +9,11 @@ import os
 import subprocess
 import sys
 import threading
+from collections.abc import Callable
 from datetime import datetime
 from numbers import Integral, Real
 from pathlib import Path
-from typing import Any, Callable, TypedDict, TypeVar
+from typing import Any, TypedDict, TypeVar
 
 import config
 
@@ -1496,8 +1496,7 @@ def seconds_to_timestamp(total_seconds: float, *, force_hours: bool = False) -> 
     whole seconds so the ``:d``/``:02d`` format specs can't crash.
     """
     total_seconds = int(total_seconds)
-    if total_seconds < 0:
-        total_seconds = 0
+    total_seconds = max(total_seconds, 0)
     hours, rem = divmod(total_seconds, config.SECONDS_PER_HOUR)
     minutes, seconds = divmod(rem, config.SECONDS_PER_MINUTE)
     if hours > 0 or force_hours:
@@ -1703,8 +1702,7 @@ def cluster_spans(
             groups.append((cur_start, cur_end, cur_members))
             cur_start, cur_end, cur_members = s, e, [orig_idx]
         else:
-            if e > cur_end:
-                cur_end = e
+            cur_end = max(cur_end, e)
             cur_members.append(orig_idx)
     groups.append((cur_start, cur_end, cur_members))
 
@@ -1756,8 +1754,7 @@ def apply_span_padding(
         s = min(s, max(0.0, limit - 1))
     if max_duration > 0 and (e - s) > max_duration:
         e = s + max_duration
-    if e < s + 1:
-        e = s + 1
+    e = max(e, s + 1)
     return s, e
 
 

--- a/video.py
+++ b/video.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Video processing operations for clipgen."""
 
 import concurrent.futures

--- a/video.py
+++ b/video.py
@@ -18,6 +18,7 @@ from typing import Any
 import config
 import files
 import utils
+import itertools
 
 INVALID_END_TIMESTAMP = None
 
@@ -1462,8 +1463,10 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         "-v",
         "error",
         "-show_entries",
-        "stream=width,height,codec_name,codec_type,r_frame_rate,nb_frames,"
-        "pix_fmt,sample_rate,channels,channel_layout",
+        (
+            "stream=width,height,codec_name,codec_type,r_frame_rate,nb_frames,"
+            "pix_fmt,sample_rate,channels,channel_layout"
+        ),
         "-show_entries",
         "stream_tags=title,language,handler_name",
         "-show_entries",
@@ -1791,7 +1794,7 @@ def probe_max_keyframe_gap(filepath: str) -> float | None:
 
     if len(keyframe_times) >= 2:
         keyframe_times.sort()
-        gaps = [b - a for a, b in zip(keyframe_times, keyframe_times[1:]) if b - a > 0]
+        gaps = [b - a for a, b in itertools.pairwise(keyframe_times) if b - a > 0]
         if gaps:
             result = max(gaps)
 
@@ -1841,8 +1844,7 @@ def extract_frame_at_timestamp(
     try:
         result = subprocess.run(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=10,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/video.py
+++ b/video.py
@@ -129,11 +129,15 @@ def _probe_ffmpeg_listing(listing_arg: str, target_tokens: set[str]) -> bool:
     listing whose second column is the encoder/filter name.
     """
     try:
+        # check=False throughout this module: every ffmpeg/ffprobe call inspects
+        # returncode itself and turns a failure into a warning or a None return.
+        # check=True would raise past that handling and lose the diagnostics.
         result = subprocess.run(
             ["ffmpeg", "-hide_banner", listing_arg],
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
         )
     except (OSError, subprocess.SubprocessError):
         return False
@@ -281,7 +285,9 @@ def run_ffmpeg_process(
                 return subprocess.CompletedProcess(
                     ffmpeg_command, proc.returncode, out, err
                 )
-        return subprocess.run(ffmpeg_command, encoding="utf-8", capture_output=True)
+        return subprocess.run(
+            ffmpeg_command, encoding="utf-8", capture_output=True, check=False
+        )
     except FileNotFoundError:
         utils.error_print(
             "ffmpeg is not installed or not found in system PATH.",
@@ -360,8 +366,7 @@ def _run_ffmpeg_with_progress(
         # Read until EOF; without this the stderr pipe can fill its 64 KB
         # OS buffer and deadlock ffmpeg while we're blocked on stdout.
         assert proc.stderr is not None
-        for chunk in proc.stderr:
-            stderr_chunks.append(chunk)
+        stderr_chunks.extend(proc.stderr)
 
     stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
     stderr_thread.start()
@@ -906,7 +911,7 @@ def extract_thumbnail_bytes(
     ]
 
     try:
-        result = subprocess.run(cmd, capture_output=True, timeout=15)
+        result = subprocess.run(cmd, capture_output=True, timeout=15, check=False)
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
 
@@ -980,7 +985,7 @@ def extract_sprite_sheet_bytes(
     ]
 
     try:
-        result = subprocess.run(cmd, capture_output=True, timeout=20)
+        result = subprocess.run(cmd, capture_output=True, timeout=20, check=False)
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
 
@@ -1035,7 +1040,7 @@ def _extract_sprite_sheet_seek(
             "pipe:1",
         ]
         try:
-            result = subprocess.run(cmd, capture_output=True, timeout=15)
+            result = subprocess.run(cmd, capture_output=True, timeout=15, check=False)
         except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
             return None
         if result.returncode != 0 or not result.stdout:
@@ -1134,7 +1139,7 @@ def extract_audio_segment_bytes(
     ]
 
     try:
-        result = subprocess.run(cmd, capture_output=True, timeout=20)
+        result = subprocess.run(cmd, capture_output=True, timeout=20, check=False)
         if result.returncode != 0:
             return None
         data = Path(tmp_path).read_bytes()
@@ -1846,6 +1851,7 @@ def extract_frame_at_timestamp(
             cmd,
             capture_output=True,
             timeout=10,
+            check=False,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return None
@@ -1943,9 +1949,12 @@ def enforce_filesize_limit(
     artifact after any titlecard wrap or concat — never to an intermediate cut
     that will be re-encoded downstream (see the note in :func:`run_ffmpeg`).
     """
-    if config.MAX_FILESIZE_MB and config.MAX_FILESIZE_MB > 0:
-        if not compress_to_size(path, config.MAX_FILESIZE_MB, cancel_flag=cancel_flag):
-            utils.warning_print(f"Could not compress '{path}' to target size")
+    if (
+        config.MAX_FILESIZE_MB
+        and config.MAX_FILESIZE_MB > 0
+        and not compress_to_size(path, config.MAX_FILESIZE_MB, cancel_flag=cancel_flag)
+    ):
+        utils.warning_print(f"Could not compress '{path}' to target size")
 
 
 def compress_to_size(

--- a/viewer.py
+++ b/viewer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Timeline and gallery viewer generation, manifest persistence.
 
 Timeline viewer (--viewer / interactive 'viewer'):
@@ -30,7 +29,7 @@ import functools
 import json
 import re
 import threading
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -134,7 +133,7 @@ def finalize_timeline_data(
         "meta": {
             "study": study,
             "participant": participant,
-            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "generatedAt": datetime.now(UTC).isoformat(),
             "mode": mode,
             "sourceSpreadsheet": worksheet_title,
             "sourceFileType": "excel" if is_excel else "google",
@@ -460,7 +459,7 @@ def finalize_gallery_data(
     return {
         "meta": {
             "sourceVideo": source_video,
-            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "generatedAt": datetime.now(UTC).isoformat(),
             "mode": "gallery",
             "format": output_format,
             "interval": interval,

--- a/workflows.py
+++ b/workflows.py
@@ -60,8 +60,9 @@ test, patch the owning sibling module.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import config
 import utils
@@ -906,8 +907,7 @@ def _exec_interval_captures(
         float(params.get("interval", config.GALLERY_INTERVAL_SECONDS) or 0)
         or config.GALLERY_INTERVAL_SECONDS
     )
-    if interval < 1:
-        interval = 1
+    interval = max(interval, 1)
     fmt = (
         "gif" if str(params.get("output_format", "screen") or "") == "gif" else "screen"
     )

--- a/workflows_catalog.py
+++ b/workflows_catalog.py
@@ -1028,7 +1028,7 @@ _MULTITOOL_STEP_TOOLS = frozenset(
     {"color", "change", "flow", "text", "numbers", "inactivity"}
 )
 
-for _ss_tool in _SS_DETECTOR_SPECS:
+for _ss_tool, _ss_param_spec in _SS_DETECTOR_SPECS.items():
     NODE_TYPES[f"ss_{_ss_tool}"] = {
         "id": f"ss_{_ss_tool}",
         "label": _SS_DETECTOR_LABELS[_ss_tool],
@@ -1041,7 +1041,7 @@ for _ss_tool in _SS_DETECTOR_SPECS:
             {"name": "timeRange", "type": "timeRange", "optional": True},
         ],
         "outputs": [{"name": "events", "type": "events"}],
-        "params": list(_SS_DETECTOR_SPECS[_ss_tool]),
+        "params": list(_ss_param_spec),
         "requires": ["videoDir"],
         # Hidden from the palette: the unified "detect" node below is the
         # palette-facing entry. These stay in the catalog as the per-detector

--- a/workflows_catalog.py
+++ b/workflows_catalog.py
@@ -21,9 +21,10 @@ module, before running graphs — this module alone is an unwired catalog.
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, NotRequired, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 import config
 import utils

--- a/workflows_runner.py
+++ b/workflows_runner.py
@@ -19,9 +19,10 @@ import json
 import os
 import threading
 import time
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import utils
 from workflows_catalog import ADAPTERS, NODE_TYPES, NodeContext
@@ -89,7 +90,7 @@ class WorkflowCycleError(ValueError):
 
 def _now_iso() -> str:
     """UTC ISO-8601 timestamp for run/node start+complete stamps."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def topo_order(nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> list[str]:

--- a/workflows_runner.py
+++ b/workflows_runner.py
@@ -667,8 +667,9 @@ class WorkflowRunner:
             self._last_notify = now
             try:
                 self.on_update()
-            except Exception:
-                pass
+            except Exception as exc:
+                # A broken progress listener must never abort the run itself.
+                utils.verbose_print(f"workflow progress notify failed: {exc}")
 
     def _make_progress(self, node_id: str) -> Callable[[float], None]:
         def _on_progress(fraction: float) -> None:

--- a/workflows_server.py
+++ b/workflows_server.py
@@ -25,7 +25,7 @@ import shutil
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -184,7 +184,7 @@ def api_blueprints_create() -> Any:
         # Auto-run binding: null when never armed, else {"type": <TRIGGER_TYPES
         # id>, "enabled": bool} — see api_blueprint_trigger.
         "trigger": None,
-        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "createdAt": datetime.now(UTC).isoformat(),
     }
     with _manifest_lock:
         _manifest.setdefault("blueprints", []).append(blueprint)
@@ -317,7 +317,7 @@ def api_stashes_create() -> Any:
         "nodes": nodes,
         "edges": data.get("edges", []),
         "builtin": False,  # P4 built-ins are served from code; CRUD guards on this
-        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "createdAt": datetime.now(UTC).isoformat(),
     }
     with _manifest_lock:
         _manifest.setdefault("stashes", []).append(stash)
@@ -817,7 +817,7 @@ def _precompute_shared_nodes(
             continue
         try:
             result = executor(ctx, {}, node.get("params", {}) or {})
-        except Exception as exc:  # noqa: BLE001 — child re-runs it; don't sink the batch
+        except Exception as exc:  # the child run re-runs this; don't sink the batch
             utils.warning_print(f"workflow batch precompute failed: {exc}")
             continue
         if isinstance(result, dict):
@@ -978,7 +978,7 @@ def api_batch_create() -> Any:
             "participants": participants,
             "runIds": run_ids,
             "cancel_event": threading.Event(),
-            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "createdAt": datetime.now(UTC).isoformat(),
         }
 
     threading.Thread(
@@ -1072,7 +1072,7 @@ def _transcript_markers() -> dict[str, str]:
     re-parsed only when its file actually changed — a handful of times per
     session, not once per poll tick.
     """
-    global _watch_transcript_cache  # noqa: PLW0603
+    global _watch_transcript_cache
     mtime = _manifest_mtime(config.TRANSCRIPTS_MANIFEST_FILENAME)
     if mtime == _watch_transcript_cache[0]:
         return _watch_transcript_cache[1]
@@ -1093,7 +1093,7 @@ def _transcript_markers() -> dict[str, str]:
 
 def _scan_markers() -> dict[str, str]:
     """``{task_id: participant}`` for every completed Screenspace task (mtime-gated)."""
-    global _watch_scan_cache  # noqa: PLW0603
+    global _watch_scan_cache
     mtime = _manifest_mtime(config.SCREENSPACE_MANIFEST_FILENAME)
     if mtime == _watch_scan_cache[0]:
         return _watch_scan_cache[1]
@@ -1121,7 +1121,7 @@ def _seed_watch_seen() -> None:
     scans are all recorded; the watcher fires only for arrivals/completions
     that happen *after* this call.
     """
-    global _watch_transcript_cache, _watch_scan_cache  # noqa: PLW0603
+    global _watch_transcript_cache, _watch_scan_cache
     with _watch_lock:
         _watch_seen.clear()
         _watch_pending.clear()
@@ -1276,14 +1276,14 @@ def _watch_loop() -> None:
     while not _watch_stop.is_set():
         try:
             _watch_poll_once()
-        except Exception as exc:  # noqa: BLE001 — a poll error must not kill the daemon
+        except Exception as exc:  # a poll error must not kill the daemon
             utils.warning_print(f"watch-dir trigger poll failed: {exc}")
         _watch_stop.wait(config.WORKFLOWS_WATCH_POLL_SECONDS)
 
 
 def _start_watch_thread() -> None:
     """Start the watch-dir daemon (idempotent; daemon dies with the process)."""
-    global _watch_thread  # noqa: PLW0603
+    global _watch_thread
     with _watch_lock:
         if _watch_thread is not None and _watch_thread.is_alive():
             return
@@ -1307,7 +1307,7 @@ def _init_workflows_state(
     ``participant_list`` is accepted for parity with the other blueprints' init
     signatures; per-participant video paths are resolved on demand.
     """
-    global _input_dir, _sheet_context, _worksheet, _manifest  # noqa: PLW0603
+    global _input_dir, _sheet_context, _worksheet, _manifest
 
     _input_dir = str(utils.get_effective_input_dir())
     _sheet_context = sheet_context


### PR DESCRIPTION
## Summary

Ruff 0.16 enables ~413 rules by default (up from 59), so this config-less repo went from clean to 466 findings overnight. This adds an explicit `[tool.ruff]` block, pins CI to match, and clears every finding.

- `pyproject.toml` — `required-version = ">=0.16.0"` so a stale local ruff fails loudly instead of silently disagreeing with CI, plus five documented ignores (`BLE001`, `I001`, `DTZ005`/`DTZ007`, `UP047`) and `tests/**` ignores for `B018`/`RUF012`.
- 299 autofixes in two passes (safe, then unsafe reviewed rule by rule), and 33 findings fixed by hand — notably explicit `check=False` on `video.py`'s seven ffmpeg calls, narrowed `except` clauses, and a `with`-block for the subtitle tempfile so a failing write can't leak the handle.
- `TRY004` was deliberately suppressed rather than applied: every caller catches `ValueError`, so raising `TypeError` would have turned a 400 into a 500.
- 0.16 also formats Python fences inside Markdown, which reflows `AGENTS.md` and three archived plans.

## Test plan

- [x] `ruff check` and `ruff format --check` clean
- [x] `uvx ty@0.0.33 check` (the CI pin) clean
- [x] Full suite green — 2238 passed
- [x] Real-ffmpeg smoke: a successful cut; a failing cut still errors loudly and writes no file (so `check=False` didn't turn failure into silent success); Screenspace region scan + zero-dimension guard; subtitle tempfile cleaned up on both success and failed-write paths
- [ ] ⚠️ Browser UIs not checked — no JS/CSS changed, but four server modules did, so a click through Studio / Screenspace / Transcripts is worth it

Heads-up, pre-existing and not from this PR: local `ty` 0.0.63 flags 3 `invalid-argument-type` errors in `workflows_runner.topo_order` (untouched code). CI's pinned `ty@0.0.33` passes, so they'll only surface when CI bumps `ty`.
