### PR TITLE
fix: start Ollama on the right route and resolve intake videos live

### DIFF
--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2700,7 +2700,7 @@
         progress.classList.remove("hidden");
         progressText.textContent = opts.state === "stopped" ? "Starting…" : "Checking…";
         var step = opts.state === "stopped"
-          ? apiPost("/api/models/ollama/start", {}).catch(function () { return null; })
+          ? apiPost("api/models/ollama/start", {}).catch(function () { return null; })
           : Promise.resolve(null);
         // Re-enabling the button and relabelling Cancel is the only way out of
         // the "Checking…" state, so it has to happen on *every* ending — a
@@ -2772,7 +2772,7 @@
             return;
           }
           progressText.textContent = "Installed. Starting Ollama…";
-          apiPost("/api/models/ollama/start", {}).catch(function () { return null; })
+          apiPost("api/models/ollama/start", {}).catch(function () { return null; })
             .then(function () {
               _trModelsCache = null;
               _trModelsCachePromise = null;

--- a/source/server.py
+++ b/source/server.py
@@ -1013,23 +1013,16 @@ def _save_manifest_quiet() -> None:
 def _resolve_intake_video_paths(participant: str, source: str = "") -> list[str]:
     """Resolve the ordered source-video path(s) for an intake participant.
 
-    Tries the source-specific participant list first, then falls back to the
-    other.  Both lists are populated from the same source videos so the
-    fallback is a safety net. Returns [] when the participant has no video.
-    A multi-video participant returns all parts (one continuous timeline).
+    Reads the live input directory (and the open sheet, when there is one)
+    rather than the Screenspace/Transcripts ``_participants`` caches. Those
+    only refresh on ``/api/participants``; ``POST /api/dirs`` and a MindNode-only
+    session never hit that route, so a generate would look at the boot-time
+    scan and report "No video for P01". ``source`` is kept for call-site
+    compatibility — both tool lists scan the same files.
     """
-    import screenspace_server
-    import transcripts_server
-
-    lists = (
-        [transcripts_server._participants, screenspace_server._participants]
-        if source == "transcript"
-        else [screenspace_server._participants, transcripts_server._participants]
-    )
-    for plist in lists:
-        for p in plist:
-            if p["id"] == participant and p.get("has_video"):
-                return list(p["video_paths"])
+    for p in files.resolve_participant_videos(_sheet_context):
+        if p["id"] == participant and p.get("has_video"):
+            return list(p["video_paths"])
     return []
 
 

--- a/tests/test_mindnode.py
+++ b/tests/test_mindnode.py
@@ -641,6 +641,34 @@ def test_document_route_404s_when_the_bundle_disappears(mn_client):
 # ---- Generation plumbing -----------------------------------------------------
 
 
+def test_intake_video_paths_follow_the_input_dir(monkeypatch, tmp_path):
+    """POST /api/dirs moves INPUT_DIR; intake must not keep a boot-time scan.
+
+    The MindNode-only Start overlay never hits /api/participants on Screenspace
+    or Transcripts, so those caches stay empty. Generating from the map would
+    then 404 every clip with "No video for P01" even though the file is there.
+    """
+    import screenspace_server
+    import transcripts_server
+    import server
+
+    boot = tmp_path / "boot"
+    boot.mkdir()
+    chosen = tmp_path / "chosen"
+    chosen.mkdir()
+    video = chosen / "study_P01.mp4"
+    video.write_bytes(b"fake")
+
+    monkeypatch.setattr(config, "INPUT_DIR", str(chosen))
+    monkeypatch.setattr(server, "_sheet_context", None)
+    # Stale caches as after boot, before anyone opens Transcripts/Screenspace.
+    monkeypatch.setattr(screenspace_server, "_participants", [])
+    monkeypatch.setattr(transcripts_server, "_participants", [])
+
+    paths = server._resolve_intake_video_paths("P01", "mindnode")
+    assert paths == [str(video)]
+
+
 def test_effective_study_falls_back_to_the_mind_map(monkeypatch):
     """With no spreadsheet, artifacts must still get a study name."""
     import server

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -767,6 +767,19 @@ def test_the_wip_badge_is_shared_not_forked():
 # ---- Transcribe All (Quick action -> batch transcription enqueue) ----
 
 
+def test_ollama_start_posts_to_the_transcripts_blueprint():
+    """A leading slash would hit GET-only /api/models on the combined app.
+
+    The start route lives on transcripts_bp as POST /transcripts/api/models/ollama/start
+    (sibling of install/pull). apiPost("/api/models/ollama/start") 404s; the
+    .catch swallows it, so after a managed install — whose silent Windows
+    installer does not auto-start the tray — Ollama never comes up and the
+    Start Ollama button is a no-op.
+    """
+    assert _JS.count('apiPost("api/models/ollama/start"') == 2
+    assert 'apiPost("/api/models/ollama/start"' not in _JS
+
+
 def test_transcribe_all_reaches_a_published_satellite_function():
     """The hub delegates to TS.transcribeParticipants, which lives in the pills
     satellite. test_frontend_satellite_wiring.py only catches *bare* cross-file


### PR DESCRIPTION
## Summary

Two user-visible 404s from the same class of stale path: a leading slash on Start Ollama, and intake clip generation reading boot-time participant caches.

- `apiPost("/api/models/ollama/start")` hit the combined app (GET-only `/api/models`); the start route lives at `/transcripts/api/models/ollama/start`. The 404 was swallowed, so a managed install never started the server.
- `_resolve_intake_video_paths` read Screenspace/Transcripts `_participants` caches that only refresh on `/api/participants`. After the Start overlay picks a folder — especially a MindNode-only session — those caches still held the empty boot-time scan, so every clip failed with "No video for P01". Intake now resolves against the live input directory.

## Test plan

- [x] `ruff format` / `ruff check` / `ty check`
- [x] `pytest` (`test_transcripts_dom_wiring`, `test_mindnode`, `test_studio_api`, full suite)
- [x] Transcripts: Download & install Ollama (or Start Ollama when installed-but-stopped) and confirm it comes up
- [x] Start overlay: pick an input folder, open a MindNode map, generate a clip — should find `{study}_P01.mp4` without visiting Transcripts/Screenspace
- ⚠️ UI not browser-checked: the Ollama change is a fetch URL (guarded by a source test); intake is server-side path resolution