### PR TITLE
fix(transcripts): surface empty citation/friction results, unstall the chain

### DIFF
--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -88,7 +88,17 @@
         state.citationsGenerating = false;
         renderCitations();
       },
-      onEmpty: function () { _clearCitationsStatus(); },
+      onEmpty: function () {
+        // The poll only runs while a citations run is in flight, and the route
+        // 404s (which apiGet rejects) once that run ends without persisting —
+        // after find_citations' failure return, the Ollama-unavailable path.
+        // Either way the run is over with nothing to show, so say so instead of
+        // just dropping "Finding sources…". Cause is a suggestion, not a claim:
+        // a transport blip lands here too, and the fix is the same. Navigating
+        // away and the poll timeout go to onStale, which stays silent.
+        state.citationsGenerating = false;
+        _renderCitationsNote("Couldn't find sources. Check that Ollama is running, then re-run citations.");
+      },
       onStale: function () { _clearCitationsStatus(); },
     },
     friction: {
@@ -493,9 +503,11 @@
 
     if (!state.summaryCitations) return;
 
+    var dataRefs = 0;
     var refNum = 1;
     for (var i = 0; i < state.summaryCitations.length; i++) {
       var cite = state.summaryCitations[i];
+      dataRefs += (cite.refs || []).length;
       if (!cite.refs || cite.refs.length === 0) continue;
       var el = qs('#summaryContent [data-cite-index="' + i + '"]');
       if (!el) continue;
@@ -516,6 +528,29 @@
         refNum++;
       }
     }
+
+    // Rendering nothing is itself a result: say so, rather than leaving the
+    // panel looking like citations never ran. dataRefs separates "the model
+    // found no supporting segments" from "it found some, but renderSummary's
+    // sentence split didn't line up with the backend's" \u2014 the two splits are
+    // independent implementations, and that mismatch is otherwise silent.
+    if (refNum === 1) {
+      _renderCitationsNote(dataRefs === 0
+        ? "No supporting segments found for this summary."
+        : "Sources were found but couldn't be matched to the summary text. Re-run citations.");
+    }
+  }
+
+  // Terminal one-line status in the summary panel (nothing found / run failed).
+  // Shares .citations-status with the in-flight "Finding sources\u2026" line, minus
+  // its elapsed clock and Cancel button.
+  function _renderCitationsNote(text) {
+    var existing = qs("#summaryContent .citations-status");
+    if (existing) existing.remove();
+    var p = document.createElement("p");
+    p.className = "citations-status";
+    p.textContent = text;
+    qs("#summaryContent").appendChild(p);
   }
 
   // startedAtMs (optional): server-recorded run start in epoch ms \u2014 seeds the
@@ -866,6 +901,12 @@
       } else if (fd.stale) {
         statusEl.textContent = "Stale: segments edited since last run" +
           (fd.model ? " · " + fd.model : "");
+      } else if (!(fd.moments && fd.moments.length)) {
+        // A completed run that surfaced nothing. Without this the header reads
+        // like any successful run and the only hint is the jump strip's one
+        // italic line, well below the fold of the eye.
+        statusEl.textContent = "No friction moments found · computed " +
+          _friendlyTimeAgo(fd.computed_at) + (fd.model ? " · " + fd.model : "");
       } else {
         statusEl.textContent = "Computed " + _friendlyTimeAgo(fd.computed_at) +
           (fd.model ? " · " + fd.model : "");
@@ -1028,11 +1069,14 @@
     // numbering and the set of inline callouts can't drift apart.
     var visible = [];
     var cited = {};
+    var unsourced = 0;
     var all = (fd && fd.moments) || [];
     for (i = 0; i < all.length; i++) {
       if (!_frictionMomentMatches(all[i])) continue;
       var idxs = _momentSegmentIndices(all[i]);
-      if (idxs.length === 0) continue; // unsourced moment: nothing to quote or seek to
+      // Unsourced moment: nothing to quote or seek to. Counted, not just
+      // dropped, so the empty strip can name this cause instead of the filter.
+      if (idxs.length === 0) { unsourced++; continue; }
       visible.push({ moment: all[i], idxs: idxs });
       for (j = 0; j < idxs.length; j++) {
         var seg = state.segments[idxs[j]];
@@ -1041,6 +1085,7 @@
     }
     state.frictionVisibleMoments = visible;
     state.frictionCitedBySegId = cited;
+    state.frictionUnsourcedMoments = unsourced;
   }
 
   // The single entry point for "the filter changed": recompute, then reflect it
@@ -1412,8 +1457,14 @@
         : "Run Summary to surface AI-refined friction moments.";
     }
     if (fd.llm_ok === false) return "Moment detection failed. Re-run with an installed Ollama model.";
-    if (fd.moments && fd.moments.length) return "No moments match the current filter.";
-    return "No moments detected.";
+    if (!(fd.moments && fd.moments.length)) return "No friction moments found in this transcript.";
+    // Moments exist but none reached the strip. Either the filter excluded them
+    // all, or they cite segments that are gone — different causes, different
+    // fixes, so don't blame the filter for both.
+    if (state.frictionUnsourcedMoments) {
+      return "Moments found, but the segments they cite are no longer in the transcript. Re-run friction.";
+    }
+    return "No moments match the current filter.";
   }
 
   function renderFrictionJumpStrip() {

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -89,13 +89,16 @@
         renderCitations();
       },
       onEmpty: function () {
-        // The poll only runs while a citations run is in flight, and the route
-        // 404s (which apiGet rejects) once that run ends without persisting —
-        // after find_citations' failure return, the Ollama-unavailable path.
-        // Either way the run is over with nothing to show, so say so instead of
-        // just dropping "Finding sources…". Cause is a suggestion, not a claim:
-        // a transport blip lands here too, and the fix is the same. Navigating
-        // away and the poll timeout go to onStale, which stays silent.
+        // Cancel clears the flag (via _clearCitationsStatus) but cannot recall a
+        // GET already on the wire, so that response still lands here — stay
+        // silent, a deliberate abort is not a failure.
+        if (!state.citationsGenerating) return;
+        // Otherwise the run is genuinely over with nothing to show: the route
+        // 404s (which apiGet rejects) once it ends without persisting — after
+        // find_citations' failure return, the Ollama-unavailable path. Say so
+        // instead of just dropping "Finding sources…". The cause is a
+        // suggestion, not a claim: a transport blip lands here too, and the fix
+        // is the same. Participant switch and poll timeout go to onStale.
         state.citationsGenerating = false;
         _renderCitationsNote("Couldn't find sources. Check that Ollama is running, then re-run citations.");
       },
@@ -264,6 +267,11 @@
     var ver = state.participantReqVer;
     apiGet(AGENT_DESCRIPTORS.citations.urlBase + "/" + pid).then(function (data) {
       if (ver !== state.participantReqVer || state.selectedParticipant !== pid) return;
+      // A run may have started while this GET was in flight (Regenerate, or the
+      // chain reaching citations). Restoring the old result now would replace
+      // the live "Finding sources…" line — renderCitations() removes it — with
+      // superscripts the run is about to supersede.
+      if (state.citationsGenerating) return;
       if (!data.ok || !data.citations) return;
       state.summaryCitations = data.citations;
       renderCitations();

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -981,9 +981,19 @@
   }
 
   function renderFrictionGenerating() {
-    qs("#frictionContent").classList.add("hidden");
+    // Keep the programmatic scores on screen while the agent runs. They come
+    // from the deterministic scorer, are already computed, and are independent
+    // of the LLM — blanking the pane costs the user the histogram, chips and
+    // transcript tinting for the whole run, and the agent only ever *adds*
+    // moments on top. The standalone box is for when there is nothing yet.
+    var hasData = !!state.frictionData;
+    qs("#frictionContent").classList.toggle("hidden", !hasData);
     qs("#frictionEmpty").classList.add("hidden");
-    qs("#frictionGenerating").classList.remove("hidden");
+    qs("#frictionGenerating").classList.toggle("hidden", hasData);
+    if (hasData) {
+      renderFrictionHistogram();
+      applyFrictionDecorations();
+    }
     _renderFrictionHeader();
   }
 
@@ -1471,6 +1481,10 @@
 
   function _frictionJumpEmptyText() {
     var fd = state.frictionData;
+    // The pane now stays up during a run (renderFrictionGenerating), so the
+    // strip has to speak for the in-flight case too — otherwise it advertises
+    // the Run button that is currently mid-run.
+    if (state.frictionGenerating) return "Analyzing friction…";
     if (!fd) return "No moments detected.";
     if (fd.deterministic) {
       return _frictionDepMet()

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -227,9 +227,9 @@
   }
 
   // Summary landed (via initial load OR the fallback poll's onResult hook):
-  // render it, then — if citations are still generating server-side — surface
-  // their status and start the citations poll. Shared so the loader and the
-  // poll stay in lockstep (the summary poll's descriptor onResult delegates here).
+  // render it, then attach citations — still generating (surface the status and
+  // poll), or already stored (fetch them). Shared so the loader and the poll
+  // stay in lockstep (the summary poll's descriptor onResult delegates here).
   function _onSummaryResult(pid, data) {
     // Clear any citation state carried over from a previous participant before
     // rendering — renderSummary() reapplies state.summaryCitations, so stale
@@ -249,7 +249,28 @@
       );
       _startCitationsPoll(pid);
       _refreshAgentStateNow();
+    } else {
+      _loadStoredCitations(pid);
     }
+  }
+
+  // The summary response carries citations' *status* but not their payload (the
+  // generic agent GET returns only its own manifest field, and inlining the
+  // dependents would put the whole friction blob on the 1.2s summary poll). So
+  // a settled load has to ask for them separately, or every loadSummary —
+  // participant switch, tab refocus, post-cancel re-sync — would render the
+  // summary with its superscripts permanently stripped.
+  function _loadStoredCitations(pid) {
+    var ver = state.participantReqVer;
+    apiGet(AGENT_DESCRIPTORS.citations.urlBase + "/" + pid).then(function (data) {
+      if (ver !== state.participantReqVer || state.selectedParticipant !== pid) return;
+      if (!data.ok || !data.citations) return;
+      state.summaryCitations = data.citations;
+      renderCitations();
+    }).catch(function () {
+      // 404 = citations never ran (or are disabled). Not a failed run, so stay
+      // quiet — the poll's onEmpty owns the "a run just ended empty" message.
+    });
   }
 
   // Open the SSE token stream for a generating summary. Falls back to the GET

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -66,6 +66,10 @@
     frictionMatchBySegId: {},
     frictionVisibleMoments: [],
     frictionCitedBySegId: {},
+    // Moments that passed the filter but cite segment ids absent from
+    // state.segments (transcript edited since the run). Counted alongside the
+    // three maps above so the jump strip can say *why* it came out empty.
+    frictionUnsourcedMoments: 0,
     frictionMomentIndex: -1,
     transcribePrewarm: "queue_open",
     modelStatus: null,

--- a/source/thinking_agents.py
+++ b/source/thinking_agents.py
@@ -26,7 +26,7 @@ import re
 import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 import config
 import friction
@@ -378,23 +378,74 @@ def _run_citations(
 _MAX_FRICTION_SUMMARY_CHARS = 2000  # cap summary context fed to the friction prompt
 
 
+def _extract_json_objects(text: str) -> list[dict[str, Any]]:
+    """Decode every top-level ``{...}`` chunk in *text*, skipping broken ones.
+
+    The salvage path for a model that emits an array with one malformed entry:
+    scanning brace-balanced spans recovers the entries that *are* valid instead
+    of losing the whole response to a single stray character. Braces inside
+    strings are ignored so a rationale containing one can't unbalance the scan.
+    """
+    decoder = json.JSONDecoder()
+    objects: list[dict[str, Any]] = []
+    depth = 0
+    start = -1
+    in_string = False
+    escaped = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}" and depth > 0:
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    data, _ = decoder.raw_decode(text[start : i + 1])
+                    if isinstance(data, dict):
+                        objects.append(cast(dict[str, Any], data))
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+    return objects
+
+
 def _extract_json_array(text: str) -> list[Any]:
-    """Best-effort extraction of the first JSON array from a model response.
+    """Best-effort extraction of a model response's JSON array of objects.
 
     Qwen sometimes wraps JSON in prose, ``<think>`` blocks, or markdown fences
     despite "JSON only" instructions. Strips think-blocks, tries a fenced block,
-    then scans for the first ``[`` that ``raw_decode`` can parse into a list.
-    Returns ``[]`` if nothing parses.
+    then scans for a ``[`` that ``raw_decode`` parses into a list.
+
+    Only arrays *of objects* count. The callers all want a list of moment dicts,
+    and a malformed outer array otherwise makes the scan settle on the first
+    inner array it can decode — a ``segment_ids`` value — which parses cleanly
+    into a list of strings and silently yields zero moments. When no array
+    survives, fall back to salvaging individual objects so one stray character
+    costs one entry rather than the whole response.
     """
     if not text:
         return []
     cleaned = _strip_think(text)
 
+    def _is_object_array(data: Any) -> bool:
+        return isinstance(data, list) and all(isinstance(x, dict) for x in data)
+
     fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", cleaned, re.DOTALL)
     if fence:
         try:
             data = json.loads(fence.group(1))
-            if isinstance(data, list):
+            if _is_object_array(data):
                 return data
         except json.JSONDecodeError:
             pass
@@ -404,12 +455,13 @@ def _extract_json_array(text: str) -> list[Any]:
     while start != -1:
         try:
             data, _ = decoder.raw_decode(cleaned[start:])
-            if isinstance(data, list):
+            if _is_object_array(data):
                 return data
         except json.JSONDecodeError:
             pass
         start = cleaned.find("[", start + 1)
-    return []
+
+    return list(_extract_json_objects(cleaned))
 
 
 def _format_friction_candidates(

--- a/source/thinking_agents.py
+++ b/source/thinking_agents.py
@@ -303,8 +303,10 @@ def find_citations(
     to avoid multi-chunk latency. Uses ``config.OLLAMA_SUMMARY_MODEL`` unless an
     explicit *model* override is provided. If *cancel_event* is set during the
     model call, the request is aborted and ``None`` is returned. Returns an
-    ordered list of ``{"sentence", "refs": [...]}`` dicts, or ``None`` if inputs
-    are empty or the run was cancelled.
+    ordered list of ``{"sentence", "refs": [...]}`` dicts — one entry per claim,
+    with an empty ``refs`` for claims the model found no support for — or
+    ``None`` if inputs are empty, the run was cancelled, or the model call
+    itself failed.
     """
     sentences = _split_summary_sentences(summary)
     if not sentences or not segments:
@@ -334,9 +336,15 @@ def find_citations(
         cancel_event=cancel_event,
     )
 
-    parsed: dict[int, list[dict[str, Any]]] = {}
-    if response:
-        parsed = _parse_citation_response(_strip_think(response), segments)
+    if not response:
+        # The model call itself failed (Ollama down, model missing, aborted
+        # mid-request). Returning a full list of empty refs here would persist a
+        # success-shaped result the UI cannot tell apart from "no sources
+        # exist", so report the failure and let the caller retry.
+        utils.warning_print("Citations: no response from the model")
+        return None
+
+    parsed = _parse_citation_response(_strip_think(response), segments)
 
     citations: list[dict[str, Any]] = []
     for i, sentence in enumerate(sentences):

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -1815,7 +1815,10 @@ class AgentOrchestrator:
         return True
 
     def next_eligible(
-        self, participant: str, force: bool = False
+        self,
+        participant: str,
+        force: bool = False,
+        skip: set[str] | None = None,
     ) -> thinking_agents.Agent | None:
         """Find the first agent that should run next for *participant*.
 
@@ -1823,13 +1826,20 @@ class AgentOrchestrator:
           - it is enabled (unless *force* is True — manual triggers bypass this),
           - its result is not already on the entry,
           - all of its dependencies are satisfied,
-          - it is not already running for this participant.
+          - it is not already running for this participant,
+          - its key is not in *skip*.
+
+        *skip* exists for the chain advance after a run that stored nothing: the
+        agent's field is still empty, so it would otherwise be picked again
+        immediately and loop.
         """
         with self._lock:
             entry = _manifest.get("source_transcripts", {}).get(participant)
             if not entry or not entry.get("segments"):
                 return None
             for agent in thinking_agents.AGENTS:
+                if skip and agent["key"] in skip:
+                    continue
                 if not force and not _agent_enabled(agent):
                     continue
                 if entry.get(agent["manifest_field"]):
@@ -1918,6 +1928,15 @@ class AgentOrchestrator:
                     # regenerate (e.g. Citations) would cross-trigger a disabled
                     # sibling (e.g. Friction), since they share depends_on=["summary"].
                     self.run_chain(participant, force=False)
+                else:
+                    # The run finished but stored nothing (the model call failed,
+                    # or its inputs were empty). Its field stays empty so it is
+                    # still eligible on the next chain entry — but this chain must
+                    # advance *past* it, or a sibling that does not depend on it
+                    # (friction needs only the summary) would never start. Skip
+                    # this agent for that lookup: without it next_eligible picks
+                    # the same empty field straight back and the chain spins.
+                    self.run_chain(participant, force=False, skip={agent_key})
             except Exception as exc:
                 utils.warning_print(
                     f"{agent_key} generation failed for {participant}: {exc}"
@@ -1949,14 +1968,17 @@ class AgentOrchestrator:
             self._threads[agent_key].add(t)
         t.start()
 
-    def run_chain(self, participant: str, force: bool = False) -> None:
+    def run_chain(
+        self, participant: str, force: bool = False, skip: set[str] | None = None
+    ) -> None:
         """Advance the thinking-agent chain for *participant* by one step.
 
         Starts the first eligible agent (if any). When that agent completes,
         ``run_agent`` re-enters this method to start the next step. Pass
-        *force* to bypass config enable checks for manual/UI-triggered runs.
+        *force* to bypass config enable checks for manual/UI-triggered runs, and
+        *skip* to exclude agent keys from consideration (see ``next_eligible``).
         """
-        agent = self.next_eligible(participant, force=force)
+        agent = self.next_eligible(participant, force=force, skip=skip)
         if agent is not None:
             self.run_agent(agent["key"], participant, force=force)
 

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -1851,19 +1851,32 @@ class AgentOrchestrator:
                 return agent
         return None
 
-    def run_agent(self, agent_key: str, participant: str, force: bool = False) -> None:
+    def run_agent(
+        self,
+        agent_key: str,
+        participant: str,
+        force: bool = False,
+        skip: set[str] | None = None,
+    ) -> None:
         """Spawn a daemon thread to run a single agent for *participant*.
 
         On success, the agent's result is written to the manifest and the chain
         advances to the next eligible agent. Guards against double-spawning via
         the in-flight set. Pass *force* to bypass the config enabled check
         (used by manual triggers from the UI).
+
+        *skip* carries the keys of agents that already had their turn in this
+        chain and stored nothing; it is forwarded to the next ``run_chain`` so
+        the exclusion accumulates. Without that, two agents that both fail to
+        commit take turns re-qualifying each other forever — each one's field
+        stays empty and it leaves the in-flight set when its thread ends.
         """
         agent = thinking_agents.get_agent(agent_key)
         if agent is None:
             return
         if not force and not _agent_enabled(agent):
             return
+        chain_skip = set(skip or ())
 
         cancel_event = threading.Event()
         # Atomically check-and-claim the in-flight slot so two near-simultaneous
@@ -1927,7 +1940,7 @@ class AgentOrchestrator:
                     # respect their enabled config. Otherwise a single-agent
                     # regenerate (e.g. Citations) would cross-trigger a disabled
                     # sibling (e.g. Friction), since they share depends_on=["summary"].
-                    self.run_chain(participant, force=False)
+                    self.run_chain(participant, force=False, skip=chain_skip)
                 else:
                     # The run finished but stored nothing (the model call failed,
                     # or its inputs were empty). Its field stays empty so it is
@@ -1936,11 +1949,21 @@ class AgentOrchestrator:
                     # (friction needs only the summary) would never start. Skip
                     # this agent for that lookup: without it next_eligible picks
                     # the same empty field straight back and the chain spins.
-                    self.run_chain(participant, force=False, skip={agent_key})
+                    self.run_chain(
+                        participant, force=False, skip=chain_skip | {agent_key}
+                    )
             except Exception as exc:
                 utils.warning_print(
                     f"{agent_key} generation failed for {participant}: {exc}"
                 )
+                # A raising agent stores nothing either, so the chain has to move
+                # on for the same reason as the else-branch above. Skip it after a
+                # cancel, though: Stop is not a failure to route around, and the
+                # early returns above deliberately leave the chain where it is.
+                if not cancel_event.is_set():
+                    self.run_chain(
+                        participant, force=False, skip=chain_skip | {agent_key}
+                    )
             finally:
                 with self._lock:
                     # Only clean up if the slot is still ours. A
@@ -1980,7 +2003,7 @@ class AgentOrchestrator:
         """
         agent = self.next_eligible(participant, force=force, skip=skip)
         if agent is not None:
-            self.run_agent(agent["key"], participant, force=force)
+            self.run_agent(agent["key"], participant, force=force, skip=skip)
 
 
 _orchestrator = AgentOrchestrator(_manifest_lock)

--- a/tests/test_friction_agent.py
+++ b/tests/test_friction_agent.py
@@ -39,6 +39,36 @@ class TestExtractJsonArray:
         text = '{"not": "an array"} then [{"yes": 1}]'
         assert thinking_agents._extract_json_array(text) == [{"yes": 1}]
 
+    def test_does_not_settle_on_a_nested_value_array(self):
+        """A malformed outer array must not degrade to an inner one.
+
+        Observed from qwen3.5:9b: a stray ``[`` in the second entry breaks the
+        outer array, and a scan that accepts *any* decodable list settles on
+        the first entry's ``segment_ids`` value. That parses cleanly into a
+        list of strings, so every element is dropped as a non-dict and the run
+        silently yields zero moments — the model's output looked usable.
+        """
+        text = (
+            '[{"segment_ids":["P03:9"],"category":"help_seeking",'
+            '"rationale":"Asked for help.","score":1.0},'
+            '{"segment_ids":["P03:21"],["category":"frustration",'
+            '"rationale":"Overwhelmed.","score":0.95}]}'
+        )
+        out = thinking_agents._extract_json_array(text)
+        assert out != ["P03:9"]
+        assert [m["segment_ids"] for m in out] == [["P03:9"]]
+
+    def test_salvages_valid_entries_from_a_broken_array(self):
+        # One stray character should cost one entry, not the whole response.
+        text = '[{"segment_ids":["a"],"score":0.5}, {oops}, {"segment_ids":["b"],"score":0.4}]'
+        out = thinking_agents._extract_json_array(text)
+        assert [m["segment_ids"] for m in out] == [["a"], ["b"]]
+
+    def test_salvage_tolerates_braces_inside_strings(self):
+        text = '[{"segment_ids":["a"],"rationale":"said {this} aloud"}, {broken]'
+        out = thinking_agents._extract_json_array(text)
+        assert [m["rationale"] for m in out] == ["said {this} aloud"]
+
 
 class TestParseFrictionResponse:
     def test_normalizes_and_ignores_extra_fields(self):

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -388,14 +388,23 @@ class TestFindCitations:
         assert result[1]["refs"][0]["start"] == 10
 
     @patch("thinking_agents.ollama_client.generate")
-    def test_returns_empty_refs_when_generate_fails(self, mock_generate):
+    def test_returns_none_when_generate_fails(self, mock_generate):
+        # A failed model call must not return the success sentinel: a full list
+        # of empty-ref claims is indistinguishable from "the model found no
+        # sources", so it would persist and read as a completed run.
         mock_generate.return_value = None
         segments = [{"start": 0, "end": 5, "text": "Some text"}]
-        result = thinking_agents.find_citations("A sentence.", segments)
-        # Returns citations list but with empty refs
+        assert thinking_agents.find_citations("A sentence.", segments) is None
+
+    @patch("thinking_agents.ollama_client.generate")
+    def test_returns_empty_refs_when_model_finds_no_sources(self, mock_generate):
+        # The genuine empty case still persists one entry per claim, so the UI
+        # can tell it apart from the failure above.
+        mock_generate.return_value = "1: NONE\n2: NONE"
+        segments = [{"start": 0, "end": 5, "text": "Some text"}]
+        result = thinking_agents.find_citations("First claim. Second claim.", segments)
         assert result is not None
-        assert len(result) == 1
-        assert result[0]["refs"] == []
+        assert [c["refs"] for c in result] == [[], []]
 
     @patch("thinking_agents.ollama_client.generate")
     def test_multiple_refs_per_claim(self, mock_generate):

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1265,6 +1265,62 @@ def test_friction_force_eligible_regardless_of_flag(
     assert agent is not None and agent["key"] == "friction"
 
 
+def test_next_eligible_honors_skip(tr_client, _agent_state_clean, monkeypatch):
+    """skip lets the chain advance past an agent that stored nothing.
+
+    Its manifest field is still empty, so without skip it is picked straight
+    back and the chain spins on it instead of reaching its siblings.
+    """
+    monkeypatch.setattr(config, "OLLAMA_FRICTION_ENABLED", True)
+    monkeypatch.setattr(config, "OLLAMA_CITATIONS_ENABLED", True)
+    _seed_friction_entry()  # summary present; citations + friction both pending
+
+    agent = transcripts_server._orchestrator.next_eligible("P01")
+    assert agent is not None and agent["key"] == "citations"
+
+    agent = transcripts_server._orchestrator.next_eligible("P01", skip={"citations"})
+    assert agent is not None and agent["key"] == "friction"
+
+
+def test_failed_citations_still_chains_to_friction(
+    tr_client, _agent_state_clean, monkeypatch
+):
+    """A citations run that stores nothing must not strand friction.
+
+    find_citations returns None when the model call fails, so nothing is
+    committed. Friction depends only on the summary, so the chain has to carry
+    on past the failure rather than stopping at the uncommitted step.
+    """
+    monkeypatch.setattr(config, "OLLAMA_FRICTION_ENABLED", True)
+    monkeypatch.setattr(config, "OLLAMA_CITATIONS_ENABLED", True)
+    monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
+    _seed_friction_entry()
+
+    started: list[str] = []
+    orch = transcripts_server._orchestrator
+    real_run_agent = orch.run_agent
+
+    def _spy(agent_key, participant, force=False):
+        started.append(agent_key)
+        if agent_key == "citations":
+            # Simulate the model-call failure: run for real, but with the agent's
+            # run callable returning None so nothing is committed.
+            monkeypatch.setitem(
+                thinking_agents.get_agent("citations"),  # type: ignore[arg-type]
+                "run",
+                lambda entry, cancel, on_token=None: None,
+            )
+            real_run_agent(agent_key, participant, force=force)
+
+    monkeypatch.setattr(orch, "run_agent", _spy)
+    orch.run_chain("P01")
+    _join_orchestrator_threads(orch)
+
+    assert started[0] == "citations"
+    assert "friction" in started, f"chain stalled after citations: {started}"
+    assert "citations" not in transcripts_server._manifest["source_transcripts"]["P01"]
+
+
 def test_segment_edit_marks_friction_stale(tr_client, _agent_state_clean, monkeypatch):
     monkeypatch.setattr(transcripts_server, "_schedule_persist", lambda: None)
     _seed_friction_entry(friction={"stale": False, "moments": []})

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1,6 +1,7 @@
 """Smoke tests for Transcripts Flask API (prewarm + model status)."""
 
 import threading
+import time
 from typing import cast
 
 import pytest
@@ -1300,7 +1301,7 @@ def test_failed_citations_still_chains_to_friction(
     orch = transcripts_server._orchestrator
     real_run_agent = orch.run_agent
 
-    def _spy(agent_key, participant, force=False):
+    def _spy(agent_key, participant, force=False, skip=None):
         started.append(agent_key)
         if agent_key == "citations":
             # Simulate the model-call failure: run for real, but with the agent's
@@ -1310,7 +1311,7 @@ def test_failed_citations_still_chains_to_friction(
                 "run",
                 lambda entry, cancel, on_token=None: None,
             )
-            real_run_agent(agent_key, participant, force=force)
+            real_run_agent(agent_key, participant, force=force, skip=skip)
 
     monkeypatch.setattr(orch, "run_agent", _spy)
     orch.run_chain("P01")
@@ -1319,6 +1320,98 @@ def test_failed_citations_still_chains_to_friction(
     assert started[0] == "citations"
     assert "friction" in started, f"chain stalled after citations: {started}"
     assert "citations" not in transcripts_server._manifest["source_transcripts"]["P01"]
+
+
+def test_raising_agent_still_chains_past_it(tr_client, _agent_state_clean, monkeypatch):
+    """An agent that raises stores nothing, so the chain must route around it.
+
+    Same stall as the uncommitted-result path — friction depends only on the
+    summary and would otherwise never start after a citations exception.
+    """
+    monkeypatch.setattr(config, "OLLAMA_FRICTION_ENABLED", True)
+    monkeypatch.setattr(config, "OLLAMA_CITATIONS_ENABLED", True)
+    monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
+    _seed_friction_entry()
+
+    def _boom(entry, cancel, on_token=None):
+        raise RuntimeError("model exploded")
+
+    monkeypatch.setitem(
+        thinking_agents.get_agent("citations"),  # type: ignore[arg-type]
+        "run",
+        _boom,
+    )
+
+    started: list[str] = []
+    orch = transcripts_server._orchestrator
+    real_run_agent = orch.run_agent
+
+    def _spy(agent_key, participant, force=False, skip=None):
+        started.append(agent_key)
+        real_run_agent(agent_key, participant, force=force, skip=skip)
+
+    monkeypatch.setattr(orch, "run_agent", _spy)
+    orch.run_chain("P01")
+    _join_orchestrator_threads(orch)
+
+    assert started[0] == "citations"
+    assert "friction" in started, f"chain stalled after the exception: {started}"
+
+
+def test_chain_terminates_when_every_agent_stores_nothing(
+    tr_client, _agent_state_clean, monkeypatch
+):
+    """Agents that all store nothing must not re-qualify each other forever.
+
+    Their manifest fields stay empty and each leaves the in-flight set when its
+    thread ends, so a skip set carrying only the *last* agent would let two of
+    them take turns indefinitely — one live model call per lap. The skip set
+    accumulates across the chain to make each agent run at most once.
+    """
+    monkeypatch.setattr(config, "OLLAMA_FRICTION_ENABLED", True)
+    monkeypatch.setattr(config, "OLLAMA_CITATIONS_ENABLED", True)
+    monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
+    _seed_friction_entry()
+
+    # Citations returns immediately; friction lingers. That ordering is what
+    # makes the regression deterministic rather than a race: citations' thread
+    # reaches its `finally` and frees its in-flight slot while friction is still
+    # working, so by the time friction advances the chain, citations looks
+    # eligible again (empty field, not in flight) to a skip set that only
+    # remembers friction.
+    monkeypatch.setitem(
+        thinking_agents.get_agent("citations"),  # type: ignore[arg-type]
+        "run",
+        lambda entry, cancel, on_token=None: None,
+    )
+
+    def _slow_none(entry, cancel, on_token=None):
+        # Falls off the end, i.e. returns None: "ran, stored nothing".
+        time.sleep(0.15)
+
+    monkeypatch.setitem(
+        thinking_agents.get_agent("friction"),  # type: ignore[arg-type]
+        "run",
+        _slow_none,
+    )
+
+    started: list[str] = []
+    orch = transcripts_server._orchestrator
+    real_run_agent = orch.run_agent
+
+    def _spy(agent_key, participant, force=False, skip=None):
+        started.append(agent_key)
+        # Circuit-breaker so a regression fails the assert below instead of
+        # spinning the test suite forever.
+        if len(started) > 6:
+            return
+        real_run_agent(agent_key, participant, force=force, skip=skip)
+
+    monkeypatch.setattr(orch, "run_agent", _spy)
+    orch.run_chain("P01")
+    _join_orchestrator_threads(orch)
+
+    assert started == ["citations", "friction"]
 
 
 def test_segment_edit_marks_friction_stale(tr_client, _agent_state_clean, monkeypatch):

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1086,7 +1086,10 @@ def test_citations_get_generating_includes_started_at(tr_client, _agent_state_cl
 
 def test_summary_get_includes_citations_started_at(tr_client, _agent_state_clean):
     """On a fresh load with the summary done but citations still running, the
-    citations start rides on the summary response (the only call the UI makes)."""
+    citations start rides on the summary response, so the UI can seed the
+    elapsed clock without waiting a poll interval. Only the *status* rides
+    along; a settled load fetches the payload from the citations endpoint (see
+    test_summary_get_omits_citations_payload)."""
     _seed_friction_entry()  # summary present, no citations yet
     _claim_slot("citations", "P01", 3000.0)
     resp = tr_client.get("/transcripts/api/agent/summary/P01")
@@ -1095,6 +1098,33 @@ def test_summary_get_includes_citations_started_at(tr_client, _agent_state_clean
     assert data["ok"] is True
     assert data["citations_generating"] is True
     assert data["citations_started_at"] == 3000.0
+
+
+def test_summary_get_omits_citations_payload(tr_client, _agent_state_clean):
+    """The summary response carries citations' status but not their payload —
+    the generic agent GET returns only its own manifest field, and inlining the
+    dependents would put the whole friction blob on the 1.2s summary poll.
+
+    The frontend therefore re-fetches stored citations from their own endpoint
+    after a settled summary load (_loadStoredCitations). Without that second
+    call, every loadSummary renders the summary with its superscripts stripped.
+    """
+    cites = [
+        {
+            "sentence": "A session summary.",
+            "refs": [{"start": 0.0, "end": 1.0, "segment_index": 0}],
+        }
+    ]
+    _seed_friction_entry(citations=cites)
+
+    summary = tr_client.get("/transcripts/api/agent/summary/P01").get_json()
+    assert summary["ok"] is True
+    assert summary["citations_generating"] is False
+    assert "citations" not in summary
+
+    stored = tr_client.get("/transcripts/api/agent/citations/P01").get_json()
+    assert stored["ok"] is True
+    assert stored["citations"] == cites
 
 
 def test_friction_get_generating_includes_started_at(tr_client, _agent_state_clean):


### PR DESCRIPTION
## Summary

Citations and friction could both complete while producing nothing to show, and the UI rendered zero DOM for it — indistinguishable from "never ran". Fixing that surfaced four further defects in the same path.

- **Empty results now speak.** A terminal line under the summary distinguishes "no supporting segments" from "refs found but unmatched to the summary text" (previously a silent bug — frontend and backend split sentences independently); the Friction header reports a zero-moment run, and the jump strip stops blaming the filter for moments whose cited segments are gone.
- **Friction moments were almost never returned.** Root cause was `_extract_json_array`, not the model: when the model emits a malformed array, the fallback scan accepted the first `[` decoding to *any* list — the first entry's `segment_ids` value — so every element was dropped as a non-dict while `llm_ok` stayed `True`. It now requires arrays of objects and salvages individual entries. Sampled on real data: 4/4 runs yielded 0 moments before, moments on every run after. (The prompt's `Return EXACTLY {limit}` was the other suspect; softening it to "up to" made the model return nothing 4/4, so it stays.)
- **Citations no longer vanish on reload.** The summary GET carries citations' *status* but not their payload, yet `_onSummaryResult` cleared state and only restored from `data.citations` — so any later `loadSummary` stripped the superscripts for good. Settled loads now fetch them from their own endpoint.
- **The agent chain no longer stalls.** `find_citations` returning `None` on model failure (instead of a success-shaped list of empty refs) meant nothing committed, and `run_chain` only fired on commit — stranding friction, which depends on the summary alone. The chain now advances past an agent that stores nothing *or* raises, with an accumulating skip set so two non-committing agents cannot re-qualify each other in a loop.
- **Three races closed**, plus programmatic friction scores now stay on screen while the agent runs instead of being blanked for its duration.

## Test plan

- [x] `/check` green: ruff format + lint, ty, full suite
- [x] `/ui-check` — six pages load clean, screenshots reviewed
- [x] New chain/parser tests each confirmed to **fail** without their fix; the loop test pins thread ordering so it catches the regression deterministically rather than as a race
- [x] Each new empty/error state driven in-browser via `tests/ui/shot.py --eval` and read back
- [x] End-to-end `_run_friction` against a real transcript with a live Ollama model
- [x] Browser-verifiable: the friction pane's keep-scores-visible toggle during a run — the model-install gate is destructured at page load, so the headless harness can't get past it. Worth a glance on a real run.