### PR TITLE
fix: repair defects found auditing the last ten days of merged commits

### DIFF
--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -1860,10 +1860,46 @@
       }
       var skipSpreadsheet = state.activeTab === "none" || !state.selection;
       if (skipSpreadsheet) {
-        recordSession(inputVal, outputVal, null, nameVal).finally(function () {
-          releaseConfirm();
-          close();
-        });
+        // "No spreadsheet" has to actually close whatever is open, not just
+        // record the session. Nothing else in the UI ever posted to
+        // /api/spreadsheets/close, so a source opened earlier lived for the
+        // rest of the process — a mind map especially, since it is never
+        // cleared by opening a sheet either.
+        var st = state.statusData || {};
+        var needsClose = !!(st.sheet_loaded || st.mindnode_loaded);
+        // One call per source: the route drops the mind map for
+        // {type: "mindnode"} and the worksheet otherwise, and the two coexist,
+        // so closing both takes both calls.
+        function postClose(body) {
+          return fetch("/api/spreadsheets/close", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }).catch(function () { return null; });
+        }
+        var closeStep = Promise.resolve(null);
+        if (st.mindnode_loaded) {
+          closeStep = closeStep.then(function () {
+            return postClose({ type: "mindnode" });
+          });
+        }
+        if (st.sheet_loaded) {
+          closeStep = closeStep.then(function () { return postClose({}); });
+        }
+        closeStep
+          .then(function () {
+            return recordSession(inputVal, outputVal, null, nameVal);
+          })
+          .finally(function () {
+            releaseConfirm();
+            // Reload only when something was actually unloaded — the other
+            // frontends are holding data for a source that no longer exists.
+            if (needsClose) {
+              window.location.reload();
+              return;
+            }
+            close();
+          });
         return;
       }
       // Built explicitly rather than posting state.selection verbatim so the
@@ -2052,9 +2088,20 @@
 
   function applyCurrentSessionPrefill() {
     var s = state.statusData || {};
-    // A mind map is an independent source with no worksheet, so it is restored
-    // ahead of the spreadsheet branches and short-circuits them.
-    if (s.mindnode_loaded && s.mindnode_path) {
+    // A mind map is an independent source with no worksheet, so it gets its own
+    // branch ahead of the spreadsheet ones. Gate on active_source, NOT on
+    // mindnode_loaded: opening a mind map never clears the sheet and opening a
+    // sheet never clears the mind map (they coexist by design), so a bare
+    // mindnode_loaded check meant that once a mind map had been opened it
+    // hijacked the prefill for the rest of the session — the recents list would
+    // highlight the spreadsheet the user opened afterwards while this panel
+    // switched to the Mind map tab, and confirming re-opened the map.
+    // currentSessionKey() already keys on active_source; these must agree.
+    // An empty active_source (nothing recorded for this session yet) keeps the
+    // original precedence, so a mind-map-only launch still prefills.
+    var activeType = (s.active_source && s.active_source.type) || "";
+    var mindnodeIsActive = activeType === "mindnode" || !activeType;
+    if (mindnodeIsActive && s.mindnode_loaded && s.mindnode_path) {
       setTab("mindnode");
       setSelection({
         type: "mindnode",

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -1869,36 +1869,60 @@
         var needsClose = !!(st.sheet_loaded || st.mindnode_loaded);
         // One call per source: the route drops the mind map for
         // {type: "mindnode"} and the worksheet otherwise, and the two coexist,
-        // so closing both takes both calls.
+        // so closing both takes both calls. Each is checked for r.ok like the
+        // open path below — the route refuses with 409 while a generation is
+        // running, and swallowing that would record a no-spreadsheet session
+        // and reload with the source still very much loaded.
         function postClose(body) {
           return fetch("/api/spreadsheets/close", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(body),
-          }).catch(function () { return null; });
-        }
-        var closeStep = Promise.resolve(null);
-        if (st.mindnode_loaded) {
-          closeStep = closeStep.then(function () {
-            return postClose({ type: "mindnode" });
+          }).then(function (r) {
+            return r.json().then(
+              function (j) { return { ok: r.ok && j && j.ok !== false, body: j }; },
+              function () { return { ok: false, body: null }; }
+            );
           });
         }
+        var closeStep = Promise.resolve({ ok: true, body: null });
+        function chainClose(prev, payload) {
+          return prev.then(function (res) {
+            if (!res.ok) return res; // first failure wins; don't keep closing
+            return postClose(payload);
+          });
+        }
+        if (st.mindnode_loaded) {
+          closeStep = chainClose(closeStep, { type: "mindnode" });
+        }
         if (st.sheet_loaded) {
-          closeStep = closeStep.then(function () { return postClose({}); });
+          closeStep = chainClose(closeStep, {});
         }
         closeStep
-          .then(function () {
-            return recordSession(inputVal, outputVal, null, nameVal);
-          })
-          .finally(function () {
-            releaseConfirm();
-            // Reload only when something was actually unloaded — the other
-            // frontends are holding data for a source that no longer exists.
-            if (needsClose) {
-              window.location.reload();
-              return;
+          .then(function (res) {
+            if (!res.ok) {
+              releaseConfirm();
+              markSheetError(
+                (res.body && res.body.error) || "Could not close the current source"
+              );
+              return null;
             }
-            close();
+            return recordSession(inputVal, outputVal, null, nameVal).finally(
+              function () {
+                releaseConfirm();
+                // Reload only when something was actually unloaded — the other
+                // frontends are holding data for a source that is now gone.
+                if (needsClose) {
+                  window.location.reload();
+                  return;
+                }
+                close();
+              }
+            );
+          })
+          .catch(function (err) {
+            releaseConfirm();
+            markSheetError("Close failed: " + (err && err.message));
           });
         return;
       }

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -617,28 +617,45 @@
   // updateCellClasses highlights queued spreadsheet cells. Driven by the render
   // queue functions (so every mutation re-syncs) and the intake render functions
   // (so the highlight survives the poll that rebuilds cards).
+  // Every intake panel, not just the two that existed first: MindNode and
+  // Composer cards also carry .in-queue (and the CSS rule for it), but were
+  // never visited here, so a queued card showed no "already queued" state and
+  // clicking it again silently toggled it back out. Driven off each panel's
+  // own config so a new panel cannot be forgotten the same way.
+  function intakeCardPanels() {
+    return [
+      {
+        cardsSel: "#intakeCards",
+        cardSel: ".intake-queue-card",
+        idxAttr: "intakeIdx",
+        filtered: filteredIntakeClusters,
+        clusterToItem: screenspaceClusterToItem,
+      },
+      {
+        cardsSel: "#trIntakeCards",
+        cardSel: ".tr-intake-queue-card",
+        idxAttr: "trIntakeIdx",
+        filtered: filteredTranscriptIntakeClusters,
+        clusterToItem: transcriptClusterToItem,
+      },
+      CO_INTAKE,
+      MN_INTAKE,
+    ];
+  }
+
   function refreshIntakeCardStates() {
-    var ssClusters = filteredIntakeClusters();
-    qsa("#intakeCards .intake-queue-card").forEach(function (card) {
-      var c = ssClusters[parseInt(card.dataset.intakeIdx, 10)];
-      if (!c) return;
-      var item = screenspaceClusterToItem(c);
-      card.classList.toggle(
-        "in-queue",
-        findIntakeInQueue(state.artifactQueue, item) >= 0 ||
-          findIntakeInQueue(state.reelQueue, item) >= 0,
-      );
-    });
-    var trClusters = filteredTranscriptIntakeClusters();
-    qsa("#trIntakeCards .tr-intake-queue-card").forEach(function (card) {
-      var c = trClusters[parseInt(card.dataset.trIntakeIdx, 10)];
-      if (!c) return;
-      var item = transcriptClusterToItem(c);
-      card.classList.toggle(
-        "in-queue",
-        findIntakeInQueue(state.artifactQueue, item) >= 0 ||
-          findIntakeInQueue(state.reelQueue, item) >= 0,
-      );
+    intakeCardPanels().forEach(function (panel) {
+      var items = panel.filtered();
+      qsa(panel.cardsSel + " " + panel.cardSel).forEach(function (card) {
+        var c = items[parseInt(card.dataset[panel.idxAttr], 10)];
+        if (!c) return;
+        var item = panel.clusterToItem(c);
+        card.classList.toggle(
+          "in-queue",
+          findIntakeInQueue(state.artifactQueue, item) >= 0 ||
+            findIntakeInQueue(state.reelQueue, item) >= 0,
+        );
+      });
     });
   }
 

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2763,11 +2763,20 @@
         }, function () { return cancelled; }).then(function (installed) {
           if (cancelled) return;
           if (!installed) {
-            progressText.textContent = "Installation failed. You can install Ollama yourself:";
+            progressText.textContent = "Installation failed. Retry, or install Ollama yourself:";
             if (opts.hint && opts.hint.length) {
               hintEl.textContent = opts.hint.join("\n");
               hintEl.classList.remove("hidden");
             }
+            // Both buttons come back, same as stillUnavailable() above: hiding
+            // them left the only recovery path behind a dismiss-and-redo of
+            // the whole AI action. Retrying is safe now that the server no
+            // longer reports a broken install as already_installed.
+            progress.classList.add("hidden");
+            confirmBtn.classList.remove("hidden");
+            confirmBtn.disabled = false;
+            altBtn.classList.remove("hidden");
+            altBtn.disabled = false;
             cancelBtn.textContent = "Close";
             return;
           }

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -3245,8 +3245,30 @@
     return all.filter(function (p) { return p.id === pid; });
   }
 
+  // Container extension of a participant's first source file, lowercased.
+  function _embedSubsExt(p) {
+    var path = (p.video_paths && p.video_paths[0]) || "";
+    var dot = path.lastIndexOf(".");
+    return dot === -1 ? "" : path.slice(dot).toLowerCase();
+  }
+
+  function _embedSubsContainers() {
+    return CLIPGEN_CONFIG.subtitleContainers || { supported: [], alwaysDefault: [] };
+  }
+
+  // A container mux_subtitles has no codec for is rejected server-side at its
+  // `codec is None` guard. Filtering here for the same reason multi-part is
+  // filtered here: otherwise the summary promises "8 subtitled videos" and the
+  // run comes back with 8 failure lines.
+  function _embedSubsIsUnsupported(p) {
+    var supported = _embedSubsContainers().supported || [];
+    return supported.indexOf(_embedSubsExt(p)) === -1;
+  }
+
   function _embedSubsTargets() {
-    return _embedSubsScoped().filter(function (p) { return !_embedSubsIsMultiPart(p); });
+    return _embedSubsScoped().filter(function (p) {
+      return !_embedSubsIsMultiPart(p) && !_embedSubsIsUnsupported(p);
+    });
   }
 
   // The mp4 family always ships its subtitle track enabled — measured on ffmpeg
@@ -3254,11 +3276,10 @@
   // ISOBMFF track is enabled or absent; only .mkv/.webm have a present-but-off
   // state). Unticking the box is therefore a no-op for those files, and a
   // control that silently does nothing is worse than one that says so.
-  var EMBED_SUBS_ALWAYS_DEFAULT_EXT = /\.(mp4|m4v|mov)$/i;
-
   function _embedSubsAlwaysDefault(targets) {
+    var always = _embedSubsContainers().alwaysDefault || [];
     return targets.filter(function (p) {
-      return EMBED_SUBS_ALWAYS_DEFAULT_EXT.test(p.video_paths ? p.video_paths[0] : "");
+      return always.indexOf(_embedSubsExt(p)) !== -1;
     });
   }
 
@@ -3268,18 +3289,34 @@
     if (!summaryEl || !confirmBtn) return;
     if (_embedSubsRun) return; // progress block owns the copy while a run streams
     var targets = _embedSubsTargets();
-    var skipped = _embedSubsScoped().filter(_embedSubsIsMultiPart);
+    var scoped = _embedSubsScoped();
+    var skipped = scoped.filter(_embedSubsIsMultiPart);
+    var unsupported = scoped.filter(function (p) {
+      return !_embedSubsIsMultiPart(p) && _embedSubsIsUnsupported(p);
+    });
     var skipNote = skipped.length
       ? " " + skipped.map(function (p) { return p.id; }).join(", ") +
         " skipped (multi-part " + (skipped.length === 1 ? "recording" : "recordings") + ")."
       : "";
+    if (unsupported.length) {
+      skipNote += " " + unsupported.map(function (p) { return p.id; }).join(", ") +
+        " skipped (subtitles cannot be muxed into " +
+        _embedSubsExt(unsupported[0]) + ").";
+    }
     if (!targets.length) {
       var scope = (qs("#embedSubsScope") || {}).value;
-      // Two different dead ends: nothing transcribed yet, versus transcripts
-      // that exist but every one of them spans several files. Only the first is
-      // fixed by running a transcription, so telling the user to do that when
-      // the real blocker is multi-part footage sends them at a no-op.
-      if (skipped.length) {
+      // Three different dead ends: nothing transcribed yet, transcripts that
+      // exist but span several files, or a container the muxer cannot write.
+      // Only the first is fixed by running a transcription, so saying that when
+      // the real blocker is the footage sends the user at a no-op.
+      if (unsupported.length && !skipped.length) {
+        summaryEl.textContent =
+          (unsupported.length === 1
+            ? unsupported[0].id + "'s recording is " + _embedSubsExt(unsupported[0])
+            : "These recordings are in a container") +
+          ", which cannot carry an embedded subtitle track. Supported: " +
+          (_embedSubsContainers().supported || []).join(", ") + ".";
+      } else if (skipped.length) {
         summaryEl.textContent =
           (skipped.length === 1
             ? skipped[0].id + "'s transcript spans several video files"
@@ -3383,14 +3420,17 @@
     _renderEmbedSubsProgress();
     var outputDir = "";
 
+    var sawDone = false;
+
     function handleLine(line) {
       var data;
       try { data = JSON.parse(line); } catch (_) { return; }
       if (!data) return;
       // The header line carries the destination and the trailing
-      // {"cancelled": true} carries nothing — neither has an index, which is
-      // also what keeps them out of the completion tally.
+      // {"cancelled": true} / {"done": true} carry nothing — none has an
+      // index, which is also what keeps them out of the completion tally.
       if (data.output_dir) outputDir = data.output_dir;
+      if (data.done) sawDone = true;
       if (typeof data.index !== "number") return;
       run.done++;
       if (!data.ok) run.failed++;
@@ -3415,6 +3455,18 @@
         return readNDJSONStream(response, handleLine).then(function () {
           var made = run.done - run.failed;
           var where = outputDir ? " to " + outputDir : "";
+          // No sentinel means the server died partway and the body simply
+          // stopped. readNDJSONStream cannot tell that from a clean end, so
+          // without this check a run that blew up at participant 4 of 10
+          // reported "3 subtitled videos written" and nothing else.
+          if (!sawDone) {
+            finish(
+              "Subtitle embedding stopped early — " +
+                clipgenPluralUnit(made, "video was", "videos were") + " written" + where +
+                " of " + run.total + ". Check the clipgen log."
+            );
+            return;
+          }
           finish(
             run.failed
               ? clipgenPluralUnit(made, "subtitled video", "subtitled videos") + " written" + where + ", " + run.failed + " failed"

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -70,6 +70,13 @@ var CLIPGEN_CONFIG = {
   composerScrubMaxAudioSeconds: 180.0,
   composerDoubleClickCuts: true,
   mediaContainerWarning: true,
+  // Mirrors video.SUBTITLE_CODEC_BY_CONTAINER / SUBTITLE_ALWAYS_DEFAULT_CONTAINERS.
+  // `supported` is what mux_subtitles can write at all; `alwaysDefault` is the
+  // mp4 family, whose muxer ignores -disposition:s:0.
+  subtitleContainers: {
+    supported: [".m4v", ".mkv", ".mov", ".mp4", ".webm"],
+    alwaysDefault: [".m4v", ".mov", ".mp4"],
+  },
   hotkeyOverrides: {},
 };
 
@@ -137,6 +144,9 @@ var clipgenApplyConfig = function (payload) {
   }
   if (typeof payload.mediaContainerWarning === "boolean") {
     CLIPGEN_CONFIG.mediaContainerWarning = payload.mediaContainerWarning;
+  }
+  if (payload.subtitleContainers && typeof payload.subtitleContainers === "object") {
+    CLIPGEN_CONFIG.subtitleContainers = payload.subtitleContainers;
   }
   if (payload.hotkeyOverrides && typeof payload.hotkeyOverrides === "object") {
     CLIPGEN_CONFIG.hotkeyOverrides = payload.hotkeyOverrides;

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -1387,8 +1387,26 @@ def _init_composer_state(sheet_context: Any = None) -> None:
 
     Participants are resolved from ``_sheet_context`` + the input dir on demand
     (:func:`files.resolve_participant_videos`), so nothing is snapshotted here.
+
+    Called once, from ``build_combined_app``. A worksheet swap goes through
+    :func:`repin_sheet_state` instead — re-running this would reload the
+    manifest and could drop a write still sitting in the persist debounce.
     """
     global _sheet_context, _manifest
 
     _sheet_context = sheet_context
     _manifest = _load_manifest()
+
+
+def repin_sheet_state(sheet_context: Any = None) -> None:
+    """Point the blueprint at a newly opened (or closed) worksheet.
+
+    The sheet-only half of :func:`_init_composer_state`, called by
+    ``server._swap_worksheet``. Without it Composer kept the sheet the
+    *process* started with — normally none — so opening a spreadsheet from the
+    Start overlay left its participant list on bare disk discovery, missing
+    every sheet-only column and every filename override.
+    """
+    global _sheet_context
+
+    _sheet_context = sheet_context

--- a/source/mindnode.py
+++ b/source/mindnode.py
@@ -45,6 +45,7 @@ import html
 import plistlib
 import re
 from pathlib import Path
+from xml.parsers import expat
 from typing import Any
 
 import config
@@ -106,13 +107,32 @@ def _is_timestamp_token(token: str) -> bool:
     return utils.timestamp_to_seconds(cleaned) is not None
 
 
+def _is_timestamp_run(token: str) -> bool:
+    """Whether a whitespace-split token is *entirely* timestamps.
+
+    ``utils._split_timestamp_tokens`` also splits on ``+``, ``;`` and ``,``, so
+    ``0:01:00+0:05:00`` parses as two pairs — but a whitespace-only split
+    leaves it as one token that ``_is_timestamp_token`` rejects, and the raw
+    times then survive into the description and the output filename. Splitting
+    on the separators *within* a token rather than splitting the whole string
+    on them keeps prose punctuation intact: "obs, 1:00" still describes as
+    "obs," because "obs," is not a run of timestamps.
+    """
+    parts = [p for p in re.split(r"[+;,]", token) if p]
+    if len(parts) < 2:
+        return False
+    return all(_is_timestamp_token(p) for p in parts)
+
+
 def _describe(text: str) -> str:
     """Strip timestamp and annotation tokens, leaving the observation text."""
     known_annotations = set(utils.get_known_annotation_map().keys())
     kept = [
         tok
         for tok in text.split()
-        if tok.lower() not in known_annotations and not _is_timestamp_token(tok)
+        if tok.lower() not in known_annotations
+        and not _is_timestamp_token(tok)
+        and not _is_timestamp_run(tok)
     ]
     return " ".join(kept).strip()
 
@@ -133,7 +153,19 @@ def load_document(path: str | Path) -> list[dict[str, Any]]:
     try:
         with contents.open("rb") as fh:
             data = plistlib.load(fh)
-    except (OSError, plistlib.InvalidFileException, ValueError) as exc:
+    except (
+        OSError,
+        plistlib.InvalidFileException,
+        ValueError,
+        # A .mindnode saved in XML rather than binary plist format (and then
+        # truncated, e.g. by a sync client) raises ExpatError, which derives
+        # from Exception — not from any of the above. Without it the error
+        # escapes this function's documented ValueError contract and every
+        # caller's `except ValueError`, surfacing as a 500 with a stack trace
+        # instead of "Could not read …". The binary path is already fine:
+        # _BinaryPlistParser normalizes to InvalidFileException.
+        expat.ExpatError,
+    ) as exc:
         raise ValueError(f"Could not read {contents}: {exc}") from exc
 
     canvas = data.get("canvas") if isinstance(data, dict) else None

--- a/source/ollama_client.py
+++ b/source/ollama_client.py
@@ -15,8 +15,10 @@ Key functions:
   resolve_ollama_bin()- the binary actually used: PATH first, managed second
   start_server()      - spawn `ollama serve` and wait for it to answer
   install_guidance_lines() - platform-specific "how to install Ollama" text
+  is_working_install()- stronger than is_installed(): the binary actually runs
   can_install_managed() / install_managed() - consent-gated in-app download of
-    the official standalone CLI into clipgen's config dir (macOS only)
+    the official CLI: the standalone tarball into clipgen's config dir on
+    macOS, the silent OllamaSetup.exe on Windows
   list_models()       - enumerate installed models with metadata
   is_model_installed()- check whether a specific model is installed locally
   generate()          - send a prompt and get a text response
@@ -91,9 +93,18 @@ _OLLAMA_WINDOWS_SHA256 = (
 )
 _OLLAMA_WINDOWS_SIZE_BYTES = 1_563_078_600
 _INSTALL_CHUNK = 1024 * 1024
-_INSTALL_TIMEOUT = 120  # seconds; connect + first byte, GitHub is normally fast
+_INSTALL_TIMEOUT = 120  # seconds; per-socket-read stall, GitHub is normally fast
+# Wall-clock backstop for the whole download, same reasoning as
+# _GENERATE_DEADLINE: _INSTALL_TIMEOUT bounds a stall *between* reads, so a
+# server trickling a byte per window never trips it. Generous — the Windows
+# asset is ~1.5 GB, which is ~14 min on a 15 Mbit line.
+_INSTALL_DEADLINE = 3600  # seconds
 _INSTALLER_RUN_TIMEOUT = 900  # seconds; silent Inno Setup unpacks ~2 GB of runners
 _VERSION_PROBE_TIMEOUT = 15  # seconds; `ollama --version` sanity check
+# The post-install probe is the binary's *first* execution, so it pays for the
+# OS scanning the freshly written tree (Defender real-time over ~2 GB of runner
+# libs). Timing out there fails a correct install.
+_FIRST_RUN_PROBE_TIMEOUT = 120  # seconds
 # 0 off-Windows, so passing it unconditionally leaves darwin/linux unchanged.
 _NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
@@ -256,6 +267,20 @@ def managed_ollama_path() -> Path | None:
     return None
 
 
+def is_working_install() -> bool:
+    """True when a reachable ``ollama`` binary actually runs.
+
+    Deliberately stronger than :func:`is_installed`, which only answers "a file
+    is present" — a half-extracted managed tree (disk filled partway through
+    the tarball, an installer killed mid-run) satisfies that and then reports
+    itself installed forever. Callers that gate *whether to install* must use
+    this one; :func:`is_installed` remains right for gating advice text, where
+    the extra ``--version`` subprocess would be wasteful.
+    """
+    binary = resolve_ollama_bin()
+    return binary is not None and _managed_binary_works(Path(binary))
+
+
 def resolve_ollama_bin() -> str | None:
     """The ``ollama`` binary clipgen should run, or None when there is none.
 
@@ -339,19 +364,60 @@ def managed_install_size_mb() -> int:
     return round(_OLLAMA_DARWIN_SIZE_BYTES / 1e6)
 
 
-def _managed_binary_works(binary: Path) -> bool:
-    """Sanity-run ``ollama --version`` on the managed copy."""
+def _managed_binary_works(
+    binary: Path, timeout: float = _VERSION_PROBE_TIMEOUT
+) -> bool:
+    """Sanity-run ``ollama --version`` on the managed copy.
+
+    *timeout* is widened by the post-install verification caller: the very
+    first execution of a freshly written binary pays for the OS scanning the
+    whole install tree (Defender real-time on ~2 GB of Windows runner libs),
+    which the steady-state probe budget does not allow for. A false negative
+    there reports a correct install as broken.
+    """
     try:
         probe = subprocess.run(
             [str(binary), "--version"],
-            capture_output=True,
-            timeout=_VERSION_PROBE_TIMEOUT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
             check=False,
             creationflags=_NO_WINDOW,
         )
     except (OSError, subprocess.TimeoutExpired):
         return False
     return probe.returncode == 0
+
+
+def _sweep_stale_downloads(target_dir: Path) -> None:
+    """Remove partial download temp files left in the managed dir.
+
+    ``tempfile.NamedTemporaryFile(dir=target_dir)`` names are ``tmp*``; the
+    real payload is ``ollama`` (plus runner libs), so the prefix cannot
+    collide with anything the install produces. Best-effort by design — a
+    sweep failure must not block the install that follows.
+    """
+    for stale in target_dir.glob("tmp*"):
+        try:
+            if stale.is_file():
+                stale.unlink()
+        except OSError:
+            pass
+
+
+def _clear_managed_dir(target_dir: Path) -> None:
+    """Delete clipgen's managed Ollama tree after a failed install.
+
+    Only ever called on ``_managed_ollama_dir()``, which clipgen creates and
+    owns outright — never on the Windows per-user install location, which the
+    user may have populated themselves. Best-effort: if the removal fails the
+    caller is already returning False, and a stale tree is no worse than the
+    one we were trying to clear.
+    """
+    try:
+        shutil.rmtree(target_dir, ignore_errors=True)
+    except OSError as exc:  # rmtree(ignore_errors) is quiet, but be safe
+        utils.warning_print(f"Could not clear the managed Ollama dir: {exc}")
 
 
 def _download_pinned(
@@ -367,23 +433,42 @@ def _download_pinned(
     Verifies the SHA256 incrementally; on any failure (network, disk, hash
     mismatch) the temp file is removed and None is returned. On success the
     caller owns the returned path and must unlink it when done.
+
+    ``_INSTALL_TIMEOUT`` reaches urlopen as the *socket* timeout, which bounds
+    a stall between reads and not total elapsed time — a server trickling one
+    byte per timeout window would keep the loop alive forever, and with it the
+    install slot (``_ollama_install_status["done"]`` never flips, so every
+    later click answers ``already_installing``). ``_INSTALL_DEADLINE`` is the
+    wall-clock backstop, mirroring ``generate()``'s ``_GENERATE_DEADLINE``.
+
+    The NamedTemporaryFile call is inside the try: it takes a filesystem hit
+    of its own (read-only mount, ENOSPC on the directory entry) and this
+    function's contract — like install_managed's — is to return None rather
+    than raise.
     """
-    with tempfile.NamedTemporaryFile(
-        dir=target_dir, suffix=suffix, delete=False
-    ) as tmp:
-        download_path = Path(tmp.name)
+    download_path: Path | None = None
     digest = hashlib.sha256()
     received = 0
     request = urllib.request.Request(
         url, headers={"User-Agent": "clipgen-ollama-install"}
     )
+    deadline = time.monotonic() + _INSTALL_DEADLINE
     try:
+        with tempfile.NamedTemporaryFile(
+            dir=target_dir, suffix=suffix, delete=False
+        ) as tmp:
+            download_path = Path(tmp.name)
         with (
             urllib.request.urlopen(request, timeout=_INSTALL_TIMEOUT) as response,
             download_path.open("wb") as out,
         ):
             total = int(response.headers.get("Content-Length") or size_fallback)
             while chunk := response.read(_INSTALL_CHUNK):
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"download exceeded the {_INSTALL_DEADLINE}s deadline "
+                        f"after {received} of {total} bytes"
+                    )
                 digest.update(chunk)
                 out.write(chunk)
                 received += len(chunk)
@@ -397,7 +482,8 @@ def _download_pinned(
                     )
     except (urllib.error.URLError, OSError, ValueError) as exc:
         utils.warning_print(f"Ollama install failed (download): {exc}")
-        download_path.unlink(missing_ok=True)
+        if download_path is not None:
+            download_path.unlink(missing_ok=True)
         return None
 
     if digest.hexdigest() != expected_sha256:
@@ -428,15 +514,27 @@ def _run_windows_installer(
     setup_path: Path,
     on_progress: Callable[[dict[str, Any]], None] | None,
 ) -> bool:
-    """Run the verified OllamaSetup.exe silently and wait for it to finish."""
+    """Run the verified OllamaSetup.exe silently and wait for it to finish.
+
+    Output goes to DEVNULL rather than being captured. ``capture_output=True``
+    makes subprocess.run wait on ``communicate()``, which returns when the
+    pipes reach EOF — i.e. when every handle holder closes them, not when the
+    direct child exits. Inno Setup extracts and launches a ``setup.tmp`` helper
+    that inherits those handles, so a 60-second successful install can sit on
+    the pipe until the timeout fires and be reported as a failure. Nothing
+    reads the captured text anyway; only the return code is used.
+    """
     if on_progress is not None:
-        # No completed/total — the frontend renders total-less statuses as
-        # plain text, same as "unpacking Ollama" on macOS.
+        # No completed/total. _on_progress in transcripts_server merges chunks
+        # into a status dict rather than replacing it, so the download's final
+        # completed/total survive and the bar reads 100% under this label —
+        # cosmetic, and better than resetting the bar to zero mid-install.
         on_progress({"status": "running installer"})
     try:
         proc = subprocess.run(
             [str(setup_path), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART"],
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             timeout=_INSTALLER_RUN_TIMEOUT,
             check=False,
             creationflags=_NO_WINDOW,
@@ -484,6 +582,13 @@ def install_managed(
         utils.warning_print(f"Ollama install failed (create dir): {exc}")
         return False
 
+    # Reclaim temp files a previous attempt orphaned. The download runs on a
+    # daemon thread, which is killed at interpreter shutdown *without*
+    # unwinding, so quitting clipgen mid-download leaves the partial file
+    # behind and nothing else ever removes it — at ~1.5 GB for the Windows
+    # asset that adds up fast across retries.
+    _sweep_stale_downloads(target_dir)
+
     on_windows = sys.platform == "win32"
     download_path = _download_pinned(
         url=_OLLAMA_WINDOWS_URL if on_windows else _OLLAMA_DARWIN_URL,
@@ -505,6 +610,16 @@ def install_managed(
             if on_progress is not None:
                 on_progress({"status": "unpacking Ollama"})
             if not _extract_darwin_archive(download_path, target_dir):
+                # A partial extractall leaves `ollama` (0755) on disk without
+                # its runner libs, and managed_ollama_path() only tests
+                # is_file() + the exec bit — so the wreckage reads as a
+                # finished install and every later attempt short-circuits.
+                # Clearing our own managed dir is the only way back. Windows
+                # installs into %LOCALAPPDATA%\Programs\Ollama, which clipgen
+                # does not own (a user may have installed there themselves),
+                # so that side is left alone and recovers by re-running the
+                # installer, which repairs in place.
+                _clear_managed_dir(target_dir)
                 return False
     finally:
         download_path.unlink(missing_ok=True)
@@ -519,10 +634,14 @@ def install_managed(
             except OSError:
                 pass
             installed = managed_ollama_path()
-    if installed is None or not _managed_binary_works(installed):
+    if installed is None or not _managed_binary_works(
+        installed, timeout=_FIRST_RUN_PROBE_TIMEOUT
+    ):
         utils.warning_print(
             "Ollama install failed: installed binary is missing or does not run."
         )
+        if not on_windows:
+            _clear_managed_dir(target_dir)
         return False
     if on_progress is not None:
         on_progress({"status": "success"})

--- a/source/server.py
+++ b/source/server.py
@@ -3217,14 +3217,27 @@ def _spreadsheet_label() -> str:
 
 
 def _swap_worksheet(new_worksheet: Any) -> None:
-    """Replace the active worksheet and refresh all three blueprints' state.
+    """Replace the active worksheet and refresh every blueprint's sheet state.
 
-    Atomic: if any of the three init steps fails, the prior state is restored
-    so Studio / Screenspace / Transcripts don't end up pointing at different
-    sheets. Used by ``/api/spreadsheets/open`` and ``/api/spreadsheets/close``.
+    All five that ``build_combined_app`` initializes, not just the three that
+    hold a full init: Workflows and Composer were left holding whatever sheet
+    the *process* started with, which on a desktop launch is none — so a
+    spreadsheet opened from the Start overlay never reached a workflow run's
+    NodeContext or Composer's participant list.
+
+    Those two re-pin through a sheet-only ``repin_sheet_state`` rather than
+    their init: re-running the full init would reload their manifests, and
+    Workflows' would also reseed the watch-dir baseline and restart the trigger
+    daemon on every spreadsheet the user opens.
+
+    Atomic: if any step fails, the prior state is restored so the blueprints
+    don't end up pointing at different sheets. Used by
+    ``/api/spreadsheets/open`` and ``/api/spreadsheets/close``.
     """
+    import composer_server
     import screenspace_server
     import transcripts_server
+    import workflows_server
 
     global _worksheet, _generated_artifacts, _generated_reels
     prev_worksheet = _worksheet
@@ -3239,6 +3252,11 @@ def _swap_worksheet(new_worksheet: Any) -> None:
         transcripts_server._init_transcripts_state(
             sheet_context=_sheet_context,
         )
+        workflows_server.repin_sheet_state(
+            sheet_context=_sheet_context,
+            worksheet=new_worksheet,
+        )
+        composer_server.repin_sheet_state(sheet_context=_sheet_context)
     except Exception:
         _worksheet = prev_worksheet
         _set_sheet_context(prev_sheet_context)
@@ -3246,7 +3264,7 @@ def _swap_worksheet(new_worksheet: Any) -> None:
             _generated_artifacts = prev_artifacts
             _generated_reels = prev_reels
             _rebuild_artifact_index()
-        # Best-effort: re-pin the two sister blueprints to the restored state.
+        # Best-effort: re-pin the sister blueprints to the restored state.
         # If these themselves throw, swallow — the studio state is already
         # consistent and the original exception is what we want to surface.
         try:
@@ -3259,6 +3277,14 @@ def _swap_worksheet(new_worksheet: Any) -> None:
             transcripts_server._init_transcripts_state(
                 sheet_context=_sheet_context,
             )
+        except Exception:  # noqa: S110 - deliberate, see the comment above
+            pass
+        try:
+            workflows_server.repin_sheet_state(
+                sheet_context=_sheet_context,
+                worksheet=prev_worksheet,
+            )
+            composer_server.repin_sheet_state(sheet_context=_sheet_context)
         except Exception:  # noqa: S110 - deliberate, see the comment above
             pass
         raise

--- a/source/server.py
+++ b/source/server.py
@@ -930,6 +930,19 @@ def api_mindnode() -> FlaskResponse:
         # rather than serving a stale tree the researcher can no longer see.
         return err(str(exc), 404)
     with _mindnode_lock:
+        # Re-check under the lock: the parse above runs with it released (it is
+        # slow, and the route re-parses on every request so an edited map shows
+        # new notes), so a close landing in that window would otherwise be
+        # undone here — the map would be open again on the server while the UI
+        # believed it was shut.
+        if _mindnode_doc is not doc:
+            return jsonify(
+                {
+                    "ok": True,
+                    "mindnode_loaded": _mindnode_doc is not None,
+                    "document": _mindnode_doc,
+                }
+            )
         _mindnode_doc = fresh
     return jsonify({"ok": True, "mindnode_loaded": True, "document": fresh})
 

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -100,6 +100,13 @@ WHISPER_MODELS: list[dict[str, Any]] = [
 
 _cached_model: Any = None
 _cached_model_name: str | None = None
+# The full construction signature the cached model was built from. The name
+# alone is not enough: device, compute type and thread count are all read at
+# WhisperModel() time and are all user-editable in Studio settings, so keying
+# on the name meant changing TRANSCRIBE_DEVICE to cuda saved, persisted, and
+# displayed while every later transcription silently kept running on the model
+# already loaded for cpu.
+_cached_model_key: tuple[Any, ...] | None = None
 _model_load_lock = threading.Lock()
 # True while _load_model is actually constructing a WhisperModel — the ~10s a
 # cold load takes. Lets the model-status endpoint report "warming" for
@@ -117,12 +124,36 @@ def is_transcription_model_loading() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _model_load_key(model_name: str) -> tuple[Any, ...]:
+    """The full signature ``_do_load`` would construct a WhisperModel from.
+
+    Every element is read at construction time and is user-editable, so any of
+    them changing means the cached model is no longer the one the settings
+    describe. Resolved rather than raw: ``TRANSCRIBE_DEVICE="auto"`` and
+    ``"cpu"`` are the same model in a frozen build, and reloading between them
+    would cost ~10s for nothing.
+    """
+    threads = config.TRANSCRIBE_CPU_THREADS or (os.cpu_count() or 0)
+    return (
+        model_name,
+        _resolve_transcribe_device(),
+        config.TRANSCRIBE_COMPUTE_TYPE,
+        threads,
+    )
+
+
 def is_transcription_model_loaded() -> bool:
-    """Return True if the cached Whisper model matches the current config name."""
+    """Return True if a usable model for the current settings is warm.
+
+    Keyed on the whole load signature, not just the name: after a device change
+    the loaded model no longer matches the settings, and reporting it as loaded
+    would hide the reload the next transcription pays for.
+    """
     if config.DEBUGGING:
         return True
-    model_name = config.TRANSCRIBE_MODEL
-    return _cached_model is not None and _cached_model_name == model_name
+    return _cached_model is not None and _cached_model_key == _model_load_key(
+        config.TRANSCRIBE_MODEL
+    )
 
 
 def is_whisper_model_cached(model_name: str | None = None) -> bool:
@@ -242,16 +273,19 @@ def _load_model(model_name: str | None = None) -> Any:
     """Lazy-load the WhisperModel, caching it for reuse (thread-safe).
 
     When *model_name* is None, uses ``config.TRANSCRIBE_MODEL``. Passing a
-    different name swaps the cached model.
+    different name swaps the cached model — as does changing any other setting
+    the construction reads (device, compute type, thread count); see
+    :func:`_model_load_key`.
     """
-    global _cached_model, _cached_model_name
+    global _cached_model, _cached_model_name, _cached_model_key
 
     model_name = model_name or config.TRANSCRIBE_MODEL
-    if _cached_model is not None and _cached_model_name == model_name:
+    load_key = _model_load_key(model_name)
+    if _cached_model is not None and _cached_model_key == load_key:
         return _cached_model
 
     with _model_load_lock:
-        if _cached_model is not None and _cached_model_name == model_name:
+        if _cached_model is not None and _cached_model_key == load_key:
             return _cached_model
 
         try:
@@ -271,17 +305,22 @@ def _load_model(model_name: str | None = None) -> Any:
 
             _cached_model = None
             _cached_model_name = None
+            _cached_model_key = None
             gc.collect()
 
         def _do_load() -> Any:
+            # Built from load_key, not re-read from config, so what is cached
+            # is exactly what was constructed even if a setting changes while
+            # this load is in flight.
+            #
             # cpu_threads: 0 = auto (all cores). CTranslate2's own default heuristic
             # under-uses many-core CPUs, so resolve to os.cpu_count() when unset.
             # num_workers is left at its default — the transcript poller runs one job
             # at a time and >1 workers multiplies model memory for no gain here.
-            threads = config.TRANSCRIBE_CPU_THREADS or (os.cpu_count() or 0)
+            _name, device, compute_type, threads = load_key
             load_kwargs: dict[str, Any] = {
-                "compute_type": config.TRANSCRIBE_COMPUTE_TYPE,
-                "device": _resolve_transcribe_device(),
+                "compute_type": compute_type,
+                "device": device,
             }
             if threads > 0:
                 load_kwargs["cpu_threads"] = threads
@@ -298,6 +337,7 @@ def _load_model(model_name: str | None = None) -> Any:
                 "Loading transcription model...", _do_load
             )
             _cached_model_name = model_name
+            _cached_model_key = load_key
             return _cached_model
         finally:
             _model_loading = False

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -1227,7 +1227,22 @@ class TranscriptWorker:
                     continue
                 task["status"] = TASK_STATUS_RUNNING
 
-            self._execute_task(task)
+            # The worker must outlive any single task. _execute_task owns its
+            # own try/except for the transcription itself, but work outside it
+            # (the model preload, ffprobe/timeline setup) can still raise, and
+            # there is no restart path for this thread — is_alive is reported
+            # to the frontend but never acted on, so a death here wedges every
+            # later transcribe request in a queue nothing drains.
+            try:
+                self._execute_task(task)
+            except Exception as exc:
+                utils.error_print(f"Transcription task failed: {exc}")
+                with self._lock:
+                    if task.get("status") == TASK_STATUS_RUNNING:
+                        task["status"] = TASK_STATUS_FAILED
+                        task["error"] = str(exc)
+                        task.setdefault("partial_segments", [])
+                        task["completed_at"] = datetime.now(UTC).isoformat()
 
             if self.on_task_complete:
                 try:
@@ -1302,10 +1317,24 @@ class TranscriptWorker:
         if not config.DEBUGGING and not task.get("_cancelled"):
             with self._lock:
                 task["phase"] = "loading_model"
-            if _load_model(task.get("model")) is None:
+            # _load_model does not only return None on failure — it raises.
+            # run_with_spinner calls its callback bare, and the WhisperModel
+            # construction inside has a finally but no except, so a CTranslate2
+            # "Library cublas64_12.dll is not found", an unsupported
+            # compute_type, or a huggingface download OSError all propagate.
+            # This sits outside the try below, so without this handler the
+            # exception escapes _run and kills the worker thread for good.
+            try:
+                loaded = _load_model(task.get("model"))
+            except Exception as exc:
+                loaded = None
+                load_error = f"Transcription model failed to load: {exc}"
+            else:
+                load_error = "Transcription model failed to load."
+            if loaded is None:
                 with self._lock:
                     task["status"] = TASK_STATUS_FAILED
-                    task["error"] = "Transcription model failed to load."
+                    task["error"] = load_error
                     task["partial_segments"] = []
                     task["completed_at"] = datetime.now(UTC).isoformat()
                 return

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -620,23 +620,37 @@ def api_audio_track(participant: str, idx: int) -> FlaskResponse:
 _embed_cancel_event = threading.Event()
 _embed_lock = threading.Lock()
 _embed_busy = False
+# Identifies the run currently holding the slot. The release is attempted twice
+# per run (the generator's finally, and the response's call_on_close for the
+# case where the generator is never started at all), and a bare release would
+# let the second of those clear a *successor* run's claim. Releasing by token
+# makes both attempts idempotent and scoped to their own run.
+_embed_owner: str | None = None
 
 
-def _claim_embed_slot() -> bool:
-    """Take the single embed slot, or return False if a run already holds it."""
-    global _embed_busy
+def _claim_embed_slot() -> str | None:
+    """Take the single embed slot, returning its token, or None if held."""
+    global _embed_busy, _embed_owner
     with _embed_lock:
         if _embed_busy:
-            return False
+            return None
         _embed_busy = True
+        _embed_owner = uuid.uuid4().hex
         _embed_cancel_event.clear()
-        return True
+        return _embed_owner
 
 
-def _release_embed_slot() -> None:
-    global _embed_busy
+def _release_embed_slot(token: str | None = None) -> None:
+    """Free the slot, but only if *token* still owns it.
+
+    ``token=None`` releases unconditionally (tests and teardown).
+    """
+    global _embed_busy, _embed_owner
     with _embed_lock:
+        if token is not None and _embed_owner != token:
+            return
         _embed_busy = False
+        _embed_owner = None
 
 
 def _embed_subtitle_for_participant(
@@ -774,7 +788,8 @@ def api_embed_subtitles() -> FlaskResponse:
         return err("No participants specified")
     default_track = bool(data.get("default_track", True))
 
-    if not _claim_embed_slot():
+    embed_token = _claim_embed_slot()
+    if embed_token is None:
         return err("A subtitle embed is already in progress", 409)
 
     output_dir = Path(utils.get_effective_output_dir())
@@ -808,13 +823,20 @@ def api_embed_subtitles() -> FlaskResponse:
         finally:
             # Also runs when the client disconnects mid-stream, so a closed tab
             # cannot wedge the slot for the rest of the session.
-            _release_embed_slot()
+            _release_embed_slot(embed_token)
 
-    return Response(
+    response = Response(
         stream(),
         mimetype="application/x-ndjson",
         headers={"X-Accel-Buffering": "no"},
     )
+    # The generator's finally covers a stream that was started and then dropped.
+    # It does *not* cover one that was never started: closing an unstarted
+    # generator just marks it closed, running no body at all. call_on_close
+    # fires whenever the response is torn down either way, and the token makes
+    # the double release harmless.
+    response.call_on_close(lambda: _release_embed_slot(embed_token))
+    return response
 
 
 @transcripts_bp.route("/api/embed-subtitles/cancel", methods=["POST"])

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -730,6 +730,12 @@ def _embed_subtitle_for_participant(
                 pass
 
     if not ok:
+        # get_unique_filename reserves by *creating* an empty placeholder, so
+        # aborting without releasing leaves a 0-byte file that looks like a
+        # finished export — one per participant on a whole-study run whose
+        # container ffmpeg cannot mux — and pushes the next run's names onto
+        # -1/-2 suffixes.
+        files.release_reservation(output_path)
         return {
             "participant": participant,
             "ok": False,
@@ -794,6 +800,11 @@ def api_embed_subtitles() -> FlaskResponse:
                 yield json.dumps(outcome) + "\n"
             if cancel_flag():
                 yield json.dumps({"cancelled": True}) + "\n"
+            # Terminal sentinel. A generator that dies mid-run just truncates
+            # the body, and a truncated NDJSON stream is indistinguishable from
+            # a complete one to the reader — the client would report the
+            # partial count as a success. Its absence is the failure signal.
+            yield json.dumps({"done": True}) + "\n"
         finally:
             # Also runs when the client disconnects mid-stream, so a closed tab
             # cannot wedge the slot for the rest of the session.

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -1604,7 +1604,7 @@ def api_ollama_start() -> FlaskResponse:
 
 @transcripts_bp.route("/api/models/ollama/install", methods=["POST"])
 def api_ollama_install() -> FlaskResponse:
-    """Download the Ollama CLI itself into clipgen's managed dir (macOS only).
+    """Download and install the Ollama CLI (macOS and Windows).
 
     The consent-gated counterpart of /api/models/ollama/pull one level down:
     same background-thread + status-dict + polling shape, so the frontend
@@ -1614,7 +1614,12 @@ def api_ollama_install() -> FlaskResponse:
     global _ollama_install_status
     if not ollama_client.can_install_managed():
         return err("In-app Ollama install is not supported on this platform")
-    if ollama_client.is_installed():
+    # is_working_install, not is_installed: the latter only asks whether a file
+    # is present, which a half-extracted tree also satisfies — and answering
+    # already_installed there is a dead end, since this route is the only way
+    # to repair one. install_managed applies the same predicate internally, so
+    # a genuinely working install still short-circuits immediately.
+    if ollama_client.is_working_install():
         return ok(already_installed=True)
     with _ollama_install_lock:
         if _ollama_install_status is not None and not _ollama_install_status.get(

--- a/source/utils.py
+++ b/source/utils.py
@@ -1091,7 +1091,29 @@ def get_frontend_config() -> dict[str, Any]:
         "composerScrubMaxAudioSeconds": config.COMPOSER_SCRUB_MAX_AUDIO_SECONDS,
         "composerDoubleClickCuts": config.COMPOSER_DOUBLE_CLICK_CUTS,
         "mediaContainerWarning": config.MEDIA_CONTAINER_WARNING,
+        "subtitleContainers": _subtitle_container_config(),
         "hotkeyOverrides": dict(config.HOTKEY_OVERRIDES),
+    }
+
+
+def _subtitle_container_config() -> dict[str, list[str]]:
+    """Container extensions the subtitle muxer can write, split by disposition.
+
+    ``supported`` is every container ``video.mux_subtitles`` has a codec for —
+    the Embed Subtitles dialog filters against it so a run that ffmpeg would
+    reject at its ``codec is None`` guard is never promised in the summary.
+    ``alwaysDefault`` is the mp4 family, whose muxer ships the subtitle track
+    enabled no matter what ``-disposition:s:0`` says, so the dialog's
+    "set as default" toggle has to declare itself a no-op there.
+
+    Imported lazily: video.py pulls in the ffmpeg helpers, and utils is on the
+    import path of everything.
+    """
+    import video
+
+    return {
+        "supported": sorted(video.SUBTITLE_CODEC_BY_CONTAINER),
+        "alwaysDefault": sorted(video.SUBTITLE_ALWAYS_DEFAULT_CONTAINERS),
     }
 
 

--- a/source/video.py
+++ b/source/video.py
@@ -783,13 +783,22 @@ def build_ffmpeg_cut_command(
     return base + encoder_args + [output_file]
 
 
-_SUBTITLE_CODEC_BY_CONTAINER = {
+# Output containers mux_subtitles can write, and the codec each needs. Public
+# because the frontend needs the same list: it flows to JS through
+# utils.get_frontend_config()["subtitleContainers"] so the Embed Subtitles
+# dialog can filter out sources this function would reject, rather than
+# promising output and collecting a failure line per participant.
+SUBTITLE_CODEC_BY_CONTAINER = {
     ".mp4": "mov_text",
     ".m4v": "mov_text",
     ".mov": "mov_text",
     ".mkv": "srt",
     ".webm": "webvtt",
 }
+# The mp4 family reports the subtitle track default=1 whatever -disposition:s:0
+# is given (measured on ffmpeg 8.1.2): an ISOBMFF track is enabled or absent,
+# with no present-but-off state. Only .mkv/.webm honour the flag.
+SUBTITLE_ALWAYS_DEFAULT_CONTAINERS = frozenset({".mp4", ".m4v", ".mov"})
 
 
 def mux_subtitles(
@@ -837,13 +846,13 @@ def mux_subtitles(
         return False
 
     suffix = Path(output_video).suffix.lower()
-    codec = _SUBTITLE_CODEC_BY_CONTAINER.get(suffix)
+    codec = SUBTITLE_CODEC_BY_CONTAINER.get(suffix)
     if codec is None:
         utils.error_print(
             f"Unsupported output container '{suffix}' for subtitle muxing.",
             [
                 f"Output: '{output_video}'",
-                "Supported: " + ", ".join(sorted(_SUBTITLE_CODEC_BY_CONTAINER)),
+                "Supported: " + ", ".join(sorted(SUBTITLE_CODEC_BY_CONTAINER)),
             ],
         )
         return False
@@ -857,8 +866,18 @@ def mux_subtitles(
         input_video,
         "-i",
         srt_path,
+        # Video + audio only from the source, never `-map 0`. Mapping every
+        # input stream carries any pre-existing subtitle track into the output
+        # *ahead* of the new one, and the three index-0 arguments below then
+        # address that old track instead: it would be relabelled and marked
+        # default while the transcript arrives untagged. A pre-existing bitmap
+        # track (PGS/VobSub) is worse — `-c:s` targets it too, mov_text cannot
+        # encode it, and the whole command fails. The `?` suffixes make each
+        # map optional, so a silent video still muxes.
         "-map",
-        "0",
+        "0:v?",
+        "-map",
+        "0:a?",
         "-map",
         "1:0",
         "-c",

--- a/source/workflows_server.py
+++ b/source/workflows_server.py
@@ -8,8 +8,9 @@ lifecycle: ``POST /api/runs`` spawns a :class:`workflows.WorkflowRunner` on a
 daemon thread, with per-run SSE (``/api/runs/<id>/stream``) + a polling fallback
 (``GET /api/runs/<id>``), mirroring ``screenspace_server``'s task stream.
 
-Module-level state (``_input_dir``, ``_sheet_context``, ``_worksheet``,
-``_manifest``, ``_runs``) is initialized by :func:`_init_workflows_state`,
+Module-level state (``_sheet_context``, ``_worksheet``, ``_manifest``,
+``_runs``) is initialized by :func:`_init_workflows_state`, and the sheet half
+is re-pointed on a worksheet swap by :func:`repin_sheet_state`,
 mirroring the Screenspace and Transcripts blueprints. Mutations hold
 ``_manifest_lock`` and persist via :func:`_persist_locked` (mirrors
 ``screenspace_server._do_persist``). Live runner progress stays in ``_runs``;
@@ -38,7 +39,6 @@ from server_utils import err, make_sse_channel, ok
 
 # ---- Module state (initialized by _init_workflows_state) ----
 
-_input_dir: str = ""
 _sheet_context: Any = None
 _worksheet: Any = None
 _manifest: dict[str, Any] = {}
@@ -105,8 +105,6 @@ utils.register_static_routes(
     "workflows.html",
     # Per request, not a snapshot — POST /api/dirs moves config.INPUT_DIR
     # mid-session and never re-inits this blueprint. See transcripts_bp.
-    # (_input_dir survives below for _build_node_context, which pins the
-    # directory a run started against on purpose.)
     media_dir_getter=lambda: str(utils.get_effective_input_dir()),
     media_error="Input directory not configured",
     icons=True,
@@ -367,10 +365,14 @@ def api_stashes_delete(stash_id: str) -> Any:
 
 
 def _build_node_context(cancel_event: threading.Event) -> workflows.NodeContext:
-    """Build the per-run ``NodeContext`` from the active launch context."""
-    input_dir = Path(_input_dir) if _input_dir else utils.get_effective_input_dir()
+    """Build the per-run ``NodeContext`` from the active launch context.
+
+    Both directories resolve live, for the same reason the media route does:
+    the Start overlay's folder picker moves ``config.INPUT_DIR`` long after
+    this blueprint was initialized.
+    """
     return workflows.NodeContext(
-        input_dir=input_dir,
+        input_dir=utils.get_effective_input_dir(),
         output_dir=utils.get_effective_output_dir(),
         sheet_context=_sheet_context,
         worksheet=_worksheet,
@@ -1304,14 +1306,18 @@ def _init_workflows_state(
 ) -> None:
     """Initialize module-level state for Workflows routes.
 
-    Loads the workflows manifest and records the active input dir + sheet
-    context + worksheet (the latter feeds the ``sheet_selection`` executor), then
-    seeds the watch-dir baseline and starts the trigger daemon (P6).
-    Per-participant video paths are resolved on demand.
-    """
-    global _input_dir, _sheet_context, _worksheet, _manifest
+    Loads the workflows manifest and records the active sheet context +
+    worksheet (the latter feeds the ``sheet_selection`` executor), then seeds
+    the watch-dir baseline and starts the trigger daemon (P6). Per-participant
+    video paths and the input dir are resolved on demand.
 
-    _input_dir = str(utils.get_effective_input_dir())
+    Called once, from ``build_combined_app``. A worksheet swap goes through
+    :func:`repin_sheet_state` instead — re-running this would reload the
+    manifest, reseed the watch baseline and restart the trigger daemon on
+    every spreadsheet the user opens.
+    """
+    global _sheet_context, _worksheet, _manifest
+
     _sheet_context = sheet_context
     _worksheet = worksheet
     _manifest = workflows.load_workflows_manifest()
@@ -1322,3 +1328,18 @@ def _init_workflows_state(
         _persist_locked()
     _seed_watch_seen()
     _start_watch_thread()
+
+
+def repin_sheet_state(sheet_context: Any = None, worksheet: Any = None) -> None:
+    """Point the blueprint at a newly opened (or closed) worksheet.
+
+    The sheet-only half of :func:`_init_workflows_state`, called by
+    ``server._swap_worksheet``. Without it this blueprint kept whatever sheet
+    the *process* started with — normally none, since a desktop launch has no
+    ``-s`` — so a spreadsheet opened from the Start overlay never reached the
+    canvas or any run's ``NodeContext``.
+    """
+    global _sheet_context, _worksheet
+
+    _sheet_context = sheet_context
+    _worksheet = worksheet

--- a/tests/test_mindnode.py
+++ b/tests/test_mindnode.py
@@ -255,6 +255,50 @@ def test_ignored_token_is_not_description_text(make_bundle):
     assert note["times"] == []
 
 
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Note 3 0:01:00+0:05:00",
+        "Note 3 0:01:00,0:05:00",
+        "Note 3 0:01:00;0:05:00",
+        "Note 3 0:01:00, 0:05:00",
+    ],
+)
+def test_separator_joined_timestamps_leave_the_description(make_bundle, title):
+    """utils._split_timestamp_tokens splits on + ; , as well as whitespace, so
+    all four forms parse to the same two pairs. A whitespace-only split in
+    _describe left the raw times in the description — and desc becomes the
+    intake event_type, so they ended up in the output filename too."""
+    bundle = make_bundle(_node("study", [_node("Q", [_node("P01", [_node(title)])])]))
+    (note,) = mindnode.parse_document(bundle)["notes"]
+    assert note["desc"] == "Note 3"
+    assert note["times"] == [("0:01:00", "0:02:00"), ("0:05:00", "0:06:00")]
+
+
+def test_prose_punctuation_survives_the_timestamp_strip(make_bundle):
+    """Splitting the whole string on , would also eat commas out of real prose,
+    so only tokens that are *entirely* timestamps are dropped."""
+    bundle = make_bundle(
+        _node("study", [_node("Q", [_node("P01", [_node("obs, then this 1:00")])])])
+    )
+    (note,) = mindnode.parse_document(bundle)["notes"]
+    assert note["desc"] == "obs, then this"
+
+
+def test_malformed_xml_plist_raises_value_error(tmp_path):
+    """plistlib raises ExpatError (not ValueError/OSError/InvalidFileException)
+    on a truncated *XML* plist. Every caller catches only ValueError, so
+    without normalizing it here the Start overlay's preview and Open both
+    return a 500 with a stack trace instead of a readable message."""
+    bundle = tmp_path / "broken.mindnode"
+    bundle.mkdir()
+    (bundle / mindnode.CONTENTS_FILENAME).write_bytes(
+        b'<?xml version="1.0"?>\n<!DOCTYPE plist><plist version="1.0"><dict>'
+    )
+    with pytest.raises(ValueError, match="Could not read"):
+        mindnode.parse_document(bundle)
+
+
 def test_node_ids_are_carried_through(make_bundle):
     bundle = make_bundle(
         _node(
@@ -625,6 +669,38 @@ def test_document_route_rereads_from_disk(mn_client):
         )
     doc = client.get("/studio/api/mindnode").get_json()["document"]
     assert [n["desc"] for n in doc["notes"]] == ["only one"]
+
+
+def test_document_refresh_does_not_resurrect_a_closed_map(mn_client, monkeypatch):
+    """The re-parse runs with _mindnode_lock released (it is slow, and the
+    route re-reads on every request). A close landing in that window must win —
+    otherwise the refresh writes the map back and the server believes it is
+    open while the UI has already shut it."""
+    import server as server_mod
+
+    client, bundle, _ = mn_client
+    client.post(
+        "/api/spreadsheets/open", json={"type": "mindnode", "id_or_path": str(bundle)}
+    )
+    assert server_mod._mindnode_doc is not None
+
+    real_parse = mindnode.parse_document
+
+    def _parse_then_close(path):
+        parsed = real_parse(path)
+        # The close landing mid-parse, applied directly: a nested test-client
+        # request would unwind Flask's request-context stack out of order.
+        # This is exactly the state /api/spreadsheets/close leaves behind.
+        server_mod._mindnode_doc = None
+        return parsed
+
+    # The route imports mindnode function-locally, so patch the module itself.
+    monkeypatch.setattr(mindnode, "parse_document", _parse_then_close)
+
+    body = client.get("/studio/api/mindnode").get_json()
+    assert body["mindnode_loaded"] is False
+    assert body["document"] is None
+    assert server_mod._mindnode_doc is None
 
 
 def test_document_route_404s_when_the_bundle_disappears(mn_client):

--- a/tests/test_multi_video.py
+++ b/tests/test_multi_video.py
@@ -853,6 +853,21 @@ def test_screenspace_map_participant_time(monkeypatch):
 # ---- Transcripts worker: single vs multi-video execution ----
 
 
+@pytest.fixture(autouse=True)
+def _stub_whisper_load(monkeypatch):
+    """Keep _execute_task's model preload out of these tests.
+
+    The preload (added with the loading_model phase) runs before the
+    transcribe_video/transcribe_timeline stubs below get a look in, and it is
+    not stubbed by them — so without this these tests constructed a *real*
+    WhisperModel, downloading ~140 MB on any machine with a cold HF cache and
+    leaving the shared transcripts._cached_model populated for whatever ran
+    next. That shared cache is what made them fail intermittently depending on
+    file order.
+    """
+    monkeypatch.setattr(transcripts, "_load_model", lambda name=None: object())
+
+
 def test_transcript_worker_multi_video_builds_timeline(monkeypatch):
     worker = transcripts.TranscriptWorker()
     task = transcripts.create_transcript_task("P01", ["a.mp4", "b.mp4"])

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -677,7 +677,7 @@ class TestManagedInstall:
         monkeypatch.setattr(ollama_client.sys, "platform", "darwin")
         self._make_managed(tmp_path)
         monkeypatch.setattr(
-            ollama_client, "_managed_binary_works", lambda _binary: True
+            ollama_client, "_managed_binary_works", lambda _binary, **_kw: True
         )
         assert ollama_client.install_managed() is True
         mock_urlopen.assert_not_called()
@@ -685,6 +685,111 @@ class TestManagedInstall:
     def test_install_managed_refused_on_linux(self, monkeypatch):
         monkeypatch.setattr(ollama_client.sys, "platform", "linux")
         assert ollama_client.install_managed() is False
+
+    @patch("ollama_client.shutil.which", return_value=None)
+    def test_is_working_install_rejects_a_present_but_broken_binary(
+        self, mock_which, tmp_path, monkeypatch
+    ):
+        """is_installed() only asks "is a file there"; a half-extracted tree
+        satisfies it. is_working_install() must actually run the binary, or a
+        broken install reports itself finished and can never be repaired."""
+        self._make_managed(tmp_path)
+        assert ollama_client.is_installed() is True
+        monkeypatch.setattr(
+            ollama_client, "_managed_binary_works", lambda _binary, **_kw: False
+        )
+        assert ollama_client.is_working_install() is False
+        monkeypatch.setattr(
+            ollama_client, "_managed_binary_works", lambda _binary, **_kw: True
+        )
+        assert ollama_client.is_working_install() is True
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_install_managed_clears_the_dir_when_the_binary_will_not_run(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        """A download that unpacks but produces a binary that does not run must
+        not leave the wreckage behind — managed_ollama_path() would keep
+        reporting it as installed forever."""
+        monkeypatch.setattr(ollama_client.sys, "platform", "darwin")
+        payload = b"fake tarball"
+        monkeypatch.setattr(
+            ollama_client, "_OLLAMA_DARWIN_SHA256", hashlib.sha256(payload).hexdigest()
+        )
+        mock_urlopen.return_value = self._make_download_resp(payload)
+        # Extraction "succeeds" and drops a binary that never runs.
+        binary = tmp_path / "cfg" / "tools" / "ollama" / "ollama"
+        monkeypatch.setattr(
+            ollama_client,
+            "_extract_darwin_archive",
+            lambda _a, _t: (binary.write_bytes(b"junk"), binary.chmod(0o755), True)[2],
+        )
+        monkeypatch.setattr(
+            ollama_client, "_managed_binary_works", lambda _binary, **_kw: False
+        )
+
+        assert ollama_client.install_managed() is False
+        assert ollama_client.managed_ollama_path() is None
+        assert not (tmp_path / "cfg" / "tools" / "ollama").exists()
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_install_managed_clears_the_dir_on_a_failed_extract(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        """Same contract for a partial extractall: `ollama` can already be on
+        disk with its exec bit when the disk fills before the runner libs."""
+        monkeypatch.setattr(ollama_client.sys, "platform", "darwin")
+        payload = b"fake tarball"
+        monkeypatch.setattr(
+            ollama_client, "_OLLAMA_DARWIN_SHA256", hashlib.sha256(payload).hexdigest()
+        )
+        mock_urlopen.return_value = self._make_download_resp(payload)
+        binary = tmp_path / "cfg" / "tools" / "ollama" / "ollama"
+
+        def _partial_extract(_archive, _target):
+            binary.write_bytes(b"#!/bin/sh\nexit 0\n")
+            binary.chmod(0o755)
+            return False
+
+        monkeypatch.setattr(ollama_client, "_extract_darwin_archive", _partial_extract)
+
+        assert ollama_client.install_managed() is False
+        assert ollama_client.managed_ollama_path() is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_install_managed_sweeps_orphaned_partial_downloads(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        """The download thread is a daemon, so quitting mid-download skips every
+        finally and strands the temp file. Nothing else ever removes it."""
+        monkeypatch.setattr(ollama_client.sys, "platform", "darwin")
+        managed = tmp_path / "cfg" / "tools" / "ollama"
+        managed.mkdir(parents=True, exist_ok=True)
+        orphan = managed / "tmpabcdef.tgz"
+        orphan.write_bytes(b"x" * 1024)
+
+        mock_urlopen.return_value = self._make_download_resp(b"tampered")
+        assert ollama_client.install_managed() is False
+        assert not orphan.exists()
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_download_gives_up_on_a_trickling_server(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        """urlopen's timeout bounds a stall *between* reads, so a server that
+        dribbles one chunk per window never trips it. The wall-clock deadline
+        is what stops the install slot being held for the session."""
+        monkeypatch.setattr(ollama_client.sys, "platform", "darwin")
+        monkeypatch.setattr(ollama_client, "_INSTALL_DEADLINE", 0)
+        resp = MagicMock()
+        resp.headers = {"Content-Length": "999999"}
+        resp.read.return_value = b"z" * 16  # never yields b"" — an endless trickle
+        resp.__enter__ = lambda self_: resp
+        resp.__exit__ = lambda self_, *exc: False
+        mock_urlopen.return_value = resp
+
+        assert ollama_client.install_managed() is False
+        assert ollama_client.managed_ollama_path() is None
 
     @patch("ollama_client.urllib.request.urlopen")
     def test_install_managed_rejects_bad_hash(self, mock_urlopen, monkeypatch):
@@ -737,7 +842,7 @@ class TestManagedInstall:
 
         mock_run.side_effect = _fake_install
         monkeypatch.setattr(
-            ollama_client, "_managed_binary_works", lambda _binary: True
+            ollama_client, "_managed_binary_works", lambda _binary, **_kw: True
         )
         progress: list[dict] = []
         assert ollama_client.install_managed(on_progress=progress.append) is True

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -24,7 +24,10 @@ def _js_source() -> str:
 def _parse_js_object_literal(name: str) -> dict:
     """Extract a top-level JS object literal `var <name> = { ... };` as a dict.
 
-    Handles unquoted keys and trailing commas; values must be JSON-compatible.
+    Handles unquoted keys, trailing commas, and whole-line `//` comments (the
+    fallback block documents which Python constant each key mirrors); values
+    must be JSON-compatible. Only line-leading comments are stripped, so a
+    value containing `//` is never mangled.
     """
     match = re.search(
         r"var\s+" + re.escape(name) + r"\s*=\s*(\{.+?\n\});",
@@ -33,6 +36,7 @@ def _parse_js_object_literal(name: str) -> dict:
     )
     assert match, f"{name} not found in utils.js"
     raw = match.group(1)
+    raw = re.sub(r"^\s*//.*$", "", raw, flags=re.MULTILINE)
     raw = re.sub(r"(\b\w+)\s*:", r'"\1":', raw)
     raw = re.sub(r",\s*([}\]])", r"\1", raw)
     return json.loads(raw)
@@ -138,6 +142,10 @@ def test_clipgen_config_defaults_match_python():
     )
     assert js_config["composerDoubleClickCuts"] == py_config["composerDoubleClickCuts"]
     assert js_config["mediaContainerWarning"] == py_config["mediaContainerWarning"]
+    # The Embed Subtitles dialog filters its target list against these, so JS
+    # drifting from video.SUBTITLE_CODEC_BY_CONTAINER means promising output
+    # ffmpeg will refuse to write (or hiding one it would have written).
+    assert js_config["subtitleContainers"] == py_config["subtitleContainers"]
 
 
 def test_get_frontend_config_shape():
@@ -170,6 +178,7 @@ def test_get_frontend_config_shape():
         "composerScrubMaxAudioSeconds",
         "composerDoubleClickCuts",
         "mediaContainerWarning",
+        "subtitleContainers",
         "hotkeyOverrides",
     }
     assert isinstance(cfg["defaultDuration"], int)

--- a/tests/test_start_overlay_source.py
+++ b/tests/test_start_overlay_source.py
@@ -81,3 +81,41 @@ def test_refresh_button_has_its_css():
     css = read("start-overlay.css")
     for rule in (".sheet-panel__status-row", ".sheet-panel__refresh", "is-spinning"):
         assert rule in css, f"{rule} toggled/used in the overlay but absent from CSS"
+
+
+def test_session_prefill_follows_active_source_not_mindnode_loaded():
+    """A mind map and a spreadsheet coexist by design — _open_mindnode never
+    clears the sheet and api_spreadsheets_open never clears the map. Branching
+    on mindnode_loaded therefore meant that once a map had been opened it
+    hijacked the prefill forever: the recents list highlighted the spreadsheet
+    opened afterwards (currentSessionKey keys on active_source) while the panel
+    switched to the Mind map tab, and confirming re-opened the map."""
+    src = strip_comments(read("start-overlay.js"))
+    body = src[src.index("function applyCurrentSessionPrefill") :]
+    body = body[: body.index("\n  function ")]
+    assert "active_source" in body, (
+        "the mindnode branch must agree with currentSessionKey's active_source"
+    )
+    assert body.index("active_source") < body.index("mindnode_loaded"), (
+        "active_source has to gate the mindnode branch, not follow it"
+    )
+
+
+def test_no_spreadsheet_actually_closes_the_open_source():
+    """The 'No spreadsheet' tab only recorded a session. Nothing in the UI ever
+    posted to /api/spreadsheets/close, so a source opened earlier stayed loaded
+    for the rest of the process — a mind map especially, since opening a sheet
+    does not clear one."""
+    src = strip_comments(read("start-overlay.js"))
+    assert "/api/spreadsheets/close" in src, (
+        "the overlay must be able to close what it opened"
+    )
+    body = src[src.index("var skipSpreadsheet") :][:1600]
+    assert "/api/spreadsheets/close" in body, (
+        "the close belongs on the skipSpreadsheet path"
+    )
+    # One call per source: the route drops the map for {type: "mindnode"} and
+    # the worksheet otherwise, and both can be open at once.
+    assert "mindnode_loaded" in body and "sheet_loaded" in body, (
+        "both sources have to be closed, not just whichever is active"
+    )

--- a/tests/test_start_overlay_source.py
+++ b/tests/test_start_overlay_source.py
@@ -119,3 +119,24 @@ def test_no_spreadsheet_actually_closes_the_open_source():
     assert "mindnode_loaded" in body and "sheet_loaded" in body, (
         "both sources have to be closed, not just whichever is active"
     )
+
+
+def test_close_failures_do_not_record_a_session_or_reload():
+    """/api/spreadsheets/close answers 409 while a generation is running. A
+    catch-only handler treats that as success: it records a no-spreadsheet
+    session and reloads with the source still loaded. The open path right
+    below has always checked r.ok; this one must too."""
+    src = strip_comments(read("start-overlay.js"))
+    body = src[src.index("var skipSpreadsheet") :][:2200]
+    assert "r.ok" in body, "the close response status must be checked"
+    assert "markSheetError(" in body, (
+        "a refused close has to surface, not fall through to the reload"
+    )
+    # The reload and the session record both sit behind the ok branch.
+    ok_gate = body.index("if (!res.ok)")
+    assert ok_gate < body.index("recordSession("), (
+        "recordSession must not run when the source is still loaded"
+    )
+    assert ok_gate < body.index("window.location.reload()"), (
+        "the reload must not run when the close was refused"
+    )

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -2419,6 +2419,120 @@ def test_swap_worksheet_rollback_clears_sheet_payload_cache(monkeypatch):
     assert server._sheet_payload_cache is None
 
 
+def test_swap_worksheet_repins_workflows_and_composer(monkeypatch):
+    """All five blueprints follow the swap, not just the three with a full init.
+
+    Workflows and Composer used to keep whatever sheet the *process* started
+    with — none, on a desktop launch — so a spreadsheet opened from the Start
+    overlay never reached a run's NodeContext or Composer's participant list.
+    """
+    import types
+
+    import composer_server
+    import screenspace_server
+    import spreadsheet
+    import transcripts_server
+    import workflows_server
+
+    new_ctx = spreadsheet.SheetContext(
+        sheet_data=[["ID"]],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        observation_cell=types.SimpleNamespace(row=1, col=1),
+        category_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=0,
+        study_name="opened",
+    )
+    new_ws = object()
+
+    def fake_init_studio_state(worksheet):
+        server._worksheet = worksheet
+        server._sheet_context = new_ctx if worksheet is not None else None
+
+    monkeypatch.setattr(server, "_worksheet", None)
+    monkeypatch.setattr(server, "_sheet_context", None)
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_init_studio_state", fake_init_studio_state)
+    monkeypatch.setattr(
+        screenspace_server, "_init_screenspace_state", lambda **kw: None
+    )
+    monkeypatch.setattr(
+        transcripts_server, "_init_transcripts_state", lambda **kw: None
+    )
+    monkeypatch.setattr(workflows_server, "_sheet_context", None)
+    monkeypatch.setattr(workflows_server, "_worksheet", None)
+    monkeypatch.setattr(composer_server, "_sheet_context", None)
+
+    server._swap_worksheet(new_ws)
+
+    assert workflows_server._sheet_context is new_ctx
+    assert workflows_server._worksheet is new_ws
+    assert composer_server._sheet_context is new_ctx
+
+    # ...and closing has to clear them again, or both keep a dead worksheet.
+    server._swap_worksheet(None)
+
+    assert workflows_server._sheet_context is None
+    assert workflows_server._worksheet is None
+    assert composer_server._sheet_context is None
+
+
+def test_swap_worksheet_rollback_restores_workflows_and_composer(monkeypatch):
+    """A failed swap must leave the sister blueprints on the prior sheet, not
+    the half-applied one."""
+    import types
+
+    import composer_server
+    import screenspace_server
+    import spreadsheet
+    import workflows_server
+
+    prev_ctx = spreadsheet.SheetContext(
+        sheet_data=[["ID"]],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        observation_cell=types.SimpleNamespace(row=1, col=1),
+        category_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=0,
+        study_name="previous",
+    )
+    prev_ws = object()
+
+    attempted_ctx = spreadsheet.SheetContext(
+        sheet_data=[["ID"]],
+        id_cell=types.SimpleNamespace(row=1, col=1),
+        observation_cell=types.SimpleNamespace(row=1, col=1),
+        category_cell=types.SimpleNamespace(row=1, col=1),
+        num_participants=0,
+        study_name="attempted",
+    )
+
+    def fake_init_studio_state(worksheet):
+        server._worksheet = worksheet
+        server._sheet_context = attempted_ctx
+
+    monkeypatch.setattr(server, "_worksheet", prev_ws)
+    monkeypatch.setattr(server, "_sheet_context", prev_ctx)
+    monkeypatch.setattr(server, "_sheet_payload_cache", None)
+    monkeypatch.setattr(server, "_generated_artifacts", [])
+    monkeypatch.setattr(server, "_generated_reels", [])
+    monkeypatch.setattr(server, "_init_studio_state", fake_init_studio_state)
+
+    def _boom(**kwargs):
+        raise RuntimeError("screenspace failed")
+
+    monkeypatch.setattr(screenspace_server, "_init_screenspace_state", _boom)
+    monkeypatch.setattr(workflows_server, "_sheet_context", prev_ctx)
+    monkeypatch.setattr(workflows_server, "_worksheet", prev_ws)
+    monkeypatch.setattr(composer_server, "_sheet_context", prev_ctx)
+
+    with pytest.raises(RuntimeError, match="screenspace failed"):
+        server._swap_worksheet(object())
+
+    assert workflows_server._sheet_context is prev_ctx
+    assert workflows_server._worksheet is prev_ws
+    assert composer_server._sheet_context is prev_ctx
+
+
 def test_api_generate_passes_titlecard_options_to_pipeline(client, monkeypatch):
     """Generate passes per-request titlecard options without mutating config."""
     import types

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -239,3 +239,25 @@ def test_studio_card_scrubber_gates_on_thumbnail_and_prefetches():
     assert "function processSpritePrefetch()" in src
     assert "function loadCardSprite(thumb, done)" in src
     assert "SPRITE_PREFETCH_CONCURRENCY" in src
+
+
+def test_intake_queued_state_covers_every_panel():
+    """refreshIntakeCardStates visited only the Screenspace and Transcript
+    panels, so a queued MindNode or Composer card showed no "already queued"
+    highlight and clicking it again silently toggled it back out. The rule
+    (.intake-queue-card.in-queue) and the class were both already there — only
+    the sweep was missing. Driving it off each panel's own config is what keeps
+    the next panel from being forgotten the same way."""
+    src = _studio_js()
+    start = src.index("function intakeCardPanels(")
+    body = src[start : src.index("\n  function ", start + 1)]
+    for cfg in ("CO_INTAKE", "MN_INTAKE"):
+        assert cfg in body, f"{cfg} is missing from the queued-state sweep"
+    sweep_start = src.index("function refreshIntakeCardStates(")
+    sweep = src[sweep_start : src.index("\n  function ", sweep_start + 1)]
+    assert "intakeCardPanels()" in sweep, (
+        "the sweep must iterate the panel list, not hardcode two selectors"
+    )
+    # Scoped per panel: every card also carries the shared .intake-queue-card,
+    # so an unscoped query would index one panel's cards against another's list.
+    assert "panel.cardsSel" in sweep and "panel.cardSel" in sweep

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1140,6 +1140,82 @@ class TestTranscriptWorker:
         assert task["phase"] == "loading_model"
         load_model.assert_called_once()
 
+    def test_execute_task_model_load_raising_fails_task(self, monkeypatch):
+        """_load_model raises as well as returning None (run_with_spinner calls
+        its callback bare, and the WhisperModel construction has no except), so
+        the preload must catch it rather than let it escape _execute_task."""
+        import video as video_mod
+
+        monkeypatch.setattr(config, "DEBUGGING", False)
+        monkeypatch.setattr(video_mod, "timeline_or_none", lambda *_a: None)
+        monkeypatch.setattr(
+            video_mod,
+            "probe_video_properties",
+            lambda *_a, **_k: {"duration": 100.0, "audio_codec": "aac"},
+        )
+        monkeypatch.setattr(
+            transcripts, "load_transcripts_manifest", lambda: {"corrections": []}
+        )
+        monkeypatch.setattr(transcripts, "_resolve_audio_index", lambda *_a: 0)
+
+        def _raising_load(*_a, **_k):
+            raise RuntimeError("Library cublas64_12.dll is not found")
+
+        monkeypatch.setattr(transcripts, "_load_model", _raising_load)
+
+        worker = transcripts.TranscriptWorker()
+        task = transcripts.create_transcript_task("P01", ["/v.mp4"])
+        task["status"] = "running"
+
+        worker._execute_task(task)
+
+        assert task["status"] == "failed"
+        assert "cublas64_12" in task["error"]
+        assert task["completed_at"]
+
+    def test_worker_loop_survives_a_raising_task(self, monkeypatch):
+        """A task that raises anywhere outside _execute_task's own try must not
+        kill the worker thread: there is no restart path, so the next task
+        would queue into a loop nothing drains."""
+        import time
+
+        monkeypatch.setattr(config, "DEBUGGING", False)
+
+        seen = []
+
+        # Keyed on the participant, not execution order: both tasks enqueue at
+        # the same priority and the tie breaks on a random task id, so which
+        # one the worker picks up first is not deterministic.
+        def _boom(task):
+            seen.append(task["id"])
+            if task["participant"] == "P01":
+                raise RuntimeError("model exploded")
+            task["status"] = "completed"
+
+        worker = transcripts.TranscriptWorker()
+        monkeypatch.setattr(worker, "_execute_task", _boom)
+        worker.start()
+        try:
+            first = worker.enqueue(
+                transcripts.create_transcript_task("P01", ["/v.mp4"])
+            )
+            second = worker.enqueue(
+                transcripts.create_transcript_task("P02", ["/v.mp4"])
+            )
+            deadline = time.monotonic() + 5
+            while len(seen) < 2 and time.monotonic() < deadline:
+                time.sleep(0.02)
+        finally:
+            worker.stop()
+
+        assert len(seen) == 2, "worker died on the first task"
+        failed = worker.get_task(first)
+        completed = worker.get_task(second)
+        assert failed is not None and completed is not None
+        assert failed["status"] == "failed"
+        assert "model exploded" in failed["error"]
+        assert completed["status"] == "completed"
+
     def test_remove_task(self):
         worker = transcripts.TranscriptWorker()
         task = transcripts.create_transcript_task("P01", ["/v.mp4"])

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1271,6 +1271,7 @@ class TestLoadModelCpuThreads:
         monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
         monkeypatch.setattr(transcripts, "_cached_model", None)
         monkeypatch.setattr(transcripts, "_cached_model_name", None)
+        monkeypatch.setattr(transcripts, "_cached_model_key", None)
         return seen
 
     def test_cpu_threads_passed_when_set(self, monkeypatch):
@@ -1292,6 +1293,50 @@ class TestLoadModelCpuThreads:
         monkeypatch.setattr(transcripts.os, "cpu_count", lambda: None)
         transcripts._load_model("base")
         assert "cpu_threads" not in seen["kwargs"]
+
+    def test_changing_the_device_reloads_the_cached_model(self, monkeypatch):
+        """TRANSCRIBE_DEVICE is a user-editable Studio setting, but device is
+        read at WhisperModel() time — keying the cache on the model name alone
+        meant a cpu→cuda change saved, persisted and displayed while every
+        later transcription silently kept running the model loaded for cpu."""
+        seen = self._capture_model(monkeypatch)
+        loads: list[str] = []
+        monkeypatch.setattr(config, "TRANSCRIBE_DEVICE", "cpu")
+        transcripts._load_model("base")
+        loads.append(seen["kwargs"]["device"])
+
+        # Same name, different device → must construct again.
+        monkeypatch.setattr(config, "TRANSCRIBE_DEVICE", "cuda")
+        assert transcripts.is_transcription_model_loaded() is False
+        transcripts._load_model("base")
+        loads.append(seen["kwargs"]["device"])
+        assert loads == ["cpu", "cuda"]
+
+        # ...and an unchanged signature must still hit the cache.
+        seen.clear()
+        transcripts._load_model("base")
+        assert seen == {}, "an unchanged load signature must not reconstruct"
+
+    def test_changing_the_thread_count_reloads_the_cached_model(self, monkeypatch):
+        """Same contract for the other construction-time settings."""
+        seen = self._capture_model(monkeypatch)
+        monkeypatch.setattr(config, "TRANSCRIBE_CPU_THREADS", 4)
+        transcripts._load_model("base")
+        assert seen["kwargs"]["cpu_threads"] == 4
+        monkeypatch.setattr(config, "TRANSCRIBE_CPU_THREADS", 8)
+        transcripts._load_model("base")
+        assert seen["kwargs"]["cpu_threads"] == 8
+
+    def test_download_gate_stays_keyed_on_the_name(self, monkeypatch):
+        """is_whisper_model_cached answers "is this model downloaded", which
+        device and thread count do not affect — it must not start reporting
+        False (and re-prompting for a download) after a device change."""
+        self._capture_model(monkeypatch)
+        monkeypatch.setattr(config, "TRANSCRIBE_DEVICE", "cpu")
+        transcripts._load_model("base")
+        assert transcripts.is_whisper_model_cached("base") is True
+        monkeypatch.setattr(config, "TRANSCRIBE_DEVICE", "cuda")
+        assert transcripts.is_whisper_model_cached("base") is True
 
     def test_device_is_always_passed_explicitly(self, monkeypatch):
         """Never leave it to faster-whisper's ``device="auto"`` default."""

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1192,6 +1192,47 @@ def test_embed_subtitles_409_while_a_run_holds_the_slot(tr_client, monkeypatch):
     assert resp.get_json()["ok"] is False
 
 
+def test_embed_slot_is_freed_when_the_stream_is_never_consumed(tr_client, monkeypatch):
+    """Closing a generator that was never *started* runs no body at all — not
+    its finally — so a response discarded before the first read would have left
+    the slot held and every later embed answering 409 until restart."""
+    monkeypatch.setattr(transcripts_server, "_embed_busy", False)
+    monkeypatch.setattr(transcripts_server, "_embed_owner", None)
+
+    resp = tr_client.post(
+        "/transcripts/api/embed-subtitles", json={"participants": ["P01"]}
+    )
+    assert resp.status_code == 200
+    # Tear the response down without ever pulling a line from the body.
+    resp.close()
+
+    assert transcripts_server._embed_busy is False
+    assert transcripts_server._embed_owner is None
+
+
+def test_embed_slot_release_is_scoped_to_its_own_run(monkeypatch):
+    """The release is attempted twice per run (the generator's finally and the
+    response's call_on_close). An ungated release would let the late one clear
+    a successor's claim — the 863edf8f pattern."""
+    monkeypatch.setattr(transcripts_server, "_embed_busy", False)
+    monkeypatch.setattr(transcripts_server, "_embed_owner", None)
+
+    first = transcripts_server._claim_embed_slot()
+    assert first is not None
+    transcripts_server._release_embed_slot(first)
+
+    second = transcripts_server._claim_embed_slot()
+    assert second is not None and second != first
+
+    # The first run's straggler release must not free the second run's slot.
+    transcripts_server._release_embed_slot(first)
+    assert transcripts_server._embed_busy is True
+    assert transcripts_server._claim_embed_slot() is None
+
+    transcripts_server._release_embed_slot(second)
+    assert transcripts_server._embed_busy is False
+
+
 def test_embed_subtitles_cancel_route_sets_the_event(tr_client):
     transcripts_server._embed_cancel_event.clear()
     resp = tr_client.post("/transcripts/api/embed-subtitles/cancel")

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -2273,10 +2273,24 @@ def test_ollama_install_rejected_where_unsupported(tr_client, monkeypatch):
 
 
 def test_ollama_install_short_circuits_when_installed(tr_client, monkeypatch):
+    """The idempotent path: a working install must not re-download.
+
+    Stubs is_working_install, which is what the route gates on — stubbing only
+    is_installed leaves the real predicate running, and on a machine with no
+    ollama on PATH that answers False, so the route falls through and spawns a
+    genuine 145 MB install_managed() on a daemon thread.
+    """
     import ollama_client
 
     monkeypatch.setattr(ollama_client, "can_install_managed", lambda: True)
-    monkeypatch.setattr(ollama_client, "is_installed", lambda: True)
+    monkeypatch.setattr(ollama_client, "is_working_install", lambda: True)
+
+    def _must_not_run(on_progress=None):
+        raise AssertionError("install_managed must not run for a working install")
+
+    monkeypatch.setattr(ollama_client, "install_managed", _must_not_run)
+    monkeypatch.setattr(transcripts_server, "_ollama_install_status", None)
+
     resp = tr_client.post("/transcripts/api/models/ollama/install", json={})
     assert resp.status_code == 200
     assert resp.get_json()["already_installed"] is True
@@ -2342,24 +2356,6 @@ def test_ollama_install_retries_a_broken_install(tr_client, monkeypatch):
     body = tr_client.post("/transcripts/api/models/ollama/install", json={}).get_json()
     assert body.get("already_installed") is not True
     assert body["started"] is True
-
-
-def test_ollama_install_short_circuits_a_working_install(tr_client, monkeypatch):
-    """The idempotent path still has to short-circuit, or every dialog open
-    would re-download."""
-    import ollama_client
-
-    monkeypatch.setattr(ollama_client, "can_install_managed", lambda: True)
-    monkeypatch.setattr(ollama_client, "is_working_install", lambda: True)
-
-    def _must_not_run(on_progress=None):
-        raise AssertionError("install_managed must not run for a working install")
-
-    monkeypatch.setattr(ollama_client, "install_managed", _must_not_run)
-    monkeypatch.setattr(transcripts_server, "_ollama_install_status", None)
-
-    body = tr_client.post("/transcripts/api/models/ollama/install", json={}).get_json()
-    assert body["already_installed"] is True
 
 
 def test_ollama_install_second_post_attaches(tr_client, monkeypatch):

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -2220,7 +2220,9 @@ def test_ollama_install_starts_and_reports_success(tr_client, monkeypatch):
     import ollama_client
 
     monkeypatch.setattr(ollama_client, "can_install_managed", lambda: True)
-    monkeypatch.setattr(ollama_client, "is_installed", lambda: False)
+    # The route gates on is_working_install (is_installed only asks whether a
+    # file exists, which a half-extracted tree also satisfies).
+    monkeypatch.setattr(ollama_client, "is_working_install", lambda: False)
 
     def _fake_install(on_progress=None):
         if on_progress:
@@ -2248,13 +2250,50 @@ def test_ollama_install_starts_and_reports_success(tr_client, monkeypatch):
     assert status["status"] == "success"
 
 
+def test_ollama_install_retries_a_broken_install(tr_client, monkeypatch):
+    """A half-extracted tree satisfies is_installed(), and this route is the
+    only way to repair one — so gating on it answered already_installed
+    forever and stranded the user with no in-app recovery."""
+    import ollama_client
+
+    monkeypatch.setattr(ollama_client, "can_install_managed", lambda: True)
+    monkeypatch.setattr(ollama_client, "is_installed", lambda: True)
+    monkeypatch.setattr(ollama_client, "is_working_install", lambda: False)
+    monkeypatch.setattr(ollama_client, "install_managed", lambda on_progress=None: True)
+    monkeypatch.setattr(transcripts_server, "_ollama_install_status", None)
+
+    body = tr_client.post("/transcripts/api/models/ollama/install", json={}).get_json()
+    assert body.get("already_installed") is not True
+    assert body["started"] is True
+
+
+def test_ollama_install_short_circuits_a_working_install(tr_client, monkeypatch):
+    """The idempotent path still has to short-circuit, or every dialog open
+    would re-download."""
+    import ollama_client
+
+    monkeypatch.setattr(ollama_client, "can_install_managed", lambda: True)
+    monkeypatch.setattr(ollama_client, "is_working_install", lambda: True)
+
+    def _must_not_run(on_progress=None):
+        raise AssertionError("install_managed must not run for a working install")
+
+    monkeypatch.setattr(ollama_client, "install_managed", _must_not_run)
+    monkeypatch.setattr(transcripts_server, "_ollama_install_status", None)
+
+    body = tr_client.post("/transcripts/api/models/ollama/install", json={}).get_json()
+    assert body["already_installed"] is True
+
+
 def test_ollama_install_second_post_attaches(tr_client, monkeypatch):
     import threading as threading_mod
 
     import ollama_client
 
     monkeypatch.setattr(ollama_client, "can_install_managed", lambda: True)
-    monkeypatch.setattr(ollama_client, "is_installed", lambda: False)
+    # The route gates on is_working_install (is_installed only asks whether a
+    # file exists, which a half-extracted tree also satisfies).
+    monkeypatch.setattr(ollama_client, "is_working_install", lambda: False)
     release = threading_mod.Event()
     monkeypatch.setattr(
         ollama_client,

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1004,7 +1004,8 @@ def test_embed_subtitles_happy_path(tr_client, tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.mimetype == "application/x-ndjson"
-    header, result = _ndjson(resp)
+    header, result, done = _ndjson(resp)
+    assert done == {"done": True}
     assert header == {"total": 1, "output_dir": str(tmp_path)}
     assert result["index"] == 0
     assert result["participant"] == "P01"
@@ -1077,7 +1078,7 @@ def test_embed_subtitles_streams_failure_for_missing_transcript(
     assert resp.status_code == 200
     lines = _ndjson(resp)
     assert lines[0]["total"] == 2
-    assert [ln["participant"] for ln in lines[1:]] == ["P01", "P02"]
+    assert [ln["participant"] for ln in lines[1:-1]] == ["P01", "P02"]
     assert lines[1]["ok"] is True
     assert lines[2]["ok"] is False
     assert lines[2]["error"] == "No transcript for participant"
@@ -1103,9 +1104,43 @@ def test_embed_subtitles_streams_failure_when_ffmpeg_fails(
         "/transcripts/api/embed-subtitles", json={"participants": ["P01"]}
     )
     assert resp.status_code == 200
-    _, result = _ndjson(resp)
+    _, result, done = _ndjson(resp)
+    assert done == {"done": True}
     assert result["ok"] is False
     assert result["error"] == "ffmpeg failed to mux subtitles"
+    # get_unique_filename reserves by creating an empty file; a failed mux that
+    # does not release it leaves a 0-byte artifact looking like a real export.
+    assert not list(tmp_path.glob("*-subtitled.mp4"))
+
+
+def test_embed_subtitles_truncated_stream_has_no_done_sentinel(
+    tr_client, tmp_path, monkeypatch
+):
+    """A generator that dies mid-run just truncates the body, which the client's
+    NDJSON reader cannot distinguish from a clean end — so the terminal
+    sentinel's absence is what marks the run as incomplete."""
+    video_path = tmp_path / "study_P01.mp4"
+    video_path.write_bytes(b"\x00")
+    transcripts_server._participants = [
+        {"id": "P01", "video_paths": [str(video_path)], "has_video": True}
+    ]
+    _seed_transcript("P01", str(video_path))
+    monkeypatch.setattr(
+        transcripts_server.utils, "get_effective_output_dir", lambda: tmp_path
+    )
+
+    def _explode(*_a, **_kw):
+        raise RuntimeError("mux blew up")
+
+    monkeypatch.setattr(transcripts_server, "_embed_subtitle_for_participant", _explode)
+
+    resp = tr_client.post(
+        "/transcripts/api/embed-subtitles", json={"participants": ["P01"]}
+    )
+    with pytest.raises(RuntimeError, match="mux blew up"):
+        resp.get_data()
+    # The slot must still be free — the generator's finally runs on teardown.
+    assert transcripts_server._embed_busy is False
 
 
 def test_embed_subtitles_cancel_stops_before_the_next_file(
@@ -1140,7 +1175,8 @@ def test_embed_subtitles_cancel_stops_before_the_next_file(
     lines = _ndjson(resp)
     assert lines[0]["total"] == 2
     assert lines[1]["participant"] == "P01"
-    assert lines[-1] == {"cancelled": True}
+    assert lines[-2] == {"cancelled": True}
+    assert lines[-1] == {"done": True}
     assert not any(ln.get("participant") == "P02" for ln in lines)
     # The slot is released even on the cancel path, so the next run can claim it.
     assert transcripts_server._embed_busy is False

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -528,7 +528,13 @@ def test_embed_subs_warns_the_default_toggle_is_inert_on_mp4():
     present-but-off state). Unticking the box therefore changes nothing for the
     commonest source container, and a control that silently no-ops is the
     "wrong output, no error" class — so the summary has to say so."""
-    assert "EMBED_SUBS_ALWAYS_DEFAULT_EXT" in _JS
+    # The container lists come from CLIPGEN_CONFIG (mirroring
+    # video.SUBTITLE_ALWAYS_DEFAULT_CONTAINERS), never a hardcoded JS regex —
+    # see the "no duplicated constants between Python and JS" rule.
+    assert "CLIPGEN_CONFIG.subtitleContainers" in _JS
+    assert "/\\.(mp4|m4v|mov)$/i" not in _JS, (
+        "the mp4-family list must not be re-hardcoded in JS"
+    )
     start = _JS.index("function renderEmbedSubsSummary(")
     body = _JS[start : _JS.index("\n  function ", start + 1)]
     assert "_embedSubsAlwaysDefault(" in body, (
@@ -537,6 +543,23 @@ def test_embed_subs_warns_the_default_toggle_is_inert_on_mp4():
     assert '"#embedSubsDefault"' in body and ".checked" in body, (
         "the caveat only applies when the box is unticked, so the summary has "
         "to read the checkbox"
+    )
+
+
+def test_embed_subs_filters_containers_the_muxer_cannot_write():
+    """mux_subtitles rejects any container it has no codec for. Filtering only
+    multi-part participants left the summary promising "8 subtitled videos" for
+    a study of .avi sources and the run returning 8 failure lines."""
+    assert "_embedSubsIsUnsupported(" in _JS
+    start = _JS.index("function _embedSubsTargets(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    assert "_embedSubsIsUnsupported(p)" in body, (
+        "the target list must drop unsupported containers, not just multi-part"
+    )
+    summary = _JS[_JS.index("function renderEmbedSubsSummary(") :]
+    summary = summary[: summary.index("\n  function ")]
+    assert "unsupported" in summary, (
+        "the summary must account for what it dropped, like it does multi-part"
     )
     # The caveat depends on the checkbox, so the checkbox must re-render it.
     init_start = _JS.index("function initEmbedSubsModal(")

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1703,8 +1703,11 @@ def test_mux_subtitles_mp4_uses_mov_text(monkeypatch, tmp_path):
     assert cmd[:2] == ["ffmpeg", "-y"]
     assert "-c:s" in cmd and cmd[cmd.index("-c:s") + 1] == "mov_text"
     assert "-c" in cmd and cmd[cmd.index("-c") + 1] == "copy"
-    assert "-map" in cmd
-    assert "0" in cmd and "1:0" in cmd
+    # Video + audio only, never a bare `-map 0`: mapping the source's own
+    # subtitle streams would push the new track off output index 0, so the
+    # -metadata/-disposition arguments below would land on the wrong one.
+    maps = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-map"]
+    assert maps == ["0:v?", "0:a?", "1:0"]
     assert cmd[cmd.index("-disposition:s:0") + 1] == "default"
     assert cmd[-1] == str(out)
 

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -42,7 +42,8 @@ def wf_client(wf_app, tmp_path, monkeypatch):
     monkeypatch.setattr(
         workflows_server, "_manifest", workflows.empty_workflows_manifest()
     )
-    monkeypatch.setattr(workflows_server, "_input_dir", str(tmp_path))
+    # The input dir is read live from config, not snapshotted on the module.
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path), raising=False)
     monkeypatch.setattr(workflows_server, "_sheet_context", None)
     monkeypatch.setattr(workflows_server, "_worksheet", None)
     # Reset run state so runners/SSE clients never leak across tests.
@@ -95,6 +96,22 @@ def test_page_serves(wf_client):
     body = resp.get_data(as_text=True)
     assert 'data-frontend="workflows"' in body
     assert "workflows.js" in body
+
+
+def test_node_context_follows_the_live_input_dir(wf_client, tmp_path, monkeypatch):
+    """Both dirs resolve per run, not at blueprint init.
+
+    _init_workflows_state runs once, from build_combined_app, and the Start
+    overlay's folder picker moves config.INPUT_DIR long afterwards — a snapshot
+    taken at init pointed every run at the process's launch directory.
+    """
+    picked = tmp_path / "picked-later"
+    picked.mkdir()
+    monkeypatch.setattr(config, "INPUT_DIR", str(picked))
+
+    ctx = workflows_server._build_node_context(threading.Event())
+
+    assert ctx.input_dir == picked
 
 
 def test_blueprints_empty_by_default(wf_client):


### PR DESCRIPTION
## Summary

An audit of the ten substantive commits merged 2026-08-04 → 2026-08-14 (#675–#687) found defects in most of them; this fixes all of them, each with a regression test verified to fail against the pre-fix source.

- **The transcription worker died permanently** on a raising model load — #682 moved the preload outside `_execute_task`'s `try`, and `_run` never wrapped it either, so one CTranslate2 failure left the task "running" forever and every later transcribe queued behind a dead loop.
- **The Ollama install could wedge itself unrecoverably**: a half-extracted tree read as installed and the route gated on a weaker predicate than the installer's own, so retries answered `already_installed`. Also adds a wall-clock download deadline, cleans up on failure, and stops `capture_output` reporting successful Windows installs as timeouts.
- **`_swap_worksheet` refreshed three of five blueprints**, so a spreadsheet opened from the Start overlay never reached Workflows or Composer; and **MindNode sources outlived their session** (prefill hijack plus a `/api/spreadsheets/close` route no UI ever called).
- **Embed Subtitles** reported truncated runs as success, tagged the wrong subtitle stream when the source already had one, left 0-byte placeholders, and promised output for containers ffmpeg rejects.
- Smaller: the Whisper cache ignoring device/thread settings, `+`/`,`-separated timestamps leaking into clip filenames, a malformed XML `.mindnode` 500, a refresh/close race, the embed slot leaking on an unconsumed stream, and intake cards never showing their queued state.

## Test plan

- [x] `/check` green — ruff format + lint, `ty`, full suite (2768 passed)
- [x] `/ui-check` — all six pages load with no page errors; screenshots reviewed
- [x] Live-probed in-browser: the Embed Subtitles container filtering, the Composer intake queued state (A/B'd against the pre-fix file), and the close-409 path (records nothing, no reload, error surfaced)
- [x] Fixed a pre-existing test that loaded a real Whisper model (~140 MB on a cold cache) and one that could start a real 145 MB Ollama download on CI
- [ ] **Windows Ollama paths unverified on real hardware** — the `capture_output` and first-run probe-timeout changes are reasoned, not reproduced; #686 flagged Windows verification as pending too
