### PR TITLE
perf(test): build each test module's Flask app once

### DIFF
--- a/source/server.py
+++ b/source/server.py
@@ -3334,29 +3334,25 @@ def _set_cache_headers(response):
     return response
 
 
-def build_combined_app(
+def _init_combined_state(
     worksheet: Any = None,
-    default_page: str = "studio",
     gspread_client: Any = None,
-) -> Flask:
-    """Build the combined Studio + Screenspace + Transcripts + Workflows Flask app.
+) -> None:
+    """Wire every blueprint's process state for a combined-app launch.
 
-    Same setup as :func:`start_combined_server` but stops short of
-    ``app.run`` so tests (and any embedding caller) can hold the live
-    ``Flask`` instance and exercise routes via ``app.test_client()``.
+    Split out of :func:`build_combined_app` so the state wiring can be re-run on
+    its own, without also recompiling the app's ~200 Werkzeug URL rules — that
+    compilation is ~90 % of an app build, and the tests reuse one app across a
+    module while re-initialising state per test.
+
+    Order matters: ``_init_studio_state`` populates the ``_sheet_context`` /
+    ``_worksheet`` globals that every sibling initialiser below reads.
     """
     import composer_server
     import screenspace_server
     import start_settings
     import transcripts_server
     import workflows_server
-
-    combined = Flask(__name__, static_folder=None)
-    # Preserve insertion order in JSON responses. Flask defaults to sorting object
-    # keys alphabetically, which would clobber manifest-ordered data such as the
-    # region list (drag-to-reorder relies on GET /api/regions echoing manifest order).
-    assert isinstance(combined.json, DefaultJSONProvider)  # Flask's stock provider
-    combined.json.sort_keys = False
 
     _init_studio_state(worksheet)
     # Seed the meta + recent-projects rail for CLI launches that already
@@ -3372,37 +3368,24 @@ def build_combined_app(
             str(utils.get_effective_output_dir()),
             _active_sheet_meta,
         )
-    combined.register_blueprint(studio_bp, url_prefix="/studio")
 
     screenspace_server._init_screenspace_state(
         sheet_context=_sheet_context,
     )
-    combined.register_blueprint(
-        screenspace_server.screenspace_bp, url_prefix="/screenspace"
-    )
-
     transcripts_server._init_transcripts_state(
         sheet_context=_sheet_context,
     )
-    combined.register_blueprint(
-        transcripts_server.transcripts_bp, url_prefix="/transcripts"
-    )
-
     workflows_server._init_workflows_state(
         sheet_context=_sheet_context,
         worksheet=_worksheet,
     )
-    combined.register_blueprint(workflows_server.workflows_bp, url_prefix="/workflows")
-
     composer_server._init_composer_state(
         sheet_context=_sheet_context,
     )
-    combined.register_blueprint(composer_server.composer_bp, url_prefix="/composer")
 
     import overview
 
     overview.configure(observation_rows_getter=_sheet_observation_rows)
-    combined.register_blueprint(overview.overview_bp, url_prefix="/overview")
 
     # The report thinking agent reads sheet observations and transcript marks,
     # both of which live in other modules' process state — inject them the same
@@ -3414,6 +3397,44 @@ def build_combined_app(
         observation_rows_getter=_sheet_observation_rows,
         participant_marks_getter=transcripts_server.marks_for_participant,
     )
+
+
+def build_combined_app(
+    worksheet: Any = None,
+    default_page: str = "studio",
+    gspread_client: Any = None,
+) -> Flask:
+    """Build the combined Studio + Screenspace + Transcripts + Workflows Flask app.
+
+    Same setup as :func:`start_combined_server` but stops short of
+    ``app.run`` so tests (and any embedding caller) can hold the live
+    ``Flask`` instance and exercise routes via ``app.test_client()``.
+    """
+    import composer_server
+    import overview
+    import screenspace_server
+    import transcripts_server
+    import workflows_server
+
+    combined = Flask(__name__, static_folder=None)
+    # Preserve insertion order in JSON responses. Flask defaults to sorting object
+    # keys alphabetically, which would clobber manifest-ordered data such as the
+    # region list (drag-to-reorder relies on GET /api/regions echoing manifest order).
+    assert isinstance(combined.json, DefaultJSONProvider)  # Flask's stock provider
+    combined.json.sort_keys = False
+
+    _init_combined_state(worksheet, gspread_client)
+
+    combined.register_blueprint(studio_bp, url_prefix="/studio")
+    combined.register_blueprint(
+        screenspace_server.screenspace_bp, url_prefix="/screenspace"
+    )
+    combined.register_blueprint(
+        transcripts_server.transcripts_bp, url_prefix="/transcripts"
+    )
+    combined.register_blueprint(workflows_server.workflows_bp, url_prefix="/workflows")
+    combined.register_blueprint(composer_server.composer_bp, url_prefix="/composer")
+    combined.register_blueprint(overview.overview_bp, url_prefix="/overview")
 
     combined.after_request(_set_cache_headers)
 

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -19,11 +19,22 @@ import utils
 import video
 
 
-@pytest.fixture
-def co_client(tmp_path, monkeypatch):
+@pytest.fixture(scope="module")
+def co_app():
+    """The Flask app, built once for the module.
+
+    Registering the blueprint compiles ~23 Werkzeug URL rules, which dominates
+    this fixture's cost — and the app object holds no per-test state: everything
+    these tests touch lives in ``composer_server`` module globals, re-pinned per
+    test by the function-scoped ``co_client`` below.
+    """
     app = Flask(__name__)
     app.register_blueprint(composer_server.composer_bp, url_prefix="/composer")
+    return app
 
+
+@pytest.fixture
+def co_client(co_app, tmp_path, monkeypatch):
     # Seed module globals via monkeypatch so they auto-restore on teardown.
     monkeypatch.setattr(composer_server, "_manifest", composer_server._empty_manifest())
     monkeypatch.setattr(composer_server, "_input_dir", str(tmp_path))
@@ -48,7 +59,7 @@ def co_client(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(video, "get_file_duration", lambda path: 10)
 
-    with app.test_client() as c:
+    with co_app.test_client() as c:
         yield c
 
 

--- a/tests/test_desktop_chrome.py
+++ b/tests/test_desktop_chrome.py
@@ -38,6 +38,12 @@ def test_chrome_is_a_no_op_off_macos(monkeypatch):
 def test_apply_declines_a_window_without_a_native_handle(monkeypatch):
     """Backends other than cocoa never set `native`; that is not a crash."""
     monkeypatch.setattr(desktop_chrome.sys, "platform", "darwin")
+    # apply() imports AppKit before it looks at `native`, and on a real Mac that
+    # drags the whole pyobjc stack in (~2 s cold) for a branch that never touches
+    # it. Stubbing the accessor also makes the test hermetic: the `native is None`
+    # path is now exercised on Linux and macOS alike, rather than passing on Linux
+    # only because the import happens to fail first.
+    monkeypatch.setattr(desktop_chrome, "_appkit", lambda: object())
 
     class Window:
         native = None

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -386,12 +386,19 @@ def test_feature_matrix_windows_shape_and_null_policy(seeded_output_dir):
 # ---- Route smokes ----------------------------------------------------------
 
 
-@pytest.fixture
-def overview_client(seeded_output_dir):
+@pytest.fixture(scope="module")
+def overview_app():
+    """The Flask app, built once for the module — see ``client`` in
+    tests/test_screenspace_api.py for why the build is safe to share."""
     Flask = pytest.importorskip("flask").Flask
     app = Flask(__name__)
     app.register_blueprint(overview.overview_bp, url_prefix="/overview")
-    with app.test_client() as c:
+    return app
+
+
+@pytest.fixture
+def overview_client(overview_app, seeded_output_dir):
+    with overview_app.test_client() as c:
         yield c
 
 

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -14,12 +14,24 @@ import screenspace_preview
 import screenspace_server
 
 
-@pytest.fixture
-def client(tmp_path, monkeypatch):
+@pytest.fixture(scope="module")
+def ss_app():
+    """The Flask app, built once for the module.
+
+    Registering the blueprint compiles ~50 Werkzeug URL rules, which costs far
+    more than everything else this fixture pair does — and the app object itself
+    is inert: every piece of state these tests touch lives in ``screenspace_server``
+    module globals, which the function-scoped ``client`` below re-pins per test.
+    So the build is module-scoped and only the reset is per-test.
+    """
     app = Flask(__name__)
     app.json.sort_keys = False  # mirror start_combined_server: preserve manifest order
     app.register_blueprint(screenspace_server.screenspace_bp, url_prefix="/screenspace")
+    return app
 
+
+@pytest.fixture
+def client(ss_app, tmp_path, monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
     # Seed module globals via monkeypatch so they auto-restore on teardown —
     # otherwise a later test that reads these globals without the fixture would
@@ -59,7 +71,7 @@ def client(tmp_path, monkeypatch):
         ),
     )
 
-    with app.test_client() as c:
+    with ss_app.test_client() as c:
         yield c
     # Cancel any debounced manifest write armed during the test so a stray Timer
     # doesn't fire _do_persist into torn-down state after the fixture exits.

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -28,8 +28,24 @@ import server
 import start_settings
 
 
+@pytest.fixture(scope="module")
+def combined_app():
+    """The combined Flask app, built once for the module.
+
+    A build costs ~23 ms, almost all of it compiling the six blueprints' ~200
+    Werkzeug URL rules; the app object itself carries no per-test state. What it
+    *cannot* share is the process-state wiring ``build_combined_app`` also does —
+    ``conftest``'s autouse ``_reset_overview_observation_getter`` /
+    ``_reset_thinking_agents_getters`` snapshot-and-restore exactly those getters
+    around every test, so a once-only build would have its wiring torn down by
+    the first test's teardown. Hence the split: routes here, state per test in
+    ``app`` below via ``server._init_combined_state``.
+    """
+    return server.build_combined_app(worksheet=None, default_page="studio")
+
+
 @pytest.fixture
-def app(monkeypatch, tmp_path):
+def app(combined_app, monkeypatch, tmp_path):
     """Combined Flask app with the worksheet unset and dirs pinned to tmp."""
     in_dir = tmp_path / "in"
     out_dir = tmp_path / "out"
@@ -60,7 +76,12 @@ def app(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_sheet_payload_cache", None)
     monkeypatch.setattr(server, "_active_sheet_meta", None)
 
-    return server.build_combined_app(worksheet=None, default_page="studio")
+    # Re-run only the state half of the app build. The monkeypatch calls above
+    # already reset what this test file drives directly; this re-wires the
+    # cross-module getters the autouse conftest fixtures restore after each test.
+    server._init_combined_state(worksheet=None)
+
+    return combined_app
 
 
 @pytest.fixture

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -16,11 +16,22 @@ def _set_artifacts(monkeypatch, artifacts):
     server._rebuild_artifact_index()
 
 
-@pytest.fixture
-def client(monkeypatch):
+@pytest.fixture(scope="module")
+def studio_app():
+    """The Flask app, built once for the module.
+
+    Registering the blueprint compiles ~40 Werkzeug URL rules, which dominates
+    this fixture's cost — and the app object holds no per-test state: everything
+    these tests touch lives in ``server`` module globals, re-pinned per test by
+    the function-scoped ``client`` below.
+    """
     app = Flask(__name__)
     app.register_blueprint(server.studio_bp, url_prefix="/studio")
+    return app
 
+
+@pytest.fixture
+def client(studio_app, monkeypatch):
     # Default: no worksheet/context loaded (error state)
     monkeypatch.setattr(server, "_worksheet", None)
     monkeypatch.setattr(server, "_sheet_context", None)
@@ -30,7 +41,7 @@ def client(monkeypatch):
     server._release_busy("generate")
     server._release_busy("reel")
 
-    with app.test_client() as c:
+    with studio_app.test_client() as c:
         yield c
 
     server._release_busy("generate")

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -16,11 +16,22 @@ import video
 import viewer
 
 
-@pytest.fixture
-def tr_client(tmp_path, monkeypatch):
+@pytest.fixture(scope="module")
+def tr_app():
+    """The Flask app, built once for the module.
+
+    Registering the blueprint compiles ~35 Werkzeug URL rules, which dominates
+    this fixture's cost — and the app object holds no per-test state: everything
+    these tests touch lives in ``transcripts_server`` module globals, re-pinned
+    per test by the function-scoped ``tr_client`` below.
+    """
     app = Flask(__name__)
     app.register_blueprint(transcripts_server.transcripts_bp, url_prefix="/transcripts")
+    return app
 
+
+@pytest.fixture
+def tr_client(tr_app, tmp_path, monkeypatch):
     # Seed module globals via monkeypatch so they auto-restore on teardown —
     # otherwise a later test that reads these globals without the fixture would
     # inherit this test's state (matters under random ordering).
@@ -54,7 +65,7 @@ def tr_client(tmp_path, monkeypatch):
 
     monkeypatch.setattr(viewer, "load_manifest_artifacts", list)
 
-    with app.test_client() as c:
+    with tr_app.test_client() as c:
         yield c
     # Cancel any debounced manifest write armed during the test so a stray Timer
     # doesn't fire _do_persist into torn-down state after the fixture exits.
@@ -1472,18 +1483,32 @@ def test_chain_terminates_when_every_agent_stores_nothing(
         lambda entry, cancel, on_token=None: None,
     )
 
-    def _slow_none(entry, cancel, on_token=None):
+    orch = transcripts_server._orchestrator
+    saw_citations_retire: list[bool] = []
+
+    def _wait_out_citations(entry, cancel, on_token=None):
         # Falls off the end, i.e. returns None: "ran, stored nothing".
-        time.sleep(0.15)
+        #
+        # Hold friction open until citations has actually left the in-flight set
+        # — that overlap *is* the regression window, so wait on the real signal
+        # rather than sleeping a fixed span past it. run_chain fires from inside
+        # citations' `try` (transcripts_server.py:2011) while its slot is still
+        # claimed, and the `finally` (:2026) releases it a moment later, so this
+        # normally returns in well under a millisecond.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if not orch.is_generating("P01", "citations"):
+                saw_citations_retire.append(True)
+                return
+            time.sleep(0.001)
 
     monkeypatch.setitem(
         thinking_agents.get_agent("friction"),  # type: ignore[arg-type]
         "run",
-        _slow_none,
+        _wait_out_citations,
     )
 
     started: list[str] = []
-    orch = transcripts_server._orchestrator
     real_run_agent = orch.run_agent
 
     def _spy(agent_key, participant, force=False, skip=None):
@@ -1498,6 +1523,14 @@ def test_chain_terminates_when_every_agent_stores_nothing(
     orch.run_chain("P01")
     _join_orchestrator_threads(orch)
 
+    # Assert the window held before reading anything into the chain order. If
+    # friction never observed citations retire, the state this test exists to
+    # cover never occurred and `started` proves nothing about the skip set.
+    assert saw_citations_retire, (
+        "friction ran but never saw citations leave the in-flight set, so the "
+        "re-qualification window never opened; this assertion is the only thing "
+        "standing between a real regression check and a vacuous one"
+    )
     assert started == ["citations", "friction"]
 
 

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -20,11 +20,22 @@ import workflows
 import workflows_server
 
 
-@pytest.fixture
-def wf_client(tmp_path, monkeypatch):
+@pytest.fixture(scope="module")
+def wf_app():
+    """The Flask app, built once for the module.
+
+    Registering the blueprint compiles ~26 Werkzeug URL rules, which dominates
+    this fixture's cost — and the app object holds no per-test state: everything
+    these tests touch lives in ``workflows_server`` module globals, re-pinned per
+    test by the function-scoped ``wf_client`` below.
+    """
     app = Flask(__name__)
     app.register_blueprint(workflows_server.workflows_bp, url_prefix="/workflows")
+    return app
 
+
+@pytest.fixture
+def wf_client(wf_app, tmp_path, monkeypatch):
     # Seed module globals via monkeypatch so they auto-restore on teardown —
     # otherwise a later test that reads these globals without the fixture would
     # inherit this test's state (matters under random ordering).
@@ -53,7 +64,7 @@ def wf_client(tmp_path, monkeypatch):
     # Sandbox save_workflows_manifest's write into tmp (it targets the output dir).
     monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
 
-    with app.test_client() as c:
+    with wf_app.test_client() as c:
         yield c
 
 


### PR DESCRIPTION
## Summary

Every API test rebuilt its Flask app from scratch, and profiling showed ~90% of that is Werkzeug URL-rule compilation — 5.45 ms per screenspace app, 22.6 ms for the six-blueprint combined app — repeated across ~550 tests, so the build moves to a module-scoped fixture while the per-test `monkeypatch` reset stays exactly where it was (the app object carries no per-test state).

- `server.build_combined_app` interleaved state wiring with route registration, and conftest's autouse getter-restore fixtures tear that wiring down after every test, so the non-route half is now `server._init_combined_state()` for the test fixture to re-run per test — no behaviour change.
- `test_chain_terminates_when_every_agent_stores_nothing` carried a bare `time.sleep(0.15)` that was load-bearing but unasserted, and was verified vacuous (stubbing the delay out left the chain-order assertion passing); it now waits on `orch.is_generating()` going false and asserts it observed that.
- `test_apply_declines_a_window_without_a_native_handle` pinned the platform to darwin, so `apply()` imported the whole pyobjc stack (~2 s cold on macOS) before reaching the `native is None` branch under test — stubbing `_appkit` also makes it hermetic across platforms.

Full suite: **22.2 s → 17.5 s serial, 7.37 s → 6.10 s at `-n 4`**, 2524 passed.

## Test plan

- [x] `/check` green: ruff format, ruff check, ty, full suite (2524 passed)
- [x] Green serial and serial-shuffled ×3, `-n auto` shuffled ×3, and CI's exact `-n auto --randomly-seed=20240601` shape — module-scoped fixtures are precisely what breaks under shuffle, so this was the load-bearing check rather than the timings
- [x] Mutation-tested the new in-flight guard: stubbing the wait out fails the test with its intended message
- [x] Flake-checked the rewritten timing test 8×
- [ ] No UI check — no frontend files touched