### PR TITLE
refactor(server,video): collapse duplicated backend patterns

### DIFF
--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -63,6 +63,7 @@ import video
 from server_utils import (
     MediaCache,
     err,
+    err_no_video,
     find_by_id,
     ok,
     parse_clip_window,
@@ -834,15 +835,15 @@ MAX_OVERLAY_WINDOWS = 20
 
 def _find_participant_parts(participant: str) -> list[dict[str, Any]] | None:
     """Ordered ``{name, path, duration, offset}`` parts, or None."""
-    for p in files.resolve_participant_videos(_sheet_context):
-        if p["id"] == participant and p.get("has_video"):
-            parts = _participant_parts(p["video_paths"])
-            if parts is None:
-                return None
-            for part, vp in zip(parts, p["video_paths"]):
-                part["path"] = str(vp)
-            return parts
-    return None
+    p = files.find_participant_record(_sheet_context, participant)
+    if p is None or not p.get("has_video"):
+        return None
+    parts = _participant_parts(p["video_paths"])
+    if parts is None:
+        return None
+    for part, vp in zip(parts, p["video_paths"]):
+        part["path"] = str(vp)
+    return parts
 
 
 def _part_for_time(parts: list[dict[str, Any]], t: float) -> dict[str, Any]:
@@ -963,7 +964,7 @@ def api_audio_track(participant: str, idx: int) -> Any:
     """Stream one demuxed audio track for the browser's per-track volume mixer."""
     parts = _find_participant_parts(participant)
     if not parts:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     out = video.extract_audio_track(parts[0]["path"], idx)
     if out is None:
         return err("Could not extract audio track", 500)

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -61,7 +61,14 @@ import pipeline
 import remux_server
 import utils
 import video
-from server_utils import MediaCache, err, ok, parse_clip_window
+from server_utils import (
+    MediaCache,
+    err,
+    find_by_id,
+    ok,
+    parse_clip_window,
+    remove_by_id,
+)
 import itertools
 
 # ---- Module state (initialized by _init_composer_state) ----
@@ -268,9 +275,7 @@ def api_cut_create() -> Any:
 def api_cut_update(cut_id: str) -> Any:
     data = request.get_json(silent=True) or {}
     with _manifest_lock:
-        cut = next(
-            (c for c in _manifest.get("cuts", []) if c.get("id") == cut_id), None
-        )
+        cut = find_by_id(_manifest.get("cuts", []), cut_id)
         if cut is None:
             return err(f"No cut {cut_id}", 404)
         start = cut["start"]
@@ -294,11 +299,8 @@ def api_cut_update(cut_id: str) -> Any:
 @composer_bp.route("/api/cuts/<cut_id>", methods=["DELETE"])
 def api_cut_delete(cut_id: str) -> Any:
     with _manifest_lock:
-        cuts = _manifest.get("cuts", [])
-        remaining = [c for c in cuts if c.get("id") != cut_id]
-        if len(remaining) == len(cuts):
+        if remove_by_id(_manifest.get("cuts", []), cut_id) is None:
             return err(f"No cut {cut_id}", 404)
-        _manifest["cuts"] = remaining
         _persist_locked()
     return ok()
 
@@ -529,10 +531,7 @@ def api_annotation_create() -> Any:
 def api_annotation_update(ann_id: str) -> Any:
     data = request.get_json(silent=True) or {}
     with _manifest_lock:
-        ann = next(
-            (a for a in _manifest.get("annotations", []) if a.get("id") == ann_id),
-            None,
-        )
+        ann = find_by_id(_manifest.get("annotations", []), ann_id)
         if ann is None:
             return err(f"No annotation {ann_id}", 404)
         if data.get("span") is not None:
@@ -554,11 +553,8 @@ def api_annotation_update(ann_id: str) -> Any:
 @composer_bp.route("/api/annotations/<ann_id>", methods=["DELETE"])
 def api_annotation_delete(ann_id: str) -> Any:
     with _manifest_lock:
-        annotations = _manifest.get("annotations", [])
-        remaining = [a for a in annotations if a.get("id") != ann_id]
-        if len(remaining) == len(annotations):
+        if remove_by_id(_manifest.get("annotations", []), ann_id) is None:
             return err(f"No annotation {ann_id}", 404)
-        _manifest["annotations"] = remaining
         _persist_locked()
     return ok()
 

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -44,7 +44,6 @@ Mutations hold ``_manifest_lock`` and persist via :func:`_persist_locked`.
 from __future__ import annotations
 
 import copy
-import json
 import math
 import os
 import threading
@@ -107,10 +106,6 @@ remux_server.register_remux_routes(composer_bp, lambda: _sheet_context)
 # ---- Manifest I/O ----
 
 
-def _manifest_path() -> Path:
-    return Path(utils.get_effective_output_dir()) / config.COMPOSER_MANIFEST_FILENAME
-
-
 def _empty_manifest() -> dict[str, Any]:
     return {
         "cuts": [],
@@ -124,17 +119,10 @@ def _empty_manifest() -> dict[str, Any]:
 
 
 def _load_manifest() -> dict[str, Any]:
-    path = _manifest_path()
-    if path.is_file():
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                return data
-        except (OSError, json.JSONDecodeError):
-            utils.warning_print(
-                f"Could not read {path.name}; starting with an empty composer manifest."
-            )
-    return _empty_manifest()
+    data = utils.load_json_manifest(
+        config.COMPOSER_MANIFEST_FILENAME, warn_label="the composer manifest"
+    )
+    return data if isinstance(data, dict) else _empty_manifest()
 
 
 def _persist_locked() -> None:

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -52,7 +52,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from flask import Blueprint, Response, request, send_file
+from flask import Blueprint, request, send_file
 
 import config
 import files
@@ -62,11 +62,11 @@ import utils
 import video
 from server_utils import (
     MediaCache,
+    clip_media_response,
     err,
     err_no_video,
     find_by_id,
     ok,
-    parse_clip_window,
     remove_by_id,
 )
 import itertools
@@ -880,64 +880,6 @@ def _resolve_scrub_source(
     return part["path"], local_start, clamped
 
 
-def _scrub_media_response(participant: str, cache: MediaCache, kind: str) -> Any:
-    """Shared guts of the sprite / audio scrub routes (parse → resolve → cache)."""
-    window = parse_clip_window()
-    if window is None:
-        return err("Invalid time range")
-    start_sec, duration = window
-    if kind == "audio":
-        duration = min(duration, config.COMPOSER_SCRUB_MAX_AUDIO_SECONDS)
-
-    resolved = _resolve_scrub_source(participant, start_sec, duration)
-    if resolved is None:
-        return err("Source video not found", 404)
-    video_path, local_start, duration = resolved
-
-    try:
-        mtime = os.stat(video_path).st_mtime
-    except OSError:
-        mtime = 0.0
-
-    if kind == "sprite":
-        cols = config.STUDIO_SCRUBBER_SPRITE_COLS
-        rows = config.STUDIO_SCRUBBER_SPRITE_ROWS
-        cache_key: tuple = (
-            video_path,
-            round(local_start, 3),
-            round(duration, 3),
-            cols,
-            rows,
-            mtime,
-        )
-        media_bytes = cache.get_or_compute(
-            cache_key,
-            # seek_frames: per-frame fast seeks keep the cost O(frames), not
-            # O(span) — timeline tiles can cover minutes of source video.
-            lambda: video.extract_sprite_sheet_bytes(
-                video_path, local_start, duration, cols, rows, seek_frames=True
-            ),
-        )
-        mimetype = "image/jpeg"
-    else:
-        cache_key = (video_path, round(local_start, 3), round(duration, 3), mtime)
-        media_bytes = cache.get_or_compute(
-            cache_key,
-            lambda: video.extract_audio_segment_bytes(
-                video_path, local_start, duration
-            ),
-        )
-        mimetype = "audio/wav"
-
-    if media_bytes is None:
-        return err(f"{kind.capitalize()} extraction failed", 404)
-    return Response(
-        media_bytes,
-        mimetype=mimetype,
-        headers={"Cache-Control": "public, max-age=86400"},
-    )
-
-
 @composer_bp.route("/api/sprite/<participant>")
 def api_sprite(participant: str) -> Any:
     """Tiled JPEG sprite sheet for one thumbnail-strip tile.
@@ -946,7 +888,21 @@ def api_sprite(participant: str) -> Any:
     slot-seconds ladder), not per marker span, so zooming in refines the strip
     with additional frames instead of stretching the same ones.
     """
-    return _scrub_media_response(participant, _sprite_cache, "sprite")
+    cols = config.STUDIO_SCRUBBER_SPRITE_COLS
+    rows = config.STUDIO_SCRUBBER_SPRITE_ROWS
+    return clip_media_response(
+        cache=_sprite_cache,
+        resolve=lambda start, dur: _resolve_scrub_source(participant, start, dur),
+        # seek_frames: per-frame fast seeks keep the cost O(frames), not
+        # O(span) — timeline tiles can cover minutes of source video.
+        produce=lambda path, local_start, dur: video.extract_sprite_sheet_bytes(
+            path, local_start, dur, cols, rows, seek_frames=True
+        ),
+        mimetype="image/jpeg",
+        kind_label="Sprite",
+        key_extras=(cols, rows),
+        invalid_message="Invalid time range",
+    )
 
 
 @composer_bp.route("/api/audio/<participant>")
@@ -956,7 +912,16 @@ def api_audio(participant: str) -> Any:
     Capped at ``config.COMPOSER_SCRUB_MAX_AUDIO_SECONDS`` — markers can span
     minutes, and the WAV is decoded whole in the browser's WebAudio context.
     """
-    return _scrub_media_response(participant, _audio_cache, "audio")
+    return clip_media_response(
+        cache=_audio_cache,
+        resolve=lambda start, dur: _resolve_scrub_source(
+            participant, start, min(dur, config.COMPOSER_SCRUB_MAX_AUDIO_SECONDS)
+        ),
+        produce=video.extract_audio_segment_bytes,
+        mimetype="audio/wav",
+        kind_label="Audio",
+        invalid_message="Invalid time range",
+    )
 
 
 @composer_bp.route("/api/audio-track/<participant>/<int:idx>")

--- a/source/files.py
+++ b/source/files.py
@@ -319,6 +319,21 @@ def resolve_participant_videos(sheet_context: Any = None) -> list[dict[str, Any]
     return entries
 
 
+def find_participant_record(
+    sheet_context: Any, participant_id: str
+) -> dict[str, Any] | None:
+    """First :func:`resolve_participant_videos` record matching *participant_id*.
+
+    A fresh resolve on every call — for routes that must see the live input
+    directory (e.g. after ``POST /api/dirs``) rather than a blueprint's
+    ``_participants`` cache.
+    """
+    for participant in resolve_participant_videos(sheet_context):
+        if participant["id"] == participant_id:
+            return participant
+    return None
+
+
 def prepare_clip(clip: ClipRecord) -> ClipRecord:
     """Parse timestamps and sanitize description/category for filename use.
 

--- a/source/overview.py
+++ b/source/overview.py
@@ -10,7 +10,6 @@ the Convergence tab's per-lane display offsets, persisted in the output dir.
 from __future__ import annotations
 
 import math
-from pathlib import Path
 from typing import Any, cast
 
 from flask import Blueprint, request
@@ -90,15 +89,9 @@ def api_convergence_offsets_put():
 
     cleaned = _clean_convergence_offsets(raw)
 
-    settings_path = (
-        Path(utils.get_effective_output_dir()) / config.CONVERGENCE_OFFSETS_FILENAME
-    )
     if not cleaned:
-        if settings_path.is_file():
-            try:
-                settings_path.unlink()
-            except OSError:
-                pass
+        # Also sweeps a stale .tmp sibling from an interrupted save.
+        utils.remove_json_manifest(config.CONVERGENCE_OFFSETS_FILENAME)
     else:
         utils.save_json_manifest(
             config.CONVERGENCE_OFFSETS_FILENAME, {"offsets": cleaned}

--- a/source/remux_server.py
+++ b/source/remux_server.py
@@ -32,10 +32,10 @@ _jobs_lock = threading.Lock()
 
 def _participant_paths(sheet_context_getter: Any, pid: str) -> list[str]:
     """Existing source files for ``pid``, or [] when it has none."""
-    for participant in files.resolve_participant_videos(sheet_context_getter()):
-        if participant["id"] == pid:
-            return [str(p) for p in participant["video_paths"] if Path(p).is_file()]
-    return []
+    record = files.find_participant_record(sheet_context_getter(), pid)
+    if record is None:
+        return []
+    return [str(p) for p in record["video_paths"] if Path(p).is_file()]
 
 
 def _media_state(sheet_context_getter: Any) -> tuple[dict[str, list[str]], list[str]]:

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -58,6 +58,7 @@ import binascii
 import copy
 import json
 import math
+import sys
 import threading
 import uuid
 from collections import OrderedDict
@@ -81,6 +82,7 @@ from server_utils import (
     find_by_id,
     json_endpoint,
     make_debounced_persist,
+    make_participant_cache,
     make_sse_channel,
     ok,
     parse_number_arg,
@@ -260,45 +262,18 @@ remux_server.register_remux_routes(
 _NOTES_MAX_BYTES = 64 * 1024
 
 
-def _refresh_participants() -> None:
-    """Rebuild ``_participants`` when the input directory changed since the last build.
-
-    Keyed on the input dir's ``st_mtime_ns`` (which advances on add/remove/rename),
-    mirroring ``utils.discover_participant_videos``' own memo — the steady-state
-    cost is one ``stat()``. This is what lets a video dropped into ``-i`` mid-session
-    show up without a server restart.
-
-    No-op until :func:`_init_screenspace_state` has configured the source. The
-    rebuild rebinds ``_participants`` (atomic under the GIL), so a concurrent
-    reader sees either the old list or the new one, never a torn one.
-    """
-    global _participants
-
-    source = _participant_source
-    if source is None:
-        return
-    input_dir = str(Path(utils.get_effective_input_dir()))
-    try:
-        mtime: int | None = Path(input_dir).stat().st_mtime_ns
-    except OSError:
-        mtime = None
-    if source["dir"] == input_dir and source["mtime"] == mtime:
-        return
-    with _participants_lock:
-        # A racing request may have rebuilt, or a sheet swap may have replaced the
-        # source entirely, while we waited on the lock.
-        if _participant_source is not source:
-            return
-        if source["dir"] == input_dir and source["mtime"] == mtime:
-            return
-        _participants = files.resolve_participant_videos(source["sheet_context"])
-        source["dir"] = input_dir
-        source["mtime"] = mtime
+# The refresh/find pair over this module's _participants globals; the factory
+# reads them as module attributes so _init_screenspace_state and tests that
+# monkeypatch them keep working. See server_utils.make_participant_cache.
+_refresh_participants, _find_participant_record = make_participant_cache(
+    sys.modules[__name__],
+    input_dir_getter=utils.get_effective_input_dir,
+    resolve=files.resolve_participant_videos,
+)
 
 
 def _participant_exists(pid: str) -> bool:
-    _refresh_participants()
-    return any(p["id"] == pid for p in _participants)
+    return _find_participant_record(pid) is not None
 
 
 @screenspace_bp.route("/api/participants")

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -86,9 +86,24 @@ from server_utils import (
     make_participant_cache,
     make_sse_channel,
     ok,
+    opt_number,
     parse_number_arg,
     remove_by_id,
 )
+
+# Per-tool optional float overrides api_preview reads straight into params.
+_PREVIEW_FLOAT_ARGS: dict[str, tuple[str, ...]] = {
+    "color": ("h", "s", "v"),
+    "attention": (
+        # Channel-weight / center-bias overrides so the Model view tunes the
+        # same math the scan runs (saliency_kwargs_from_params on both paths).
+        "weight_spectral",
+        "weight_contrast",
+        "weight_motion",
+        "weight_face",
+        "center_bias",
+    ),
+}
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -1205,77 +1220,37 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
         default_gap = (
             config.SCREENSPACE_ATTENTION_INTERVAL if tool == "attention" else 1.0
         )
-        prev_ts_raw = request.args.get("prev")
-        if prev_ts_raw is not None:
-            try:
-                prev_ts = float(prev_ts_raw)
-            except ValueError:
-                prev_ts = max(0.0, ts - default_gap)
-        else:
-            prev_ts = max(0.0, ts - default_gap)
+        prev_raw = opt_number(request.args, "prev")
+        prev_ts = prev_raw if prev_raw is not None else max(0.0, ts - default_gap)
         if prev_ts < ts:
             prev_frame = frame_at(prev_ts)
 
     # Build params dict for the preview (subset of task parameters)
     params: dict[str, Any] = {}
-    if tool == "color":
-        for key in ("h", "s", "v"):
-            raw = request.args.get(key)
-            if raw is not None:
-                try:
-                    params[key] = float(raw)
-                except ValueError:
-                    pass
-    elif tool == "change":
-        raw = request.args.get("noise")
-        if raw is not None:
-            try:
-                params["noise_threshold"] = int(float(raw))
-            except ValueError:
-                pass
+    for key in _PREVIEW_FLOAT_ARGS.get(tool, ()):
+        value = opt_number(request.args, key)
+        if value is not None:
+            params[key] = value
+    if tool == "change":
+        value = opt_number(request.args, "noise")
+        if value is not None and math.isfinite(value):
+            params["noise_threshold"] = int(value)
     elif tool == "flow":
-        raw = request.args.get("magnitude")
-        if raw is not None:
-            try:
-                params["magnitude_threshold"] = float(raw)
-            except ValueError:
-                pass
-    elif tool == "attention":
-        # Channel-weight / center-bias overrides so the Model view tunes the
-        # same math the scan runs (saliency_kwargs_from_params on both paths).
-        for key in (
-            "weight_spectral",
-            "weight_contrast",
-            "weight_motion",
-            "weight_face",
-            "center_bias",
-        ):
-            raw = request.args.get(key)
-            if raw is not None:
-                try:
-                    params[key] = float(raw)
-                except ValueError:
-                    pass
+        value = opt_number(request.args, "magnitude")
+        if value is not None:
+            params["magnitude_threshold"] = value
     elif tool in ("text", "numbers"):
         raw = (request.args.get("ocr_preprocess") or "").strip().lower()
         if raw in ("1", "true", "yes", "on"):
             params["ocr_preprocess"] = True
     elif tool == "similarity":
-        ref_ts_raw = request.args.get("ref")
-        if ref_ts_raw is not None and region_coords is not None:
-            ref_ts: float | None = None
-            try:
-                ref_ts = float(ref_ts_raw)
-            except ValueError:
-                pass
-            if ref_ts is not None:
-                ref_frame = frame_at(ref_ts)
-                if ref_frame is not None:
-                    import screenspace as _ss
+        ref_ts = opt_number(request.args, "ref")
+        if ref_ts is not None and region_coords is not None:
+            ref_frame = frame_at(ref_ts)
+            if ref_frame is not None:
+                import screenspace as _ss
 
-                    params["reference_frame"] = _ss.extract_region(
-                        ref_frame, region_coords
-                    )
+                params["reference_frame"] = _ss.extract_region(ref_frame, region_coords)
 
     elif tool == "template":
         import screenspace as _ss_tpl
@@ -1296,19 +1271,13 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
             if mask is not None:
                 params["template_mask"] = mask
         else:
-            ref_ts_raw = request.args.get("ref")
-            if ref_ts_raw is not None and region_coords is not None:
-                ref_ts_tpl: float | None = None
-                try:
-                    ref_ts_tpl = float(ref_ts_raw)
-                except ValueError:
-                    pass
-                if ref_ts_tpl is not None:
-                    ref_frame_tpl = frame_at(ref_ts_tpl)
-                    if ref_frame_tpl is not None:
-                        params["template_image"] = _ss_tpl.extract_region(
-                            ref_frame_tpl, region_coords
-                        )
+            ref_ts_tpl = opt_number(request.args, "ref")
+            if ref_ts_tpl is not None and region_coords is not None:
+                ref_frame_tpl = frame_at(ref_ts_tpl)
+                if ref_frame_tpl is not None:
+                    params["template_image"] = _ss_tpl.extract_region(
+                        ref_frame_tpl, region_coords
+                    )
 
     layer = (request.args.get("layer") or "").strip()
     if layer:

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -79,6 +79,7 @@ import video
 from server_utils import (
     MediaCache,
     err,
+    err_no_video,
     find_by_id,
     json_endpoint,
     make_debounced_persist,
@@ -748,7 +749,7 @@ def api_calibrate() -> FlaskResponse:
 
     resolved = _find_participant_video_with_mtime(participant)
     if resolved is None:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     video_path, _mtime_ns = resolved
 
     props = video.probe_video_properties(video_path)
@@ -859,11 +860,8 @@ def _participant_video_paths(participant_id: str) -> list[str]:
     The refresh is one ``stat()`` in the steady state — nothing against the
     ffmpeg work these callers are about to do.
     """
-    _refresh_participants()
-    for p in _participants:
-        if p["id"] == participant_id:
-            return list(p["video_paths"]) if p.get("has_video") else []
-    return []
+    record = _find_participant_record(participant_id)
+    return list(record["video_paths"]) if record and record.get("has_video") else []
 
 
 def _part_mtimes(paths: list[str]) -> tuple[int, ...] | None:
@@ -1034,7 +1032,7 @@ def api_video_frame(participant: str, timestamp: str) -> FlaskResponse:
     # frontend can keep requesting frames by global time; single-video unchanged.
     mapped = _map_participant_time(participant, ts)
     if mapped is None:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     video_path, local_ts = mapped
     mtime_ns = _mtime_or_zero(video_path)
 
@@ -1152,7 +1150,7 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
 
     video_path = _find_participant_video(participant)
     if video_path is None:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
 
     tool = (request.args.get("tool") or "").strip() or "color"
     if tool not in _VALID_TASK_TYPES:
@@ -1412,7 +1410,7 @@ def api_video_info(participant: str) -> FlaskResponse:
 
     resolved = _find_participant_video_with_mtime(participant)
     if resolved is None:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     video_path, mtime_ns = resolved
 
     with _video_metadata_cache_lock:
@@ -1464,7 +1462,7 @@ def api_video_stream(participant: str) -> FlaskResponse:
     """
     paths = _participant_video_paths(participant)
     if not paths:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     # Multi-video participants: ?part=N selects the sub-video; the frontend swaps
     # the <video> source per part as it scrubs the global timeline. Defaults to
     # part 0 (and is the only file for single-video participants).
@@ -1482,7 +1480,7 @@ def api_video_audio_track(participant: str, idx: int) -> FlaskResponse:
     """Stream one demuxed audio track for the browser's per-track volume mixer."""
     paths = _participant_video_paths(participant)
     if not paths:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     part = request.args.get("part", type=int)
     video_path = (
         paths[part] if part is not None and 0 <= part < len(paths) else paths[0]
@@ -2276,7 +2274,7 @@ def api_tasks_create() -> FlaskResponse:
 
     video_paths = _participant_video_paths(participant)
     if not video_paths:
-        return err(f"No video for participant {participant}")
+        return err_no_video(participant, 400)
     video_path = video_paths[0]
 
     # Default per-task source label; the per-part scan tags each event with the

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -2598,68 +2598,54 @@ def api_export_events() -> FlaskResponse:
     return err(f"Unsupported format: {fmt}")
 
 
-@screenspace_bp.route("/api/events/<event_id>/exclude", methods=["PUT"])
-def api_event_exclude(event_id: str) -> FlaskResponse:
-    """Set an event as excluded."""
+def _set_event_excluded(event_id: str, excluded: bool) -> FlaskResponse:
+    """Set one event's excluded flag; 404 when the id is unknown."""
     with _manifest_lock:
         for e in _manifest.get("events", []):
             if e["id"] == event_id:
-                e["excluded"] = True
+                e["excluded"] = excluded
                 _bump_events_version()
                 _do_persist(drain_events=False)
                 return ok()
     return err("Event not found", 404)
+
+
+def _bulk_set_excluded(excluded: bool) -> FlaskResponse:
+    """Set the excluded flag on every event named in the request's id list."""
+    data = request.get_json(silent=True) or {}
+    ids = set(data.get("ids", []))
+    if not ids:
+        return err("ids list required")
+    with _manifest_lock:
+        count = 0
+        for e in _manifest.get("events", []):
+            if e["id"] in ids:
+                e["excluded"] = excluded
+                count += 1
+        if count:
+            _bump_events_version()
+        _do_persist(drain_events=False)
+    return ok(updated=count)
+
+
+@screenspace_bp.route("/api/events/<event_id>/exclude", methods=["PUT"])
+def api_event_exclude(event_id: str) -> FlaskResponse:
+    return _set_event_excluded(event_id, True)
 
 
 @screenspace_bp.route("/api/events/<event_id>/include", methods=["PUT"])
 def api_event_include(event_id: str) -> FlaskResponse:
-    """Set an event as included."""
-    with _manifest_lock:
-        for e in _manifest.get("events", []):
-            if e["id"] == event_id:
-                e["excluded"] = False
-                _bump_events_version()
-                _do_persist(drain_events=False)
-                return ok()
-    return err("Event not found", 404)
+    return _set_event_excluded(event_id, False)
 
 
 @screenspace_bp.route("/api/events/bulk-exclude", methods=["PUT"])
 def api_events_bulk_exclude() -> FlaskResponse:
-    """Bulk-exclude events by ID list."""
-    data = request.get_json(silent=True) or {}
-    ids = set(data.get("ids", []))
-    if not ids:
-        return err("ids list required")
-    with _manifest_lock:
-        count = 0
-        for e in _manifest.get("events", []):
-            if e["id"] in ids:
-                e["excluded"] = True
-                count += 1
-        if count:
-            _bump_events_version()
-        _do_persist(drain_events=False)
-    return ok(updated=count)
+    return _bulk_set_excluded(True)
 
 
 @screenspace_bp.route("/api/events/bulk-include", methods=["PUT"])
 def api_events_bulk_include() -> FlaskResponse:
-    """Bulk-include events by ID list."""
-    data = request.get_json(silent=True) or {}
-    ids = set(data.get("ids", []))
-    if not ids:
-        return err("ids list required")
-    with _manifest_lock:
-        count = 0
-        for e in _manifest.get("events", []):
-            if e["id"] in ids:
-                e["excluded"] = False
-                count += 1
-        if count:
-            _bump_events_version()
-        _do_persist(drain_events=False)
-    return ok(updated=count)
+    return _bulk_set_excluded(False)
 
 
 # ---- Helpers ----

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -78,11 +78,13 @@ import video
 from server_utils import (
     MediaCache,
     err,
+    find_by_id,
     json_endpoint,
     make_debounced_persist,
     make_sse_channel,
     ok,
     parse_number_arg,
+    remove_by_id,
 )
 
 FlaskResponse = Response | tuple[Response, int]
@@ -1821,7 +1823,7 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
     name = data.get("name", "").strip()
     with _manifest_lock:
         stashes = _manifest.get("stashes", [])
-        stash = next((s for s in stashes if s["id"] == stash_id), None)
+        stash = find_by_id(stashes, stash_id)
         if stash is None:
             return err("Stash not found", 404)
         if name:
@@ -1834,11 +1836,8 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
 def api_stashes_delete(stash_id: str) -> FlaskResponse:
     """Dismiss a region stash."""
     with _manifest_lock:
-        stashes = _manifest.get("stashes", [])
-        idx = next((i for i, s in enumerate(stashes) if s["id"] == stash_id), None)
-        if idx is None:
+        if remove_by_id(_manifest.get("stashes", []), stash_id) is None:
             return err("Stash not found", 404)
-        stashes.pop(idx)
         _do_persist(drain_events=False)
     return ok()
 
@@ -1847,8 +1846,7 @@ def api_stashes_delete(stash_id: str) -> FlaskResponse:
 def api_stashes_restore(stash_id: str) -> FlaskResponse:
     """Restore a stash: replace active regions with stashed ones (stash is kept)."""
     with _manifest_lock:
-        stashes = _manifest.get("stashes", [])
-        stash = next((s for s in stashes if s["id"] == stash_id), None)
+        stash = find_by_id(_manifest.get("stashes", []), stash_id)
         if stash is None:
             return err("Stash not found", 404)
         _manifest["regions"] = copy.deepcopy(stash["regions"])
@@ -1874,9 +1872,7 @@ def api_stashes_add_region(stash_id: str) -> FlaskResponse:
         regions = _manifest.get("regions", {})
         if name not in regions:
             return err(f"Region '{name}' not found", 404)
-        stash = next(
-            (s for s in _manifest.get("stashes", []) if s["id"] == stash_id), None
-        )
+        stash = find_by_id(_manifest.get("stashes", []), stash_id)
         if stash is None:
             return err("Stash not found", 404)
         stash.setdefault("regions", {})[name] = copy.deepcopy(regions[name])

--- a/source/screenspace_tools.py
+++ b/source/screenspace_tools.py
@@ -337,6 +337,16 @@ class AnalysisTool:
     # Detail-dict key holding the threshold-independent calibration scalar that
     # ``check_frame`` populates on both branches. Empty ⇒ tool not calibratable.
     score_key: ClassVar[str] = ""
+    # Name of the module-global ``scan_<x>`` function the base ``scan`` calls.
+    # A *name* resolved via ``globals()`` at call time — never the function
+    # object, which would snapshot the original and blind tests that
+    # monkeypatch ``screenspace_tools.scan_<x>``. Empty ⇒ the subclass
+    # overrides ``scan`` outright (template, timelapse, multitool).
+    scan_fn_name: ClassVar[str] = ""
+    # Tool-specific scan kwargs, forwarded as ``params.get(key, default)``.
+    scan_defaults: ClassVar[dict[str, Any]] = {}
+    # Sampling interval when ``params`` carries none (the OCR tools use 2.0).
+    scan_interval_default: ClassVar[float] = 0
 
     def check_frame(
         self,
@@ -373,6 +383,21 @@ class AnalysisTool:
         passed, detail = self.check_frame(frame, prev_frame, region, params)
         return _score_result(self.score_key, passed, detail)
 
+    def _scan_kwargs(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Tool-specific kwargs for the scan function, from ``scan_defaults``.
+
+        Subclasses override to post-process (or-expression defaults, config
+        reads, saliency merges). Dict-valued defaults are copied so a callee
+        can never mutate the shared ClassVar.
+        """
+        kwargs: dict[str, Any] = {}
+        for key, default in self.scan_defaults.items():
+            value = params.get(key, default)
+            if value is default and isinstance(default, dict):
+                value = dict(default)
+            kwargs[key] = value
+        return kwargs
+
     def scan(
         self,
         video_path: str,
@@ -386,14 +411,41 @@ class AnalysisTool:
         on_result: Callable[[dict[str, Any]], None] | None,
         fast_opts: dict[str, Any] | None,
     ) -> Any:
-        """Run a full-video scan. Subclasses must override."""
-        raise NotImplementedError
+        """Run a full-video scan.
+
+        Declarative dispatch: forwards the common tail plus ``_scan_kwargs``
+        to the module-global named by ``scan_fn_name``. Tools whose scan
+        differs structurally (template's downscale, timelapse's output file,
+        multitool's chaining) override this outright.
+        """
+        if not self.scan_fn_name:
+            raise NotImplementedError
+        scan_fn = globals()[self.scan_fn_name]
+        return scan_fn(
+            video_path,
+            region,
+            interval_seconds=params.get("interval", self.scan_interval_default),
+            start_seconds=params.get("start_seconds", 0.0),
+            end_seconds=params.get("end_seconds"),
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=on_result,
+            fast_opts=fast_opts,
+            **self._scan_kwargs(params),
+        )
 
 
 class ColorTool(AnalysisTool):
     name = "color"
     fast_scan_region_dim = 32
     score_key = "_confidence"
+    scan_fn_name = "scan_color"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "target_color": {"h": 0, "s": 0, "v": 0},
+        "tolerance": {"h": 10, "s": 50, "v": 50},
+        "color_mode": "average",
+        "min_coverage": 0.0,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -423,21 +475,16 @@ class ColorTool(AnalysisTool):
         on_result,
         fast_opts,
     ):
-        color_mode = params.get("color_mode", "average")
         # Presence scans must stay full-resolution: the fast-scan max_region_dim
         # downscale uses INTER_AREA averaging, which erases small color patches.
-        if color_mode == "presence":
+        if params.get("color_mode", "average") == "presence":
             fast_opts = None
-        return scan_color(
+        return super().scan(
             video_path,
             region,
-            target_color=params.get("target_color", {"h": 0, "s": 0, "v": 0}),
-            tolerance=params.get("tolerance", {"h": 10, "s": 50, "v": 50}),
-            interval_seconds=params.get("interval", 0),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            color_mode=color_mode,
-            min_coverage=params.get("min_coverage", 0.0),
+            params,
+            task_id=task_id,
+            scan_mode=scan_mode,
             on_progress=on_progress,
             cancel_flag=cancel_flag,
             on_result=on_result,
@@ -449,6 +496,12 @@ class ChangeTool(AnalysisTool):
     name = "change"
     fast_scan_region_dim = 128
     score_key = "magnitude"
+    scan_fn_name = "scan_changes"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "threshold": 0,
+        "noise_threshold": 0,
+        "require_consecutive": 1,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -469,34 +522,6 @@ class ChangeTool(AnalysisTool):
         )
         return mag >= threshold, {"magnitude": round(mag, 4)}
 
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_changes(
-            video_path,
-            region,
-            threshold=params.get("threshold", 0),
-            interval_seconds=params.get("interval", 0),
-            noise_threshold=params.get("noise_threshold", 0),
-            require_consecutive=params.get("require_consecutive", 1),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-        )
-
 
 class SimilarityTool(AnalysisTool):
     # A spatial Similarity heatmap is feasible but deferred: this tool computes
@@ -507,6 +532,11 @@ class SimilarityTool(AnalysisTool):
     name = "similarity"
     fast_scan_region_dim = 128
     score_key = "score"
+    scan_fn_name = "scan_similarity"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "reference_frame": None,
+        "threshold": 0,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -532,17 +562,16 @@ class SimilarityTool(AnalysisTool):
         on_result,
         fast_opts,
     ):
-        ref_frame = params.get("reference_frame")
-        if ref_frame is None:
+        # `is None` on purpose (contrast Scene's falsy check): the reference is
+        # an ndarray, whose truthiness is ambiguous.
+        if params.get("reference_frame") is None:
             raise ValueError("Similarity scan requires a reference_frame parameter")
-        return scan_similarity(
+        return super().scan(
             video_path,
             region,
-            reference_frame=ref_frame,
-            threshold=params.get("threshold", 0),
-            interval_seconds=params.get("interval", 0),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
+            params,
+            task_id=task_id,
+            scan_mode=scan_mode,
             on_progress=on_progress,
             cancel_flag=cancel_flag,
             on_result=on_result,
@@ -556,6 +585,22 @@ class TextTool(AnalysisTool):
     # ``_extract_confidence``'s "confidence" key (OCR reading confidence) — two
     # different axes; do not unify them.
     score_key = "fuzzy_ratio"
+    scan_fn_name = "scan_text"
+    scan_interval_default = 2.0
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "search_string": "",
+        "fuzzy_threshold": 0,
+        "ocr_confidence_threshold": None,
+        "ocr_preprocess": False,
+        "require_consecutive": 1,
+        "languages": None,
+    }
+
+    def _scan_kwargs(self, params):
+        kwargs = super()._scan_kwargs(params)
+        # or-expression, not a get-default: an explicit "" must coerce to "off".
+        kwargs["ocr_normalize"] = params.get("ocr_normalize") or "off"
+        return kwargs
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -572,42 +617,23 @@ class TextTool(AnalysisTool):
         )
         return _score_text_readings(readings, params)
 
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_text(
-            video_path,
-            region,
-            search_string=params.get("search_string", ""),
-            interval_seconds=params.get("interval", 2.0),
-            fuzzy_threshold=params.get("fuzzy_threshold", 0),
-            ocr_confidence_threshold=params.get("ocr_confidence_threshold"),
-            ocr_preprocess=params.get("ocr_preprocess", False),
-            ocr_normalize=params.get("ocr_normalize") or "off",
-            require_consecutive=params.get("require_consecutive", 1),
-            languages=params.get("languages"),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-        )
-
 
 class NumbersTool(AnalysisTool):
     name = "numbers"
     score_key = "confidence"
+    scan_fn_name = "scan_numbers"
+    scan_interval_default = 2.0
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "operator": "gt",
+        "target_value": 0,
+        "range_min": None,
+        "range_max": None,
+        "ocr_confidence_threshold": None,
+        "ocr_preprocess": False,
+        "integers_only": False,
+        "require_consecutive": 1,
+        "languages": None,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -624,40 +650,6 @@ class NumbersTool(AnalysisTool):
             preprocess=params.get("ocr_preprocess", False),
         )
         return _score_numbers_readings(readings, params)
-
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_numbers(
-            video_path,
-            region,
-            operator=params.get("operator", "gt"),
-            target_value=params.get("target_value", 0),
-            interval_seconds=params.get("interval", 2.0),
-            range_min=params.get("range_min"),
-            range_max=params.get("range_max"),
-            ocr_confidence_threshold=params.get("ocr_confidence_threshold"),
-            ocr_preprocess=params.get("ocr_preprocess", False),
-            integers_only=params.get("integers_only", False),
-            require_consecutive=params.get("require_consecutive", 1),
-            languages=params.get("languages"),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-        )
 
 
 class TemplateTool(AnalysisTool):
@@ -768,6 +760,11 @@ class FlowTool(AnalysisTool):
     name = "flow"
     fast_scan_region_dim = 128
     score_key = "magnitude"
+    scan_fn_name = "scan_flow"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "magnitude_threshold": 0,
+        "require_consecutive": 1,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -787,38 +784,16 @@ class FlowTool(AnalysisTool):
             "angle": flow_result["angle"],
         }
 
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_flow(
-            video_path,
-            region,
-            magnitude_threshold=params.get("magnitude_threshold", 0),
-            interval_seconds=params.get("interval", 0),
-            require_consecutive=params.get("require_consecutive", 1),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-        )
-
 
 class SceneTool(AnalysisTool):
     name = "scene"
     fast_scan_region_dim = 64
     score_key = "score"
+    scan_fn_name = "scan_scene"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "reference_scenes": None,
+        "threshold": 0,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -875,17 +850,16 @@ class SceneTool(AnalysisTool):
         on_result,
         fast_opts,
     ):
-        ref_scenes = params.get("reference_scenes")
-        if not ref_scenes:
+        # Falsy on purpose (an empty reference list is as unusable as None);
+        # contrast Similarity's `is None`, forced by ndarray truthiness.
+        if not params.get("reference_scenes"):
             raise ValueError("Scene scan requires reference_scenes parameter")
-        return scan_scene(
+        return super().scan(
             video_path,
             region,
-            reference_scenes=ref_scenes,
-            threshold=params.get("threshold", 0),
-            interval_seconds=params.get("interval", 0),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
+            params,
+            task_id=task_id,
+            scan_mode=scan_mode,
             on_progress=on_progress,
             cancel_flag=cancel_flag,
             on_result=on_result,
@@ -899,6 +873,11 @@ class InactivityTool(AnalysisTool):
     # Calibration scalar is the raw phash distance (Sensitivity-slider units);
     # the strip inverts the axis for display (lower distance = more inactive).
     score_key = "distance"
+    scan_fn_name = "scan_inactivity"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "threshold": 0,
+        "min_duration": 0.0,
+    }
 
     def check_frame(
         self, frame, prev_frame, region, params, cache=None, prev_cache=None
@@ -915,33 +894,6 @@ class InactivityTool(AnalysisTool):
             conf = 1.0 if dist <= thresh else 0.0
         return dist <= thresh, {"distance": dist, "_confidence": conf}
 
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_inactivity(
-            video_path,
-            region,
-            threshold=params.get("threshold", 0),
-            min_duration=params.get("min_duration", 0.0),
-            interval_seconds=params.get("interval", 0),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-        )
-
 
 class BoundaryTool(AnalysisTool):
     name = "boundary"
@@ -953,37 +905,19 @@ class BoundaryTool(AnalysisTool):
     # calibration later means adding score_key + a per-frame check_frame here,
     # plus a `needs_prev` entry and full-frame handling in the calibrate endpoint
     # (boundary needs the previous sampled frame and always scans the full frame).
+    scan_fn_name = "scan_boundaries"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "threshold": 0,
+        "min_gap": 0.0,
+    }
 
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_boundaries(
-            video_path,
-            region,
-            threshold=params.get("threshold", 0),
-            min_gap=params.get("min_gap", 0.0),
-            interval_seconds=params.get("interval", 0),
-            # Policy default lives here, not in the scan primitive: a task with
-            # no metric (UI "Auto") gets the configured default; the primitive's
-            # own default stays "phash" for direct callers/tests.
-            metric=params.get("metric") or config.SCREENSPACE_BOUNDARY_METRIC,
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-        )
+    def _scan_kwargs(self, params):
+        kwargs = super()._scan_kwargs(params)
+        # Policy default lives here, not in the scan primitive: a task with
+        # no metric (UI "Auto") gets the configured default; the primitive's
+        # own default stays "phash" for direct callers/tests.
+        kwargs["metric"] = params.get("metric") or config.SCREENSPACE_BOUNDARY_METRIC
+        return kwargs
 
 
 class AttentionTool(AnalysisTool):
@@ -995,36 +929,18 @@ class AttentionTool(AnalysisTool):
     # Scan-only: full-frame with temporal state (EMA + shift confirmation), so
     # it is neither a multitool step nor calibratable (no score_key); the
     # pinned-frame strip and /api/calibrate correctly skip it.
+    scan_fn_name = "scan_attention"
+    scan_defaults: ClassVar[dict[str, Any]] = {
+        "shift_threshold": 0.0,
+        "ema_alpha": 0.0,
+    }
 
-    def scan(
-        self,
-        video_path,
-        region,
-        params,
-        *,
-        task_id,
-        scan_mode,
-        on_progress,
-        cancel_flag,
-        on_result,
-        fast_opts,
-    ):
-        return scan_attention(
-            video_path,
-            region,
-            shift_threshold=params.get("shift_threshold", 0.0),
-            interval_seconds=params.get("interval", 0),
-            ema_alpha=params.get("ema_alpha", 0.0),
-            start_seconds=params.get("start_seconds", 0.0),
-            end_seconds=params.get("end_seconds"),
-            on_progress=on_progress,
-            cancel_flag=cancel_flag,
-            on_result=on_result,
-            fast_opts=fast_opts,
-            # Per-task channel weights / center bias / face toggle (absent
-            # keys fall back to the SCREENSPACE_ATTENTION_* config defaults).
-            **saliency_kwargs_from_params(params),
-        )
+    def _scan_kwargs(self, params):
+        kwargs = super()._scan_kwargs(params)
+        # Per-task channel weights / center bias / face toggle (absent
+        # keys fall back to the SCREENSPACE_ATTENTION_* config defaults).
+        kwargs.update(saliency_kwargs_from_params(params))
+        return kwargs
 
 
 class TimelapseTool(AnalysisTool):
@@ -1129,3 +1045,29 @@ TOOLS: dict[str, AnalysisTool] = {
         MultitoolTool(),
     )
 }
+
+# ``AnalysisTool.scan`` dispatches by *name* — ``globals()[scan_fn_name]``,
+# resolved at call time so tests monkeypatching ``screenspace_tools.scan_<x>``
+# are seen. This set keeps those imports lexically referenced (they would
+# otherwise read as unused), and the loop turns a typo'd ``scan_fn_name`` into
+# an import-time failure instead of a KeyError mid-scan.
+_DISPATCHABLE_SCAN_FNS = {
+    scan_attention,
+    scan_boundaries,
+    scan_changes,
+    scan_color,
+    scan_flow,
+    scan_inactivity,
+    scan_numbers,
+    scan_scene,
+    scan_similarity,
+    scan_text,
+}
+for _tool in TOOLS.values():
+    if (
+        _tool.scan_fn_name
+        and globals()[_tool.scan_fn_name] not in _DISPATCHABLE_SCAN_FNS
+    ):
+        raise AssertionError(
+            f"{_tool.name}: unknown scan_fn_name {_tool.scan_fn_name!r}"
+        )

--- a/source/server.py
+++ b/source/server.py
@@ -807,6 +807,20 @@ def _sheet_observation_rows() -> list[dict[str, Any]]:
     return records
 
 
+def _sheet_common_fields() -> dict[str, Any]:
+    """Payload fields shared by both branches of :func:`api_sheet`."""
+    return {
+        "version": utils.get_version(),
+        "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
+        "titlecardsEnabled": config.TITLECARDS_ENABLED,
+        "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
+        "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
+        "cardScrubberEnabled": config.STUDIO_CARD_SCRUBBER,
+        "metadataClusterScreenspace": config.STUDIO_METADATA_CLUSTER_SCREENSPACE,
+        "config": utils.get_frontend_config(),
+    }
+
+
 @studio_bp.route("/api/sheet")
 def api_sheet() -> FlaskResponse:
     if _sheet_context is None:
@@ -820,14 +834,7 @@ def api_sheet() -> FlaskResponse:
                 "sheet_loaded": False,
                 "study": str(mn.get("study", "")),
                 "mindnodeParticipants": list(mn.get("participants", [])),
-                "version": utils.get_version(),
-                "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
-                "titlecardsEnabled": config.TITLECARDS_ENABLED,
-                "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
-                "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
-                "cardScrubberEnabled": config.STUDIO_CARD_SCRUBBER,
-                "metadataClusterScreenspace": config.STUDIO_METADATA_CLUSTER_SCREENSPACE,
-                "config": utils.get_frontend_config(),
+                **_sheet_common_fields(),
                 "participants": [],
                 "rows": [],
             }
@@ -841,15 +848,8 @@ def api_sheet() -> FlaskResponse:
             "ok": True,
             "sheet_loaded": True,
             "study": ctx.study_name,
-            "version": utils.get_version(),
-            "highlightsDuration": config.HIGHLIGHTS_REEL_DURATION_SECONDS,
-            "titlecardsEnabled": config.TITLECARDS_ENABLED,
-            "titlecardDuration": config.TITLECARD_DURATION_SECONDS,
-            "cellExpandHover": config.STUDIO_CELL_EXPAND_HOVER,
-            "cardScrubberEnabled": config.STUDIO_CARD_SCRUBBER,
-            "metadataClusterScreenspace": config.STUDIO_METADATA_CLUSTER_SCREENSPACE,
+            **_sheet_common_fields(),
             "defaultDuration": config.DEFAULT_DURATION_SECONDS,
-            "config": utils.get_frontend_config(),
             "participants": sheet_payload["participants"],
             "rows": sheet_payload["rows"],
         }

--- a/source/server.py
+++ b/source/server.py
@@ -156,13 +156,15 @@ _intake_cancel_event = threading.Event()
 _timeline_viewer_cancel_event = threading.Event()
 _gallery_cancel_event = threading.Event()
 _busy_lock = threading.Lock()
-_generate_in_progress = False
-_reel_in_progress = False
 # Single-job slots for those builds: each shares one module-level cancel event, so
 # a second concurrent build (a second Studio tab) must be rejected rather than
 # allowed to clobber the other's signal.
-_timeline_viewer_in_progress = False
-_gallery_in_progress = False
+_busy_slots: dict[str, bool] = {
+    "generate": False,
+    "reel": False,
+    "timeline_viewer": False,
+    "gallery": False,
+}
 # Count of in-flight /api/generate-intake streams. Intake has no single-job
 # slot (it must run alongside /api/generate for mixed queues), but a sheet
 # swap still needs to know whether any intake work is active.
@@ -290,37 +292,15 @@ _audio_cache = _MediaCache(_AUDIO_CACHE_MAX)
 def _try_claim_busy(slot: str) -> bool:
     """Atomically reserve the single-job slot for *slot*.
 
-    Valid slots: ``'generate'``, ``'reel'``, ``'timeline_viewer'``, ``'gallery'``.
-    Returns True on success (caller must call ``_release_busy`` when done) or
-    False if another request is already holding the slot.
+    Valid slots: the ``_busy_slots`` keys. Returns True on success (caller must
+    call ``_release_busy`` when done) or False if another request is already
+    holding the slot (or the slot name is unknown).
     """
-    global \
-        _generate_in_progress, \
-        _reel_in_progress, \
-        _timeline_viewer_in_progress, \
-        _gallery_in_progress
     with _busy_lock:
-        if slot == "generate":
-            if _generate_in_progress:
-                return False
-            _generate_in_progress = True
-            return True
-        if slot == "reel":
-            if _reel_in_progress:
-                return False
-            _reel_in_progress = True
-            return True
-        if slot == "timeline_viewer":
-            if _timeline_viewer_in_progress:
-                return False
-            _timeline_viewer_in_progress = True
-            return True
-        if slot == "gallery":
-            if _gallery_in_progress:
-                return False
-            _gallery_in_progress = True
-            return True
-    return False
+        if slot not in _busy_slots or _busy_slots[slot]:
+            return False
+        _busy_slots[slot] = True
+        return True
 
 
 def _parse_titlecard_request(
@@ -387,24 +367,10 @@ def _append_generated_reel(reel: dict[str, Any]) -> None:
 
 
 def _release_busy(slot: str) -> None:
-    """Release the single-job slot for *slot*.
-
-    Valid slots: ``'generate'``, ``'reel'``, ``'timeline_viewer'``, ``'gallery'``.
-    """
-    global \
-        _generate_in_progress, \
-        _reel_in_progress, \
-        _timeline_viewer_in_progress, \
-        _gallery_in_progress
+    """Release the single-job slot for *slot* (unknown slots are a no-op)."""
     with _busy_lock:
-        if slot == "generate":
-            _generate_in_progress = False
-        elif slot == "reel":
-            _reel_in_progress = False
-        elif slot == "timeline_viewer":
-            _timeline_viewer_in_progress = False
-        elif slot == "gallery":
-            _gallery_in_progress = False
+        if slot in _busy_slots:
+            _busy_slots[slot] = False
 
 
 def _reset_reel_job_state(endpoint: str) -> None:
@@ -489,13 +455,7 @@ def _generation_busy() -> bool:
     old-sheet artifacts into the new sheet's freshly-rebound list/manifest).
     """
     with _busy_lock:
-        return (
-            _generate_in_progress
-            or _reel_in_progress
-            or _timeline_viewer_in_progress
-            or _gallery_in_progress
-            or _intake_active > 0
-        )
+        return any(_busy_slots.values()) or _intake_active > 0
 
 
 @contextmanager
@@ -3061,8 +3021,8 @@ def api_job_status() -> FlaskResponse:
     shared cancel events, which the workers continue to honor.
     """
     with _busy_lock:
-        reel_busy = _reel_in_progress
-        generate_busy = _generate_in_progress
+        reel_busy = _busy_slots["reel"]
+        generate_busy = _busy_slots["generate"]
         intake_busy = _intake_active > 0
     with _job_state_lock:
         reel_snapshot = dict(_reel_job_state)

--- a/source/server.py
+++ b/source/server.py
@@ -91,10 +91,11 @@ import video
 import viewer
 from server_utils import (
     MediaCache,
+    clip_media_response,
     err,
     json_endpoint,
+    mtime_or_zero,
     ok,
-    parse_clip_window,
     parse_number_arg,
 )
 from datetime import UTC
@@ -549,12 +550,8 @@ def api_thumbnail(participant: str, start_seconds: str) -> FlaskResponse:
         video_path = Path(mapped[0])
         cut_sec = int(mapped[1])
 
-    try:
-        mtime = video_path.stat().st_mtime
-    except OSError:
-        mtime = 0.0
     # Include mtime so replacing a source file on disk invalidates stale thumbnails.
-    cache_key = (str(video_path), cut_sec, mtime)
+    cache_key = (str(video_path), cut_sec, mtime_or_zero(video_path))
     jpeg_bytes = _thumbnail_cache.get_or_compute(
         cache_key,
         lambda: video.extract_thumbnail_bytes(
@@ -594,6 +591,17 @@ def _resolve_clip_media_source(
     return sources[0], max(0.0, start_sec)
 
 
+def _resolve_clip_media_paths(
+    participant: str, start_sec: float, duration: float
+) -> tuple[str, float, float] | None:
+    """clip_media_response-shaped adapter over :func:`_resolve_clip_media_source`."""
+    resolved = _resolve_clip_media_source(participant, start_sec)
+    if resolved is None:
+        return None
+    video_path, local_start = resolved
+    return str(video_path), local_start, duration
+
+
 @studio_bp.route("/api/sprite/<participant>")
 def api_sprite(participant: str) -> FlaskResponse:
     """Tiled JPEG sprite sheet of a clip for the opt-in hover card scrubber.
@@ -603,43 +611,17 @@ def api_sprite(participant: str) -> FlaskResponse:
     """
     if _sheet_context is None:
         return err("No spreadsheet loaded", 404)
-    window = parse_clip_window()
-    if window is None:
-        return err("Invalid clip range")
-    start_sec, duration = window
-
-    resolved = _resolve_clip_media_source(participant, start_sec)
-    if resolved is None:
-        return err("Source video not found", 404)
-    video_path, local_start = resolved
     cols = config.STUDIO_SCRUBBER_SPRITE_COLS
     rows = config.STUDIO_SCRUBBER_SPRITE_ROWS
-
-    try:
-        mtime = video_path.stat().st_mtime
-    except OSError:
-        mtime = 0.0
-    cache_key = (
-        str(video_path),
-        round(local_start, 3),
-        round(duration, 3),
-        cols,
-        rows,
-        mtime,
-    )
-    sprite_bytes = _sprite_cache.get_or_compute(
-        cache_key,
-        lambda: video.extract_sprite_sheet_bytes(
-            str(video_path), local_start, duration, cols, rows
+    return clip_media_response(
+        cache=_sprite_cache,
+        resolve=lambda start, dur: _resolve_clip_media_paths(participant, start, dur),
+        produce=lambda path, local_start, dur: video.extract_sprite_sheet_bytes(
+            path, local_start, dur, cols, rows
         ),
-    )
-    if sprite_bytes is None:
-        return err("Sprite extraction failed", 404)
-
-    return Response(
-        sprite_bytes,
         mimetype="image/jpeg",
-        headers={"Cache-Control": "public, max-age=86400"},
+        kind_label="Sprite",
+        key_extras=(cols, rows),
     )
 
 
@@ -653,34 +635,12 @@ def api_clip_audio(participant: str) -> FlaskResponse:
     """
     if _sheet_context is None:
         return err("No spreadsheet loaded", 404)
-    window = parse_clip_window()
-    if window is None:
-        return err("Invalid clip range")
-    start_sec, duration = window
-
-    resolved = _resolve_clip_media_source(participant, start_sec)
-    if resolved is None:
-        return err("Source video not found", 404)
-    video_path, local_start = resolved
-
-    try:
-        mtime = video_path.stat().st_mtime
-    except OSError:
-        mtime = 0.0
-    cache_key = (str(video_path), round(local_start, 3), round(duration, 3), mtime)
-    wav_bytes = _audio_cache.get_or_compute(
-        cache_key,
-        lambda: video.extract_audio_segment_bytes(
-            str(video_path), local_start, duration
-        ),
-    )
-    if wav_bytes is None:
-        return err("Audio extraction failed", 404)
-
-    return Response(
-        wav_bytes,
+    return clip_media_response(
+        cache=_audio_cache,
+        resolve=lambda start, dur: _resolve_clip_media_paths(participant, start, dur),
+        produce=video.extract_audio_segment_bytes,
         mimetype="audio/wav",
-        headers={"Cache-Control": "public, max-age=86400"},
+        kind_label="Audio",
     )
 
 

--- a/source/server.py
+++ b/source/server.py
@@ -982,10 +982,8 @@ def _resolve_intake_video_paths(participant: str, source: str = "") -> list[str]
     scan and report "No video for P01". ``source`` is kept for call-site
     compatibility — both tool lists scan the same files.
     """
-    for p in files.resolve_participant_videos(_sheet_context):
-        if p["id"] == participant and p.get("has_video"):
-            return list(p["video_paths"])
-    return []
+    p = files.find_participant_record(_sheet_context, participant)
+    return list(p["video_paths"]) if p is not None and p.get("has_video") else []
 
 
 def _effective_study() -> str:

--- a/source/server_utils.py
+++ b/source/server_utils.py
@@ -16,8 +16,9 @@ same numeric-arg parse-and-validate block dozens of times. Collapsed here:
   (Transcripts + Screenspace).
 - :func:`make_sse_channel` builds one SSE pub/sub channel (bounded per-client
   queue + coalesce-on-overflow + keepalive + cleanup).
-- :class:`MediaCache` + :func:`parse_clip_window` back the hover-scrubber media
-  routes (sprite sheets / audio snippets).
+- :class:`MediaCache` + :func:`parse_clip_window` + :func:`clip_media_response`
+  + :func:`mtime_or_zero` back the hover-scrubber media routes (sprite sheets /
+  audio snippets).
 
 Deliberately tiny and Flask-only (no ``config``/``utils`` imports) so it stays
 import-clean: ``utils`` is Flask-free on purpose and imported by non-server
@@ -200,6 +201,14 @@ class MediaCache:
             self._inflight.clear()
 
 
+def mtime_or_zero(path: str | Path) -> float:
+    """A file's ``st_mtime`` for cache keys, or 0.0 when it can't be stat'd."""
+    try:
+        return Path(path).stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def parse_clip_window() -> tuple[float, float] | None:
     """Parse + validate the ``?start=&end=`` seconds shared by the scrubber
     media routes. Returns ``(start_seconds, duration_seconds)`` or ``None`` when
@@ -213,6 +222,54 @@ def parse_clip_window() -> tuple[float, float] | None:
     if duration <= 0:
         return None
     return start_sec, duration
+
+
+def clip_media_response(
+    *,
+    cache: MediaCache,
+    resolve: Callable[[float, float], tuple[str, float, float] | None],
+    produce: Callable[[str, float, float], bytes | None],
+    mimetype: str,
+    kind_label: str,
+    key_extras: tuple[Any, ...] = (),
+    invalid_message: str = "Invalid clip range",
+):
+    """Shared guts of the hover-scrubber sprite / audio routes.
+
+    Parses the ``?start=&end=`` window, maps it through *resolve* →
+    ``(path, local_start, duration)`` (None → 404), then serves *produce*'s
+    bytes from *cache* keyed on
+    ``(path, start, duration, *key_extras, mtime)`` — the mtime so a replaced
+    source file invalidates stale media. *kind_label* names the 404 when
+    extraction fails (``"Sprite extraction failed"``).
+    """
+    window = parse_clip_window()
+    if window is None:
+        return err(invalid_message)
+    start_sec, duration = window
+
+    resolved = resolve(start_sec, duration)
+    if resolved is None:
+        return err("Source video not found", 404)
+    path, local_start, duration = resolved
+
+    key = (
+        path,
+        round(local_start, 3),
+        round(duration, 3),
+        *key_extras,
+        mtime_or_zero(path),
+    )
+    media_bytes = cache.get_or_compute(
+        key, lambda: produce(path, local_start, duration)
+    )
+    if media_bytes is None:
+        return err(f"{kind_label} extraction failed", 404)
+    return Response(
+        media_bytes,
+        mimetype=mimetype,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 def make_debounced_persist(

--- a/source/server_utils.py
+++ b/source/server_utils.py
@@ -8,6 +8,8 @@ same numeric-arg parse-and-validate block dozens of times. Collapsed here:
 - :class:`ApiError` + :func:`json_endpoint` let a handler ``raise`` a uniform
   4xx instead of threading an ``err(...)`` tuple back through every guard.
 - :func:`parse_number_arg` parses + bound-checks one numeric value.
+- :func:`find_by_id` / :func:`remove_by_id` are the manifest-collection CRUD
+  lookups (stashes, blueprints, cuts, annotations).
 - :func:`make_debounced_persist` builds the manifest-write debounce.
 - :func:`make_sse_channel` builds one SSE pub/sub channel (bounded per-client
   queue + coalesce-on-overflow + keepalive + cleanup).
@@ -103,6 +105,19 @@ def parse_number_arg(
     if max_ is not None and value > max_:
         raise ApiError(f"{name} must be <= {max_}")
     return int(value) if int_only else value
+
+
+def find_by_id(items: Any, id_: Any) -> dict[str, Any] | None:
+    """First item whose ``"id"`` equals *id_*, else None."""
+    return next((it for it in items if it.get("id") == id_), None)
+
+
+def remove_by_id(items: list[dict[str, Any]], id_: Any) -> dict[str, Any] | None:
+    """Pop and return the first item whose ``"id"`` equals *id_*; None when absent."""
+    for i, it in enumerate(items):
+        if it.get("id") == id_:
+            return items.pop(i)
+    return None
 
 
 class MediaCache:

--- a/source/server_utils.py
+++ b/source/server_utils.py
@@ -11,6 +11,8 @@ same numeric-arg parse-and-validate block dozens of times. Collapsed here:
 - :func:`find_by_id` / :func:`remove_by_id` are the manifest-collection CRUD
   lookups (stashes, blueprints, cuts, annotations).
 - :func:`make_debounced_persist` builds the manifest-write debounce.
+- :func:`make_participant_cache` builds the mtime-guarded participant cache
+  (Transcripts + Screenspace).
 - :func:`make_sse_channel` builds one SSE pub/sub channel (bounded per-client
   queue + coalesce-on-overflow + keepalive + cleanup).
 - :class:`MediaCache` + :func:`parse_clip_window` back the hover-scrubber media
@@ -29,6 +31,7 @@ import threading
 from collections import OrderedDict
 from collections.abc import Callable
 from functools import wraps
+from pathlib import Path
 from typing import Any
 
 from flask import Response, jsonify, request
@@ -254,6 +257,65 @@ def make_debounced_persist(
                 persist()
 
     return schedule_persist, flush_pending_persist, cancel_pending_persist_timer
+
+
+def make_participant_cache(
+    module: Any,
+    *,
+    input_dir_getter: Callable[[], Any],
+    resolve: Callable[[Any], list[dict[str, Any]]],
+) -> tuple[Callable[[], None], Callable[[str], dict[str, Any] | None]]:
+    """Build the mtime-guarded participant cache shared by the Transcripts and
+    Screenspace blueprints; returns ``(refresh, find)``.
+
+    Operates on ``module._participants`` / ``module._participant_source`` under
+    ``module._participants_lock`` — module attributes, not closure state — so
+    the blueprints' init/set-source functions, the remux ``sheet_context``
+    getters, and tests that monkeypatch those globals all keep working (the
+    same late-binding contract as :func:`make_debounced_persist`).
+
+    ``refresh()`` rebuilds ``module._participants`` when the input directory
+    changed since the last build. Keyed on the dir's ``st_mtime_ns`` (which
+    advances on add/remove/rename), mirroring
+    ``utils.discover_participant_videos``' own memo — the steady-state cost is
+    one ``stat()``. This is what lets a video dropped into ``-i`` mid-session
+    show up without a server restart. No-op while ``_participant_source`` is
+    None (blueprint not configured yet). The rebuild rebinds ``_participants``
+    (atomic under the GIL), so a concurrent reader sees either the old list or
+    the new one, never a torn one.
+
+    ``find(pid)`` refreshes, then returns the cached record or None. The
+    ``input_dir_getter`` / ``resolve`` callables keep ``utils``/``files``
+    imports out of this module.
+    """
+
+    def refresh() -> None:
+        source = module._participant_source
+        if source is None:
+            return
+        input_dir = str(Path(input_dir_getter()))
+        try:
+            mtime: int | None = Path(input_dir).stat().st_mtime_ns
+        except OSError:
+            mtime = None
+        if source["dir"] == input_dir and source["mtime"] == mtime:
+            return
+        with module._participants_lock:
+            # A racing request may have rebuilt, or a sheet swap may have
+            # replaced the source entirely, while we waited on the lock.
+            if module._participant_source is not source:
+                return
+            if source["dir"] == input_dir and source["mtime"] == mtime:
+                return
+            module._participants = resolve(source["sheet_context"])
+            source["dir"] = input_dir
+            source["mtime"] = mtime
+
+    def find(participant_id: str) -> dict[str, Any] | None:
+        refresh()
+        return find_by_id(module._participants, participant_id)
+
+    return refresh, find
 
 
 def make_sse_channel(

--- a/source/server_utils.py
+++ b/source/server_utils.py
@@ -47,6 +47,11 @@ def err(message: str, code: int = 400):
     return jsonify({"ok": False, "error": message}), code
 
 
+def err_no_video(participant: str, code: int = 404):
+    """The shared "No video for participant <id>" error envelope."""
+    return err(f"No video for participant {participant}", code)
+
+
 class ApiError(Exception):
     """Raised inside a :func:`json_endpoint` handler to short-circuit to ``err``.
 

--- a/source/server_utils.py
+++ b/source/server_utils.py
@@ -7,7 +7,8 @@ same numeric-arg parse-and-validate block dozens of times. Collapsed here:
 - :func:`ok` / :func:`err` build either envelope in one call.
 - :class:`ApiError` + :func:`json_endpoint` let a handler ``raise`` a uniform
   4xx instead of threading an ``err(...)`` tuple back through every guard.
-- :func:`parse_number_arg` parses + bound-checks one numeric value.
+- :func:`parse_number_arg` parses + bound-checks one numeric value;
+  :func:`opt_number` is its lenient fall-back-don't-fail sibling.
 - :func:`find_by_id` / :func:`remove_by_id` are the manifest-collection CRUD
   lookups (stashes, blueprints, cuts, annotations).
 - :func:`make_debounced_persist` builds the manifest-write debounce.
@@ -113,6 +114,22 @@ def parse_number_arg(
     if max_ is not None and value > max_:
         raise ApiError(f"{name} must be <= {max_}")
     return int(value) if int_only else value
+
+
+def opt_number(args: Any, name: str, default: float | None = None) -> float | None:
+    """Lenient optional float from a request-args mapping.
+
+    Missing or unparseable returns *default* — never raises. For preview-style
+    override knobs where a malformed value silently falls back; the strict,
+    raising sibling is :func:`parse_number_arg`.
+    """
+    raw = args.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
 
 
 def find_by_id(items: Any, id_: Any) -> dict[str, Any] | None:

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -41,6 +41,7 @@ API endpoints (all under /transcripts/):
 import atexit
 import json
 import os
+import sys
 import tempfile
 import threading
 import time
@@ -62,7 +63,7 @@ import thinking_agents
 import transcripts
 import utils
 import video
-from server_utils import err, make_debounced_persist, ok
+from server_utils import err, make_debounced_persist, make_participant_cache, ok
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -246,40 +247,14 @@ remux_server.register_remux_routes(
 # ---- Participants ----
 
 
-def _refresh_participants() -> None:
-    """Rebuild ``_participants`` when the input directory changed since the last build.
-
-    Keyed on the input dir's ``st_mtime_ns`` (which advances on add/remove/rename),
-    mirroring ``utils.discover_participant_videos``' own memo — the steady-state
-    cost is one ``stat()``. This is what lets a video dropped into ``-i`` mid-session
-    show up without a server restart.
-
-    No-op until :func:`_init_transcripts_state` has configured the source. The
-    rebuild rebinds ``_participants`` (atomic under the GIL), so a concurrent
-    reader sees either the old list or the new one, never a torn one.
-    """
-    global _participants
-
-    source = _participant_source
-    if source is None:
-        return
-    input_dir = str(Path(utils.get_effective_input_dir()))
-    try:
-        mtime: int | None = Path(input_dir).stat().st_mtime_ns
-    except OSError:
-        mtime = None
-    if source["dir"] == input_dir and source["mtime"] == mtime:
-        return
-    with _participants_lock:
-        # A racing request may have rebuilt, or a sheet swap may have replaced the
-        # source entirely, while we waited on the lock.
-        if _participant_source is not source:
-            return
-        if source["dir"] == input_dir and source["mtime"] == mtime:
-            return
-        _participants = files.resolve_participant_videos(source["sheet_context"])
-        source["dir"] = input_dir
-        source["mtime"] = mtime
+# The refresh/find pair over this module's _participants globals; the factory
+# reads them as module attributes so _init_transcripts_state and tests that
+# monkeypatch them keep working. See server_utils.make_participant_cache.
+_refresh_participants, _find_participant_record = make_participant_cache(
+    sys.modules[__name__],
+    input_dir_getter=utils.get_effective_input_dir,
+    resolve=files.resolve_participant_videos,
+)
 
 
 @transcripts_bp.route("/api/participants")

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -63,7 +63,13 @@ import thinking_agents
 import transcripts
 import utils
 import video
-from server_utils import err, make_debounced_persist, make_participant_cache, ok
+from server_utils import (
+    err,
+    err_no_video,
+    make_debounced_persist,
+    make_participant_cache,
+    ok,
+)
 
 FlaskResponse = Response | tuple[Response, int]
 
@@ -533,11 +539,8 @@ def api_vtt(participant: str) -> FlaskResponse:
 
 def _video_paths_for_participant(participant: str) -> list[str]:
     """Return the ordered source video path(s) for *participant*, or [] if unknown."""
-    _refresh_participants()
-    for p in _participants:
-        if p["id"] == participant:
-            return list(p["video_paths"])
-    return []
+    record = _find_participant_record(participant)
+    return list(record["video_paths"]) if record else []
 
 
 @transcripts_bp.route("/api/audio-info/<participant>")
@@ -554,7 +557,7 @@ def api_audio_info(participant: str) -> FlaskResponse:
     """
     video_paths = _video_paths_for_participant(participant)
     if not video_paths:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     props = video.probe_video_properties(video_paths[0])
     if props is None:
         return err("Could not probe video file", 500)
@@ -571,7 +574,7 @@ def api_audio_track(participant: str, idx: int) -> FlaskResponse:
     """Stream one demuxed audio track for the browser's per-track volume mixer."""
     video_paths = _video_paths_for_participant(participant)
     if not video_paths:
-        return err(f"No video for participant {participant}", 404)
+        return err_no_video(participant)
     out = video.extract_audio_track(video_paths[0], idx)
     if out is None:
         return err("Could not extract audio track", 500)

--- a/source/utils.py
+++ b/source/utils.py
@@ -757,10 +757,14 @@ def require_optional(module_name: str, feature_label: str) -> None:
         ) from None
 
 
-def load_json_manifest(filename: str, *, default: Any = None) -> Any:
+def load_json_manifest(
+    filename: str, *, default: Any = None, warn_label: str = ""
+) -> Any:
     """Load a JSON manifest from the output directory.
 
-    Returns parsed data, or *default* on missing/corrupt file.
+    Returns parsed data, or *default* on missing/corrupt file. An unreadable
+    (as opposed to missing) file logs a warning when *warn_label* is set,
+    mirroring :func:`save_json_manifest`.
     """
     path = Path(get_effective_output_dir()) / filename
     if not path.is_file():
@@ -768,6 +772,8 @@ def load_json_manifest(filename: str, *, default: Any = None) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        if warn_label:
+            warning_print(f"Could not read {warn_label}; using defaults.")
         return default
 
 

--- a/source/video.py
+++ b/source/video.py
@@ -38,6 +38,40 @@ _video_properties_cache: dict[tuple[str, int], dict[str, Any]] = {}
 # Max keyframe gap (seconds) per file; None means "unknown / too sparse to
 # confirm" and callers must treat that as "do not enable keyframe-only decode".
 _keyframe_gap_cache: dict[tuple[str, int], float | None] = {}
+
+
+def _ffmpeg_cmd(*args: str) -> list[str]:
+    """Standard ffmpeg argv prefix (``-y -loglevel ...``) plus *args.
+
+    A function rather than a constant: ``config.FFMPEG_LOGLEVEL`` must be read
+    at call time, not import time.
+    """
+    return ["ffmpeg", "-y", "-loglevel", config.FFMPEG_LOGLEVEL, *args]
+
+
+# Argv tail shared by the thumbnail/sprite grabbers: one JPEG frame on stdout.
+_MJPEG_PIPE_TAIL: tuple[str, ...] = (
+    "-f",
+    "image2pipe",
+    "-vcodec",
+    "mjpeg",
+    "-q:v",
+    "5",
+    "pipe:1",
+)
+
+
+def _ffmpeg_bytes(cmd: list[str], *, timeout: float) -> bytes | None:
+    """Run an ffmpeg argv, returning stdout bytes; None on any failure."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=timeout, check=False)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout
+
+
 # Container seekability per file; None means "shape not determined" (not an
 # MP4, truncated, unreadable) and callers must stay silent rather than warn.
 _container_seekability_cache: dict[tuple[str, int], dict[str, Any] | None] = {}
@@ -737,18 +771,14 @@ def build_ffmpeg_cut_command(
     Returns:
         argv list for subprocess (e.g. ['ffmpeg', '-y', ...])
     """
-    base = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    base = _ffmpeg_cmd(
         "-ss",
         start_pos,
         "-i",
         input_file,
         "-t",
         str(duration_seconds),
-    ]
+    )
     if not reencode:
         if audio_normalize:
             # loudnorm: I=-16 (target LUFS), TP=-1.5 (true peak dB), LRA=11 (loudness range)
@@ -854,11 +884,7 @@ def mux_subtitles(
         )
         return False
 
-    ffmpeg_command = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    ffmpeg_command = _ffmpeg_cmd(
         "-i",
         input_video,
         "-i",
@@ -886,7 +912,7 @@ def mux_subtitles(
         "-disposition:s:0",
         "default" if set_default else "0",
         output_video,
-    ]
+    )
 
     utils.verbose_print(f"Muxing subtitles into {Path(output_video).name} ({codec}).")
     if config.DEBUGGING:
@@ -1096,11 +1122,7 @@ def extract_screenshot(
         )
         return False
 
-    ffmpeg_command = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    ffmpeg_command = _ffmpeg_cmd(
         "-ss",
         timestamp,
         "-i",
@@ -1110,7 +1132,7 @@ def extract_screenshot(
         "-q:v",
         config.FFMPEG_SCREENSHOT_QUALITY,
         output_file,
-    ]
+    )
     utils.debug_print(f"ffmpeg screenshot command: {' '.join(ffmpeg_command)}")
 
     ffmpeg_result = run_ffmpeg_process(
@@ -1155,11 +1177,7 @@ def extract_thumbnail_bytes(
         return None
 
     pre_seek, post_seek = accurate_seek_args(max(0.0, start_seconds))
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    cmd = _ffmpeg_cmd(
         *pre_seek,
         "-i",
         input_file,
@@ -1168,23 +1186,9 @@ def extract_thumbnail_bytes(
         "1",
         "-vf",
         f"scale={width}:-1",
-        "-f",
-        "image2pipe",
-        "-vcodec",
-        "mjpeg",
-        "-q:v",
-        "5",
-        "pipe:1",
-    ]
-
-    try:
-        result = subprocess.run(cmd, capture_output=True, timeout=15, check=False)
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return None
-
-    if result.returncode != 0 or not result.stdout:
-        return None
-    return result.stdout
+        *_MJPEG_PIPE_TAIL,
+    )
+    return _ffmpeg_bytes(cmd, timeout=15)
 
 
 def extract_sprite_sheet_bytes(
@@ -1227,11 +1231,7 @@ def extract_sprite_sheet_bytes(
 
     frame_count = max(1, cols * rows)
     duration = max(0.1, duration_seconds)
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    cmd = _ffmpeg_cmd(
         "-ss",
         str(max(0.0, start_seconds)),
         "-t",
@@ -1242,23 +1242,9 @@ def extract_sprite_sheet_bytes(
         "1",
         "-vf",
         f"fps={frame_count}/{duration},scale={frame_width}:-1,tile={cols}x{rows}",
-        "-f",
-        "image2pipe",
-        "-vcodec",
-        "mjpeg",
-        "-q:v",
-        "5",
-        "pipe:1",
-    ]
-
-    try:
-        result = subprocess.run(cmd, capture_output=True, timeout=20, check=False)
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return None
-
-    if result.returncode != 0 or not result.stdout:
-        return None
-    return result.stdout
+        *_MJPEG_PIPE_TAIL,
+    )
+    return _ffmpeg_bytes(cmd, timeout=20)
 
 
 def _extract_sprite_sheet_seek(
@@ -1285,11 +1271,7 @@ def _extract_sprite_sheet_seek(
     times = [start + (i + 0.5) * step for i in range(frame_count)]
 
     def grab(ts: float) -> bytes | None:
-        cmd = [
-            "ffmpeg",
-            "-y",
-            "-loglevel",
-            config.FFMPEG_LOGLEVEL,
+        cmd = _ffmpeg_cmd(
             "-ss",
             str(ts),
             "-i",
@@ -1298,21 +1280,9 @@ def _extract_sprite_sheet_seek(
             "1",
             "-vf",
             f"scale={frame_width}:-1",
-            "-f",
-            "image2pipe",
-            "-vcodec",
-            "mjpeg",
-            "-q:v",
-            "5",
-            "pipe:1",
-        ]
-        try:
-            result = subprocess.run(cmd, capture_output=True, timeout=15, check=False)
-        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-            return None
-        if result.returncode != 0 or not result.stdout:
-            return None
-        return result.stdout
+            *_MJPEG_PIPE_TAIL,
+        )
+        return _ffmpeg_bytes(cmd, timeout=15)
 
     workers = min(8, os.cpu_count() or 4, frame_count)
     if frame_count >= 2:
@@ -1382,11 +1352,7 @@ def extract_audio_segment_bytes(
     duration = max(0.05, duration_seconds)
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".wav")
     os.close(tmp_fd)
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    cmd = _ffmpeg_cmd(
         "-ss",
         str(max(0.0, start_seconds)),
         "-t",
@@ -1403,7 +1369,7 @@ def extract_audio_segment_bytes(
         "-f",
         "wav",
         tmp_path,
-    ]
+    )
 
     try:
         result = subprocess.run(cmd, capture_output=True, timeout=20, check=False)
@@ -1494,11 +1460,7 @@ def extract_gif(
     is_webm = out_lower.endswith(".webm")
     is_webp = out_lower.endswith(".webp")
 
-    ffmpeg_command = [
-        "ffmpeg",
-        "-y",
-        "-loglevel",
-        config.FFMPEG_LOGLEVEL,
+    ffmpeg_command = _ffmpeg_cmd(
         "-ss",
         timestamp,
         "-t",
@@ -1507,7 +1469,7 @@ def extract_gif(
         input_file,
         "-vf",
         f"fps={config.GIF_FPS},scale={config.GIF_SCALE_WIDTH}:-1:flags=lanczos",
-    ]
+    )
     if is_webm:
         # Silent VP9 loop; the loop is controlled by the <video loop> attribute
         # in the viewer, not by the container. -an strips audio.
@@ -2310,11 +2272,7 @@ def remux_to_faststart(
         # hidden name alone would not keep the scratch file out of the
         # participant list. -f mp4 supplies the format the name no longer does.
         tmp = src.parent / f".{src.stem}.remux.{os.getpid()}.{threading.get_ident()}"
-        command = [
-            "ffmpeg",
-            "-y",
-            "-loglevel",
-            config.FFMPEG_LOGLEVEL,
+        command = _ffmpeg_cmd(
             "-i",
             str(src),
             # Every stream: these recordings routinely carry two audio tracks
@@ -2328,7 +2286,7 @@ def remux_to_faststart(
             "-f",
             "mp4",
             str(tmp),
-        ]
+        )
         try:
             result = _run_ffmpeg_with_progress(
                 command,
@@ -2634,11 +2592,7 @@ def compress_to_size(
 
     try:
         null_output = "/dev/null" if os.name != "nt" else "NUL"
-        pass1_command = [
-            "ffmpeg",
-            "-y",
-            "-loglevel",
-            config.FFMPEG_LOGLEVEL,
+        pass1_command = _ffmpeg_cmd(
             "-i",
             filepath,
             "-c:v",
@@ -2653,7 +2607,7 @@ def compress_to_size(
             "-f",
             "null",
             null_output,
-        ]
+        )
 
         utils.debug_print(f"Pass 1 command: {' '.join(pass1_command)}")
         # Split the progress bar 50/50 between the two passes so the UI shows a
@@ -2684,11 +2638,7 @@ def compress_to_size(
             )
             return False
 
-        pass2_command = [
-            "ffmpeg",
-            "-y",
-            "-loglevel",
-            config.FFMPEG_LOGLEVEL,
+        pass2_command = _ffmpeg_cmd(
             "-i",
             filepath,
             "-c:v",
@@ -2704,7 +2654,7 @@ def compress_to_size(
             "-b:a",
             f"{config.AUDIO_BITRATE_KBPS}k",
             compressed_temp_path,
-        ]
+        )
 
         utils.debug_print(f"Pass 2 command: {' '.join(pass2_command)}")
         pass2_progress = (
@@ -2967,7 +2917,7 @@ def _concatenate_filter_complex(
     )
 
     def build_command(encoder: str) -> list[str]:
-        ffmpeg_command = ["ffmpeg", "-y", "-loglevel", config.FFMPEG_LOGLEVEL]
+        ffmpeg_command = _ffmpeg_cmd()
         for path in clip_paths:
             ffmpeg_command.extend(["-i", str(Path(path).resolve())])
         ffmpeg_command.extend(["-filter_complex", filter_str])
@@ -3025,11 +2975,7 @@ def _concatenate_demuxer(
     """Concatenate clips using concat demuxer (fast path for matching properties)."""
     with _concat_list_file(clip_paths) as concat_list_file:
         try:
-            ffmpeg_command = [
-                "ffmpeg",
-                "-y",
-                "-loglevel",
-                config.FFMPEG_LOGLEVEL,
+            ffmpeg_command = _ffmpeg_cmd(
                 "-f",
                 "concat",
                 "-safe",
@@ -3039,7 +2985,7 @@ def _concatenate_demuxer(
                 "-c",
                 "copy",
                 output_file,
-            ]
+            )
             utils.debug_print(f"ffmpeg concat command: {' '.join(ffmpeg_command)}")
 
             ffmpeg_result = run_ffmpeg_process(
@@ -3058,11 +3004,7 @@ def _concatenate_demuxer(
                 )
 
                 def build_reencode(encoder: str) -> list[str]:
-                    return [
-                        "ffmpeg",
-                        "-y",
-                        "-loglevel",
-                        config.FFMPEG_LOGLEVEL,
+                    return _ffmpeg_cmd(
                         "-f",
                         "concat",
                         "-safe",
@@ -3073,7 +3015,7 @@ def _concatenate_demuxer(
                         "-c:a",
                         "aac",
                         output_file,
-                    ]
+                    )
 
                 ffmpeg_result = run_ffmpeg_encode(
                     build_reencode,
@@ -3128,11 +3070,7 @@ def concat_copy(
     """
     with _concat_list_file(clip_paths) as concat_list_file:
         try:
-            ffmpeg_command = [
-                "ffmpeg",
-                "-y",
-                "-loglevel",
-                config.FFMPEG_LOGLEVEL,
+            ffmpeg_command = _ffmpeg_cmd(
                 "-f",
                 "concat",
                 "-safe",
@@ -3142,7 +3080,7 @@ def concat_copy(
                 "-c",
                 "copy",
                 output_file,
-            ]
+            )
             utils.debug_print(f"ffmpeg concat-copy command: {' '.join(ffmpeg_command)}")
             ffmpeg_result = run_ffmpeg_process(
                 ffmpeg_command,
@@ -3184,11 +3122,7 @@ def _batch_extract_screenshots(
         # i then still maps to timestamps[i] because the grid is evenly spaced.
         start_offset = timestamps[0] if timestamps else 0
         seek_args = ["-ss", str(start_offset)] if start_offset > 0 else []
-        ffmpeg_command = [
-            "ffmpeg",
-            "-y",
-            "-loglevel",
-            config.FFMPEG_LOGLEVEL,
+        ffmpeg_command = _ffmpeg_cmd(
             *seek_args,
             "-i",
             input_file,
@@ -3198,7 +3132,7 @@ def _batch_extract_screenshots(
             config.FFMPEG_SCREENSHOT_QUALITY,
             "-f",
             "image2",
-        ]
+        )
         if ext.lower() == ".webp":
             ffmpeg_command += ["-c:v", "libwebp", "-quality", str(config.WEBP_QUALITY)]
         ffmpeg_command.append(os.path.join(tmpdir, f"frame_%04d{ext}"))

--- a/source/workflows_server.py
+++ b/source/workflows_server.py
@@ -32,7 +32,7 @@ from flask import Blueprint, Response, request
 import config
 import utils
 import workflows
-from server_utils import err, make_sse_channel, ok
+from server_utils import err, find_by_id, make_sse_channel, ok, remove_by_id
 
 # ---- Module state (initialized by _init_workflows_state) ----
 
@@ -197,7 +197,7 @@ def api_blueprints_update(bp_id: str) -> Any:
         return err("JSON body required")
     with _manifest_lock:
         blueprints = _manifest.get("blueprints", [])
-        blueprint = next((b for b in blueprints if b.get("id") == bp_id), None)
+        blueprint = find_by_id(blueprints, bp_id)
         if blueprint is None:
             return err("Blueprint not found", 404)
         for key in ("name", "nodes", "edges", "viewport"):
@@ -211,11 +211,8 @@ def api_blueprints_update(bp_id: str) -> Any:
 def api_blueprints_delete(bp_id: str) -> Any:
     """Delete a blueprint by id."""
     with _manifest_lock:
-        blueprints = _manifest.get("blueprints", [])
-        idx = next((i for i, b in enumerate(blueprints) if b.get("id") == bp_id), None)
-        if idx is None:
+        if remove_by_id(_manifest.get("blueprints", []), bp_id) is None:
             return err("Blueprint not found", 404)
-        blueprints.pop(idx)
         _persist_locked()
     return ok()
 
@@ -241,7 +238,7 @@ def api_blueprint_trigger(bp_id: str) -> Any:
         return err("Unknown trigger type")
     with _manifest_lock:
         blueprints = _manifest.get("blueprints", [])
-        target = next((b for b in blueprints if b.get("id") == bp_id), None)
+        target = find_by_id(blueprints, bp_id)
         if target is None:
             return err("Blueprint not found", 404)
         if enabled:
@@ -331,7 +328,7 @@ def api_stashes_update(stash_id: str) -> Any:
         return err("JSON body required")
     with _manifest_lock:
         stashes = _manifest.get("stashes", [])
-        stash = next((s for s in stashes if s.get("id") == stash_id), None)
+        stash = find_by_id(stashes, stash_id)
         if stash is None:
             return err("Stash not found", 404)
         if "name" in data:
@@ -346,11 +343,8 @@ def api_stashes_delete(stash_id: str) -> Any:
     if any(s["id"] == stash_id for s in workflows.BUILTIN_STASHES):
         return err("Built-in recipes are read-only", 403)
     with _manifest_lock:
-        stashes = _manifest.get("stashes", [])
-        idx = next((i for i, s in enumerate(stashes) if s.get("id") == stash_id), None)
-        if idx is None:
+        if remove_by_id(_manifest.get("stashes", []), stash_id) is None:
             return err("Stash not found", 404)
-        stashes.pop(idx)
         _persist_locked()
     return ok()
 

--- a/tests/screenspace/test_scan_pipeline.py
+++ b/tests/screenspace/test_scan_pipeline.py
@@ -744,3 +744,206 @@ class TestFacadeReExports:
 # ---------------------------------------------------------------------------
 # 2F: Parallel worker
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Declarative AnalysisTool.scan kwarg forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestDeclarativeScanForwarding:
+    """The exact kwargs each declarative tool forwards to its scan function.
+
+    Expectations were written from the pre-refactor per-tool scan bodies; a
+    mismatch here means a tool's scan function silently receives different
+    arguments than it used to (the failure mode reviews miss).
+    """
+
+    _REF_FRAME = object()
+    _REF_SCENES = [{"name": "menu", "frame": object()}]
+
+    # tool -> (scan_fn_name, params passed in, expected tool-specific kwargs,
+    #          expected interval_seconds default)
+    CASES = {
+        "color": (
+            "scan_color",
+            {},
+            {
+                "target_color": {"h": 0, "s": 0, "v": 0},
+                "tolerance": {"h": 10, "s": 50, "v": 50},
+                "color_mode": "average",
+                "min_coverage": 0.0,
+            },
+            0,
+        ),
+        "change": (
+            "scan_changes",
+            {},
+            {"threshold": 0, "noise_threshold": 0, "require_consecutive": 1},
+            0,
+        ),
+        "similarity": (
+            "scan_similarity",
+            {"reference_frame": _REF_FRAME},
+            {"reference_frame": _REF_FRAME, "threshold": 0},
+            0,
+        ),
+        "text": (
+            "scan_text",
+            {},
+            {
+                "search_string": "",
+                "fuzzy_threshold": 0,
+                "ocr_confidence_threshold": None,
+                "ocr_preprocess": False,
+                "ocr_normalize": "off",
+                "require_consecutive": 1,
+                "languages": None,
+            },
+            2.0,
+        ),
+        "numbers": (
+            "scan_numbers",
+            {},
+            {
+                "operator": "gt",
+                "target_value": 0,
+                "range_min": None,
+                "range_max": None,
+                "ocr_confidence_threshold": None,
+                "ocr_preprocess": False,
+                "integers_only": False,
+                "require_consecutive": 1,
+                "languages": None,
+            },
+            2.0,
+        ),
+        "flow": (
+            "scan_flow",
+            {},
+            {"magnitude_threshold": 0, "require_consecutive": 1},
+            0,
+        ),
+        "scene": (
+            "scan_scene",
+            {"reference_scenes": _REF_SCENES},
+            {"reference_scenes": _REF_SCENES, "threshold": 0},
+            0,
+        ),
+        "inactivity": (
+            "scan_inactivity",
+            {},
+            {"threshold": 0, "min_duration": 0.0},
+            0,
+        ),
+        "boundary": (
+            "scan_boundaries",
+            {},
+            {
+                "threshold": 0,
+                "min_gap": 0.0,
+                "metric": config.SCREENSPACE_BOUNDARY_METRIC,
+            },
+            0,
+        ),
+    }
+
+    @pytest.mark.parametrize("tool_name", sorted(CASES))
+    def test_forwards_expected_kwargs(self, monkeypatch, tool_name):
+        fn_name, params, expected_specific, expected_interval = self.CASES[tool_name]
+        captured = {}
+
+        def fake_scan(video_path, region, **kwargs):
+            captured["positional"] = (video_path, region)
+            captured["kwargs"] = kwargs
+            return []
+
+        monkeypatch.setattr(screenspace_tools, fn_name, fake_scan)
+
+        def on_progress(f):
+            pass
+
+        def cancel_flag():
+            return False
+
+        region = {"x": 0, "y": 0, "w": 10, "h": 10}
+        result = screenspace_tools.TOOLS[tool_name].scan(
+            "/fake.mp4",
+            region,
+            dict(params),
+            task_id="t1",
+            scan_mode="precise",
+            on_progress=on_progress,
+            cancel_flag=cancel_flag,
+            on_result=None,
+            fast_opts=None,
+        )
+
+        assert result == []
+        assert captured["positional"] == ("/fake.mp4", region)
+        assert captured["kwargs"] == {
+            "interval_seconds": expected_interval,
+            "start_seconds": 0.0,
+            "end_seconds": None,
+            "on_progress": on_progress,
+            "cancel_flag": cancel_flag,
+            "on_result": None,
+            "fast_opts": None,
+            **expected_specific,
+        }
+
+    def test_attention_merges_saliency_kwargs(self, monkeypatch):
+        captured = {}
+
+        def fake_scan(video_path, region, **kwargs):
+            captured["kwargs"] = kwargs
+            return []
+
+        monkeypatch.setattr(screenspace_tools, "scan_attention", fake_scan)
+        screenspace_tools.TOOLS["attention"].scan(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 10, "h": 10},
+            {"weight_face": 0.5},
+            task_id="t1",
+            scan_mode="precise",
+            on_progress=lambda f: None,
+            cancel_flag=lambda: False,
+            on_result=None,
+            fast_opts=None,
+        )
+        kwargs = captured["kwargs"]
+        assert kwargs["shift_threshold"] == 0.0
+        assert kwargs["ema_alpha"] == 0.0
+        expected_saliency = screenspace_tools.saliency_kwargs_from_params(
+            {"weight_face": 0.5}
+        )
+        for key, value in expected_saliency.items():
+            assert kwargs[key] == value
+
+    def test_scan_defaults_dicts_are_copied(self, monkeypatch):
+        """A callee mutating a dict-valued default must not corrupt the ClassVar."""
+        seen = {}
+
+        def fake_scan(video_path, region, **kwargs):
+            kwargs["target_color"]["h"] = 999
+            seen["target_color"] = kwargs["target_color"]
+            return []
+
+        monkeypatch.setattr(screenspace_tools, "scan_color", fake_scan)
+        for _ in range(2):
+            screenspace_tools.TOOLS["color"].scan(
+                "/fake.mp4",
+                {"x": 0, "y": 0, "w": 10, "h": 10},
+                {},
+                task_id="t1",
+                scan_mode="precise",
+                on_progress=lambda f: None,
+                cancel_flag=lambda: False,
+                on_result=None,
+                fast_opts=None,
+            )
+        assert screenspace_tools.ColorTool.scan_defaults["target_color"] == {
+            "h": 0,
+            "s": 0,
+            "v": 0,
+        }

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -136,6 +136,20 @@ def test_api_convergence_offsets_put_empty_removes_file(
     assert not settings_file.is_file()
 
 
+def test_api_convergence_offsets_put_empty_sweeps_stale_tmp(
+    overview_client, seeded_output_dir
+):
+    """An interrupted save's .tmp sibling is removed along with the manifest."""
+    stale_tmp = seeded_output_dir / (config.CONVERGENCE_OFFSETS_FILENAME + ".tmp")
+    stale_tmp.write_text("{}")
+
+    resp = overview_client.put(
+        "/overview/api/convergence/offsets", json={"offsets": {}}
+    )
+    assert resp.status_code == 200
+    assert not stale_tmp.exists()
+
+
 def test_api_convergence_offsets_put_rejects_non_dict(
     overview_client, seeded_output_dir
 ):

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -157,3 +157,13 @@ def test_remove_by_id_missing_leaves_list_untouched():
     items = [{"id": "a"}]
     assert server_utils.remove_by_id(items, "z") is None
     assert items == [{"id": "a"}]
+
+
+def test_opt_number_missing_returns_default():
+    assert server_utils.opt_number({}, "x") is None
+    assert server_utils.opt_number({}, "x", 3.0) == 3.0
+
+
+def test_opt_number_parses_and_falls_back():
+    assert server_utils.opt_number({"x": "1.5"}, "x") == 1.5
+    assert server_utils.opt_number({"x": "nope"}, "x", 7.0) == 7.0

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -134,3 +134,26 @@ def test_json_endpoint_does_not_swallow_other_exceptions(app):
 
     with app.app_context(), pytest.raises(ValueError):
         handler()
+
+
+def test_find_by_id_returns_first_match():
+    items = [{"id": "a", "n": 1}, {"id": "b", "n": 2}, {"id": "b", "n": 3}]
+    assert server_utils.find_by_id(items, "b") == {"id": "b", "n": 2}
+
+
+def test_find_by_id_missing_and_idless_entries():
+    assert server_utils.find_by_id([], "x") is None
+    assert server_utils.find_by_id([{"name": "no id"}], "x") is None
+
+
+def test_remove_by_id_pops_in_place():
+    items = [{"id": "a"}, {"id": "b"}]
+    removed = server_utils.remove_by_id(items, "a")
+    assert removed == {"id": "a"}
+    assert items == [{"id": "b"}]
+
+
+def test_remove_by_id_missing_leaves_list_untouched():
+    items = [{"id": "a"}]
+    assert server_utils.remove_by_id(items, "z") is None
+    assert items == [{"id": "a"}]

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -948,7 +948,7 @@ def test_google_auth_records_thread_error(client, monkeypatch):
 def test_spreadsheets_open_rejected_during_generation(client, monkeypatch):
     """Switching spreadsheets is rejected with 409 while a clip generation is
     in progress, so the generated lists are not rebound under an active stream."""
-    monkeypatch.setattr(server, "_generate_in_progress", True)
+    monkeypatch.setitem(server._busy_slots, "generate", True)
     resp = client.post(
         "/api/spreadsheets/open",
         json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
@@ -974,7 +974,7 @@ def test_spreadsheets_open_rejected_during_timeline_viewer(client, monkeypatch):
     """A timeline-viewer build blocks a spreadsheet switch: it appends into the
     shared generated list/manifest, so a swap mid-build would rebind those under
     it and mix old-sheet artifacts into the new sheet."""
-    monkeypatch.setattr(server, "_timeline_viewer_in_progress", True)
+    monkeypatch.setitem(server._busy_slots, "timeline_viewer", True)
     resp = client.post(
         "/api/spreadsheets/open",
         json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
@@ -985,7 +985,7 @@ def test_spreadsheets_open_rejected_during_timeline_viewer(client, monkeypatch):
 
 def test_spreadsheets_open_rejected_during_gallery(client, monkeypatch):
     """A gallery build also blocks a spreadsheet switch."""
-    monkeypatch.setattr(server, "_gallery_in_progress", True)
+    monkeypatch.setitem(server._busy_slots, "gallery", True)
     resp = client.post(
         "/api/spreadsheets/open",
         json={"type": "excel", "id_or_path": "/tmp/whatever.xlsx"},
@@ -996,7 +996,7 @@ def test_spreadsheets_open_rejected_during_gallery(client, monkeypatch):
 
 def test_spreadsheets_close_rejected_during_reel(client, monkeypatch):
     """Closing the spreadsheet is rejected with 409 while a reel build runs."""
-    monkeypatch.setattr(server, "_reel_in_progress", True)
+    monkeypatch.setitem(server._busy_slots, "reel", True)
     resp = client.post("/api/spreadsheets/close")
     assert resp.status_code == 409
     assert resp.get_json()["ok"] is False

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -3448,12 +3448,12 @@ def test_api_reel_continues_worker_after_client_disconnect(
         # No auto-cancel on disconnect anymore.
         assert server._reel_cancel_event.is_set() is False
         # Slot still held: worker is running.
-        assert server._reel_in_progress is True
+        assert server._busy_slots["reel"] is True
     finally:
         allow_finish.set()
 
     # Once the worker finishes, manifest is updated and slot is released.
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     assert reel_record in server._generated_reels
 
 
@@ -3494,7 +3494,7 @@ def test_api_reel_busy_slot_held_during_worker_after_disconnect(
         allow_finish.set()
 
     # After worker exits, the slot frees and a fresh request can proceed.
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     third = client.post("/studio/api/reel", json={"cells": ["P01.5"]})
     assert third.status_code == 200
 
@@ -3535,7 +3535,7 @@ def test_api_reel_explicit_cancel_still_works(client, monkeypatch, tmp_path):
     # The worker observes the cancel and emits a cancelled-error event.
     final = json.loads(resp.data.decode().strip().split("\n")[-1])
     assert final.get("cancelled") is True
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
 
 
 def test_api_reel_releases_slot_on_no_clips_early_return(client, monkeypatch, tmp_path):
@@ -3548,7 +3548,7 @@ def test_api_reel_releases_slot_on_no_clips_early_return(client, monkeypatch, tm
     lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
     assert lines[-1]["ok"] is False
     assert "No clips" in lines[-1]["error"]
-    assert server._reel_in_progress is False
+    assert server._busy_slots["reel"] is False
 
 
 def test_api_reel_releases_slot_on_cached_match(client, monkeypatch, tmp_path):
@@ -3575,7 +3575,7 @@ def test_api_reel_releases_slot_on_cached_match(client, monkeypatch, tmp_path):
     lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
     assert lines[-1]["ok"] is True
     assert lines[-1]["skipped"] is True
-    assert server._reel_in_progress is False
+    assert server._busy_slots["reel"] is False
 
 
 def test_api_reel_releases_slot_on_pipeline_exception(client, monkeypatch, tmp_path):
@@ -3595,7 +3595,7 @@ def test_api_reel_releases_slot_on_pipeline_exception(client, monkeypatch, tmp_p
         ln.get("ok") is False and "ffmpeg exploded" in ln.get("error", "")
         for ln in lines
     )
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
 
 
 def test_api_reel_direct_continues_worker_after_client_disconnect(
@@ -3638,11 +3638,11 @@ def test_api_reel_direct_continues_worker_after_client_disconnect(
         assert concat_blocked.wait(timeout=5)
         resp.close()
         assert server._reel_cancel_event.is_set() is False
-        assert server._reel_in_progress is True
+        assert server._busy_slots["reel"] is True
     finally:
         allow_finish.set()
 
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     assert len(server._generated_reels) == 1
     assert server._generated_reels[0]["source"] == "intake"
 
@@ -3703,7 +3703,7 @@ def test_api_reel_direct_cleans_temp_clips_after_disconnect(
     finally:
         allow_finish.set()
 
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     assert created_temps  # sanity: ffmpeg ran
     for tmp in created_temps:
         assert not Path(tmp).exists(), f"temp clip {tmp} was not cleaned up"
@@ -3751,7 +3751,7 @@ def test_api_reel_direct_explicit_cancel_still_works(client, monkeypatch, tmp_pa
 
     final = json.loads(resp.data.decode().strip().split("\n")[-1])
     assert final.get("cancelled") is True
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
 
 
 def test_api_generate_persists_artifacts_after_disconnect(
@@ -3841,7 +3841,7 @@ def test_api_generate_persists_artifacts_after_disconnect(
         "no worker was still in flight when the client disconnected; "
         f"raise HOLD_SECONDS ({started_count[0]} started, {finished_count[0]} done)"
     )
-    assert _poll_until(lambda: server._generate_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["generate"] is False)
     persisted_rows = {a["cellRow"] for a in server._generated_artifacts}
     assert persisted_rows == {5, 6, 7, 8}
 
@@ -3913,7 +3913,7 @@ def test_api_job_status_reflects_reel_progress(client, monkeypatch, tmp_path):
         proceed.set()
         resp.close()
 
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     final = client.get("/studio/api/job-status").get_json()
     assert final["reel"]["in_progress"] is False
 
@@ -3991,7 +3991,7 @@ def test_api_job_status_reflects_generate_progress(client, monkeypatch, tmp_path
         proceed.set()
         resp.close()
 
-    assert _poll_until(lambda: server._generate_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["generate"] is False)
 
 
 def test_api_job_status_cancelling_flag(client, monkeypatch, tmp_path):
@@ -4027,7 +4027,7 @@ def test_api_job_status_cancelling_flag(client, monkeypatch, tmp_path):
         proceed.set()
         resp.close()
 
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
 
 
 def test_api_generate_explicit_cancel_still_works(client, monkeypatch, tmp_path):
@@ -4086,7 +4086,7 @@ def test_api_generate_explicit_cancel_still_works(client, monkeypatch, tmp_path)
     text = resp.data.decode()
     lines = [json.loads(ln) for ln in text.strip().split("\n") if ln.strip()]
     assert any(ln.get("cancelled") is True for ln in lines)
-    assert _poll_until(lambda: server._generate_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["generate"] is False)
 
 
 # ---- /api/reel-direct titlecards ----
@@ -4139,7 +4139,7 @@ def test_api_generate_discards_artifacts_completed_after_cancel(
     resp.data  # drain stream
     server._generate_cancel_event.clear()
 
-    assert _poll_until(lambda: server._generate_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["generate"] is False)
     ids = [a.get("id") for a in server._generated_artifacts]
     assert "a" not in ids
     assert not file_a.exists()
@@ -4369,7 +4369,7 @@ def test_api_reel_direct_wraps_segments_when_titlecards_enabled(
         },
     )
     _drain_ndjson(resp)
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     assert len(wrap_calls) == 2
     assert wrap_calls[0]["duration"] == 3
     assert wrap_calls[0]["enabled"] is True
@@ -4411,7 +4411,7 @@ def test_api_reel_direct_skips_wrap_when_titlecards_disabled(
         },
     )
     _drain_ndjson(resp)
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     assert wrap_calls == []
 
 
@@ -4439,7 +4439,7 @@ def test_api_reel_direct_clears_endcard_cache(client, monkeypatch, tmp_path):
         json={"segments": [{"participant": "P01", "start": 0, "end": 5}]},
     )
     _drain_ndjson(resp)
-    assert _poll_until(lambda: server._reel_in_progress is False)
+    assert _poll_until(lambda: server._busy_slots["reel"] is False)
     assert len(clear_calls) == 1
 
 


### PR DESCRIPTION
## Summary

Eleven independently-revertable commits that collapse repeated backend patterns into the sanctioned shared helpers (`server_utils.py`, `utils.py`), with no behavior change except one flagged correctness win.

- `video.py`: `_ffmpeg_cmd`/`_ffmpeg_bytes`/`_MJPEG_PIPE_TAIL` fold 16 copies of the argv prefix and 3 run-or-None blocks (argv stays byte-identical).
- `server.py`: four busy booleans → one `_busy_slots` dict; `api_sheet`'s twice-written config fields → `_sheet_common_fields()`.
- `server_utils.py` grows `find_by_id`/`remove_by_id` (14 manifest-CRUD copies), `err_no_video` (10 copies), `opt_number` (8 inline try/excepts in `api_preview`), `mtime_or_zero` + `clip_media_response` (Studio + Composer scrubber routes), and `make_participant_cache` — the byte-identical `_refresh_participants` clone in transcripts/screenspace, factored over module attributes so the monkeypatching tests pass unmodified.
- Composer/Overview adopt `utils.load_json_manifest`/`remove_json_manifest`; the latter also sweeps the stale `.tmp` an interrupted offsets save leaves behind (**the one intended behavior change**, now covered by a test).
- `screenspace_tools.py`: ten near-identical `scan()` overrides become a declarative base-class dispatch (`scan_fn_name` resolved via `globals()` at call time so `monkeypatch.setattr(screenspace_tools, "scan_<x>", ...)` still works), with a new per-tool kwarg-forwarding regression test written from the pre-refactor bodies.

Deliberate deferrals (details in commit messages): `_coerce_float`↔`parse_number_arg` unification, `_clamp_param`, `_find_pin`, merging the ns/float mtime helpers.

## Test plan

- [x] `uv run ruff format --check` + `ruff check` + `uv run ty check` after every commit
- [x] Full `uv run --extra dev pytest -c tests/pytest.ini` after every commit (2354 tests; `tests/test_participant_merge.py` passes unmodified — the factory design constraint)
- [x] New unit tests: `find_by_id`/`remove_by_id`/`opt_number`, offsets `.tmp` sweep, declarative-scan kwarg forwarding + ClassVar-copy guard