### PR TITLE
ci: suffix the macOS dmg and drop redundant tag artifacts

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -17,10 +17,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # release_glob is per-leg on purpose: each OS produces exactly one
+          # shippable file, so a shared two-pattern list could never be checked
+          # with fail_on_unmatched_files (see the publish step).
           - os: macos-latest
             artifact_name: clipgen-macos
+            release_glob: dist/*.dmg
           - os: windows-latest
             artifact_name: clipgen-windows
+            release_glob: dist/*.zip
 
     runs-on: ${{ matrix.os }}
 
@@ -201,7 +206,7 @@ jobs:
           cp build/THIRD-PARTY-LICENSES dmg-staging/ 2>/dev/null || true
           ln -s /Applications dmg-staging/Applications
           hdiutil create -volname "clipgen" -srcfolder dmg-staging \
-            -ov -format UDZO "dist/clipgen-${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}.dmg"
+            -ov -format UDZO "dist/clipgen-${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}-macos.dmg"
           rm -rf dmg-staging
           ls -la dist/*.dmg
 
@@ -232,18 +237,21 @@ jobs:
           Compress-Archive -Path dist/clipgen -DestinationPath "dist/clipgen-$ver-windows.zip" -Force
           Get-ChildItem dist/*.zip
 
+      # Only the upload steps below consume this, and they are non-tag-only, so
+      # the short sha is the whole answer — a tag branch here would be dead.
+      # GitHub expressions have no substring function, hence the step.
       - name: Compute artifact suffix
         id: suffix
         shell: bash
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            echo "suffix=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "suffix=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "suffix=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+      # Non-tag builds only. upload-artifact always zips its payload (no opt-out
+      # — Actions has stored artifacts as zips since v4), so on a tag these would
+      # be a redundant double-zipped copy of assets the Release already carries,
+      # at ~800 MB of artifact storage per release. Dev builds keep them because
+      # the Actions tab is the only way to get one.
       - name: Upload artifact (macOS)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' && github.ref_type != 'tag'
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact_name }}-${{ steps.suffix.outputs.suffix }}
@@ -252,7 +260,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload artifact (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && github.ref_type != 'tag'
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact_name }}-${{ steps.suffix.outputs.suffix }}
@@ -265,7 +273,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            dist/*.dmg
-            dist/*.zip
-          fail_on_unmatched_files: false
+          # This leg's own artifact only — the other leg uploads its own.
+          files: ${{ matrix.release_glob }}
+          # On a tag this is the only guard left that packaging produced anything
+          # (the upload-artifact steps above, which carry if-no-files-found:
+          # error, are skipped there) — a silent miss would otherwise publish a
+          # release with a platform absent.
+          fail_on_unmatched_files: true

--- a/agents/skills/build/SKILL.md
+++ b/agents/skills/build/SKILL.md
@@ -197,6 +197,16 @@ stay the **first statement** of the launcher's `__main__` block, before any clip
   symlinks, and signature through the round trip); Windows ships a **`.zip`**.
 - **Actions artifacts need a login and expire after 90 days.** Tagged builds publish to **GitHub
   Releases**; that step needs `permissions: contents: write`.
+- **`upload-artifact` always zips, with no opt-out** (Actions has stored artifacts as zips since
+  v4), so an artifact download is always one wrapper deeper than the Release asset: a zip *around*
+  the `.dmg` / `.zip`. It costs nothing in size — the outer zip is a wash or a small win — but on a
+  tag it would be a redundant ~800 MB copy of what the Release already carries, so the upload steps
+  are gated on `github.ref_type != 'tag'`. Dev (`workflow_dispatch`) builds keep their artifacts.
+- **`fail_on_unmatched_files: true` needs a per-leg glob.** Each matrix leg produces exactly one
+  shippable file, so the publish step takes `matrix.release_glob` (`dist/*.dmg` / `dist/*.zip`); a
+  shared two-pattern list would fail whichever leg didn't produce the other platform's file. This
+  is the only guard on a tag that packaging produced anything, since the `if-no-files-found: error`
+  uploads are skipped there.
 - **Never publish `dist/clipgen` as a file.** Under one-dir it is a *directory*. The old raw-binary
   step was removed for exactly this reason — it would have silently published the wrong thing
   rather than failing.


### PR DESCRIPTION
## Summary

Release assets were already correctly packaged — a bare `.dmg` and one Windows `.zip`; the extra layer only ever existed on the Actions artifacts tab, where `upload-artifact` always zips with no opt-out. This cleans up around that rather than changing the wrapping: the image is now `clipgen-<tag>-macos.dmg` (matching `-windows.zip`), both upload steps are gated on a non-tag ref so a tag no longer stores an ~800 MB duplicate of what the Release carries, and `fail_on_unmatched_files: true` becomes the tag-time guard that packaging produced anything — which needs a per-leg `matrix.release_glob`, since each leg builds exactly one shippable file and checking both patterns strictly would fail whichever leg lacked the other platform's. The artifact-suffix step drops to the short sha, its tag branch now being unreachable. `agents/skills/build/SKILL.md` records why neither inner wrapper can be removed: a directly-uploaded `.app` loses its exec bit and signature to `upload-artifact`'s 644, and `dist/clipgen` is a directory rather than a file.

## Test plan

- [x] `/check` green — ruff format + lint, ty, 2770 tests passing
- [x] Workflow parses as YAML; confirmed the suffix step's only consumers are the two non-tag-gated uploads
- [x] Verified against live data that no asset name is referenced anywhere (no auto-update, no `download-artifact` consumer; README/CHANGELOG say "`.dmg`" generically)
- [ ] `workflow_dispatch` on this branch: both legs still upload, macOS artifact contains `clipgen-dev-macos.dmg`
- [ ] Next tag: Release lists exactly the two assets and the run's artifact list is empty

Not verified locally — GitHub expression semantics in `if:` and the `matrix.release_glob` interpolation only resolve on a real run. Unrelated but noted while here: `permissions: actions: write` looks unnecessary (neither `cache` nor `upload-artifact` uses the REST API), left alone as out of scope.