### PR TITLE
perf(test): make the dead-JS scan a single tokenizing pass

### DIFF
--- a/tests/test_js_dead_functions.py
+++ b/tests/test_js_dead_functions.py
@@ -23,6 +23,8 @@ deleting its entry in the same commit; adding a sixth fails ``/check``.
 """
 
 import re
+from collections import Counter
+from functools import cache
 from pathlib import Path
 
 from _frontend_source import WEB
@@ -30,6 +32,7 @@ from _frontend_source import WEB
 _TOP_LEVEL_FUNCTION = re.compile(
     r"^\s*function\s+([A-Za-z_$][\w$]*)\s*\(", re.MULTILINE
 )
+_WORD = re.compile(r"\w+")
 
 # Unreferenced as of the frontend-cleanup pass. Each is a genuine deletion
 # candidate, tracked in the plan's drawdown step rather than removed here so this
@@ -54,8 +57,22 @@ def _consumer_text() -> str:
     return "\n".join(parts)
 
 
+@cache
 def _unreferenced() -> dict[str, str]:
-    """Map each unreferenced function name to the ``file:line`` that defines it."""
+    """Map each unreferenced function name to the ``file:line`` that defines it.
+
+    Counted from a single tokenizing pass rather than one ``\\bname\\b`` scan per
+    name: the corpus is ~4 MB and there are ~2000 names, so the per-name form cost
+    69 s a call — and all three tests below call this. For a name made only of
+    ``\\w`` characters the two are equivalent by definition, since ``\\b`` on both
+    ends matches exactly when the name is a whole ``\\w+`` token. A ``$`` in a name
+    breaks that equivalence (``$`` is not a ``\\w`` character), so those keep the
+    original scan; there are none today, which is why the fast path is the one
+    worth having.
+
+    Cached because it is pure over files that cannot change mid-run, and the
+    result is a shared read-only mapping — no test mutates it.
+    """
     corpus = _consumer_text()
     definitions: dict[str, str] = {}
     for path in sorted(WEB.glob("*.js")):
@@ -64,11 +81,14 @@ def _unreferenced() -> dict[str, str]:
             line = text.count("\n", 0, match.start()) + 1
             definitions.setdefault(match.group(1), f"{path.name}:{line}")
 
-    return {
-        name: site
-        for name, site in definitions.items()
-        if len(re.findall(rf"\b{re.escape(name)}\b", corpus)) == 1
-    }
+    tokens = Counter(_WORD.findall(corpus))
+
+    def _occurrences(name: str) -> int:
+        if "$" in name:
+            return len(re.findall(rf"\b{re.escape(name)}\b", corpus))
+        return tokens[name]
+
+    return {name: site for name, site in definitions.items() if _occurrences(name) == 1}
 
 
 def test_no_new_unreferenced_functions():


### PR DESCRIPTION
## Summary

`test_js_dead_functions` took the CI smoke job from **52s to 565s** when it landed in #645 — 91% of the job wall clock in one file. `_unreferenced()` ran one `\bname\b` regex over the whole ~4 MB consumer corpus per candidate name (~2000 of them, 69s a call), and all three tests in the file called it uncached; it now tokenizes the corpus once into a `Counter` and looks each name up, with the result `@cache`d so the three tests share one pass. Equivalent by construction — for a name of only `\w` characters, `\b` on both ends matches exactly when the name is a whole `\w+` token — and a `$` in a name would break that, so those keep the original scan (there are none today). No tests dropped, no coverage change.

## Test plan

- [x] Equivalence verified empirically before switching: per-name counts agree for **all 2056 names**, not just at the `==1` threshold, and the same 5 dead functions are found.
- [x] Detector mutation-tested — appending a dead function to `utils.js` still fails with the correct `file:line`.
- [x] `/check` green: ruff format + check, `ty`, full suite (2378 passed).
- [x] Exact CI invocation (`-n auto --randomly-seed=20240601 --cov=.`): 2378 passed in ~10s, coverage 78.42% vs. the 60% gate.
- [x] Profiled the rest of the suite (next-slowest test 6.8s) and audited the other twelve frontend source-scanning tests — no other instance of this pattern.
- Timings: the file goes **205s → 0.29s** locally; no UI surface touched, so `/ui-check` not applicable.