### PR TITLE
docs(plans): archive the desktop packaging plan and audit the perf plan

### DIFF
--- a/agents/skills/build/SKILL.md
+++ b/agents/skills/build/SKILL.md
@@ -156,6 +156,7 @@ Plus: measure startup (above); DMG round-trip preserves exec bit + symlinks + si
 ## Related
 
 - [agents/skills/check/SKILL.md](../check/SKILL.md) — the pre-commit gate
-- [plans/DESKTOP-PACKAGING-PLAN.md](../../../plans/DESKTOP-PACKAGING-PLAN.md) — how the current
-  shape was arrived at, including the deferred ffmpeg-bundling decision and its GPL implications
+- [plans/archive/DESKTOP-PACKAGING-PLAN.md](../../../plans/archive/DESKTOP-PACKAGING-PLAN.md) — how
+  the current shape was arrived at, including the deferred ffmpeg-bundling decision and its GPL
+  implications
 - [desktop.py](../../../source/desktop.py) — the window host and its two JS bridges

--- a/clipgen.py
+++ b/clipgen.py
@@ -9,7 +9,7 @@ Two details here are important:
 
 * The path is **absolute and resolved**. `cli.main` calls
   `os.chdir(get_runtime_working_dir())` early on, and many first-party imports
-  are deferred until after that point. 
+  are deferred until after that point.
 * The insert is **skipped when frozen**. A PyInstaller bundle has no `source/`
   next to the executable — the modules live in its archive — so the entry would
   point at a directory that does not exist.

--- a/plans/PERFORMANCE-PLAN-3.md
+++ b/plans/PERFORMANCE-PLAN-3.md
@@ -10,18 +10,23 @@ This is a thorough review of where clipgen can gain performance — real speedup
 
 ## Status
 
-| # | Item | PR type | Effort | Status |
-|---|------|---------|--------|--------|
-| 1 | Parallel ffprobe loops | feat | S | ☐ |
-| 2 | SSE-primary / poller-fallback fix | fix | S | ☐ |
-| 3 | Titlecard concat-demuxer stream copy | feat | L | ☐ |
-| 4 | Ollama model prewarm during transcription | feat | S–M | ☐ |
-| 5 | Bounded frame-0 preload (Screenspace) | feat | S | ☐ |
-| 6 | Hardware video encoding (VideoToolbox) | feat | M | ☐ |
-| 7 | Skeleton coverage for initial loads | feat | S | ☐ |
-| 8 | Small backlog (each optional, S) | mixed | S | ☐ |
+Status audited against the tree on 2026-07-29 (the table had drifted — every item still read
+☐ although #3 and three of #8's sub-items had landed). Evidence column records what the audit
+actually found, so a future pass can re-verify cheaply rather than re-grepping from scratch.
 
-Recommended landing order = table order: #1 lands `video.py` groundwork before #3 touches the same file; #6 lands after #3 so the encode call-site list is stable.
+| # | Item | PR type | Effort | Status | Evidence |
+|---|------|---------|--------|--------|----------|
+| 1 | Parallel ffprobe loops | feat | S | ☐ | `video.py:2168` still a sequential list comprehension; `video.py:1395` still a sequential fold; no `_parallel_map_ordered` in `video.py` (it exists in `pipeline.py:711` — that is the pattern to copy, not evidence of landing) |
+| 2 | SSE-primary / poller-fallback fix | fix | S | ☐ | `screenspace-tasks.js:1224` — `startSSE()` still passes no `onUnsupported`, and `onOpen` still has no `stopPolling()` |
+| 3 | Titlecard concat-demuxer stream copy | feat | L | ☑ | `video.py:2480` `concat_copy`; `titlecards.py:72` `_body_is_copy_safe` + dispatch at `:640`; `agents/PERFORMANCE.md:36` rewritten. Landed with deviations — see "Item 3 follow-ups" below |
+| 4 | Ollama model prewarm during transcription | feat | S–M | ☐ | no `prewarm_model`, `on_task_start`, or `OLLAMA_PREWARM_ENABLED` anywhere in the repo (the `prewarm` hits in `transcripts_server.py` are the pre-existing Whisper prewarm) |
+| 5 | Bounded frame-0 preload (Screenspace) | feat | S | ☐ | `screenspace.js:5031` still an unbounded `forEach`, and `pickId` is still computed *below* it |
+| 6 | Hardware video encoding (VideoToolbox) | feat | M | ☐ | zero `videotoolbox` hits outside `plans/`; `libx264` still hardcoded at `video.py:2026/2076/2354/2442` |
+| 7 | Skeleton coverage for initial loads | feat | S | ☐ | `transcripts.html:51` still ships a literal `No participants`; `:170` `#transcriptEmpty` has no `hidden`; `workflows.html:138/142` unseeded; no `.pill-skeleton` |
+| 8 | Small backlog (each optional, S) | mixed | S | ◑ | 8a/8c/8e landed via their own PRs; 8b open (retargeted); 8d half open, half superseded — see the per-bullet markers in the Item 8 section |
+
+Recommended landing order for what remains: #1 lands `video.py` groundwork; #6 lands after #3
+(done) so the encode call-site list is stable.
 
 ---
 
@@ -58,6 +63,29 @@ The acknowledged future win in `agents/PERFORMANCE.md`: `wrap_clip_with_cards()`
 - **Config**: `TITLECARD_FAST_WRAP: bool = True` near `TITLECARD_ENCODE_PRESET` + `SETTINGS_DESCRIPTIONS` entry; *not* in `STUDIO_SETTINGS` (debugging escape hatch). Update the `agents/PERFORMANCE.md` knob table and its "(A future win …)" sentence in the same PR.
 - **Tests** (`tests/test_titlecards.py`, `tests/test_video_commands.py`): probe extension; fast path asserts final command uses `-f concat`+`-c copy` with no `-filter_complex` and card commands carry the matched flags; fallback triggers (concat rc≠0, duration mismatch, hevc ineligible); endcard cache keys per spec; `concat_stream_copy` unit test.
 - **Risks**: mismatched SPS/PPS gives garbled playback without an ffmpeg error — mitigated by matching at encode time (gates), not just the duration check. AAC priming tick at joins — same artifact reels already accept. Homebrew drawtext caveat unchanged (`check_drawtext_support()` stays authoritative).
+
+### Item 3 follow-ups (shipped, but not as written above)
+
+The speedup works and is covered by five tests (`tests/test_titlecards.py:307–460`), so these are
+**optional hardening, not regressions**. Recorded because the item text above no longer describes
+the code — read this before building on it.
+
+- Helper is `video.concat_copy` (`video.py:2480`), not `concat_stream_copy`, and the planned reuse
+  did not happen: `_concatenate_demuxer` (`video.py:2388`) still builds its own concat-copy
+  command. The two share only `_concat_list_file` (`video.py:481`).
+- **No `TITLECARD_FAST_WRAP` knob.** The fast path is unconditional whenever the body is
+  copy-safe, so there is no escape hatch if some source shape corrupts. The most worthwhile
+  follow-up of the five.
+- **No post-concat duration verification.** `concat_copy` calls `verify_output_file` only
+  (`video.py:2526`); `expected_duration_sec` feeds progress reporting, not validation.
+- Eligibility gates are narrower than specified. `_body_is_copy_safe` (`titlecards.py:72`) checks
+  h264 + yuv420p + fps > 0 + aac but **not** even dimensions, `fps <= 120`, or
+  `profile in baseline/main/high`; `profile`/`level` were never added to the probe
+  (`video.py:1472`), and pix_fmt is hardcoded in `_x264_video_args` (`titlecards.py:49`) rather
+  than matched. Combined with the missing duration check, the "garbled playback with no ffmpeg
+  error" risk noted above is guarded at encode time only.
+- No standalone `concat_copy` unit test — it is exercised only indirectly through the titlecards
+  tests.
 
 ## Item 4 — Ollama model prewarm during transcription — perceived win
 
@@ -104,11 +132,11 @@ Studio sheet (`populateSheetSkeleton`, studio.js:1082) and the Screenspace frame
 
 ## Item 8 — Small backlog (optional; verified but low individual impact)
 
-- **Lazy `import gspread`** in clipgen.py:21 → first Google-Sheets use. Measured: gspread is ~200ms of the ~260ms module import (`-X importtime`); Excel-only and `--help` flows never need it. `fix:`/`perf:`-class change; check `ty` on the deferred-import pattern.
-- **TTL cache for `google_api.get_all_spreadsheets`** (server.py:3411, 3498): module-level list + timestamp, ~300s TTL, refresh param — settings opens stop paying a Sheets round-trip (and its 429 backoff risk).
-- **Transcripts segment list**: `renderSegments()` (transcripts.js:812–896) rebuilds one big innerHTML string per render. Cheap wins: `content-visibility: auto` (+ `contain-intrinsic-size`) on segment rows in transcripts.css; preserve scroll position across rebuilds. Virtualize only if profiling shows >2000-segment sessions hurting.
-- **Gate always-on pollers**: transcripts xref poller (transcripts.js:119, 30s) could start lazily on first xref use; Studio's four intake pollers (studio.js:4409–4413, 5–10s) could pause while the intake panel isn't the active tab (`createPoller` only gates on `document.hidden`).
-- **`decoding="async"`** on dynamically created thumbnails/imgs (queue cards, results) — trivial, prevents main-thread decode jank.
+- **8a ☑ Lazy `import gspread`** in clipgen.py:21 → first Google-Sheets use. Measured: gspread is ~200ms of the ~260ms module import (`-X importtime`); Excel-only and `--help` flows never need it. `fix:`/`perf:`-class change; check `ty` on the deferred-import pattern. **Landed** via `2f84d24b` (#563) rather than an Item-8 packet: `clipgen.py` imports only `sys`/`pathlib`, and `cli.py` defers gspread into function bodies (`cli.py:884/911/934/956`).
+- **8b ☐ TTL cache for `google_api.get_all_spreadsheets`** (server.py:3411, 3498): module-level list + timestamp, ~300s TTL, refresh param — settings opens stop paying a Sheets round-trip (and its 429 backoff risk). **Retarget before building**: `a609844b` (#618) moved the picker route to the richer `get_all_spreadsheet_meta` (it needs `modifiedTime`), so today the two sites are `server.py:3239` (`get_all_spreadsheets`) and `server.py:3497` (`get_all_spreadsheet_meta`). Cache the *meta* call — `get_all_spreadsheets` (`google_api.py:114`) is just the name-only wrapper over it.
+- **8c ◑ Transcripts segment list**: `renderSegments()` (transcripts.js:812–896) rebuilds one big innerHTML string per render. Cheap wins: `content-visibility: auto` (+ `contain-intrinsic-size`) on segment rows in transcripts.css; preserve scroll position across rebuilds. Virtualize only if profiling shows >2000-segment sessions hurting. **CSS half landed** via `0c9716bd` (#560): `transcripts.css:1233` carries both properties, with a comment on the `auto` fallback for `scrollToSegment()`'s rect math. The scroll-preservation half is unverified — still open.
+- **8d ◑ Gate always-on pollers**: transcripts xref poller (transcripts.js:119, 30s) could start lazily on first xref use — **still open**, it starts eagerly at boot (`transcripts.js:2733` → `:110` → `:125`, gated on backend availability, not on first xref use). Studio's intake pollers — **superseded, treat as wontfix**: there are now three (endpoints were combined per-domain), they carry `{ maxIntervalMs: 30000 }` idle backoff which removes most of the cost, and `studio.js:4786-4791` documents a deliberate decision to poll regardless of visible sub-tab so the start-overlay pills and sub-tab badges stay fresh.
+- **8e ☑ `decoding="async"`** on dynamically created thumbnails/imgs (queue cards, results) — trivial, prevents main-thread decode jank. **Landed** across ~18 sites including both the plan named (`screenspace-results.js:652/764`, `studio.js:2591`). The remaining misses are `new Image()` preload/measure objects that never enter the DOM, where the attribute is a no-op.
 - **Studio grid filter re-render** (studio.js:1432 region): known deferred item (PERF-PLAN-2 §4.1), still gated on profiling — profile before building incremental filtering.
 
 ## Rejected findings (verified against code — do not re-propose)

--- a/plans/archive/DESKTOP-PACKAGING-PLAN.md
+++ b/plans/archive/DESKTOP-PACKAGING-PLAN.md
@@ -6,7 +6,19 @@ Phase 2 is a build-system migration that needs a Windows CI run to verify.
 
 ---
 
-# Phase 1 — Finder-launched app exits immediately (BLOCKING)
+# Phase 1 — Finder-launched app exits immediately (BLOCKING) — ✅ DONE
+
+Landed in `cb607168` (#638): `utils.augment_path_for_gui_launch()` (`source/utils.py:534`, called
+from `source/cli.py:3768` ahead of both abortable steps), `utils.fatal_startup_error()` +
+`_show_native_alert()` (`source/utils.py:558-597` — `osascript … display alert … as critical` on
+darwin, `MessageBoxW` on Windows), both enumerated hard exits routed through it
+(`source/utils.py:609`, `source/video.py:121`, the latter carrying the `brew install ffmpeg`
+guidance from `_ffmpeg_install_guidance_lines()`), and the three PATH tests at
+`tests/test_cli_args.py:851-891`.
+
+One deliberate deviation from the text below: the directories are **appended**, not prepended —
+see `source/utils.py:545-547`, which argues discoverability over overriding the user's own
+resolution order.
 
 ## The bug
 
@@ -206,3 +218,25 @@ onedir a bundled ffmpeg is a real file at a stable path that can be signed indiv
 visibly user-replaceable — the strongest form of the arm's-length GPL argument. Under one-file it
 would be extracted to temp on every launch, adding ~80 MB to a startup cost we are trying to
 remove.
+
+---
+
+## Open follow-ups
+
+Both phases are implemented, so this plan is archived. Three things it did not close, kept here
+so they are findable rather than lost:
+
+1. **One silent-exit path survives.** `utils.validate_runtime_directories()` has a *second* hard
+   exit — the output-dir `mkdir` failure at `source/utils.py:624-633` — which still uses
+   `error_print` + `SystemExit(1)` instead of `fatal_startup_error()`. It falls outside the two
+   exits Phase 1b enumerated, but it contradicts that helper's own docstring
+   (`source/utils.py:591`: "Every hard exit reachable before the window exists must route through
+   here") and reproduces exactly the bug Phase 1b existed to kill: a windowed launch that dies
+   with nothing on screen. Cheap to fix; worth doing next time this file is open.
+2. **Windows was never verified.** Phase 2 verification step 6 (`workflow_dispatch`: zipped
+   folder unpacks and runs, `clipgen.exe --help` prints in cmd, double-click opens the window,
+   `credentials.json` beside the app folder is found) has not been run — `88b883a3`'s own commit
+   message says as much. The `get_runtime_working_dir()` onedir walk-up (`source/cli.py:862`) is
+   covered by unit tests but not by a real Windows build.
+3. **Inno Setup installer not done.** Floated in §2c as "worth considering" and never required;
+   the Windows artifact is a zipped folder (`.github/workflows/build-binaries.yml:110-118`).


### PR DESCRIPTION
## Summary

- **Unblocks CI.** `a07b1cec` left trailing whitespace in the `clipgen.py` docstring, which fails the blocking `ruff format --check` gate; stripped it.
- **Archives `DESKTOP-PACKAGING-PLAN.md`** — both phases are implemented (Phase 1 in #638, though it was never marked ✅; Phase 2 in #639), so it is marked done, moved to `plans/archive/`, and its link in `agents/skills/build/SKILL.md` repointed.
- **Audits `PERFORMANCE-PLAN-3.md`**, which is *not* complete: its table read all-unchecked although item 3 and three of item 8's sub-items had landed, so the status table is rewritten with an evidence column and items 8b/8d are retargeted against code that moved under them.
- Both plans now record what shipped differently from what they specified — item 3's missing `TITLECARD_FAST_WRAP` escape hatch and duration check, and a hard exit at `utils.py:624` that still bypasses `fatal_startup_error()`.

Docs and whitespace only; no runtime behaviour changes and no `build/VERSION` bump.

## Test plan

- [x] `ruff format --check` + `ruff check` clean (this PR is what makes the former pass again)
- [x] `uvx ty@0.0.63 check` clean — matches the CI pin
- [x] `pytest -c tests/pytest.ini` — 2359 passed
- [x] Verified every plan claim against the tree by grep before recording it as done/open
- [ ] `/ui-check` not run — nothing under `assets/web/` is touched