### PR TITLE
perf(test): halve the CI test step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,15 @@ jobs:
         # -n auto parallelizes across cores (each xdist worker is a separate
         # process, so module-level server globals stay isolated). The fixed
         # --randomly-seed keeps the shuffled order reproducible run-to-run.
+        env:
+          # Measure coverage through PEP 669 sys.monitoring instead of the
+          # sys.settrace-based C tracer. Same numbers (verified identical: 20377
+          # statements, 4397 missed, 78.42%) for roughly a quarter of the
+          # overhead, because the interpreter stops calling back on every line.
+          # Needs Python 3.12+ and coverage 7.4+; both are pinned above. If a
+          # future coverage release regresses this, dropping the var is the whole
+          # rollback — it only selects a measurement backend.
+          COVERAGE_CORE: sysmon
         run: >-
           uv run --no-sync pytest -c tests/pytest.ini
           -n auto --randomly-seed=20240601 --cov=. --cov-report=term

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -277,8 +277,14 @@ class TestGenerate:
 
         resp = MagicMock()
         resp.readline.side_effect = _readline_blocking
-        # When close() is called, unblock the readline so the worker exits.
-        resp.close.side_effect = lambda: block_event.set()
+        # Unblock on the socket shutdown, which is what actually frees a blocked
+        # read in production: _shutdown_response_socket documents that it must
+        # NOT call resp.close() (that races the blocked reader), so hanging the
+        # release off close() left the watcher unable to wake us and the test
+        # only ever finished by letting the 2 s timeout above expire — 2 s of
+        # wall clock, and the cancel path never actually proved it can interrupt
+        # a read. Releasing on shutdown() exercises the real mechanism.
+        resp.fp.raw._sock.shutdown.side_effect = lambda *a: block_event.set()
         mock_urlopen.return_value = resp
 
         evt = threading.Event()
@@ -292,6 +298,11 @@ class TestGenerate:
             block_event.set()  # safety net
         assert result is None
         assert resp.close.called
+        # Pin the interrupt mechanism itself. Without this the test still passes
+        # when the watcher never reaches the socket: readline just falls through
+        # its own timeout and generate() returns None because the cancel event is
+        # set. That would be a 2 s test asserting nothing about cancellation.
+        assert resp.fp.raw._sock.shutdown.called
 
     @patch("ollama_client.urllib.request.urlopen")
     def test_no_cancel_event_works_normally(self, mock_urlopen):
@@ -468,9 +479,12 @@ class TestAutoStartServer:
     @patch("ollama_client.subprocess.Popen")
     @patch("ollama_client.is_available")
     def test_start_server_polls_until_available(
-        self, mock_avail, mock_popen, mock_which
+        self, mock_avail, mock_popen, mock_which, monkeypatch
     ):
         """_start_server polls is_available until it returns True."""
+        # What is under test is the poll *loop*, not the production 0.5 s spacing
+        # between attempts — leaving it real just slept through two intervals.
+        monkeypatch.setattr(ollama_client, "_START_POLL_INTERVAL", 0)
         mock_avail.side_effect = [False, False, True]
         assert ollama_client._start_server() is True
         assert mock_avail.call_count == 3

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -3624,6 +3624,7 @@ def test_api_generate_persists_artifacts_after_disconnect(
     in the manifest. Validates that _extend_generated_artifacts moved into the
     per-clip worker."""
     import threading
+    import time
     import types
 
     monkeypatch.setattr(server, "_worksheet", object())
@@ -3648,17 +3649,24 @@ def test_api_generate_persists_artifacts_after_disconnect(
     )
 
     started_count = [0]
+    finished_count = [0]
     started_lock = threading.Lock()
-    proceed = threading.Event()
+
+    # Hold each worker long enough that the disconnect below lands while the
+    # second pool batch is still in flight. It has to be a plain sleep, not a
+    # wait-for-signal: post() does not return until the *first* batch finishes,
+    # and resp.close() then blocks draining the pool, so there is no point on the
+    # test thread from which the first batch could ever be released. This was a
+    # `proceed.wait(timeout=2)` paired with a `proceed.set()` after close() —
+    # every one of the four workers provably timed out instead, the set() was
+    # unreachable, and the test paid 2 batches x 2 s. The in-flight assertion
+    # after close() is what keeps this constant honest if it is ever too short.
+    HOLD_SECONDS = 0.15
 
     def fake_process_clips(clip_list, **kwargs):
         with started_lock:
             started_count[0] += 1
-        # Block briefly so the client has time to disconnect while futures are
-        # mid-flight. The thread-pool's shutdown(wait=True) will keep us alive.
-        # resp.close() blocks on this drain, so the timeout bounds the test's
-        # wall time; the disconnect is already registered when close() starts.
-        proceed.wait(timeout=2)
+        time.sleep(HOLD_SECONDS)
         clip = clip_list[0]
         artifact = {
             "id": f"a{clip['cell'].row}",
@@ -3667,6 +3675,8 @@ def test_api_generate_persists_artifacts_after_disconnect(
             "cellRow": clip["cell"].row,
             "cellCol": clip["cell"].col,
         }
+        with started_lock:
+            finished_count[0] += 1
         return (1, [artifact])
 
     monkeypatch.setattr("pipeline.process_clips", fake_process_clips)
@@ -3678,14 +3688,21 @@ def test_api_generate_persists_artifacts_after_disconnect(
             "format": "clip",
         },
     )
-    # Werkzeug's test client iterates the streaming body in the background,
-    # so the worker pool has already started by the time post() returns.
-    # Wait for at least two workers to be in flight, then disconnect.
+    # post() returns once the first pool batch has drained and the next one has
+    # been submitted, so some worker is always mid-flight here.
     assert _poll_until(lambda: started_count[0] >= 2)
+    with started_lock:
+        in_flight_at_disconnect = started_count[0] - finished_count[0]
     resp.close()
-    # Release the workers; shutdown(wait=True) lets them all finish + persist.
-    proceed.set()
 
+    # The whole point of the test is that a worker still running at disconnect
+    # gets its artifact persisted. If HOLD_SECONDS is ever cut so fine that every
+    # worker has already finished by now, the row assertion below would still pass
+    # while proving nothing — so fail loudly on that instead.
+    assert in_flight_at_disconnect >= 1, (
+        "no worker was still in flight when the client disconnected; "
+        f"raise HOLD_SECONDS ({started_count[0]} started, {finished_count[0]} done)"
+    )
     assert _poll_until(lambda: server._generate_in_progress is False)
     persisted_rows = {a["cellRow"] for a in server._generated_artifacts}
     assert persisted_rows == {5, 6, 7, 8}
@@ -3901,26 +3918,27 @@ def test_api_generate_explicit_cancel_still_works(client, monkeypatch, tmp_path)
 
     started = threading.Event()
 
-    def slow_clip(clip_list, **kwargs):
+    def one_clip(clip_list, **kwargs):
         started.set()
         cancel_flag = kwargs.get("cancel_flag")
-        # Busy-loop long enough for the test to post a cancel mid-run, but no
-        # longer than needed (cancellation is detected between clips / at the
-        # stream level, so this bounds the test's wall time).
-        for _ in range(150):
-            if cancel_flag and cancel_flag():
-                return (0, [])
-            threading.Event().wait(0.01)
+        if cancel_flag and cancel_flag():
+            return (0, [])
         return (1, [{"id": "a", "type": "clip", "file": "x.mp4"}])
 
-    monkeypatch.setattr("pipeline.process_clips", slow_clip)
+    monkeypatch.setattr("pipeline.process_clips", one_clip)
     server._generate_cancel_event.clear()
 
     resp = client.post(
         "/studio/api/generate", json={"cells": ["P01.5", "P01.6"], "format": "clip"}
     )
-    # The streaming body is iterated by Werkzeug in the background, so the
-    # first clip's process_clips call is already running.
+    # `client.post` does not run the stream in the background: it returns having
+    # buffered the first cell's chunk, and `resp.data` below drains the rest. So
+    # the cancel is posted between the two cells by program order, and the route
+    # sees it when it checks between clips — no timing window to hit. This used to
+    # spin a 150 x 10 ms busy-loop here to "post a cancel mid-run"; the cancel
+    # provably landed only after that loop finished, so the 2 s bought nothing.
+    # If Werkzeug ever drained both cells inside post(), the `cancelled`
+    # assertion below fails loudly rather than passing vacuously.
     assert started.wait(timeout=5)
 
     cancel_resp = client.post("/studio/api/generate/cancel")


### PR DESCRIPTION
## Summary

Cuts the smoke-tests pytest step by roughly half, via two independent changes kept in separate commits so either can be reverted alone.

- **`COVERAGE_CORE=sysmon`** (`ci:`) — measures coverage through PEP 669 `sys.monitoring` instead of the `sys.settrace` C tracer, removing ~70% of the instrumentation cost **without touching the gate**. Verified equivalent rather than assumed: both backends report exactly 20377 statements, 4397 missed, 78.42%.
- **Three tests were blocked on waits that provably never fired** (`perf(test):`) — 8.1s of the 29.2s serial runtime. In `test_api_generate_persists_artifacts_after_disconnect` the `proceed.set()` was unreachable (`post()` only returns after the first batch finishes, and `close()` then blocks draining the pool) and a trace showed all four workers timing out; `test_cancel_event_during_stream_aborts` released the blocked read from `resp.close()`, which `_shutdown_response_socket` documents it must *not* call, so cancellation was never actually exercised; and `test_api_generate_explicit_cancel_still_works` spun a 150×10ms loop to post a cancel "mid-run" that provably landed afterwards. Each is now released by the real mechanism, and each carries a new assertion so it fails loudly instead of silently going slow or vacuous.

- **`agents/skills/test-perf/SKILL.md`** (`docs(skills):`) — captures the diagnose-and-fix loop so this does not recur: measure with `--durations` twice, a per-category budget, the four patterns found here, and the step that matters most — after shortening a wait, assert the window really held and break it to prove the assertion fires. Linked from `skills/README.md`, the `test` skill, and AGENTS.md.

No tests dropped, coverage unchanged.

## Test plan

- [x] `/check` green: ruff format + lint, `ty`, full suite — 2378 passed.
- [x] Coverage identical under both backends (20377 / 4397 / 78.42%) on the real CI invocation; Python 3.12.13 locally matches CI's pinned 3.12.
- [x] Both new guards mutation-tested: at `HOLD_SECONDS=0` the in-flight assertion fires ("4 started, 4 done"); the ollama test now pins that `sock.shutdown` was reached.
- [x] Flake-checked: 8 consecutive runs of the two studio tests, plus 3 full randomized-order runs (`pytest-randomly` default seed), all clean.
- [x] Measured best-of-2, full suite: serial 29.2s → 21.1s; `-n 4` 12.1s → 6.7s; `-n 4` + coverage (CI shape) 16.1s → 8.1s.
- [x] Observed on CI (run 30525142957, all checks green): pytest step **56s -> 34s**, smoke-tests job **71s -> 47s**. My 3.5x-factor projection of ~28s was optimistic; the real runner factor is closer to 4.2x.