### PR TITLE
test(ui): drive UI states in the harness, and fix what it found

### DIFF
--- a/agents/skills/ui-check/SKILL.md
+++ b/agents/skills/ui-check/SKILL.md
@@ -82,6 +82,39 @@ on a `pageerror` or a throwing snippet, so it composes in a shell chain.
 Do not loop `shot.py` over all six pages — it boots its own server per invocation.
 That is what the suite is for.
 
+### States and themes
+
+The six-page smoke renders each page's boot state, in dark, and clicks nothing.
+Most of the frontend is not in that: every modal, every tab past the default, and
+the whole Start overlay (both boot paths pre-dismiss it). Reach the rest with:
+
+```bash
+uv run --extra ui python tests/ui/shot.py studio --theme light
+uv run --extra ui python tests/ui/shot.py studio --state settings
+uv run --extra ui python tests/ui/shot.py screenspace --state tool:template
+uv run --extra ui python tests/ui/shot.py screenspace --all-states   # 20 states, one boot
+```
+
+Every page has `settings`, `settings-hotkeys`, `cheatsheet`, `palette` and
+`start`. Tab states are **discovered from the live DOM**, not hard-coded, so a tab
+added to the HTML becomes a state for free — pass an unknown `--state` name and
+the error lists what that page actually has.
+
+`--all-states` writes `<page>-<state>.png` and drives them all from one boot,
+which is the thing looping `shot.py` cannot do. It reports every state it tried,
+reached or not: an unreachable state prints as `MISS`, never silently skipped.
+`--state` exits non-zero when the named state can't be reached; `--all-states`
+does not, because some states legitimately don't exist in the fixture.
+
+Two honest limits, worth knowing before you read the output:
+
+- Screenspace's 13 tool tabs are hidden whenever the grouped category nav is on.
+  They are activated with a DOM `.click()` — the same delegation the grouped nav
+  itself uses (`screenspace.css:1401-1410`) — and are labelled
+  `hidden; activated via DOM click` so you can tell that from a real gesture.
+- The fixture is small on purpose, so an empty panel in a state screenshot may be
+  "no data" rather than "broken". Check `tests/ui/_ui_fixtures.py` before filing it.
+
 ## Diagnosing a failure
 
 | Symptom | Where to look |

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -455,7 +455,7 @@ body {
   margin-right: calc(-1 * var(--space-1));
   padding-left: var(--space-1);
   padding-right: var(--space-1);
-  transition: background var(--transition-fast, 0.1s);
+  transition: background var(--duration-fast);
 }
 
 .ss-info-issue--clickable:hover {
@@ -871,7 +871,7 @@ body[data-frontend="screenspace"] {
   border-radius: var(--radius-sm);
   overflow: hidden;
   cursor: pointer;
-  background: var(--color-bg-elevated, var(--color-bg));
+  background: var(--bg-elevated);
   transition: box-shadow var(--duration-fast), transform var(--duration-fast);
 }
 
@@ -1799,7 +1799,7 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
   display: inline-block;
   width: var(--icon-size-xs);
   height: var(--icon-size-xs);
-  background: var(--color-warning, #f59e0b);
+  background: var(--color-warning);
   mask-size: contain;
   mask-repeat: no-repeat;
   -webkit-mask-size: contain;
@@ -1837,12 +1837,12 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
 }
 
 .scan-toggle-btn.active {
-  background: color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent);
-  border-color: var(--color-warning, #f59e0b);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  border-color: var(--color-warning);
 }
 
 .scan-toggle-btn.active .scan-toggle-icon {
-  background: var(--color-warning, #f59e0b);
+  background: var(--color-warning);
 }
 
 .task-fast-badge {
@@ -1850,7 +1850,7 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
   align-items: center;
   gap: var(--space-1);
   font-size: var(--text-xs);
-  color: var(--color-warning, #f59e0b);
+  color: var(--color-warning);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1871,9 +1871,9 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
   align-items: center;
   gap: var(--space-1);
   font-size: var(--text-xs);
-  color: var(--color-warning, #f59e0b);
+  color: var(--color-warning);
   padding: var(--space-1) var(--space-2);
-  background: color-mix(in srgb, var(--color-warning, #f59e0b) 8%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 8%, transparent);
   border-radius: var(--radius-sm);
   margin-bottom: var(--space-2);
 }
@@ -2386,7 +2386,7 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
 }
 
 .multitool-step-header:hover {
-  background: var(--color-surface-hover);
+  background: var(--bg-hover);
 }
 
 .multitool-step-num {
@@ -2416,7 +2416,7 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
 
 .multitool-step-remove:hover {
   color: var(--color-text);
-  background: var(--color-surface-hover);
+  background: var(--bg-hover);
 }
 
 .multitool-step-drag-handle {
@@ -2495,7 +2495,7 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
 .multitool-operator-btn:hover {
   color: var(--color-text);
   border-color: var(--color-accent);
-  background: var(--color-surface-hover);
+  background: var(--bg-hover);
 }
 
 .multitool-operator-btn.is-not {
@@ -2552,7 +2552,7 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
 .multitool-offset-btn:hover {
   color: var(--color-text);
   border-color: var(--color-accent);
-  background: var(--color-surface-hover);
+  background: var(--bg-hover);
 }
 
 .multitool-offset-btn.is-active {
@@ -2865,7 +2865,9 @@ html[data-theme="light"] .ss-cat-chip.active[data-active-type="numbers"],
   height: 24px;
   width: auto;
   border-radius: var(--radius-sm);
-  background: var(--color-bg-checkered, repeating-conic-gradient(var(--color-border) 0% 25%, transparent 0% 50%) 50% / 8px 8px);
+  /* Transparency checkerboard. Inlined rather than var()-wrapped: the token it
+   * used to reference was never defined, so this fallback was always the value. */
+  background: repeating-conic-gradient(var(--color-border) 0% 25%, transparent 0% 50%) 50% / 8px 8px;
 }
 
 .color-preview {

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -154,6 +154,11 @@
   --color-surface-alt:         var(--bg-input);
   --color-text:                var(--fg);
   --color-text-dim:            var(--fg-muted);
+  /* Warning amber. Screenspace referenced this for a year with a #f59e0b
+   * fallback and it was never defined, so every warning there rendered a
+   * slightly different amber from the medium-severity chips everywhere else.
+   * Aliased rather than given its own hex so the two stay in step. */
+  --color-warning:             var(--severity-medium);
   --color-accent:              var(--accent);
   --color-border:              var(--border);
   --color-selected:            rgba(45, 107, 255, 0.18);

--- a/assets/web/viewer.css
+++ b/assets/web/viewer.css
@@ -84,7 +84,7 @@ body {
 
 .attachment-label {
   font-size: var(--text-sm);
-  color: var(--color-text-muted);
+  color: var(--color-text-dim);
 }
 
 .attachment-doc {

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -2006,7 +2006,7 @@ body[data-frontend="workflows"] {
 .wf-dialog-body {
   margin: 0;
   font-size: var(--text-sm);
-  color: var(--color-text-muted);
+  color: var(--color-text-dim);
 }
 
 .wf-dialog form {

--- a/tests/test_css_custom_properties.py
+++ b/tests/test_css_custom_properties.py
@@ -1,0 +1,106 @@
+"""Every ``var(--x)`` in the CSS must resolve to a property something defines.
+
+An undefined custom property fails in one of two ways, and neither of them is
+loud. Without a fallback the whole declaration is invalid and gets dropped, so
+the element silently inherits — that is how ``.attachment-label`` in the timeline
+viewer and four Screenspace hover rules lost their color and background outright.
+With a fallback the literal simply wins forever, which is how Screenspace spent a
+year rendering warnings in ``#f59e0b`` while every medium-severity chip elsewhere
+in the app used ``#fbbf24``: the token the rules referenced had never existed.
+
+Nothing else catches this. The browser reports no error, the page still boots so
+the UI smoke passes, and a screenshot only shows it if you already know which
+shade to expect. A one-pass scan is enough, so it runs in ``/check`` rather than
+the opt-in browser harness.
+
+Scope note: this checks that a name is *defined somewhere*, not that it is in
+scope at the point of use. A property defined only on ``.co-icon-play`` and read
+from an unrelated element would pass here and still resolve to nothing. That is a
+narrower bug than the one this exists for, and catching it needs the runtime
+census rather than a text scan.
+"""
+
+import re
+
+from _frontend_source import WEB
+
+# A declaration starts at the top of a block or after a semicolon. Anchoring on
+# line-start instead would miss the single-line form the icon rules use
+# (`.co-icon-play { --co-icon: url("icons/play.svg"); }`) and report every one of
+# them as undefined.
+_DEFINITION = re.compile(r"(?:^|[{;])\s*(--[\w-]+)\s*:", re.MULTILINE)
+_REFERENCE = re.compile(r"var\(\s*(--[\w-]+)\s*(,?)")
+# Custom properties written from code rather than declared in CSS.
+_SET_PROPERTY = re.compile(r"""setProperty\(\s*["'`](--[\w-]+)""")
+_INLINE_STYLE = re.compile(r"""["'`][^"'`]*?(--[\w-]+)\s*:""")
+
+
+def _defined_in_css() -> set[str]:
+    names: set[str] = set()
+    for path in sorted(WEB.glob("*.css")):
+        names |= set(_DEFINITION.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def _set_at_runtime() -> set[str]:
+    """Properties assigned from JS, HTML style attributes, or injected Python.
+
+    ``--desktop-chrome-height`` and ``--desktop-traffic-inset`` are the live
+    example: ``utils.render_index_html`` writes them onto ``<html>`` from
+    ``config`` so the frameless macOS window can size its own title bar.
+    """
+    names: set[str] = set()
+    for path in sorted(WEB.glob("*.js")) + sorted(WEB.glob("*.html")):
+        text = path.read_text(encoding="utf-8")
+        names |= set(_SET_PROPERTY.findall(text))
+        names |= set(_INLINE_STYLE.findall(text))
+    source = WEB.parent.parent / "source"
+    for path in sorted(source.glob("*.py")):
+        names |= set(_SET_PROPERTY.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def _undefined_references() -> dict[str, list[str]]:
+    """Map each unresolvable property to the ``file:line`` sites that read it."""
+    known = _defined_in_css() | _set_at_runtime()
+    found: dict[str, list[str]] = {}
+    for path in sorted(WEB.glob("*.css")):
+        for number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            for name, _ in _REFERENCE.findall(line):
+                if name not in known:
+                    found.setdefault(name, []).append(f"{path.name}:{number}")
+    return found
+
+
+def test_every_referenced_custom_property_is_defined():
+    undefined = _undefined_references()
+    assert not undefined, "CSS reads custom properties nothing defines:\n" + "\n".join(
+        f"  {name} <- {', '.join(sites)}" for name, sites in sorted(undefined.items())
+    )
+
+
+def test_scan_sees_the_single_line_declaration_form():
+    """Guard the regex itself.
+
+    An earlier draft anchored definitions to line start and reported all ~30
+    single-line ``--co-icon`` rules as undefined. The scan silently over-reporting
+    is survivable; the fix for it — widening the allowlist — would have been the
+    damaging part, so pin the shape that broke it.
+    """
+    names = _DEFINITION.findall('.co-icon-play { --co-icon: url("icons/play.svg"); }')
+    assert names == ["--co-icon"]
+
+
+def test_warning_token_resolves_to_the_shared_severity_amber():
+    """``--color-warning`` must stay an alias, not regrow its own hex.
+
+    It was introduced to end a split between Screenspace's ``#f59e0b`` warnings
+    and the ``--severity-medium`` amber used everywhere else. Giving it a literal
+    again would silently reopen that split.
+    """
+    tokens = (WEB / "tokens.css").read_text(encoding="utf-8")
+    match = re.search(r"--color-warning\s*:\s*([^;]+);", tokens)
+    assert match, "--color-warning is no longer defined in tokens.css"
+    assert "var(--severity-medium)" in match.group(1)

--- a/tests/test_js_dead_functions.py
+++ b/tests/test_js_dead_functions.py
@@ -1,0 +1,106 @@
+"""No new unreferenced top-level function may appear in ``assets/web/*.js``.
+
+Nothing else in the suite can see dead JS. ``node --check`` proves a file parses;
+``test_frontend_satellite_wiring.py`` proves a call *resolves*; neither asks
+whether anything calls a given function at all. So a function can be written,
+wired to nothing, and live in the bundle indefinitely — which is what the five
+below did.
+
+The signal is deliberately narrow: a top-level ``function name(...)`` whose name
+occurs exactly **once** across every ``.js``, ``.html`` and ``source/*.py`` file,
+that one occurrence being its own definition. At that threshold there is no
+judgement call left — nothing references it, under any spelling, including the
+``window.Clipgen*`` namespace publishes and the guarded hub delegators.
+
+The looser "never appears in call position" variant was measured at ~174 hits and
+is dominated by handlers passed by reference (``addEventListener("click", onX)``)
+and namespace exports (``{ foo: foo }``), both legitimate. It would make a decent
+human-reviewed worklist and a terrible gate, so it is not implemented here.
+
+This is a **ratchet**, not a cleanup: the five known-dead functions are listed so
+the current state passes, and the list may only shrink. Deleting one means
+deleting its entry in the same commit; adding a sixth fails ``/check``.
+"""
+
+import re
+from pathlib import Path
+
+from _frontend_source import WEB
+
+_TOP_LEVEL_FUNCTION = re.compile(
+    r"^\s*function\s+([A-Za-z_$][\w$]*)\s*\(", re.MULTILINE
+)
+
+# Unreferenced as of the frontend-cleanup pass. Each is a genuine deletion
+# candidate, tracked in the plan's drawdown step rather than removed here so this
+# commit stays test-only. Shrink this set; never grow it.
+KNOWN_DEAD: frozenset[str] = frozenset(
+    {
+        "pointInPolygon",  # screenspace-utils.js
+        "recallArtifactStash",  # studio-stash.js
+        "recallStash",  # studio-stash.js
+        "stopDiscover",  # workflows-runs.js
+        "trIntakeCategoryColor",  # studio-intake.js
+    }
+)
+
+
+def _consumer_text() -> str:
+    """Everything that could plausibly name a frontend function."""
+    parts = [path.read_text(encoding="utf-8") for path in sorted(WEB.glob("*.js"))]
+    parts += [path.read_text(encoding="utf-8") for path in sorted(WEB.glob("*.html"))]
+    source = Path(WEB).parent.parent / "source"
+    parts += [path.read_text(encoding="utf-8") for path in sorted(source.glob("*.py"))]
+    return "\n".join(parts)
+
+
+def _unreferenced() -> dict[str, str]:
+    """Map each unreferenced function name to the ``file:line`` that defines it."""
+    corpus = _consumer_text()
+    definitions: dict[str, str] = {}
+    for path in sorted(WEB.glob("*.js")):
+        text = path.read_text(encoding="utf-8")
+        for match in _TOP_LEVEL_FUNCTION.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            definitions.setdefault(match.group(1), f"{path.name}:{line}")
+
+    return {
+        name: site
+        for name, site in definitions.items()
+        if len(re.findall(rf"\b{re.escape(name)}\b", corpus)) == 1
+    }
+
+
+def test_no_new_unreferenced_functions():
+    unexpected = {
+        name: site for name, site in _unreferenced().items() if name not in KNOWN_DEAD
+    }
+    assert not unexpected, (
+        "These top-level functions are defined and referenced nowhere. Wire them "
+        "up or delete them:\n"
+        + "\n".join(f"  {name}  ({site})" for name, site in sorted(unexpected.items()))
+    )
+
+
+def test_known_dead_list_has_no_stale_entries():
+    """A name that is no longer dead must leave the list.
+
+    Without this the set silently becomes a graveyard of names that were deleted
+    or revived years ago, and the next reader cannot tell which entries still
+    mean anything.
+    """
+    stale = sorted(KNOWN_DEAD - set(_unreferenced()))
+    assert not stale, (
+        "KNOWN_DEAD lists functions that are no longer unreferenced (deleted, or "
+        f"now called). Drop them from the set: {', '.join(stale)}"
+    )
+
+
+def test_the_scan_finds_the_known_dead_functions():
+    """Guard the detector.
+
+    If the regex or the corpus glob silently stops matching, both tests above go
+    green while checking nothing. Pinning that the five known names are still
+    *found* keeps a broken scan from reading as a clean codebase.
+    """
+    assert KNOWN_DEAD <= set(_unreferenced())

--- a/tests/ui/_ui_session.py
+++ b/tests/ui/_ui_session.py
@@ -1,0 +1,166 @@
+"""One browser context factory, and one standalone boot, shared by every UI tool.
+
+Two things live here, and they exist for different reasons.
+
+**:func:`new_context` — the context factory.** ``conftest.py``'s ``browser_context``
+fixture and ``shot.py`` each used to build their own Chromium context, and they had
+already drifted: both set the start-overlay dismissal, neither pinned locale or
+timezone. Any tool that compares one run against another — the dead-CSS census
+especially — needs every run to see the *same* browser, so the context arguments
+have to be defined once. Both callers now route through here.
+
+**:func:`ui_session` — the standalone boot.** ``shot.py`` inlined config
+redirection, workbook opening, server start and browser launch, and its own
+docstring warns not to loop it because each invocation boots a server. The census
+needs all six pages from a single boot, which is the same sequence minus pytest.
+So the sequence moves here as a context manager and ``shot.py`` becomes one of its
+callers. ``conftest.py`` deliberately does *not* use it: its fixtures need
+session scoping, ``pytest.skip`` on an unavailable browser, and ``MonkeyPatch`` so
+config is restored for the rest of the suite.
+
+What is pinned in the init script, and why each one:
+
+* ``clipgen.startOverlayDismissed`` — ``shouldAutoOpen()`` checks this key before
+  anything else, and it is the only suppression that works uniformly across all
+  six pages. Carried over from both previous copies.
+* ``clipgen-theme`` — ``applyStoredThemePreference`` (utils.js) reads this at boot
+  and sets ``data-theme`` on ``<html>``. Setting the key rather than poking the
+  attribute afterwards is the path a real user with a stored preference takes, so
+  the page boots *already* in the target theme instead of repainting into it.
+* ``CLIPGEN_DEV_TOKEN_TWEAK`` — already ``false`` by default (utils.js), so this
+  is not a fix; it is a pin. The flag exists to be flipped on while iterating on
+  the redesign, and a maintainer who left it on would otherwise silently add a
+  widget plus an injected ``<style>`` to every screenshot and every census.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import _ui_browser
+import _ui_fixtures
+import _ui_server
+import config
+import start_settings
+import utils
+
+VIEWPORT = {"width": 1600, "height": 1000}
+THEMES = ("dark", "light")
+
+
+@dataclass
+class Session:
+    """A booted server plus an open browser context."""
+
+    context: Any
+    origin: str
+
+
+def build_init_script(theme: str = "dark") -> str:
+    """JS run before any page script, in every context this module creates."""
+    if theme not in THEMES:
+        raise ValueError(f"theme must be one of {THEMES}, got {theme!r}")
+    return (
+        "try {"
+        " sessionStorage.setItem('clipgen.startOverlayDismissed', '1');"
+        f" localStorage.setItem('clipgen-theme', '{theme}');"
+        "} catch (e) {}"
+        "window.CLIPGEN_DEV_TOKEN_TWEAK = false;"
+    )
+
+
+def new_context(
+    browser: Any,
+    *,
+    viewport: dict[str, int] | None = None,
+    theme: str = "dark",
+) -> Any:
+    """Build the one Chromium context shape every UI tool should use.
+
+    ``locale``/``timezone_id`` are pinned so relative-time and clock strings
+    ("5 d ago", ``toLocaleTimeString``) render identically wherever the harness
+    runs. That does mean screenshots show UTC rather than the reviewer's local
+    time — a deliberate trade: reproducibility across machines is worth more here
+    than matching one machine's clock.
+    """
+    context = browser.new_context(
+        viewport=viewport or VIEWPORT,
+        device_scale_factor=1,
+        locale="en-US",
+        timezone_id="UTC",
+        color_scheme="light" if theme == "light" else "dark",
+    )
+    context.add_init_script(build_init_script(theme))
+    return context
+
+
+def redirect_config(settings_dir: Path | None = None) -> None:
+    """Point config at the throwaway fixture tree (one-shot processes only).
+
+    Plain assignment, no ``MonkeyPatch``: callers of :func:`ui_session` are
+    standalone scripts that exit afterwards. ``conftest.py`` needs the restoring
+    version and keeps its own.
+    """
+    config.INPUT_DIR = str(_ui_fixtures.INPUT_DIR)
+    config.OUTPUT_DIR = str(_ui_fixtures.OUTPUT_DIR)
+    # Sheet-loading chatter would bury the screenshot path and the --eval result.
+    config.VERBOSITY = config.QUIET
+    # build_combined_app records a project session, which would otherwise prepend
+    # these fixture dirs to the maintainer's real "Recently opened" rail.
+    # setattr rather than plain assignment because the attribute's declared type
+    # is the original function; this is the same rebinding monkeypatch does.
+    target = settings_dir or _ui_fixtures.SETTINGS_DIR
+    setattr(  # noqa: B010
+        start_settings, "_settings_path", lambda: target / "start.json"
+    )
+    # Only start_combined_server sets this, and we deliberately don't use it.
+    utils.NO_INPUT_MODE = True
+
+
+@contextmanager
+def ui_session(
+    *,
+    viewport: dict[str, int] | None = None,
+    theme: str = "dark",
+) -> Iterator[Session]:
+    """Boot fixtures, server and browser once; yield a context to drive.
+
+    Raises :class:`_ui_fixtures.UiUnavailable` when playwright, a Chromium build,
+    ffmpeg or the fixture workbook is missing — callers decide whether that is a
+    skip or an error.
+
+    Teardown order matters and is enforced by the nesting below: the browser
+    closes before the socket does, which is what keeps the server's
+    connection-thread join from hanging (see ``_ui_server``).
+    """
+    _ui_fixtures.ensure_inputs()
+    chromium_path = _ui_browser.resolve_chromium()
+    playwright_factory = _ui_browser.sync_playwright()
+    _ui_fixtures.ensure_run_dirs()
+    redirect_config()
+
+    workbook, reason = _ui_fixtures.open_workbook()
+    if reason:
+        raise _ui_fixtures.UiUnavailable(reason)
+
+    live = _ui_server.start(workbook)
+    playwright = playwright_factory().start()
+    browser = None
+    context = None
+    try:
+        browser = playwright.chromium.launch(
+            executable_path=str(chromium_path),
+            headless=True,
+            args=_ui_browser.LAUNCH_ARGS,
+        )
+        context = new_context(browser, viewport=viewport, theme=theme)
+        yield Session(context=context, origin=live.origin)
+    finally:
+        if context is not None:
+            context.close()
+        if browser is not None:
+            browser.close()
+        playwright.stop()
+        _ui_server.stop(live)

--- a/tests/ui/_ui_states.py
+++ b/tests/ui/_ui_states.py
@@ -1,0 +1,291 @@
+"""Drive a page into a named UI state — the overlays and tabs the smoke never opens.
+
+The smoke loads six pages in their boot state and clicks nothing, so most of the
+frontend has never been rendered by anything automated: every modal, every tab
+past the default, and (since both boot paths pre-dismiss it) the entire Start
+overlay. This module is the missing half. It is a library, used by ``shot.py``
+for screenshots, by the smoke for a boot-error check, and by the dead-CSS census
+to reach rules that only match once something is open.
+
+Two kinds of state, entered two different ways, for a reason each:
+
+**Overlays — entered through the page's own public opener.** Every one of these
+is already exposed on ``window`` for the command palette to call, so there is no
+click choreography to reverse-engineer and nothing to keep in sync with a
+toolbar's markup. They close with Escape, which every page routes through the
+hotkey registry's cascade (see AGENTS.md).
+
+**Tabs — discovered at runtime, then clicked.** Deliberately *not* a hard-coded
+list. ``_ui_pages.py``'s docstring calls its per-page selector table "the part of
+this harness most likely to rot", and a static list of tab names would rot the
+same way but worse: a renamed tab turns into a confusing timeout, and a *new* tab
+is silently never covered. Instead each page declares where its tabs live and the
+state list is read off the live DOM, so adding a tab to the HTML adds a state
+here for free. Clicking is also the contract a user has — calling the page's
+internal switch function would bypass exactly the wiring worth testing.
+
+A state that cannot be reached is *reported*, never skipped silently: three of
+Studio's four sub-tabs are ``hidden`` in the static HTML and only appear once
+intake data exists, and "we covered 1 of 4" has to be visible in the output or a
+future reader will believe all four were checked.
+"""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import _ui_browser
+
+# How long to wait for a state to become visible. Generous: these are local
+# fixtures, so a miss is a real failure rather than a slow machine.
+_STATE_TIMEOUT_MS = 5_000
+# Overlays animate in (motion.js). Let the entrance settle before capture.
+_SETTLE_MS = 350
+
+
+@dataclass(frozen=True)
+class Overlay:
+    """A modal reachable from every page through a ``window`` function."""
+
+    name: str
+    # Guarded so a page that somehow lacks the opener reports "no opener"
+    # instead of throwing an opaque TypeError from page.evaluate.
+    probe: str
+    enter: str
+    ready: str
+
+
+GLOBAL_OVERLAYS: tuple[Overlay, ...] = (
+    Overlay(
+        name="settings",
+        probe="typeof window.openSettingsModal === 'function'",
+        enter="window.openSettingsModal({ initialTab: 'General' })",
+        ready=".settings-overlay:not(.hidden)",
+    ),
+    Overlay(
+        name="settings-hotkeys",
+        probe="typeof window.openSettingsModal === 'function'",
+        enter="window.openSettingsModal({ initialTab: 'Hotkeys' })",
+        ready=".settings-overlay:not(.hidden)",
+    ),
+    Overlay(
+        name="cheatsheet",
+        probe="!!(window.ClipgenHotkeys && window.ClipgenHotkeys.toggleCheatsheet)",
+        enter="window.ClipgenHotkeys.toggleCheatsheet()",
+        ready=".hk-overlay:not(.hidden)",
+    ),
+    Overlay(
+        name="palette",
+        probe="!!(window.ClipgenCommandPalette && window.ClipgenCommandPalette.open)",
+        enter="window.ClipgenCommandPalette.open()",
+        ready=".cmdp-overlay:not(.hidden)",
+    ),
+    Overlay(
+        name="start",
+        probe="!!(window.ClipgenStartOverlay && window.ClipgenStartOverlay.open)",
+        enter="window.ClipgenStartOverlay.open()",
+        ready="#startOverlay:not(.hidden)",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class TabGroup:
+    """Where one page keeps a row of tabs, and what names its states."""
+
+    prefix: str
+    selector: str
+    attr: str
+
+
+# Workflows is absent on purpose: it has no tab row.
+PAGE_TABS: dict[str, tuple[TabGroup, ...]] = {
+    "studio": (TabGroup("tab", ".preview-tab", "data-tab"),),
+    "overview": (TabGroup("tab", ".preview-tab", "data-tab"),),
+    "transcripts": (TabGroup("tab", ".panel-tab", "data-tab"),),
+    "composer": (TabGroup("tab", ".co-panel-tab", "data-tab"),),
+    "screenspace": (
+        TabGroup("tool", ".wf-tab", "data-type"),
+        TabGroup("pane", ".rp-tab", "data-tab"),
+    ),
+}
+
+
+@dataclass
+class StateResult:
+    """What happened when we tried to reach one state."""
+
+    name: str
+    reached: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class TabState:
+    """One tab button found in the live DOM."""
+
+    name: str
+    selector: str
+    visible: bool
+
+
+def state_names(page_name: str) -> list[str]:
+    """The states this page *declares*, without booting anything.
+
+    Tab states are discovered live, so this is only the overlay list plus a
+    ``tool:``/``tab:`` hint — enough for ``--help`` and argument validation.
+    """
+    return [overlay.name for overlay in GLOBAL_OVERLAYS] + [
+        f"{group.prefix}:<name>" for group in PAGE_TABS.get(page_name, ())
+    ]
+
+
+def discover_tabs(page: Any, page_name: str) -> list[TabState]:
+    """Read this page's tab states off the live DOM.
+
+    Records visibility rather than filtering on it. A tab can be in the markup
+    but not on screen for two very different reasons, and only the caller can
+    tell them apart: Studio's intake tabs unhide once intake data exists, while
+    Screenspace's 13 ``.wf-tab``s are hidden *by design* whenever the grouped
+    category nav is on — that mode keeps them in the DOM and drives them with
+    ``.click()``. See :func:`enter_tab`.
+    """
+    found: list[TabState] = []
+    for group in PAGE_TABS.get(page_name, ()):
+        rows = page.evaluate(
+            """(sel) => Array.from(document.querySelectorAll(sel.selector)).map(
+                (el) => ({
+                    key: el.getAttribute(sel.attr),
+                    visible: !!(el.offsetParent || el.getClientRects().length),
+                })
+            )""",
+            {"selector": group.selector, "attr": group.attr},
+        )
+        for row in rows:
+            key = row.get("key")
+            if not key:
+                continue
+            found.append(
+                TabState(
+                    name=f"{group.prefix}:{key}",
+                    selector=f'{group.selector}[{group.attr}="{key}"]',
+                    visible=bool(row.get("visible")),
+                )
+            )
+    return found
+
+
+def _wait(page: Any, selector: str) -> str:
+    """Wait for ``selector``; return "" on success or the timeout's first line."""
+    try:
+        page.wait_for_selector(selector, state="visible", timeout=_STATE_TIMEOUT_MS)
+    except _ui_browser.playwright_error() as exc:
+        return str(exc).splitlines()[0]
+    return ""
+
+
+def enter_overlay(page: Any, overlay: Overlay) -> StateResult:
+    """Open one overlay through its public opener, leaving it open."""
+    if not page.evaluate(f"() => {overlay.probe}"):
+        return StateResult(overlay.name, False, "page exposes no opener")
+    try:
+        page.evaluate(f"() => {{ {overlay.enter}; }}")
+    except _ui_browser.playwright_error() as exc:
+        return StateResult(overlay.name, False, str(exc).splitlines()[0])
+    problem = _wait(page, overlay.ready)
+    if problem:
+        return StateResult(overlay.name, False, problem)
+    page.wait_for_timeout(_SETTLE_MS)
+    return StateResult(overlay.name, True)
+
+
+def close_overlay(page: Any, overlay: Overlay) -> None:
+    """Dismiss via Escape, falling back to a reload.
+
+    Escape is the documented cascade on every page, but it is also the one thing
+    a page is allowed to intercept for its own purposes. If the overlay is still
+    up afterwards the next state would be captured through it, so reload rather
+    than trust the keystroke.
+    """
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(_SETTLE_MS)
+    if page.locator(overlay.ready).count():
+        page.reload(wait_until="domcontentloaded")
+        page.wait_for_timeout(_SETTLE_MS)
+
+
+def enter_tab(page: Any, tab: TabState) -> StateResult:
+    """Activate one discovered tab, by real click where that is possible.
+
+    A visible tab gets a Playwright click — the actual user gesture, including
+    its actionability checks. A tab that is present but hidden falls back to a
+    DOM ``.click()``, which is not a shortcut around the UI so much as the same
+    path the UI itself takes: Screenspace's grouped category nav hides the flat
+    ``.wf-tab`` row and drives it by delegating to each tab's ``.click()``
+    (screenspace.css:1401-1410). Reaching those 13 tool panels is what puts the
+    largest block of ``screenspace.css`` in front of the census at all.
+
+    The distinction is recorded in ``detail`` rather than smoothed over, because
+    "clicked" and "dispatched a click at a hidden node" are not the same claim.
+    """
+    if tab.visible:
+        try:
+            page.locator(tab.selector).first.click(timeout=_STATE_TIMEOUT_MS)
+        except _ui_browser.playwright_error() as exc:
+            return StateResult(tab.name, False, str(exc).splitlines()[0])
+        page.wait_for_timeout(_SETTLE_MS)
+        return StateResult(tab.name, True)
+
+    clicked = page.evaluate(
+        """(selector) => {
+            const el = document.querySelector(selector);
+            if (!el) return false;
+            el.click();
+            return true;
+        }""",
+        tab.selector,
+    )
+    if not clicked:
+        return StateResult(tab.name, False, "not in the DOM")
+    page.wait_for_timeout(_SETTLE_MS)
+    return StateResult(tab.name, True, "hidden; activated via DOM click")
+
+
+def enter_named(page: Any, page_name: str, name: str) -> StateResult:
+    """Drive into one state by name, resolving overlays and tabs alike.
+
+    Tab names are matched against what the page actually renders, so an
+    unreachable one reports the states that *were* available rather than a bare
+    timeout — the difference between "you typed the wrong name" and "this tab is
+    empty in the fixture".
+    """
+    for overlay in GLOBAL_OVERLAYS:
+        if overlay.name == name:
+            return enter_overlay(page, overlay)
+
+    discovered = discover_tabs(page, page_name)
+    for tab in discovered:
+        if tab.name == name:
+            return enter_tab(page, tab)
+
+    available = ", ".join(
+        [overlay.name for overlay in GLOBAL_OVERLAYS] + [t.name for t in discovered]
+    )
+    return StateResult(name, False, f"unknown state; this page has: {available}")
+
+
+def each_state(page: Any, page_name: str) -> Iterator[StateResult]:
+    """Walk every reachable state on an already-loaded page.
+
+    Yields with the page *in* that state, so the caller can screenshot or probe
+    before control returns. Tabs run first because they are mutually exclusive
+    and need no teardown; overlays run last, each closed before the next opens.
+    """
+    for tab in discover_tabs(page, page_name):
+        yield enter_tab(page, tab)
+
+    for overlay in GLOBAL_OVERLAYS:
+        result = enter_overlay(page, overlay)
+        yield result
+        if result.reached:
+            close_overlay(page, overlay)

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -23,6 +23,7 @@ import pytest
 import _ui_browser
 import _ui_fixtures
 import _ui_server
+import _ui_session
 import config
 import start_settings
 import utils
@@ -71,7 +72,11 @@ def live_server(ui_env: None) -> Iterator[_ui_server.LiveServer]:
 
 @pytest.fixture(scope="session")
 def browser_context(live_server: _ui_server.LiveServer) -> Iterator[Any]:
-    """A Chromium context with the blocking start overlay pre-dismissed."""
+    """A Chromium context with the blocking start overlay pre-dismissed.
+
+    The context arguments live in ``_ui_session.new_context`` so this fixture and
+    ``shot.py`` cannot drift apart again — they had already, on locale/timezone.
+    """
     try:
         playwright = _ui_browser.sync_playwright()().start()
     except _ui_fixtures.UiUnavailable as exc:
@@ -84,15 +89,7 @@ def browser_context(live_server: _ui_server.LiveServer) -> Iterator[Any]:
             headless=True,
             args=_ui_browser.LAUNCH_ARGS,
         )
-        context = browser.new_context(
-            viewport={"width": 1600, "height": 1000}, device_scale_factor=1
-        )
-        # shouldAutoOpen() checks this key before anything else, and it is the
-        # only suppression that works uniformly across all six pages.
-        context.add_init_script(
-            "try { sessionStorage.setItem('clipgen.startOverlayDismissed', '1'); }"
-            " catch (e) {}"
-        )
+        context = _ui_session.new_context(browser)
         yield context
     except _ui_fixtures.UiUnavailable as exc:
         pytest.skip(str(exc))

--- a/tests/ui/shot.py
+++ b/tests/ui/shot.py
@@ -9,9 +9,14 @@ computed styles, count rendered nodes, dump ``state``, call
 
     uv run --extra ui python tests/ui/shot.py studio
     uv run --extra ui python tests/ui/shot.py studio --selector "#sheetGrid"
+    uv run --extra ui python tests/ui/shot.py studio --theme light
     uv run --extra ui python tests/ui/shot.py transcripts \
         --eval "return document.querySelectorAll('.pill-wrap').length"
     uv run --extra ui python tests/ui/shot.py overview --eval-file /tmp/probe.js --wait 2000
+
+``--theme light`` is worth reaching for: light is a shipped feature reachable from
+every page's theme toggle, and until it was added here nothing in the harness had
+ever rendered it.
 
 Not a test: ``norecursedirs = ui`` plus the non-``test_`` filename keep pytest
 away from it. The JS it runs only ever reaches a loopback server serving
@@ -30,10 +35,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "source"))
 import _ui_browser
 import _ui_fixtures
 import _ui_pages
-import _ui_server
-import config
-import start_settings
-import utils
+import _ui_session
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -63,6 +65,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--viewport", default="1600x1000", help="Viewport size, e.g. 1280x800."
     )
+    parser.add_argument(
+        "--theme",
+        choices=_ui_session.THEMES,
+        default="dark",
+        help="Boot the page in this theme. Light is a shipped feature the "
+        "harness otherwise never renders.",
+    )
     return parser.parse_args(argv)
 
 
@@ -91,73 +100,29 @@ def main(argv: list[str] | None = None) -> int:
     out = args.out or (_ui_fixtures.SHOT_DIR / f"{args.page}.png")
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    try:
-        _ui_fixtures.ensure_inputs()
-        chromium_path = _ui_browser.resolve_chromium()
-        playwright_factory = _ui_browser.sync_playwright()
-    except _ui_fixtures.UiUnavailable as exc:
-        print(exc, file=sys.stderr)
-        return 1
-    _ui_fixtures.ensure_run_dirs()
-
-    # Same config redirection the pytest fixtures do, minus the monkeypatch: this
-    # is a one-shot process, so plain assignment is enough.
-    config.INPUT_DIR = str(_ui_fixtures.INPUT_DIR)
-    config.OUTPUT_DIR = str(_ui_fixtures.OUTPUT_DIR)
-    # Keep stdout to the screenshot path and the --eval result; sheet-loading
-    # chatter would bury both.
-    config.VERBOSITY = config.QUIET
-    # Redirect the Start-overlay settings file, or build_combined_app's
-    # record_project_session would prepend these fixture dirs to the real
-    # "Recently opened" rail. setattr rather than plain assignment because the
-    # attribute's declared type is the original function; this is the same
-    # rebinding monkeypatch does in tests/ui/conftest.py.
-    setattr(  # noqa: B010
-        start_settings,
-        "_settings_path",
-        lambda: _ui_fixtures.SETTINGS_DIR / "start.json",
-    )
-    utils.NO_INPUT_MODE = True
-
-    workbook, reason = _ui_fixtures.open_workbook()
-    if reason:
-        print(reason, file=sys.stderr)
-        return 1
-
     log = _ui_pages.PageLog()
     result: Any = None
     eval_error: str | None = None
-    live = _ui_server.start(workbook)
-    playwright = playwright_factory().start()
     try:
-        browser = playwright.chromium.launch(
-            executable_path=str(chromium_path),
-            headless=True,
-            args=_ui_browser.LAUNCH_ARGS,
-        )
-        context = browser.new_context(viewport=viewport, device_scale_factor=1)
-        context.add_init_script(
-            "try { sessionStorage.setItem('clipgen.startOverlayDismissed', '1'); }"
-            " catch (e) {}"
-        )
-        page = context.new_page()
-        _ui_pages.wire_listeners(page, log)
-        try:
-            _ui_pages.open_and_settle(page, live.origin, args.page, log, args.wait)
-            if body:
-                try:
-                    result = page.evaluate(f"() => {{ {body} }}")
-                except _ui_browser.playwright_error() as exc:
-                    # A throwing snippet is a normal outcome when probing, not a
-                    # harness crash. Report the JS error, keep the screenshot.
-                    eval_error = str(exc).splitlines()[0]
-        finally:
-            _capture(page, args, out)
-        context.close()
-        browser.close()
-    finally:
-        playwright.stop()
-        _ui_server.stop(live)
+        with _ui_session.ui_session(viewport=viewport, theme=args.theme) as session:
+            page = session.context.new_page()
+            _ui_pages.wire_listeners(page, log)
+            try:
+                _ui_pages.open_and_settle(
+                    page, session.origin, args.page, log, args.wait
+                )
+                if body:
+                    try:
+                        result = page.evaluate(f"() => {{ {body} }}")
+                    except _ui_browser.playwright_error() as exc:
+                        # A throwing snippet is a normal outcome when probing, not
+                        # a harness crash. Report the JS error, keep the screenshot.
+                        eval_error = str(exc).splitlines()[0]
+            finally:
+                _capture(page, args, out)
+    except _ui_fixtures.UiUnavailable as exc:
+        print(exc, file=sys.stderr)
+        return 1
 
     print(f"screenshot: {out.resolve()}")
     if body and eval_error is None:

--- a/tests/ui/shot.py
+++ b/tests/ui/shot.py
@@ -10,13 +10,17 @@ computed styles, count rendered nodes, dump ``state``, call
     uv run --extra ui python tests/ui/shot.py studio
     uv run --extra ui python tests/ui/shot.py studio --selector "#sheetGrid"
     uv run --extra ui python tests/ui/shot.py studio --theme light
+    uv run --extra ui python tests/ui/shot.py studio --state settings
+    uv run --extra ui python tests/ui/shot.py screenspace --all-states
     uv run --extra ui python tests/ui/shot.py transcripts \
         --eval "return document.querySelectorAll('.pill-wrap').length"
     uv run --extra ui python tests/ui/shot.py overview --eval-file /tmp/probe.js --wait 2000
 
 ``--theme light`` is worth reaching for: light is a shipped feature reachable from
 every page's theme toggle, and until it was added here nothing in the harness had
-ever rendered it.
+ever rendered it. ``--state`` and ``--all-states`` (see ``_ui_states``) reach the
+modals and tabs the six-page smoke never opens — ``--all-states`` drives them all
+from a single boot, which is the one thing looping this script cannot do.
 
 Not a test: ``norecursedirs = ui`` plus the non-``test_`` filename keep pytest
 away from it. The JS it runs only ever reaches a loopback server serving
@@ -36,6 +40,7 @@ import _ui_browser
 import _ui_fixtures
 import _ui_pages
 import _ui_session
+import _ui_states
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -72,6 +77,18 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Boot the page in this theme. Light is a shipped feature the "
         "harness otherwise never renders.",
     )
+    parser.add_argument(
+        "--state",
+        help="Drive into one UI state before capturing, e.g. settings, "
+        "cheatsheet, palette, start, tab:map, tool:color. Pass an unknown name "
+        "to be told which states this page has.",
+    )
+    parser.add_argument(
+        "--all-states",
+        action="store_true",
+        help="Capture every reachable state on this page from one boot, to "
+        "<page>-<state>.png. Unreachable states are reported, not skipped.",
+    )
     return parser.parse_args(argv)
 
 
@@ -103,6 +120,9 @@ def main(argv: list[str] | None = None) -> int:
     log = _ui_pages.PageLog()
     result: Any = None
     eval_error: str | None = None
+    shots: list[Path] = []
+    states: list[_ui_states.StateResult] = []
+    state_problem: str = ""
     try:
         with _ui_session.ui_session(viewport=viewport, theme=args.theme) as session:
             page = session.context.new_page()
@@ -111,6 +131,24 @@ def main(argv: list[str] | None = None) -> int:
                 _ui_pages.open_and_settle(
                     page, session.origin, args.page, log, args.wait
                 )
+                if args.all_states:
+                    # Capture the boot state too: --all-states should mean all.
+                    _capture(page, args, out)
+                    shots.append(out)
+                    for state in _ui_states.each_state(page, args.page):
+                        states.append(state)
+                        if not state.reached:
+                            continue
+                        shot = out.with_name(
+                            f"{out.stem}-{state.name.replace(':', '-')}{out.suffix}"
+                        )
+                        _capture(page, args, shot)
+                        shots.append(shot)
+                elif args.state:
+                    state = _ui_states.enter_named(page, args.page, args.state)
+                    states.append(state)
+                    if not state.reached:
+                        state_problem = state.detail
                 if body:
                     try:
                         result = page.evaluate(f"() => {{ {body} }}")
@@ -119,12 +157,21 @@ def main(argv: list[str] | None = None) -> int:
                         # a harness crash. Report the JS error, keep the screenshot.
                         eval_error = str(exc).splitlines()[0]
             finally:
-                _capture(page, args, out)
+                if not args.all_states:
+                    _capture(page, args, out)
+                    shots.append(out)
     except _ui_fixtures.UiUnavailable as exc:
         print(exc, file=sys.stderr)
         return 1
 
-    print(f"screenshot: {out.resolve()}")
+    for shot in shots:
+        print(f"screenshot: {shot.resolve()}")
+    # Report every state we tried, reached or not. A silently skipped state reads
+    # as covered, which is the failure mode this whole harness exists to avoid.
+    for state in states:
+        mark = "ok  " if state.reached else "MISS"
+        suffix = f" — {state.detail}" if state.detail else ""
+        print(f"state: {mark} {state.name}{suffix}")
     if body and eval_error is None:
         print("eval: " + json.dumps(result, ensure_ascii=False, default=str))
     if eval_error is not None:
@@ -135,7 +182,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[console]   {text}", file=sys.stderr)
     if log.timeout:
         print(f"[timeout]   {log.timeout}", file=sys.stderr)
-    return 1 if (log.fatal or eval_error is not None) else 0
+    if state_problem:
+        print(f"state failed: {state_problem}", file=sys.stderr)
+    # An explicitly requested --state that could not be reached is a failure; an
+    # unreachable state during --all-states is reported above and is not, since
+    # some states legitimately do not exist in this fixture.
+    return 1 if (log.fatal or eval_error is not None or state_problem) else 0
 
 
 if __name__ == "__main__":

--- a/tests/ui/test_ui_smoke.py
+++ b/tests/ui/test_ui_smoke.py
@@ -29,10 +29,17 @@ if os.environ.get("CLIPGEN_UI_CHECK") != "1":
 
 import _ui_fixtures
 import _ui_pages
+import _ui_states
 from _ui_pages import PAGES, PageLog
 from _ui_server import LiveServer
 
 pytestmark = pytest.mark.ui
+
+# Which page to open the shared overlays on. They are page-agnostic code
+# (settings-modal.js, hotkeys.js, command-palette.js, start-overlay.js, all
+# loaded by every hub), so opening them on all six would run the same files six
+# times for the same assertion. Studio boots the most page code around them.
+_OVERLAY_HOST = "studio"
 
 
 @pytest.mark.parametrize("name", sorted(PAGES))
@@ -57,6 +64,46 @@ def test_page_loads_without_errors(
 
     assert not log.fatal, _ui_pages.format_failure(
         name, log, str(shot.resolve()), str(_ui_fixtures.REPORT_PATH.resolve())
+    )
+
+
+@pytest.mark.parametrize("overlay", _ui_states.GLOBAL_OVERLAYS, ids=lambda o: o.name)
+def test_shared_overlay_opens_without_errors(
+    overlay: _ui_states.Overlay, live_server: LiveServer, browser_context: Any
+) -> None:
+    """Open each shared modal and fail on anything it throws on the way up.
+
+    The page-load smoke above clicks nothing, so every modal in the app was
+    unreachable by any automated check: a carve that broke ``openSettingsModal``
+    would ship green. Opening is where that breaks — the overlays are built lazily
+    on first open, not at boot.
+
+    Reaching the state is itself the assertion. ``enter_overlay`` waits for the
+    overlay's own visible root, so a throw during construction surfaces here as a
+    failure to appear, with the ``pageerror`` that caused it reported alongside.
+    """
+    log = PageLog()
+    shot = _ui_fixtures.SHOT_DIR / f"{_OVERLAY_HOST}-{overlay.name}.png"
+    page = browser_context.new_page()
+    _ui_pages.wire_listeners(page, log)
+    try:
+        _ui_pages.open_and_settle(page, live_server.origin, _OVERLAY_HOST, log)
+        result = _ui_states.enter_overlay(page, overlay)
+        try:
+            page.screenshot(path=str(shot), full_page=True)
+        except Exception as exc:  # pragma: no cover - capture is best-effort
+            log.console_errors.append(f"screenshot failed: {exc}")
+    finally:
+        page.close()
+
+    assert result.reached, (
+        f"{overlay.name} did not open on {_OVERLAY_HOST}: {result.detail}\n"
+        + _ui_pages.format_failure(
+            overlay.name, log, str(shot), str(_ui_fixtures.REPORT_PATH)
+        )
+    )
+    assert not log.fatal, _ui_pages.format_failure(
+        overlay.name, log, str(shot), str(_ui_fixtures.REPORT_PATH)
     )
 
 


### PR DESCRIPTION
## Summary

The headless harness loaded six pages in their boot state, dark theme, clicking nothing — so every modal, every tab past the default, and the whole Start overlay were unreachable by any automated check. This teaches it to drive ~58 named states across the six pages, and fixes the six real defects that capability immediately surfaced.

- **`tests/ui/_ui_session.py`** — one browser-context factory shared by `conftest.py` and `shot.py`, which had already drifted on locale/timezone, plus a single-boot session so one tool can drive all six pages without restarting the server.
- **`tests/ui/_ui_states.py`** and `shot.py --state / --all-states / --theme` — overlays open through the same `window` openers the command palette already calls; tab states are discovered from the live DOM rather than hard-coded, so a tab added to the HTML becomes a covered state for free.
- **Six undefined custom properties fixed.** Two were dropping declarations outright (`--color-text-muted`, `--color-surface-hover` ×4 — no color, no hover background); `--color-warning` had Screenspace rendering warnings in `#f59e0b` while every medium-severity chip elsewhere used `#fbbf24`.
- **Three new gates** — undefined custom properties, unreferenced JS functions (5 of 2,056, seeded as a ratchet), and shared-modal open errors.

Deferred deliberately: the CSS dead-selector ratchet. A static scan yields ~26 false positives from runtime class construction (`"task-card-" + status`), so it needs the runtime census as ground truth before it can gate anything.

## Test plan

- [x] `/check` — ruff format + lint, ty, 1,932 tests green
- [x] `/ui-check` — 11 tests (6 pages + 5 overlays), screenshots reviewed
- [x] Each new gate verified by a negative control before landing: an injected undefined property, and a `ReferenceError` injected into `openSettingsModal`
- [x] `--all-states` driven by hand across studio / screenspace / composer / overview; `--theme light` rendered and reviewed
- [ ] The amber shift (`#f59e0b` → `#fbbf24`) on Screenspace's fast-scan toggle and task badge is a real visual change. Worth a glance against Studio's **Medium** severity chip, which it should now match — that match is the point of the change.
- [ ] The fast-scan Results-panel label uses the same token but was confirmed by reading CSS, not by a screenshot; it needs a completed fast scan to render.
