### PR TITLE
chore: make Conductor worktree setup faster and portable

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,21 @@
+# Gitignored files Conductor copies from the repo root into every new worktree.
+# Takes precedence over `file_include_globs` in .conductor/settings.local.toml,
+# so the pre-existing patterns are re-listed here or they stop being copied.
+# https://conductor.build/docs/reference/worktreeinclude
+
+# Conductor's built-in default. Nothing matches it today; kept so a future
+# .env just works.
+.env*
+
+# Scratch workbook for `scripts/run.sh` (-s clipgen-test). Copied per workspace
+# on purpose: a Studio run writes to it, and the main checkout's copy must stay
+# clean. The multi-GB clipgen-test_P*.mp4 sources are deliberately NOT copied —
+# run.sh points -i at the root checkout instead.
+clipgen-test.xlsx
+
+# The PostToolUse ruff hook. Without this a worktree silently loses per-file
+# formatting, which is the single most common CI failure (see AGENTS.md).
+.claude/settings.json
+
+# Permission allowlist, so a fresh workspace doesn't re-prompt for everything.
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Source video filenames follow `{study}_{participant}.mp4` (e.g. `mystudy_P01.mp4
 ## Development tools
 
 - **uv** – Always use `uv run` instead of `python` to run scripts (e.g. `uv run clipgen.py`). This ensures the correct venv is used, including in worktrees that don't yet have a `.venv`. Use `uv add` to add dependencies.
-- **Ruff** – Linting and formatting: `uv run ruff check --fix` and `uv run ruff format`. Run these yourself. A per-file `PostToolUse` hook exists in the maintainer's main checkout, but `.gitignore` excludes `.claude/settings.json`, so it is **absent in worktrees** — unformatted Python is the most common CI failure precisely because agents assume the hook ran.
+- **Ruff** – Linting and formatting: `uv run ruff check --fix` and `uv run ruff format`. A per-file `PostToolUse` hook runs both on every edited `.py`. It lives in `.claude/settings.json`, which `.gitignore` excludes, so it reaches worktrees only by being copied — [.worktreeinclude](.worktreeinclude) lists it for exactly that reason. Still run the commands yourself before committing: the hook is per-file and absent from any checkout that did not get the copy, and unformatted Python is the most common CI failure.
 - **ty** – Use `uv run ty check` for type checking.
 
 ## SVG icons

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,4 +16,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
-exec uv run clipgen.py -i "$HOME/Projects/clipgen/" -s "clipgen-test" --desktop --studio "$@"
+
+# Media comes from the root checkout (the multi-GB clipgen-test_P*.mp4 sources
+# are shared, never copied per worktree); the workbook is the per-worktree copy
+# Conductor drops in via .worktreeinclude, resolved against cwd.
+MEDIA_DIR="${CONDUCTOR_ROOT_PATH:-$HOME/Projects/clipgen}"
+
+exec uv run clipgen.py -i "$MEDIA_DIR" -s "clipgen-test" --desktop --studio "$@"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,19 +1,33 @@
 #!/usr/bin/env sh
-# Sync the current worktree's Python venv via uv.
-# macOS only for now.
+# Sync the current worktree's Python venv via uv (Conductor `scripts.setup`).
+#
+# Nothing here downloads packages in the normal case: uv materializes .venv from
+# the shared unpacked-wheel cache (~/.cache/uv/archive-v0) and the shared
+# uv-managed interpreter, cloning files copy-on-write on APFS. A fresh worktree
+# therefore costs cache reads, not network.
 set -e
-
-case "$(uname -s)" in
-Darwin) ;;
-*)
-  echo "Unsupported OS: setup.sh is macOS-only for now." >&2
-  exit 1
-  ;;
-esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
-uv sync
+
+case "$(uname -s)" in
+Darwin)
+  # --frozen: install straight from uv.lock with no resolution pass, and fail
+  #   loudly rather than silently rewriting the lock if pyproject.toml drifted.
+  # --extra dev: front-load pytest into setup, where Conductor shows progress,
+  #   instead of the first /check. `uv run` is inexact by default, so a later
+  #   plain `uv run clipgen.py` will not strip these back out.
+  uv sync --frozen --extra dev
+  ;;
+*)
+  # Linux (Conductor cloud). uv.lock pins GPU-capable torch, so a plain
+  # `uv sync` here would pull ~2.5 GB of CUDA wheels that nothing uses. Use the
+  # cpu-only install documented in agents/CLOUD.md instead.
+  uv venv
+  uv pip install ".[dev]" --torch-backend cpu
+  ;;
+esac
+
 echo "Venv ready at $REPO_ROOT/.venv"


### PR DESCRIPTION
## Summary

Conductor worktrees already reused the shared uv wheel cache (`~/.cache/uv/archive-v0`), so setup never hit the network — but three things around that did not work.

- **`.worktreeinclude`** (new) copies `.claude/settings.json` into every new worktree. Without it each worktree silently lost the `PostToolUse` ruff hook, which `AGENTS.md` names as the cause of the most common CI failure; it also copies `.claude/settings.local.json` and re-lists the two `file_include_globs` patterns, since `.worktreeinclude` takes precedence over that setting.
- **`scripts/setup.sh`** uses `uv sync --frozen --extra dev` on macOS (installs straight from `uv.lock` with no resolution pass, and puts pytest in the setup phase rather than the first `/check`), and replaces the hard `exit 1` on non-Darwin with the cpu-only torch install from `agents/CLOUD.md` so a Linux/cloud workspace sets up instead of failing.
- **`scripts/run.sh`** takes the media directory from `CONDUCTOR_ROOT_PATH`, falling back to the previously hardcoded path when run outside Conductor.

## Test plan

- [x] `/check` green: `ruff format --check` (197 files), `ruff check`, `ty check`, 2524 tests passed in 20.9s
- [x] `sh -n` on both scripts; `scripts/setup.sh` runs clean in 38ms on an already-cached worktree
- [x] Verified `uv run` is inexact by default, so a later plain `uv run clipgen.py` does not strip the dev extras
- [ ] `.worktreeinclude` only takes effect for workspaces created after this lands on `master` — confirm a fresh workspace gets `.claude/settings.json` once merged
- [ ] Linux branch of `setup.sh` not executed (no Linux host available); it mirrors the commands already documented in `agents/CLOUD.md`