### PR TITLE
refactor(web): dedupe cross-page helpers and severity CSS

### DIFF
--- a/assets/web/composer-markers.js
+++ b/assets/web/composer-markers.js
@@ -29,17 +29,13 @@
     return typeof off === "number" && isFinite(off) ? off : 0;
   }
 
-  function fetchJson(path) {
-    return fetch(path).then(function (r) { return r.json(); });
-  }
-
   function loadMarkers(pid) {
     var version = ++_loadVersion;
     // Overview, not Studio: the convergence-offsets route is deliberately on the
     // overview blueprint (see agents/ARCHITECTURE.md) so its own satellites can
     // reach it page-relative. Pointing at ../studio/ 404s, and because the catch
     // below degrades to {} every lane silently rendered at offset 0.
-    fetchJson("../overview/api/convergence/offsets")
+    apiGet("../overview/api/convergence/offsets")
       .catch(function () { return {}; })
       .then(function (offData) {
         var offsets = (offData && offData.offsets) || {};
@@ -73,8 +69,8 @@
   function loadSheetMarkers(pid, version, offsets) {
     var off = offsetFor(offsets, pid, "sheet");
     Promise.all([
-      fetchJson("../studio/api/sheet"),
-      fetchJson("../studio/api/sheet/baseline"),
+      apiGet("../studio/api/sheet"),
+      apiGet("../studio/api/sheet/baseline"),
     ]).then(function (results) {
       var sheet = results[0] || {};
       var baselines = (results[1] && results[1].baselines) || {};
@@ -116,7 +112,7 @@
 
   function loadScreenspaceMarkers(pid, version, offsets) {
     var off = offsetFor(offsets, pid, "screenspace");
-    fetchJson("../screenspace/api/events?excluded=false&participant=" + encodeURIComponent(pid))
+    apiGet("../screenspace/api/events?excluded=false&participant=" + encodeURIComponent(pid))
       .then(function (data) {
         var events = ((data && data.events) || []).filter(function (ev) {
           // Boundaries are orientation scaffolding, not clip candidates —
@@ -152,7 +148,7 @@
   // skipped (a full transcript would carpet the lane edge-to-edge).
   function loadTranscriptMarkers(pid, version, offsets) {
     var off = offsetFor(offsets, pid, "transcript");
-    fetchJson("../transcripts/api/transcript/" + encodeURIComponent(pid))
+    apiGet("../transcripts/api/transcript/" + encodeURIComponent(pid))
       .then(function (data) {
         var segments = (data && data.segments) || [];
         var markers = [];
@@ -187,7 +183,7 @@
   }
 
   function persistUi() {
-    CO.apiSend("PUT", "api/ui", {
+    apiPut("api/ui", {
       markerSources: state.sourceToggles,
       laneFolds: state.laneFolds,
       markerThumbnails: state.markerThumbnails,

--- a/assets/web/composer.css
+++ b/assets/web/composer.css
@@ -21,10 +21,6 @@ html.theme-light {
   --co-timeline-grid: rgba(0, 0, 0, 0.12);
 }
 
-.hidden {
-  display: none !important;
-}
-
 html {
   /* Root rem anchor — must stay a concrete px so rem-based tokens (--text-*,
      --space-*) resolve identically to the other frontends (see workflows.css). */

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -74,16 +74,14 @@
   function setAnnotateTool() { return CO.setAnnotateTool && CO.setAnnotateTool.apply(null, arguments); }
   function initMarkerScrub() { return CO.initMarkerScrub && CO.initMarkerScrub.apply(null, arguments); }
 
-  // ---- Multi-part video (forked from transcripts-video.js) ----
+  // ---- Multi-part video ----
   // The <video> plays one part at a time; these helpers present a single
   // GLOBAL timeline so the playhead, cuts, and markers all use global seconds.
+  // Composer's manifest calls the part-start field "offset" where the other
+  // pages say "cumulativeStart" — the startKey argument documents the fork.
 
   function partForGlobal(g) {
-    var parts = state.parts;
-    for (var i = 0; i < parts.length; i++) {
-      if (g >= parts[i].offset && g < parts[i].offset + parts[i].duration) return i;
-    }
-    return Math.max(0, parts.length - 1);
+    return clipgenPartForGlobal(state.parts, g, "offset");
   }
 
   function videoGlobalTime() {

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -74,23 +74,6 @@
   function setAnnotateTool() { return CO.setAnnotateTool && CO.setAnnotateTool.apply(null, arguments); }
   function initMarkerScrub() { return CO.initMarkerScrub && CO.initMarkerScrub.apply(null, arguments); }
 
-  // ---- API client ----
-
-  function apiGet(path) {
-    return fetch(path).then(function (r) { return r.json(); });
-  }
-
-  function apiSend(method, path, body) {
-    return fetch(path, {
-      method: method,
-      headers: { "Content-Type": "application/json" },
-      body: body === undefined ? undefined : JSON.stringify(body),
-    }).then(function (r) { return r.json(); });
-  }
-
-  CO.apiGet = apiGet;
-  CO.apiSend = apiSend;
-
   // ---- Multi-part video (forked from transcripts-video.js) ----
   // The <video> plays one part at a time; these helpers present a single
   // GLOBAL timeline so the playhead, cuts, and markers all use global seconds.
@@ -458,7 +441,7 @@
   }
 
   function applyCreate(cutData) {
-    return apiSend("POST", "api/cuts", {
+    return apiPost("api/cuts", {
       participant: cutData.participant,
       start: cutData.start,
       end: cutData.end,
@@ -472,7 +455,7 @@
   }
 
   function applyDelete(id) {
-    return apiSend("DELETE", "api/cuts/" + encodeURIComponent(id)).then(function (data) {
+    return apiDelete("api/cuts/" + encodeURIComponent(id)).then(function (data) {
       if (!data.ok) throw new Error(data.error || "Could not delete cut");
       state.cuts = state.cuts.filter(function (c) { return c.id !== id; });
       if (state.selectedCutId === id) state.selectedCutId = null;
@@ -481,7 +464,7 @@
   }
 
   function applyTimes(id, times) {
-    return apiSend("PATCH", "api/cuts/" + encodeURIComponent(id), {
+    return apiPatch("api/cuts/" + encodeURIComponent(id), {
       start: times.start,
       end: times.end,
     }).then(function (data) {
@@ -534,8 +517,8 @@
       payload.source = meta.source;
     }
     var call = payload
-      ? apiSend("PUT", "api/trims/" + encodeURIComponent(key), payload)
-      : apiSend("DELETE", "api/trims/" + encodeURIComponent(key));
+      ? apiPut("api/trims/" + encodeURIComponent(key), payload)
+      : apiDelete("api/trims/" + encodeURIComponent(key));
     return call.then(function (data) {
       if (!data.ok) throw new Error(data.error || "Could not save trim");
       var marker = findMarker(key);
@@ -744,7 +727,7 @@
   CO.refreshAnnotationViews = refreshAnnotationViews;
 
   function applyAnnCreate(record) {
-    return apiSend("POST", "api/annotations", record).then(function (data) {
+    return apiPost("api/annotations", record).then(function (data) {
       if (!data.ok) throw new Error(data.error || "Could not save annotation");
       state.annotations.push(data.annotation);
       refreshAnnotationViews();
@@ -753,7 +736,7 @@
   }
 
   function applyAnnDelete(id) {
-    return apiSend("DELETE", "api/annotations/" + encodeURIComponent(id))
+    return apiDelete("api/annotations/" + encodeURIComponent(id))
       .then(function (data) {
         if (!data.ok) throw new Error(data.error || "Could not delete annotation");
         state.annotations = state.annotations.filter(function (a) { return a.id !== id; });
@@ -764,7 +747,7 @@
   }
 
   function applyAnnPatch(id, fields) {
-    return apiSend("PATCH", "api/annotations/" + encodeURIComponent(id), fields)
+    return apiPatch("api/annotations/" + encodeURIComponent(id), fields)
       .then(function (data) {
         if (!data.ok) throw new Error(data.error || "Could not save annotation");
         var idx = state.annotations.findIndex(function (a) { return a.id === id; });
@@ -963,14 +946,16 @@
     if (_exporting) { showToast("An export is already running"); return; }
     _exporting = true;
     showToast(busyLabel + "…");
-    apiSend("POST", path, body).then(function (data) {
+    apiPost(path, body).then(function (data) {
       _exporting = false;
       if (!data.ok) { showToast(data.error || "Export failed"); return; }
       logArtifactResult({ ok: true, artifact: data.artifact }, null);
       showToast("Exported " + (data.artifact.file || ""));
-    }).catch(function () {
+    }).catch(function (err) {
       _exporting = false;
-      showToast("Export failed");
+      // A 4xx envelope now rejects; err.message carries the server's text
+      // ("An export is already running", "The span is outside the recording").
+      showToast(err && err.message ? err.message : "Export failed");
     });
   }
 
@@ -1059,7 +1044,7 @@
 
   function commitCutLabel(cut, label) {
     if (label === (cut.label || "")) return;
-    apiSend("PATCH", "api/cuts/" + encodeURIComponent(cut.id), { label: label })
+    apiPatch("api/cuts/" + encodeURIComponent(cut.id), { label: label })
       .then(function (data) {
         if (!data.ok) throw new Error(data.error || "Could not save name");
         cut.label = data.cut.label;
@@ -1362,7 +1347,7 @@
   }
 
   function onCancelGenerate() {
-    apiSend("POST", "../studio/api/generate-intake/cancel").catch(function () {});
+    apiPost("../studio/api/generate-intake/cancel", {}).catch(function () {});
     if (_generateAbort) _generateAbort.abort();
   }
 

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -1777,13 +1777,10 @@
         // A /composer/#P07 hash (command palette / cross-page links) wins;
         // otherwise restore the last-worked-on participant, falling back to
         // auto-select when there is only one.
-        var hashPid = clipgenHashParticipant();
-        var stored = getStoredUIState("composer").participant;
-        var initial = hashPid && findParticipant(hashPid)
-          ? hashPid
-          : stored && findParticipant(stored)
-            ? stored
-            : state.participants.length === 1 ? state.participants[0].id : null;
+        var initial = clipgenPickParticipant(state.participants, {
+          hashPid: clipgenHashParticipant(),
+          storedId: getStoredUIState("composer").participant,
+        }) || (state.participants.length === 1 ? state.participants[0].id : null);
         if (initial) {
           qs("#coParticipantSelect").value = initial;
           selectParticipant(initial);

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -1671,24 +1671,20 @@
         renderTimeline();
       });
     }
-    var settingsBtn = qs("#settingsBtn");
-    if (settingsBtn && typeof window.openSettingsModal === "function") {
-      settingsBtn.addEventListener("click", function () {
-        // Saved/reset settings apply live on this page: re-sync the mirrored
-        // config flag and the footer hint that advertises it.
-        function syncComposerSettings(settings) {
-          (settings || []).forEach(function (s) {
-            if (s.name === "COMPOSER_DOUBLE_CLICK_CUTS") {
-              CLIPGEN_CONFIG.composerDoubleClickCuts = !!s.value;
-            }
-          });
-          updateTimelineHint();
+    // Saved/reset settings apply live on this page: re-sync the mirrored
+    // config flag and the footer hint that advertises it.
+    function syncComposerSettings(settings) {
+      (settings || []).forEach(function (s) {
+        if (s.name === "COMPOSER_DOUBLE_CLICK_CUTS") {
+          CLIPGEN_CONFIG.composerDoubleClickCuts = !!s.value;
         }
-        window.openSettingsModal({
-          initialTab: "Composer",
-          onSave: function (_applied, settings) { syncComposerSettings(settings); },
-          onReset: function (_scope, settings) { syncComposerSettings(settings); },
-        });
+      });
+      updateTimelineHint();
+    }
+    if (window.wireSettingsButton) {
+      window.wireSettingsButton({
+        initialTab: "Composer",
+        onApply: function (_applied, settings) { syncComposerSettings(settings); },
       });
     }
 

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -1270,7 +1270,7 @@
   readPersistedSidebarOpen();
 
   // ---- Generate (Studio intake endpoint; NDJSON streaming) ----
-  // readNDJSONStream is an ambient utils.js global.
+  // apiPostNDJSON is an ambient utils.js global.
 
   var _generateAbort = null;
 
@@ -1330,16 +1330,12 @@
     }
 
     _generateAbort = new AbortController();
-    fetch("../studio/api/generate-intake", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ items: items, format: "clip" }),
-      signal: _generateAbort.signal,
-    })
-      .then(function (response) {
-        if (!response.ok) throw new Error("Server error " + response.status);
-        return readNDJSONStream(response, handleLine).then(function () { finish(); });
-      })
+    apiPostNDJSON(
+      "../studio/api/generate-intake",
+      { items: items, format: "clip" },
+      { signal: _generateAbort.signal, onLine: handleLine }
+    )
+      .then(function () { finish(); })
       .catch(function (err) {
         var aborted = err && (err.name === "AbortError" || err.code === 20);
         finish(aborted ? "Generation cancelled" : "Generation failed: " + (err && err.message));

--- a/assets/web/overview-metadata.css
+++ b/assets/web/overview-metadata.css
@@ -547,14 +547,8 @@
 }
 
 /* Severity segment colors */
-.md-stacked-segment.sev-critical { background: var(--sev-critical); }
-.md-stacked-segment.sev-high { background: var(--sev-high); }
-.md-stacked-segment.sev-medium { background: var(--sev-medium); }
-.md-stacked-segment.sev-low { background: var(--sev-low); }
-.md-stacked-segment.sev-na { background: var(--sev-na); }
-.md-stacked-segment.sev-positive { background: var(--sev-positive); }
-.md-stacked-segment.sev-very-positive { background: var(--sev-very-positive); }
-.md-stacked-segment.sev-unknown { background: var(--sev-unknown); }
+/* tokens.css severity indirection */
+.md-stacked-segment { background: var(--sev, var(--sev-unknown)); }
 
 /* Severity legend */
 .md-severity-legend {
@@ -578,14 +572,8 @@
   border-radius: var(--radius-full);
 }
 
-.md-sev-dot.sev-critical { background: var(--sev-critical); }
-.md-sev-dot.sev-high { background: var(--sev-high); }
-.md-sev-dot.sev-medium { background: var(--sev-medium); }
-.md-sev-dot.sev-low { background: var(--sev-low); }
-.md-sev-dot.sev-na { background: var(--sev-na); }
-.md-sev-dot.sev-positive { background: var(--sev-positive); }
-.md-sev-dot.sev-very-positive { background: var(--sev-very-positive); }
-.md-sev-dot.sev-unknown { background: var(--sev-unknown); }
+/* tokens.css severity indirection */
+.md-sev-dot { background: var(--sev, var(--sev-unknown)); }
 
 /* ---- Category breakdown bars ---- */
 

--- a/assets/web/overview-reports.css
+++ b/assets/web/overview-reports.css
@@ -251,15 +251,8 @@
   text-decoration: underline;
 }
 
-.rp-sev { font-weight: 600; }
-.rp-sev.sev-critical { color: var(--sev-critical); }
-.rp-sev.sev-high { color: var(--sev-high); }
-.rp-sev.sev-medium { color: var(--sev-medium); }
-.rp-sev.sev-low { color: var(--sev-low); }
-.rp-sev.sev-na { color: var(--sev-na); }
-.rp-sev.sev-positive { color: var(--sev-positive); }
-.rp-sev.sev-very-positive { color: var(--sev-very-positive); }
-.rp-sev.sev-unknown { color: var(--sev-unknown); }
+/* Colored via the tokens.css severity indirection. */
+.rp-sev { font-weight: 600; color: var(--sev, var(--sev-unknown)); }
 
 /* ---- Clips strip ---- */
 
@@ -324,6 +317,8 @@
   border-color: var(--accent);
 }
 
+/* Kept local (not the tokens.css --sev indirection): na/unknown deliberately
+   get no colored bottom edge, which the shared ladder cannot express. */
 .rp-clip.sev-critical { border-bottom-color: var(--sev-critical); }
 .rp-clip.sev-high { border-bottom-color: var(--sev-high); }
 .rp-clip.sev-medium { border-bottom-color: var(--sev-medium); }
@@ -361,14 +356,8 @@
   white-space: nowrap;
 }
 
-.rp-clip-sev.sev-critical { color: var(--sev-critical); }
-.rp-clip-sev.sev-high { color: var(--sev-high); }
-.rp-clip-sev.sev-medium { color: var(--sev-medium); }
-.rp-clip-sev.sev-low { color: var(--sev-low); }
-.rp-clip-sev.sev-na { color: var(--sev-na); }
-.rp-clip-sev.sev-positive { color: var(--sev-positive); }
-.rp-clip-sev.sev-very-positive { color: var(--sev-very-positive); }
-.rp-clip-sev.sev-unknown { color: var(--sev-unknown); }
+/* Colored via the tokens.css severity indirection. */
+.rp-clip-sev { color: var(--sev, var(--sev-unknown)); }
 
 /* ---- Inline player ---- */
 

--- a/assets/web/overview-reports.js
+++ b/assets/web/overview-reports.js
@@ -671,19 +671,19 @@
 
   function startReportPoll(pid, g) {
     stopReportPoll();
-    rpState.reportPoll = setInterval(function () {
+    rpState.reportPoll = createPoller(function () {
       if (!rpState.active || g !== rpState.gen) {
         stopReportPoll();
         return;
       }
-      if (document.hidden) return;
       fetchReport(pid, g);
-    }, REPORT_POLL_MS);
+    }, REPORT_POLL_MS, { runImmediately: false });
+    rpState.reportPoll.start();
   }
 
   function stopReportPoll() {
     if (rpState.reportPoll) {
-      clearInterval(rpState.reportPoll);
+      rpState.reportPoll.stop();
       rpState.reportPoll = null;
     }
   }
@@ -1004,12 +1004,11 @@
   function startTaskPoll() {
     rpState.taskIdleTicks = 0;
     if (rpState.taskPoll) return;
-    rpState.taskPoll = setInterval(function () {
+    rpState.taskPoll = createPoller(function () {
       if (!rpState.active) {
         stopTaskPoll();
         return;
       }
-      if (document.hidden) return;
       apiGet("../transcripts/api/participants")
         .then(function (data) {
           if (!rpState.active) return;
@@ -1024,12 +1023,13 @@
           }
         })
         .catch(function () {});
-    }, TASK_POLL_MS);
+    }, TASK_POLL_MS, { runImmediately: false });
+    rpState.taskPoll.start();
   }
 
   function stopTaskPoll() {
     if (rpState.taskPoll) {
-      clearInterval(rpState.taskPoll);
+      rpState.taskPoll.stop();
       rpState.taskPoll = null;
     }
   }

--- a/assets/web/overview-reports.js
+++ b/assets/web/overview-reports.js
@@ -772,21 +772,18 @@
     var ctrl = new AbortController();
     rpState.clipsAbort = ctrl;
     renderClips();
-    fetch("../studio/api/generate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ cells: cells, format: "clip" }),
-      signal: ctrl.signal,
-    })
-      .then(function (resp) {
-        if (resp.status === 409) throw new Error("generate-busy");
-        if (!resp.ok) throw new Error("Server error " + resp.status);
-        return readNDJSONStream(resp, function (line) {
+    apiPostNDJSON(
+      "../studio/api/generate",
+      { cells: cells, format: "clip" },
+      {
+        signal: ctrl.signal,
+        onLine: function (line) {
           if (!line || line.cancelled) return;
           rpState.clipsDone++;
           renderClipsProgress();
-        });
-      })
+        },
+      }
+    )
       .then(function () {
         resetClipsGeneration();
         if (g !== rpState.gen || !rpState.active) return;
@@ -795,7 +792,7 @@
       .catch(function (err) {
         resetClipsGeneration();
         if (g !== rpState.gen || !rpState.active) return;
-        if (err && err.message === "generate-busy") {
+        if (err && err.status === 409) {
           showNotice("Studio is already generating — wait for it to finish, then try again.", null, null, null);
         } else if (!(err && err.name === "AbortError")) {
           showNotice("Clip generation failed.", null, null, null);

--- a/assets/web/overview.css
+++ b/assets/web/overview.css
@@ -4,14 +4,6 @@
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
-/* Generic hide utility — every page CSS defines this (studio/screenspace/
- * transcripts/workflows all do). The moved Convergence/Metadata satellites
- * toggle `.hidden` on banners, buttons, and detail panels; without this rule
- * all of them render unconditionally. */
-.hidden {
-  display: none !important;
-}
-
 body {
   font-family: var(--font-sans);
   background: var(--bg);

--- a/assets/web/overview.js
+++ b/assets/web/overview.js
@@ -349,13 +349,10 @@
     // TopNav renders #themeToggle / #settingsBtn synchronously before this
     // hub loads; wire them here as the other surfaces do (utils.js owns the
     // theme logic, settings-modal.js the shared modal).
-    initThemeToggle();
-    var settingsBtn = qs("#settingsBtn");
-    if (settingsBtn && typeof window.openSettingsModal === "function") {
-      settingsBtn.addEventListener("click", function () {
-        window.openSettingsModal({});
-      });
+    if (typeof initThemeToggle === "function") {
+      initThemeToggle();
     }
+    if (window.wireSettingsButton) window.wireSettingsButton({});
 
     var refreshBtn = qs("#ovRefresh");
     if (refreshBtn) {

--- a/assets/web/overview.js
+++ b/assets/web/overview.js
@@ -252,6 +252,15 @@
     }
   }
 
+  var TAB_KEYS = ["convergence", "metadata", "reports"];
+
+  // Call a tab satellite's lifecycle hook (e.g. OV.reportsActivate) if the
+  // satellite published it.
+  function tabHook(tab, phase) {
+    var fn = OV[tab + phase];
+    if (fn) fn();
+  }
+
   function syncTab(animate) {
     var panels = {
       convergence: qs("#convergencePanel"),
@@ -263,9 +272,7 @@
       if (panels[key]) panels[key].classList.add("hidden");
     }
 
-    if (OV.convergenceDeactivate) OV.convergenceDeactivate();
-    if (OV.metadataDeactivate) OV.metadataDeactivate();
-    if (OV.reportsDeactivate) OV.reportsDeactivate();
+    TAB_KEYS.forEach(function (tab) { tabHook(tab, "Deactivate"); });
 
     // Drop any paint the outgoing tab asserted; the incoming one re-asserts it
     // from its own activate path.
@@ -273,9 +280,7 @@
 
     var activePanel = panels[state.activeTab];
     if (activePanel) activePanel.classList.remove("hidden");
-    if (state.activeTab === "convergence" && OV.convergenceActivate) OV.convergenceActivate();
-    if (state.activeTab === "metadata" && OV.metadataActivate) OV.metadataActivate();
-    if (state.activeTab === "reports" && OV.reportsActivate) OV.reportsActivate();
+    tabHook(state.activeTab, "Activate");
 
     if (activePanel && animate) {
       activePanel.classList.add("tab-slide-enter");

--- a/assets/web/screenspace-overlay-interaction.js
+++ b/assets/web/screenspace-overlay-interaction.js
@@ -1068,14 +1068,8 @@
       }
     });
 
-    // Convert vertical scroll to horizontal on region chips
     var chipsEl = qs("#regionChips");
-    chipsEl.addEventListener("wheel", function (e) {
-      if (chipsEl.scrollWidth > chipsEl.clientWidth) {
-        e.preventDefault();
-        chipsEl.scrollLeft += e.deltaY;
-      }
-    }, { passive: false });
+    clipgenWheelToHorizontal(chipsEl);
     chipsEl.addEventListener("scroll", updateRegionChipsOverflow);
   }
 

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -423,16 +423,8 @@ body {
   height: 8px;
   border-radius: var(--radius-full);
   margin-top: 0.45em;
-  background: var(--color-text-dim);
+  background: var(--sev, var(--color-text-dim)); /* tokens.css severity indirection */
 }
-
-.ss-info-issue-dot.sev-critical { background: var(--sev-critical); }
-.ss-info-issue-dot.sev-high     { background: var(--sev-high); }
-.ss-info-issue-dot.sev-medium   { background: var(--sev-medium); }
-.ss-info-issue-dot.sev-low      { background: var(--sev-low); }
-.ss-info-issue-dot.sev-na       { background: var(--sev-na); }
-.ss-info-issue-dot.sev-positive { background: var(--sev-positive); }
-.ss-info-issue-dot.sev-very-positive { background: var(--sev-very-positive); }
 
 .ss-info-issue-text {
   flex: 1;

--- a/assets/web/screenspace.css
+++ b/assets/web/screenspace.css
@@ -37,10 +37,6 @@ body {
 
 /* Utility */
 
-.hidden {
-  display: none !important;
-}
-
 /* Task-type icons (mask-image, color follows currentColor).
  * Used in tooltip headers, multitool step badges, and result rows. */
 .ss-task-icon {
@@ -4166,22 +4162,10 @@ body.panel-dragging #bottomPanel {
   background: var(--color-backdrop);
 }
 
+/* Shell comes from .cg-modal-card (tokens.css); this owns width + padding. */
 .modal-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-panel-border);
-  box-shadow: var(--shadow-xl);
   padding: var(--space-5);
   width: 340px;
-  max-width: 92vw;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-}
-
-.modal-card h3 {
-  font-size: var(--text-md);
-  font-weight: 600;
 }
 
 .modal-label {

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -330,7 +330,7 @@
   </div>
 
   <div id="regionNameModal" class="modal-overlay cg-modal-overlay hidden">
-    <div class="modal-card">
+    <div class="modal-card cg-modal-card">
       <h3>Save Region</h3>
       <label class="modal-label">Name
         <input id="regionNameInput" type="text" placeholder="e.g. healthbar" spellcheck="false" autocomplete="off">

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1583,13 +1583,8 @@
         var sec = this.closest(".ss-info-section");
         if (!sec) return;
         var n = sec.getAttribute("data-section");
-        var st = getStoredUIState("screenspace");
-        var s = (st.infoSectionsCollapsed && typeof st.infoSectionsCollapsed === "object")
-          ? st.infoSectionsCollapsed
-          : {};
-        var newCollapsed = !s[n];
-        s[n] = newCollapsed;
-        setStoredUIStateField("screenspace", "infoSectionsCollapsed", s);
+        var newCollapsed = !getStoredUIMapEntry("screenspace", "infoSectionsCollapsed", n, false);
+        setStoredUIMapEntry("screenspace", "infoSectionsCollapsed", n, newCollapsed);
         applyInfoSectionCollapsed(sec, newCollapsed);
       });
     }
@@ -1804,11 +1799,7 @@
 
   function persistVideoTime(t) {
     if (!state.selectedParticipant || !isFinite(t)) return;
-    var stored = getStoredUIState("screenspace");
-    var map = (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant === "object")
-      ? stored.videoTimeByParticipant : {};
-    map[state.selectedParticipant] = t;
-    setStoredUIStateField("screenspace", "videoTimeByParticipant", map);
+    setStoredUIMapEntry("screenspace", "videoTimeByParticipant", state.selectedParticipant, t);
   }
 
   function playVideo() {
@@ -5058,11 +5049,8 @@
     qs("#participantSelect").addEventListener("change", function () {
       var pid = this.value;
       if (pid) {
-        var stored = getStoredUIState("screenspace");
-        var ts;
-        if (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant[pid] === "number") {
-          ts = stored.videoTimeByParticipant[pid];
-        }
+        var ts = getStoredUIMapEntry("screenspace", "videoTimeByParticipant", pid);
+        if (typeof ts !== "number") ts = undefined;
         selectParticipant(pid, ts);
         state.runParticipants = [pid];
         renderRunParticipantPicker();
@@ -5109,10 +5097,8 @@
               }
             }
           }
-          var initialTs;
-          if (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant[pickId] === "number") {
-            initialTs = stored.videoTimeByParticipant[pickId];
-          }
+          var initialTs = getStoredUIMapEntry("screenspace", "videoTimeByParticipant", pickId);
+          if (typeof initialTs !== "number") initialTs = undefined;
           selectParticipant(pickId, initialTs);
           state.runParticipants = [pickId];
           if (stored.rightPaneTab === "queue" || stored.rightPaneTab === "results") {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -3773,26 +3773,34 @@
     var silent = !!(opts && opts.silent);
     function toast(msg) { if (!silent) showToast(msg); }
     var sfx = "_mt" + idx;
+    // Suffix-aware DOM readers — collapse the (qs("#id" + sfx) || {}) idiom so
+    // each branch reads as "param, default". rawNum is the deliberate-NaN
+    // reader for inputs whose emptiness is checked (target/range/scale).
+    function num(id, d) { return numberOrDefault((qs("#" + id + sfx) || {}).value, d); }
+    function intv(id, d) { return intOrDefault((qs("#" + id + sfx) || {}).value, d); }
+    function chk(id) { return !!((qs("#" + id + sfx) || {}).checked); }
+    function str(id, d) { return (qs("#" + id + sfx) || {}).value || d; }
+    function rawNum(id) { return parseFloat((qs("#" + id + sfx) || {}).value); }
     var p = {};
     if (stepType === "color") {
       p.target_color = {
-        h: numberOrDefault((qs("#paramColorH" + sfx) || {}).value, 0),
-        s: numberOrDefault((qs("#paramColorS" + sfx) || {}).value, 0),
-        v: numberOrDefault((qs("#paramColorV" + sfx) || {}).value, 0),
+        h: num("paramColorH", 0),
+        s: num("paramColorS", 0),
+        v: num("paramColorV", 0),
       };
-      var tol = numberOrDefault((qs("#paramColorTol" + sfx) || {}).value, 30);
+      var tol = num("paramColorTol", 30);
       p.tolerance = {
         h: Math.round(tol * 90 / 100),
         s: Math.round(tol * 128 / 100),
         v: Math.round(tol * 128 / 100),
       };
-      if (((qs("#paramColorMode" + sfx) || {}).value) === "presence") {
+      if (str("paramColorMode", "") === "presence") {
         p.color_mode = "presence";
-        p.min_coverage = numberOrDefault((qs("#paramColorMinArea" + sfx) || {}).value, 1) / 100;
+        p.min_coverage = num("paramColorMinArea", 1) / 100;
       }
     } else if (stepType === "change") {
-      p.threshold = numberOrDefault((qs("#paramChangeThresh" + sfx) || {}).value, 0.03);
-      p.noise_threshold = intOrDefault((qs("#paramChangeNoise" + sfx) || {}).value, 30);
+      p.threshold = num("paramChangeThresh", 0.03);
+      p.noise_threshold = intv("paramChangeNoise", 30);
     } else if (stepType === "similarity") {
       var step = state.multitoolSteps[idx];
       if (!step || step._refTs === undefined) {
@@ -3800,27 +3808,27 @@
         return null;
       }
       p.reference_timestamp = step._refTs;
-      p.threshold = numberOrDefault((qs("#paramSimThresh" + sfx) || {}).value, 0.90);
+      p.threshold = num("paramSimThresh", 0.90);
     } else if (stepType === "text") {
-      p.search_string = (qs("#paramTextSearch" + sfx) || {}).value || "";
+      p.search_string = str("paramTextSearch", "");
       if (!p.search_string.trim()) {
         toast("Step " + (idx + 1) + ": enter a search string");
         return null;
       }
-      p.fuzzy_threshold = numberOrDefault((qs("#paramTextFuzzy" + sfx) || {}).value, CLIPGEN_CONFIG.screenspaceOcrFuzzyThreshold);
-      p.ocr_confidence_threshold = numberOrDefault((qs("#paramTextOcrConf" + sfx) || {}).value, CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
-      p.ocr_preprocess = !!((qs("#paramTextOcrPreprocess" + sfx) || {}).checked);
-      p.ocr_normalize = (qs("#paramTextOcrNormalize" + sfx) || {}).value || "off";
+      p.fuzzy_threshold = num("paramTextFuzzy", CLIPGEN_CONFIG.screenspaceOcrFuzzyThreshold);
+      p.ocr_confidence_threshold = num("paramTextOcrConf", CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
+      p.ocr_preprocess = chk("paramTextOcrPreprocess");
+      p.ocr_normalize = str("paramTextOcrNormalize", "off");
     } else if (stepType === "numbers") {
-      p.operator = (qs("#paramNumOperator" + sfx) || {}).value || "gt";
-      p.target_value = parseFloat((qs("#paramNumTarget" + sfx) || {}).value);
+      p.operator = str("paramNumOperator", "gt");
+      p.target_value = rawNum("paramNumTarget");
       if (isNaN(p.target_value)) {
         toast("Step " + (idx + 1) + ": enter a valid target number");
         return null;
       }
-      p.ocr_confidence_threshold = numberOrDefault((qs("#paramNumOcrConf" + sfx) || {}).value, CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
-      p.ocr_preprocess = !!((qs("#paramNumOcrPreprocess" + sfx) || {}).checked);
-      p.integers_only = !!((qs("#paramNumIntegersOnly" + sfx) || {}).checked);
+      p.ocr_confidence_threshold = num("paramNumOcrConf", CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
+      p.ocr_preprocess = chk("paramNumOcrPreprocess");
+      p.integers_only = chk("paramNumIntegersOnly");
     } else if (stepType === "template") {
       step = state.multitoolSteps[idx];
       if (step && step._upload) {
@@ -3831,13 +3839,13 @@
         toast("Step " + (idx + 1) + ": capture a template frame or upload a PNG");
         return null;
       }
-      p.threshold = numberOrDefault((qs("#paramTemplateThresh" + sfx) || {}).value, 0.70);
-      var tScalePct = parseFloat((qs("#paramTemplateScale" + sfx) || {}).value);
+      p.threshold = num("paramTemplateThresh", 0.70);
+      var tScalePct = rawNum("paramTemplateScale");
       if (!isNaN(tScalePct) && tScalePct > 0 && tScalePct !== 100) {
         p.template_scale = tScalePct / 100;
       }
     } else if (stepType === "flow") {
-      p.magnitude_threshold = numberOrDefault((qs("#paramFlowMag" + sfx) || {}).value, 2.0);
+      p.magnitude_threshold = num("paramFlowMag", 2.0);
     } else if (stepType === "scene") {
       step = state.multitoolSteps[idx];
       if (!step || !step._scenes || step._scenes.length === 0) {
@@ -3848,7 +3856,7 @@
         return { name: ref.name, timestamp: ref.timestamp, threshold: numberOrDefault(ref.threshold, 0.75) };
       });
     } else if (stepType === "inactivity") {
-      p.threshold = intOrDefault((qs("#paramInactThresh" + sfx) || {}).value, 10);
+      p.threshold = intv("paramInactThresh", 10);
     }
     var stepRegionRef = normalizeRegionRef(state.multitoolSteps[idx].region_ref)
       || (state.multitoolSteps[idx].region ? activeRegionRef(state.multitoolSteps[idx].region) : null);
@@ -3862,6 +3870,15 @@
     // strip, which probes params continuously); the Run path omits it.
     var silent = !!(opts && opts.silent);
     function toast(msg) { if (!silent) showToast(msg); }
+    var sfx = "";
+    // Suffix-aware DOM readers — collapse the (qs("#id" + sfx) || {}) idiom so
+    // each branch reads as "param, default". rawNum is the deliberate-NaN
+    // reader for inputs whose emptiness is checked (target/range/scale).
+    function num(id, d) { return numberOrDefault((qs("#" + id + sfx) || {}).value, d); }
+    function intv(id, d) { return intOrDefault((qs("#" + id + sfx) || {}).value, d); }
+    function chk(id) { return !!((qs("#" + id + sfx) || {}).checked); }
+    function str(id, d) { return (qs("#" + id + sfx) || {}).value || d; }
+    function rawNum(id) { return parseFloat((qs("#" + id + sfx) || {}).value); }
     var params = {};
     if (type === "multitool") {
       if (state.multitoolSteps.length < 2) {
@@ -3886,7 +3903,7 @@
         }
         params.steps.push(stepP);
       }
-      params.interval = numberOrDefault((qs("#paramMultitoolInterval") || {}).value, 1.0);
+      params.interval = num("paramMultitoolInterval", 1.0);
       var mtLabelEl = qs("#paramEventLabel");
       if (mtLabelEl && mtLabelEl.value.trim()) params.event_label = mtLabelEl.value.trim();
       var mtDfEl = qs("#paramDetectFirst");
@@ -3894,26 +3911,26 @@
       return params;
     } else if (type === "color") {
       params.target_color = {
-        h: numberOrDefault((qs("#paramColorH") || {}).value, 0),
-        s: numberOrDefault((qs("#paramColorS") || {}).value, 0),
-        v: numberOrDefault((qs("#paramColorV") || {}).value, 0),
+        h: num("paramColorH", 0),
+        s: num("paramColorS", 0),
+        v: num("paramColorV", 0),
       };
-      var tol = numberOrDefault((qs("#paramColorTol") || {}).value, 30);
+      var tol = num("paramColorTol", 30);
       params.tolerance = {
         h: Math.round(tol * 90 / 100),
         s: Math.round(tol * 128 / 100),
         v: Math.round(tol * 128 / 100),
       };
-      if (((qs("#paramColorMode") || {}).value) === "presence") {
+      if (str("paramColorMode", "") === "presence") {
         params.color_mode = "presence";
-        params.min_coverage = numberOrDefault((qs("#paramColorMinArea") || {}).value, 1) / 100;
+        params.min_coverage = num("paramColorMinArea", 1) / 100;
       }
-      params.interval = numberOrDefault((qs("#paramColorInterval") || {}).value, 1.0);
+      params.interval = num("paramColorInterval", 1.0);
     } else if (type === "change") {
-      params.threshold = numberOrDefault((qs("#paramChangeThresh") || {}).value, 0.03);
-      params.noise_threshold = intOrDefault((qs("#paramChangeNoise") || {}).value, 30);
-      params.interval = numberOrDefault((qs("#paramChangeInterval") || {}).value, 1.0);
-      var rcChange = intOrDefault((qs("#paramChangeConsecutive") || {}).value, 1);
+      params.threshold = num("paramChangeThresh", 0.03);
+      params.noise_threshold = intv("paramChangeNoise", 30);
+      params.interval = num("paramChangeInterval", 1.0);
+      var rcChange = intv("paramChangeConsecutive", 1);
       if (rcChange > 1) params.require_consecutive = rcChange;
     } else if (type === "similarity") {
       if (state.referenceTimestamp === null) {
@@ -3921,29 +3938,29 @@
         return null;
       }
       params.reference_timestamp = state.referenceTimestamp;
-      params.threshold = numberOrDefault((qs("#paramSimThresh") || {}).value, 0.90);
-      params.interval = numberOrDefault((qs("#paramSimInterval") || {}).value, 1.0);
+      params.threshold = num("paramSimThresh", 0.90);
+      params.interval = num("paramSimInterval", 1.0);
     } else if (type === "text") {
-      params.search_string = (qs("#paramTextSearch") || {}).value || "";
+      params.search_string = str("paramTextSearch", "");
       if (!params.search_string.trim()) {
         toast("Enter a search string");
         return null;
       }
-      params.fuzzy_threshold = numberOrDefault((qs("#paramTextFuzzy") || {}).value, CLIPGEN_CONFIG.screenspaceOcrFuzzyThreshold);
-      params.ocr_confidence_threshold = numberOrDefault((qs("#paramTextOcrConf") || {}).value, CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
-      params.ocr_preprocess = !!((qs("#paramTextOcrPreprocess") || {}).checked);
-      params.ocr_normalize = (qs("#paramTextOcrNormalize") || {}).value || "off";
-      params.interval = numberOrDefault((qs("#paramTextInterval") || {}).value, 2.0);
-      var lang = (qs("#paramTextLang") || {}).value || "en";
+      params.fuzzy_threshold = num("paramTextFuzzy", CLIPGEN_CONFIG.screenspaceOcrFuzzyThreshold);
+      params.ocr_confidence_threshold = num("paramTextOcrConf", CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
+      params.ocr_preprocess = chk("paramTextOcrPreprocess");
+      params.ocr_normalize = str("paramTextOcrNormalize", "off");
+      params.interval = num("paramTextInterval", 2.0);
+      var lang = str("paramTextLang", "en");
       params.languages = [lang];
-      var rcText = intOrDefault((qs("#paramTextConsecutive") || {}).value, 1);
+      var rcText = intv("paramTextConsecutive", 1);
       if (rcText > 1) params.require_consecutive = rcText;
     } else if (type === "numbers") {
-      var op = (qs("#paramNumOperator") || {}).value || "gt";
+      var op = str("paramNumOperator", "gt");
       params.operator = op;
       if (op === "range") {
-        params.range_min = parseFloat((qs("#paramNumMin") || {}).value);
-        params.range_max = parseFloat((qs("#paramNumMax") || {}).value);
+        params.range_min = rawNum("paramNumMin");
+        params.range_max = rawNum("paramNumMax");
         if (isNaN(params.range_min) || isNaN(params.range_max)) {
           toast("Enter valid min and max values");
           return null;
@@ -3953,23 +3970,23 @@
           return null;
         }
       } else {
-        params.target_value = parseFloat((qs("#paramNumTarget") || {}).value);
+        params.target_value = rawNum("paramNumTarget");
         if (isNaN(params.target_value)) {
           toast("Enter a valid target number");
           return null;
         }
       }
-      params.ocr_confidence_threshold = numberOrDefault((qs("#paramNumOcrConf") || {}).value, CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
-      params.ocr_preprocess = !!((qs("#paramNumOcrPreprocess") || {}).checked);
-      params.integers_only = !!((qs("#paramNumIntegersOnly") || {}).checked);
-      params.interval = numberOrDefault((qs("#paramNumInterval") || {}).value, 2.0);
-      var rcNum = intOrDefault((qs("#paramNumConsecutive") || {}).value, 1);
+      params.ocr_confidence_threshold = num("paramNumOcrConf", CLIPGEN_CONFIG.screenspaceOcrMinConfidence);
+      params.ocr_preprocess = chk("paramNumOcrPreprocess");
+      params.integers_only = chk("paramNumIntegersOnly");
+      params.interval = num("paramNumInterval", 2.0);
+      var rcNum = intv("paramNumConsecutive", 1);
       if (rcNum > 1) params.require_consecutive = rcNum;
     } else if (type === "timelapse") {
-      params.speedup_factor = numberOrDefault((qs("#paramTlSpeed") || {}).value, 10);
-      var si = parseFloat((qs("#paramTlSampleInterval") || {}).value);
+      params.speedup_factor = num("paramTlSpeed", 10);
+      var si = rawNum("paramTlSampleInterval");
       if (si > 0) params.sample_interval = si;
-      params.output_format = (qs("#paramTlFormat") || {}).value || "mp4";
+      params.output_format = str("paramTlFormat", "mp4");
     } else if (type === "template") {
       if (state.uploadedTemplate) {
         params.template_image_data = state.uploadedTemplate.data;
@@ -3980,16 +3997,16 @@
         toast("Capture a template region or upload a PNG");
         return null;
       }
-      params.threshold = numberOrDefault((qs("#paramTemplateThresh") || {}).value, 0.70);
-      params.interval = numberOrDefault((qs("#paramTemplateInterval") || {}).value, 1.0);
-      var scalePct = parseFloat((qs("#paramTemplateScale") || {}).value);
+      params.threshold = num("paramTemplateThresh", 0.70);
+      params.interval = num("paramTemplateInterval", 1.0);
+      var scalePct = rawNum("paramTemplateScale");
       if (!isNaN(scalePct) && scalePct > 0 && scalePct !== 100) {
         params.template_scale = scalePct / 100;
       }
     } else if (type === "flow") {
-      params.magnitude_threshold = numberOrDefault((qs("#paramFlowMag") || {}).value, 2.0);
-      params.interval = numberOrDefault((qs("#paramFlowInterval") || {}).value, 1.0);
-      var rcFlow = intOrDefault((qs("#paramFlowConsecutive") || {}).value, 1);
+      params.magnitude_threshold = num("paramFlowMag", 2.0);
+      params.interval = num("paramFlowInterval", 1.0);
+      var rcFlow = intv("paramFlowConsecutive", 1);
       if (rcFlow > 1) params.require_consecutive = rcFlow;
     } else if (type === "scene") {
       if (state.sceneReferences.length === 0) {
@@ -3999,27 +4016,27 @@
       params.scene_references = state.sceneReferences.map(function (ref) {
         return { name: ref.name, timestamp: ref.timestamp, threshold: numberOrDefault(ref.threshold, 0.75) };
       });
-      params.interval = numberOrDefault((qs("#paramSceneInterval") || {}).value, 1.0);
+      params.interval = num("paramSceneInterval", 1.0);
     } else if (type === "inactivity") {
-      params.threshold = intOrDefault((qs("#paramInactThresh") || {}).value, 10);
-      params.min_duration = numberOrDefault((qs("#paramInactMinDur") || {}).value, 2.0);
-      params.interval = numberOrDefault((qs("#paramInactInterval") || {}).value, 1.0);
+      params.threshold = intv("paramInactThresh", 10);
+      params.min_duration = num("paramInactMinDur", 2.0);
+      params.interval = num("paramInactInterval", 1.0);
     } else if (type === "boundary") {
-      params.threshold = intOrDefault((qs("#paramBoundaryThresh") || {}).value, 14);
-      params.min_gap = numberOrDefault((qs("#paramBoundaryMinGap") || {}).value, 3.0);
-      params.interval = numberOrDefault((qs("#paramBoundaryInterval") || {}).value, 1.0);
+      params.threshold = intv("paramBoundaryThresh", 14);
+      params.min_gap = num("paramBoundaryMinGap", 3.0);
+      params.interval = num("paramBoundaryInterval", 1.0);
       // Auto ("") omits metric so the server applies its configured default.
-      var boundaryMetric = (qs("#paramBoundaryMetric") || {}).value || "";
+      var boundaryMetric = str("paramBoundaryMetric", "");
       if (boundaryMetric) params.metric = boundaryMetric;
     } else if (type === "attention") {
-      params.shift_threshold = numberOrDefault((qs("#paramAttnShift") || {}).value, 0.15);
-      params.ema_alpha = numberOrDefault((qs("#paramAttnSmooth") || {}).value, 0.6);
-      params.weight_spectral = numberOrDefault((qs("#paramAttnWSpectral") || {}).value, 1.0);
-      params.weight_contrast = numberOrDefault((qs("#paramAttnWContrast") || {}).value, 0.7);
-      params.weight_motion = numberOrDefault((qs("#paramAttnWMotion") || {}).value, 1.2);
-      params.weight_face = numberOrDefault((qs("#paramAttnWFace") || {}).value, 0);
-      params.center_bias = numberOrDefault((qs("#paramAttnCenterBias") || {}).value, 0.25);
-      params.interval = numberOrDefault((qs("#paramAttnInterval") || {}).value, 0.5);
+      params.shift_threshold = num("paramAttnShift", 0.15);
+      params.ema_alpha = num("paramAttnSmooth", 0.6);
+      params.weight_spectral = num("paramAttnWSpectral", 1.0);
+      params.weight_contrast = num("paramAttnWContrast", 0.7);
+      params.weight_motion = num("paramAttnWMotion", 1.2);
+      params.weight_face = num("paramAttnWFace", 0);
+      params.center_bias = num("paramAttnCenterBias", 0.25);
+      params.interval = num("paramAttnInterval", 0.5);
     }
     var labelEl = qs("#paramEventLabel");
     if (labelEl && labelEl.value.trim()) {

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -450,14 +450,6 @@
     var info = state.videoInfo;
     return info && info.parts && info.parts.length > 1 ? info.parts : null;
   }
-  function _ssPartForGlobal(parts, g) {
-    for (var i = 0; i < parts.length; i++) {
-      if (g >= parts[i].cumulativeStart && g < parts[i].cumulativeStart + parts[i].duration) {
-        return i;
-      }
-    }
-    return parts.length - 1;
-  }
   function _ssStreamUrlForPart(pid, i) {
     var url = videoStreamUrl(pid);
     return url + (url.indexOf("?") >= 0 ? "&" : "?") + "part=" + i;
@@ -1809,7 +1801,7 @@
     var parts = _ssParts();
     if (parts) {
       // Multi-video: play the part that owns the global playhead, seeking local.
-      var i = _ssPartForGlobal(parts, state.currentTimestamp);
+      var i = clipgenPartForGlobal(parts, state.currentTimestamp);
       state.videoActivePart = i;
       state.videoOffset = parts[i].cumulativeStart;
       var wantSrc = _ssStreamUrlForPart(state.selectedParticipant, i);

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5070,25 +5070,11 @@
         var pickId = null;
         if (state.participants.length > 0) {
           var stored = getStoredUIState("screenspace");
-          pickId = state.participants[0].id;
-          if (stored.selectedParticipant) {
-            for (var spi = 0; spi < state.participants.length; spi++) {
-              if (state.participants[spi].id === stored.selectedParticipant) {
-                pickId = stored.selectedParticipant;
-                break;
-              }
-            }
-          }
           // Deep link (#P07, from the Overview Map) beats the stored pick.
-          var hashPid = clipgenHashParticipant();
-          if (hashPid) {
-            for (var hpi = 0; hpi < state.participants.length; hpi++) {
-              if (state.participants[hpi].id === hashPid) {
-                pickId = hashPid;
-                break;
-              }
-            }
-          }
+          pickId = clipgenPickParticipant(state.participants, {
+            hashPid: clipgenHashParticipant(),
+            storedId: stored.selectedParticipant,
+          }) || state.participants[0].id;
           var initialTs = getStoredUIMapEntry("screenspace", "videoTimeByParticipant", pickId);
           if (typeof initialTs !== "number") initialTs = undefined;
           selectParticipant(pickId, initialTs);

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -5027,21 +5027,13 @@
     // Settings
     fetchScreenspaceSettings();
     var settingsBtn = qs("#settingsBtn");
-    if (settingsBtn) {
-      settingsBtn.addEventListener("click", function () {
-        if (typeof window.openSettingsModal === "function") {
-          window.openSettingsModal({
-            initialTab: "Screenspace",
-            onSave: function (applied, settings) {
-              applyScreenspaceSettingsSnapshot(applied, settings);
-              renderResults(); // reflect a histogram-toggle change immediately
-            },
-            onReset: function (scope, settings) {
-              applyScreenspaceSettingsSnapshot(null, settings);
-              renderResults();
-            },
-          });
-        }
+    if (window.wireSettingsButton) {
+      window.wireSettingsButton({
+        initialTab: "Screenspace",
+        onApply: function (applied, settings) {
+          applyScreenspaceSettingsSnapshot(applied, settings);
+          renderResults(); // reflect a histogram-toggle change immediately
+        },
       });
     }
 

--- a/assets/web/settings-modal.js
+++ b/assets/web/settings-modal.js
@@ -1521,4 +1521,33 @@
     _open();
     _load();
   };
+
+  // Wire the TopNav #settingsBtn to the shared modal — one call per page
+  // instead of six hand-rolled listeners with divergent guards. opts:
+  //   initialTab — tab to open on
+  //   version    — string, or a function evaluated at click time (Studio's
+  //                sheet version loads after boot)
+  //   onApply(applied, settings) — called after Save (applied = the changed
+  //                map) and after Reset (applied = null); pages re-sync their
+  //                mirrored config the same way in both cases.
+  window.wireSettingsButton = function (opts) {
+    opts = opts || {};
+    var btn = document.getElementById("settingsBtn");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      var options = {
+        initialTab: opts.initialTab,
+        version: typeof opts.version === "function" ? opts.version() : opts.version,
+      };
+      if (opts.onApply) {
+        options.onSave = function (applied, settings) {
+          opts.onApply(applied, settings);
+        };
+        options.onReset = function (_scope, settings) {
+          opts.onApply(null, settings);
+        };
+      }
+      window.openSettingsModal(options);
+    });
+  };
 })();

--- a/assets/web/studio-generate.js
+++ b/assets/web/studio-generate.js
@@ -12,7 +12,7 @@
  * _generateEtaTracker + _studioEtaTicker objects are shared elapsed-time
  * infrastructure (also driven by job-status polling and the reel/build flows);
  * buildCellOverrides lives in studio-trim.js (reached via STUDIO). isIntakeSource
- * is a hub helper. apiPost / qs / readNDJSONStream / setButtonProgress /
+ * is a hub helper. apiPost / qs / apiPostNDJSON / setButtonProgress /
  * clipgenPluralUnit are ambient utils.js / primitives.js globals (scope chain).
  *
  * The hub keeps same-named onGenerate/onCancelGenerate delegators for the button
@@ -234,18 +234,11 @@
         if (tcDur) genBody.titlecard_duration = parseInt(tcDur.value, 10) || 2;
       }
 
-      // Streaming NDJSON response — needs the raw Response (reader + AbortSignal),
-      // so this intentionally stays a manual fetch rather than an api* helper.
-      fetch("api/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(genBody),
+      apiPostNDJSON("api/generate", genBody, {
         signal: sheetAbort.signal,
+        onLine: handleLine,
       })
-        .then(function (response) {
-          if (!response.ok) throw new Error("Server error " + response.status);
-          return readNDJSONStream(response, handleLine).then(finishBranch);
-        })
+        .then(finishBranch)
         .catch(function (err) {
           if (isGenerateFetchAborted(err)) {
             cancelled = true;
@@ -316,18 +309,12 @@
         updateGenerateButtonProgress();
       }
 
-      // Streaming NDJSON response — manual fetch is required to get a reader
-      // and parse line-delimited per-item events as ffmpeg finishes each cut.
-      fetch("api/generate-intake", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: intakePayload, format: format }),
-        signal: intakeAbort.signal,
-      })
-        .then(function (response) {
-          if (!response.ok) throw new Error("Server error " + response.status);
-          return readNDJSONStream(response, handleIntakeLine).then(finishBranch);
-        })
+      apiPostNDJSON(
+        "api/generate-intake",
+        { items: intakePayload, format: format },
+        { signal: intakeAbort.signal, onLine: handleIntakeLine }
+      )
+        .then(finishBranch)
         .catch(function (err) {
           if (isGenerateFetchAborted(err)) {
             cancelled = true;

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -314,17 +314,9 @@ body {
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: currentColor;
+  background: var(--sev, currentColor); /* tokens.css severity indirection */
   flex-shrink: 0;
 }
-.studio-sidebar-row-dot.sev-critical      { background: var(--sev-critical); }
-.studio-sidebar-row-dot.sev-high          { background: var(--sev-high); }
-.studio-sidebar-row-dot.sev-medium        { background: var(--sev-medium); }
-.studio-sidebar-row-dot.sev-low           { background: var(--sev-low); }
-.studio-sidebar-row-dot.sev-na            { background: var(--sev-na); }
-.studio-sidebar-row-dot.sev-positive      { background: var(--sev-positive); }
-.studio-sidebar-row-dot.sev-very-positive { background: var(--sev-very-positive); }
-.studio-sidebar-row-dot.sev-unknown       { background: var(--sev-unknown); }
 .studio-sidebar-row-label {
   flex: 1 1 auto;
   min-width: 0;
@@ -850,33 +842,17 @@ body.bottom-animating #stashedArtifactsArea {
   flex-shrink: 0;
 }
 
-.sev-pill.sev-critical {
-  color: var(--severity-critical);
-  background: color-mix(in srgb, var(--severity-critical) 18%, transparent);
-}
-.sev-pill.sev-high {
-  color: var(--severity-high);
-  background: color-mix(in srgb, var(--severity-high) 18%, transparent);
-}
-.sev-pill.sev-medium,
-.sev-pill.sev-low {
-  color: var(--severity-medium);
-  background: color-mix(in srgb, var(--severity-medium) 18%, transparent);
+/* One rule per property via the tokens.css --sev indirection; na/unknown
+ * (below) and the light-theme positive overrides out-specify it. */
+.sev-pill {
+  color: var(--sev, var(--fg-muted));
+  background: color-mix(in srgb, var(--sev, var(--fg-muted)) 18%, transparent);
 }
 .sev-pill.sev-na,
 .sev-pill.sev-unknown {
   color: var(--fg-muted);
   background: rgba(255, 255, 255, 0.06);
 }
-.sev-pill.sev-positive {
-  color: var(--severity-positive);
-  background: color-mix(in srgb, var(--severity-positive) 18%, transparent);
-}
-.sev-pill.sev-very-positive {
-  color: var(--severity-very-positive);
-  background: color-mix(in srgb, var(--severity-very-positive) 18%, transparent);
-}
-
 html[data-theme="light"] .sev-pill.sev-na,
 html[data-theme="light"] .sev-pill.sev-unknown,
 .theme-light .sev-pill.sev-na,

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -66,10 +66,6 @@ body {
   overflow: hidden;
 }
 
-.hidden {
-  display: none !important;
-}
-
 /* Theme toggle (matches viewer.css) */
 
 #tooltipToggle {
@@ -2324,28 +2320,17 @@ html[data-theme="dark"] .queue-card-error .queue-card-thumb {
   display: none;
 }
 
+/* Shell comes from .cg-modal-card (tokens.css) — which normalizes the old
+ * hand-rolled shadow onto --shadow-xl and adds the shared 1px border. This
+ * rule owns the centered layout; its gap out-cascades the base's space-3
+ * (equal specificity, page CSS loads after tokens.css). */
 .confirm-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
   padding: var(--space-6) var(--space-8);
   max-width: 420px;
   width: 90%;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
   text-align: center;
-  display: flex;
-  flex-direction: column;
   align-items: center;
   gap: var(--space-4);
-}
-
-.confirm-card h3 {
-  font-size: var(--text-md);
-  font-weight: 600;
-}
-
-.confirm-card p {
-  font-size: var(--text-sm);
-  color: var(--color-text-dim);
 }
 
 .confirm-actions {

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -279,7 +279,7 @@
   </div>
 
   <div id="confirmOverlay" class="cg-modal-veil hidden">
-    <div class="confirm-card" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
+    <div class="confirm-card cg-modal-card" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
       <h3 id="confirmTitle"></h3>
       <p id="confirmMessage"></p>
       <div class="confirm-actions">

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3373,22 +3373,18 @@
     qs("#titlecardDuration").addEventListener("change", persistTitlecardSettings);
 
     qs("#studioRefresh").addEventListener("click", refreshActiveTab);
-    qs("#settingsBtn").addEventListener("click", function () {
-      openSettingsModal({
+    if (window.wireSettingsButton) {
+      window.wireSettingsButton({
         initialTab: "General",
-        version: state.sheetData ? state.sheetData.version : "",
-        onSave: function (_applied, full) {
-          state.settingsData = full;
-          syncInlineControls();
-          _syncMarkCategoriesFromSettings(full);
-        },
-        onReset: function (_scope, full) {
+        // Click-time function: the sheet version loads after boot.
+        version: function () { return state.sheetData ? state.sheetData.version : ""; },
+        onApply: function (_applied, full) {
           state.settingsData = full;
           syncInlineControls();
           _syncMarkCategoriesFromSettings(full);
         },
       });
-    });
+    }
 
     qs("#logBtn").addEventListener("click", openLog);
     qs("#logClose").addEventListener("click", closeLog);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -2892,17 +2892,7 @@
 
   function initWheelScroll() {
     ["#artifactsList", "#reelList"].forEach(function (sel) {
-      var el = qs(sel);
-      el.addEventListener(
-        "wheel",
-        function (e) {
-          if (el.scrollWidth > el.clientWidth) {
-            e.preventDefault();
-            el.scrollLeft += e.deltaY;
-          }
-        },
-        { passive: false },
-      );
+      clipgenWheelToHorizontal(qs(sel));
     });
   }
 

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -3505,8 +3505,8 @@
   // The streaming api/generate + api/generate-intake flow (onGenerate /
   // onCancelGenerate / buildGenerateCardIndex) lives in studio-generate.js; the
   // hub keeps onGenerate/onCancelGenerate delegators (below, for the button
-  // wiring) and publishes the card painters / ETA trackers / readNDJSONStream it
-  // shares with the reel/build path.
+  // wiring) and publishes the card painters / ETA trackers it shares with the
+  // reel/build path (both stream through utils.js's apiPostNDJSON).
 
   // ---- Elapsed-time tracking for long Studio jobs ----
   // Reels (parallel/bursty clip generation), artifact generation, and viewer
@@ -3722,31 +3722,24 @@
       }
     }
 
-    fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(reelBody),
-    })
-      .then(function (response) {
-        // Any 4xx/5xx (including 409 "reel already in progress") is a JSON
-        // error body, not an NDJSON stream — parse it as text/JSON.
-        if (!response.ok && response.status >= 400) {
-          return response.text().then(function (txt) {
-            try {
-              finalPayload = JSON.parse(txt);
-            } catch (_) {
-              finalPayload = {
-                ok: false,
-                error: txt || ("HTTP " + response.status),
-              };
-            }
-            finish();
-          });
-        }
-        return readNDJSONStream(response, handleLine).then(finish);
-      })
+    apiPostNDJSON(endpoint, reelBody, { onLine: handleLine })
+      .then(finish)
       .catch(function (err) {
-        finalPayload = { ok: false, error: "Request failed: " + err };
+        // Any 4xx/5xx (including 409 "reel already in progress") is a JSON
+        // error body, not an NDJSON stream — apiPostNDJSON delivers it as
+        // err.bodyText; parse it back into the payload shape finish() reads.
+        if (err && err.status >= 400) {
+          try {
+            finalPayload = JSON.parse(err.bodyText);
+          } catch (_) {
+            finalPayload = {
+              ok: false,
+              error: err.bodyText || ("HTTP " + err.status),
+            };
+          }
+        } else {
+          finalPayload = { ok: false, error: "Request failed: " + err };
+        }
         finish();
       });
   }

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -754,6 +754,37 @@ audio.cg-audiotrack { display: none; }
 .sev-very-positive { --sev: var(--sev-very-positive); }
 .sev-unknown       { --sev: var(--sev-unknown); }
 
+/* The page-wide hide utility. !important on purpose: it must out-cascade
+   .cg-modal-overlay's `display: flex` (and any display an adopter sets)
+   regardless of specificity or source order. gallery.css keeps its own copy —
+   exported HTML strips tokens.css. */
+.hidden {
+  display: none !important;
+}
+
+/* Modal dialog card shell — the surface inside a .cg-modal-overlay. Add
+   ALONGSIDE a page-local class that owns width and padding (and any deliberate
+   deviations), e.g. class="wf-dialog cg-modal-card". Same export caveat as
+   .cg-modal-overlay. */
+.cg-modal-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 92vw;
+}
+.cg-modal-card h3 {
+  font-size: var(--text-md);
+  font-weight: 600;
+}
+.cg-modal-card p {
+  font-size: var(--text-sm);
+  color: var(--color-text-dim);
+}
+
 /* Centered blocking-modal overlay shell — shared across pages. Add ALONGSIDE a
    page-local class that owns the backdrop color and the show/hide toggle, e.g.
    class="wf-dialog-overlay cg-modal-overlay". Unlike .cg-menu this DOES set

--- a/assets/web/tokens.css
+++ b/assets/web/tokens.css
@@ -738,6 +738,22 @@ audio.cg-audiotrack { display: none; }
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
+/* Per-severity color indirection. Elements carrying a severityClass() class
+   (utils.js: sev-critical … sev-very-positive, sev-na, sev-unknown — kept in
+   sync with Python via tests/test_shared_constants.py) get --sev bound to
+   their severity color; a component then paints whichever property it colors
+   from `var(--sev, <fallback>)` instead of repeating an eight-line ladder.
+   NOT for viewer.css/gallery.css — exported HTML strips tokens.css, so those
+   keep their local ladders. */
+.sev-critical      { --sev: var(--sev-critical); }
+.sev-high          { --sev: var(--sev-high); }
+.sev-medium        { --sev: var(--sev-medium); }
+.sev-low           { --sev: var(--sev-low); }
+.sev-na            { --sev: var(--sev-na); }
+.sev-positive      { --sev: var(--sev-positive); }
+.sev-very-positive { --sev: var(--sev-very-positive); }
+.sev-unknown       { --sev: var(--sev-unknown); }
+
 /* Centered blocking-modal overlay shell — shared across pages. Add ALONGSIDE a
    page-local class that owns the backdrop color and the show/hide toggle, e.g.
    class="wf-dialog-overlay cg-modal-overlay". Unlike .cg-menu this DOES set

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -505,7 +505,7 @@
   function selectTab(name) {
     state.activeTab = name;
     var pid = state.selectedParticipant;
-    if (pid) setStoredUIStateField("transcripts", "tabByParticipant", _withKey(getStoredUIState("transcripts").tabByParticipant, pid, name));
+    if (pid) setStoredUIMapEntry("transcripts", "tabByParticipant", pid, name);
     var isSummary = name === "summary";
     qs("#tabBtnSummary").classList.toggle("active", isSummary);
     qs("#tabBtnSummary").setAttribute("aria-selected", isSummary ? "true" : "false");
@@ -515,15 +515,11 @@
     qs("#frictionTab").classList.toggle("hidden", isSummary);
   }
 
-  function _withKey(obj, key, value) {
-    var next = obj && typeof obj === "object" ? obj : {};
-    next[key] = value;
-    return next;
-  }
-
   function _restoreActiveTab(pid) {
-    var map = getStoredUIState("transcripts").tabByParticipant;
-    var saved = map && map[pid] === "friction" ? "friction" : "summary";
+    var saved =
+      getStoredUIMapEntry("transcripts", "tabByParticipant", pid) === "friction"
+        ? "friction"
+        : "summary";
     selectTab(saved);
   }
 

--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -831,12 +831,7 @@
   function initPillWheelScroll() {
     var el = qs("#participantPills");
     if (!el) return;
-    el.addEventListener("wheel", function (e) {
-      if (el.scrollWidth > el.clientWidth) {
-        e.preventDefault();
-        el.scrollLeft += e.deltaY;
-      }
-    }, { passive: false });
+    clipgenWheelToHorizontal(el);
   }
 
   function startTranscribe(pid, force) {

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -111,14 +111,6 @@
     var last = tl[tl.length - 1];
     return last.cumulativeStart + last.duration;
   }
-  function _partForGlobal(tl, g) {
-    for (var i = 0; i < tl.length; i++) {
-      if (g >= tl[i].cumulativeStart && g < tl[i].cumulativeStart + tl[i].duration) {
-        return i;
-      }
-    }
-    return tl.length - 1;
-  }
   function _partMediaUrl(i) {
     var url = "media/" + state.videoTimeline[i].filename;
     if (state.videoVersion != null) url += "?v=" + encodeURIComponent(state.videoVersion);
@@ -1124,7 +1116,7 @@
     if (state.videoTimeline) {
       var tl = state.videoTimeline;
       var g = time < 0 ? 0 : Math.min(time, _timelineTotal(tl));
-      var i = _partForGlobal(tl, g);
+      var i = clipgenPartForGlobal(tl, g);
       var local = g - tl[i].cumulativeStart;
       if (i !== state.videoActivePart) {
         _switchToPart(i, local, true);
@@ -1270,7 +1262,7 @@
   }
 
   // ---- Published back to the hub ----
-  // Boot wires the init*; selectParticipant uses _partForGlobal/_partMediaUrl/
+  // Boot wires the init*; selectParticipant uses clipgenPartForGlobal/_partMediaUrl/
   // applyCaptionMode/cancelPendingSeek; renderEmptyState uses clearTimelineMarkers;
   // the segment list, loadTranscript, search, and the agents panel use seekVideo/
   // renderTimeline/scrollToSegment; the friction tooltip uses hasTimelineHover;
@@ -1286,7 +1278,7 @@
   TS.scrollToSegment = scrollToSegment;
   TS.ignoreNextScroll = ignoreNextScroll;
   TS.applyCaptionMode = applyCaptionMode;
-  TS._partForGlobal = _partForGlobal;
+  TS._partForGlobal = clipgenPartForGlobal;
   TS._partMediaUrl = _partMediaUrl;
   TS.cancelPendingSeek = cancelPendingSeek;
   TS.clearTimelineMarkers = clearTimelineMarkers;

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -1161,11 +1161,7 @@
 
   function persistVideoTime(t) {
     if (!state.selectedParticipant || !isFinite(t)) return;
-    var stored = getStoredUIState("transcripts");
-    var map = (stored.videoTimeByParticipant && typeof stored.videoTimeByParticipant === "object")
-      ? stored.videoTimeByParticipant : {};
-    map[state.selectedParticipant] = t;
-    setStoredUIStateField("transcripts", "videoTimeByParticipant", map);
+    setStoredUIMapEntry("transcripts", "videoTimeByParticipant", state.selectedParticipant, t);
   }
 
   // Move the .active highlight to *newIndex* and optionally seek the video to its

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1398,16 +1398,8 @@ body {
   border-radius: var(--radius-full);
   margin-top: var(--space-2);
   margin-left: calc(var(--space-1-5) - var(--space-3));
-  background: var(--sev-unknown);
+  background: var(--sev, var(--sev-unknown)); /* tokens.css severity indirection */
 }
-
-.segment-sev-dot.sev-critical { background: var(--sev-critical); }
-.segment-sev-dot.sev-high { background: var(--sev-high); }
-.segment-sev-dot.sev-medium { background: var(--sev-medium); }
-.segment-sev-dot.sev-low { background: var(--sev-low); }
-.segment-sev-dot.sev-na { background: var(--sev-na); }
-.segment-sev-dot.sev-positive { background: var(--sev-positive); }
-.segment-sev-dot.sev-very-positive { background: var(--sev-very-positive); }
 
 /* Mark popover — mirrors the redesign's AnnoPopover anatomy
    (180 px wide, 10 px padding, 18 px circular swatches with white border on

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -36,10 +36,6 @@ body {
 
 /* Utility */
 
-.hidden {
-  display: none !important;
-}
-
 /* Header — subheader (status / corrections / search, right-aligned) +
    participant pills row. The chromed panel treatment was dropped so the
    subheader's sticky glass background can read against the topnav like the

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -684,35 +684,19 @@
       }
       refreshTranscriptionModelHintOnce();
 
-      // Deep link (#P07, from the Overview Map's explain panel) wins once,
-      // on the first load that has the participant list.
+      // Precedence: deep link (#P07, from the Overview Map's explain panel;
+      // wins once, on the first load that has the participant list) > current
+      // in-memory selection (soft refresh) > localStorage (fresh page load).
       var hashPid = _hashPidApplied ? "" : clipgenHashParticipant();
-      if (hashPid && state.participants.length) {
-        _hashPidApplied = true;
-        for (var h = 0; h < state.participants.length; h++) {
-          if (state.participants[h].id === hashPid) {
-            selectParticipant(hashPid);
-            return;
-          }
-        }
-      }
-
-      // Preserve current in-memory selection if still valid (soft refresh)
-      if (state.selectedParticipant) {
-        for (var i = 0; i < state.participants.length; i++) {
-          if (state.participants[i].id === state.selectedParticipant) return;
-        }
-      }
-
-      // Restore from localStorage if present and still valid (fresh page load)
-      var storedPid = getStoredUIState("transcripts").selectedParticipant;
-      if (storedPid) {
-        for (var j = 0; j < state.participants.length; j++) {
-          if (state.participants[j].id === storedPid) {
-            selectParticipant(storedPid);
-            return;
-          }
-        }
+      if (hashPid && state.participants.length) _hashPidApplied = true;
+      var pick = clipgenPickParticipant(state.participants, {
+        hashPid: hashPid,
+        currentId: state.selectedParticipant,
+        storedId: getStoredUIState("transcripts").selectedParticipant,
+      });
+      if (pick) {
+        if (pick !== state.selectedParticipant) selectParticipant(pick);
+        return;
       }
 
       // Auto-select first participant with a transcript, or just the first

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -3153,22 +3153,18 @@
       showToast(message);
     }
 
-    fetch("../studio/api/generate-intake", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ items: items, format: "clip" }),
-      signal: run.abort.signal,
-    })
-      .then(function (response) {
-        if (!response.ok) throw new Error("Server error " + response.status);
-        return readNDJSONStream(response, handleLine).then(function () {
-          var made = run.done - run.failed;
-          finish(
-            run.failed
-              ? clipgenPluralUnit(made, "clip", "clips") + " generated, " + run.failed + " failed"
-              : clipgenPluralUnit(made, "clip", "clips") + " generated — open Studio to review"
-          );
-        });
+    apiPostNDJSON(
+      "../studio/api/generate-intake",
+      { items: items, format: "clip" },
+      { signal: run.abort.signal, onLine: handleLine }
+    )
+      .then(function () {
+        var made = run.done - run.failed;
+        finish(
+          run.failed
+            ? clipgenPluralUnit(made, "clip", "clips") + " generated, " + run.failed + " failed"
+            : clipgenPluralUnit(made, "clip", "clips") + " generated — open Studio to review"
+        );
       })
       .catch(function (err) {
         var aborted = err && (err.name === "AbortError" || err.code === 20);
@@ -3431,35 +3427,31 @@
       showToast(message);
     }
 
-    fetch("api/embed-subtitles", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participants: pids, default_track: defaultTrack }),
-      signal: run.abort.signal,
-    })
-      .then(function (response) {
-        if (!response.ok) throw new Error("Server error " + response.status);
-        return readNDJSONStream(response, handleLine).then(function () {
-          var made = run.done - run.failed;
-          var where = outputDir ? " to " + outputDir : "";
-          // No sentinel means the server died partway and the body simply
-          // stopped. readNDJSONStream cannot tell that from a clean end, so
-          // without this check a run that blew up at participant 4 of 10
-          // reported "3 subtitled videos written" and nothing else.
-          if (!sawDone) {
-            finish(
-              "Subtitle embedding stopped early — " +
-                clipgenPluralUnit(made, "video was", "videos were") + " written" + where +
-                " of " + run.total + ". Check the clipgen log."
-            );
-            return;
-          }
+    apiPostNDJSON(
+      "api/embed-subtitles",
+      { participants: pids, default_track: defaultTrack },
+      { signal: run.abort.signal, onLine: handleLine }
+    )
+      .then(function () {
+        var made = run.done - run.failed;
+        var where = outputDir ? " to " + outputDir : "";
+        // No sentinel means the server died partway and the body simply
+        // stopped. The stream reader cannot tell that from a clean end, so
+        // without this check a run that blew up at participant 4 of 10
+        // reported "3 subtitled videos written" and nothing else.
+        if (!sawDone) {
           finish(
-            run.failed
-              ? clipgenPluralUnit(made, "subtitled video", "subtitled videos") + " written" + where + ", " + run.failed + " failed"
-              : clipgenPluralUnit(made, "subtitled video", "subtitled videos") + " written" + where
+            "Subtitle embedding stopped early — " +
+              clipgenPluralUnit(made, "video was", "videos were") + " written" + where +
+              " of " + run.total + ". Check the clipgen log."
           );
-        });
+          return;
+        }
+        finish(
+          run.failed
+            ? clipgenPluralUnit(made, "subtitled video", "subtitled videos") + " written" + where + ", " + run.failed + " failed"
+            : clipgenPluralUnit(made, "subtitled video", "subtitled videos") + " written" + where
+        );
       })
       .catch(function (err) {
         var aborted = err && (err.name === "AbortError" || err.code === 20);

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2943,30 +2943,19 @@
   }
 
   function initTranscriptSettings() {
-    var btn = qs("#settingsBtn");
-    if (!btn) return;
-    btn.addEventListener("click", function () {
-      openSettingsModal({
-        initialTab: "Transcription",
-        onSave: function (applied, settings) {
-          _trModelsCache = null;
-          _trModelsCachePromise = null;
-          _onTranscribeModelMaybeChanged(
-            (applied && applied.TRANSCRIBE_MODEL) !== undefined
-              ? applied.TRANSCRIBE_MODEL
-              : _settingValueFromRecords(settings, "TRANSCRIBE_MODEL")
-          );
-          _applySettingsSnapshot(applied, settings);
-        },
-        onReset: function (scope, settings) {
-          _trModelsCache = null;
-          _trModelsCachePromise = null;
-          _onTranscribeModelMaybeChanged(
-            _settingValueFromRecords(settings, "TRANSCRIBE_MODEL")
-          );
-          _applySettingsSnapshot(null, settings);
-        },
-      });
+    if (!window.wireSettingsButton) return;
+    window.wireSettingsButton({
+      initialTab: "Transcription",
+      onApply: function (applied, settings) {
+        _trModelsCache = null;
+        _trModelsCachePromise = null;
+        _onTranscribeModelMaybeChanged(
+          applied && applied.TRANSCRIBE_MODEL !== undefined
+            ? applied.TRANSCRIBE_MODEL
+            : _settingValueFromRecords(settings, "TRANSCRIBE_MODEL")
+        );
+        _applySettingsSnapshot(applied, settings);
+      },
     });
   }
 

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -2130,6 +2130,23 @@ var setStoredUIStateField = function (page, field, value) {
   } catch (_) {}
 };
 
+// Read/write one key inside a map-valued stored field (videoTimeByParticipant,
+// tabByParticipant, ...) without every caller repeating the is-it-an-object
+// defensive dance.
+var getStoredUIMapEntry = function (page, field, key, fallback) {
+  var map = getStoredUIState(page)[field];
+  return map && typeof map === "object" && Object.prototype.hasOwnProperty.call(map, key)
+    ? map[key]
+    : fallback;
+};
+
+var setStoredUIMapEntry = function (page, field, key, value) {
+  var st = getStoredUIState(page);
+  var map = st[field] && typeof st[field] === "object" ? st[field] : {};
+  map[key] = value;
+  setStoredUIStateField(page, field, map);
+};
+
 // ---- Canvas helpers (timeline overlays) ----
 
 // Draw stacked per-series amplitude bands inside a canvas rect.

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -1313,6 +1313,40 @@ var readNDJSONStream = function (response, onLine) {
   return pump();
 };
 
+// Streaming NDJSON POST: fetch + the r.ok check + readNDJSONStream in one call
+// (the raw-Response prologue every generate flow used to repeat). opts:
+// { signal, onLine }. Resolves when the stream drains. On !r.ok rejects with an
+// Error carrying .status and .bodyText (the error body, normally a JSON
+// envelope) so callers can branch (409 busy, reel error payloads); an abort
+// passes through unchanged as AbortError.
+var apiPostNDJSON = function (path, body, opts) {
+  opts = opts || {};
+  return fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: opts.signal,
+  }).then(function (r) {
+    if (!r.ok) {
+      var mkError = function (txt) {
+        var e = new Error("Server error " + r.status);
+        e.status = r.status;
+        e.bodyText = txt || "";
+        return e;
+      };
+      return r.text().then(
+        function (txt) {
+          throw mkError(txt);
+        },
+        function () {
+          throw mkError("");
+        }
+      );
+    }
+    return readNDJSONStream(r, opts.onLine || function () {});
+  });
+};
+
 // ---- File downloads ----
 // Save generated text (JSON/CSV) to disk from any page.
 //

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -2045,6 +2045,19 @@ var setStoredTooltipPref = function (enabled) {
 // load (set by the Overview Map's explain-panel links). Accepts any simple
 // token so participant-prefix rules stay in config.py alone; the consuming
 // page validates the id against its actual participant list.
+// Which part of a multi-file recording owns global second *g*. *startKey*
+// names the part-start field: "cumulativeStart" (screenspace / transcripts
+// api payloads, the default) or "offset" (the composer manifest's name for
+// the same value). Falls back to the last part so a seek past the end clamps
+// instead of going nowhere.
+var clipgenPartForGlobal = function (parts, g, startKey) {
+  var k = startKey || "cumulativeStart";
+  for (var i = 0; i < parts.length; i++) {
+    if (g >= parts[i][k] && g < parts[i][k] + parts[i].duration) return i;
+  }
+  return Math.max(0, parts.length - 1);
+};
+
 // Resolve a page's initial participant: the first of hashPid (deep link) /
 // currentId / storedId that exists in *participants* ([{id, ...}]); "" when
 // none do. Page-specific final fallbacks (first, only-one,

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -2045,6 +2045,22 @@ var setStoredTooltipPref = function (enabled) {
 // load (set by the Overview Map's explain-panel links). Accepts any simple
 // token so participant-prefix rules stay in config.py alone; the consuming
 // page validates the id against its actual participant list.
+// Resolve a page's initial participant: the first of hashPid (deep link) /
+// currentId / storedId that exists in *participants* ([{id, ...}]); "" when
+// none do. Page-specific final fallbacks (first, only-one,
+// first-with-transcript) stay at the call site.
+var clipgenPickParticipant = function (participants, opts) {
+  opts = opts || {};
+  function present(id) {
+    if (!id) return "";
+    for (var i = 0; i < participants.length; i++) {
+      if (participants[i].id === id) return id;
+    }
+    return "";
+  }
+  return present(opts.hashPid) || present(opts.currentId) || present(opts.storedId) || "";
+};
+
 var clipgenHashParticipant = function () {
   var raw = (window.location.hash || "").replace(/^#/, "");
   if (!raw) return "";

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -1013,11 +1013,31 @@ var severityRank = function (raw) {
 
 // ---- API helpers (always check r.ok) ----
 
+// Shared !r.ok handling: reject with the server's {ok:false, error} envelope
+// message when the body carries one (so toasts show "The span is outside the
+// recording", not "Server error 400"), with .status set for callers that
+// branch on it (409 busy, etc.).
+var _apiJson = function (r) {
+  if (!r.ok) {
+    var mkError = function (message) {
+      var e = new Error(message || "Server error " + r.status);
+      e.status = r.status;
+      return e;
+    };
+    return r.json().then(
+      function (data) {
+        throw mkError(data && data.error);
+      },
+      function () {
+        throw mkError(null);
+      }
+    );
+  }
+  return r.json();
+};
+
 var apiGet = function (path) {
-  return fetch(path).then(function (r) {
-    if (!r.ok) throw new Error("Server error " + r.status);
-    return r.json();
-  });
+  return fetch(path).then(_apiJson);
 };
 
 var apiPost = function (path, body) {
@@ -1025,10 +1045,7 @@ var apiPost = function (path, body) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-  }).then(function (r) {
-    if (!r.ok) throw new Error("Server error " + r.status);
-    return r.json();
-  });
+  }).then(_apiJson);
 };
 
 var apiPut = function (path, body) {
@@ -1036,17 +1053,19 @@ var apiPut = function (path, body) {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-  }).then(function (r) {
-    if (!r.ok) throw new Error("Server error " + r.status);
-    return r.json();
-  });
+  }).then(_apiJson);
+};
+
+var apiPatch = function (path, body) {
+  return fetch(path, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).then(_apiJson);
 };
 
 var apiDelete = function (path) {
-  return fetch(path, { method: "DELETE" }).then(function (r) {
-    if (!r.ok) throw new Error("Server error " + r.status);
-    return r.json();
-  });
+  return fetch(path, { method: "DELETE" }).then(_apiJson);
 };
 
 // Blob variants for image/media routes (frame thumbnails, preview renders).

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -1011,6 +1011,22 @@ var severityRank = function (raw) {
   return null;
 };
 
+// Convert vertical wheel motion to horizontal scroll on an overflowing strip
+// (card queues, pill rows, chip bars). { passive: false } because it must
+// preventDefault to stop the page scrolling instead.
+var clipgenWheelToHorizontal = function (el) {
+  el.addEventListener(
+    "wheel",
+    function (e) {
+      if (el.scrollWidth > el.clientWidth) {
+        e.preventDefault();
+        el.scrollLeft += e.deltaY;
+      }
+    },
+    { passive: false }
+  );
+};
+
 // ---- API helpers (always check r.ok) ----
 
 // Shared !r.ok handling: reject with the server's {ok:false, error} envelope

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -143,10 +143,6 @@ body[data-frontend="workflows"] {
   line-height: 1.5;
 }
 
-.hidden {
-  display: none !important;
-}
-
 /* ---- Canvas pane: toolbar + pannable canvas ---- */
 
 #wfCanvasWrap {
@@ -1997,17 +1993,10 @@ body[data-frontend="workflows"] {
   display: none;
 }
 
+/* Shell comes from .cg-modal-card (tokens.css); this owns width + padding. */
 .wf-dialog {
-  background: var(--color-surface);
-  border: 1px solid var(--color-panel-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
   width: 360px;
-  max-width: 92vw;
   padding: var(--space-4) var(--space-5);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
 }
 
 .wf-dialog-title {

--- a/assets/web/workflows.js
+++ b/assets/web/workflows.js
@@ -1128,12 +1128,7 @@
     if (typeof initThemeToggle === "function") {
       initThemeToggle();
     }
-    var settingsBtn = qs("#settingsBtn");
-    if (settingsBtn && typeof window.openSettingsModal === "function") {
-      settingsBtn.addEventListener("click", function () {
-        window.openSettingsModal({});
-      });
-    }
+    if (window.wireSettingsButton) window.wireSettingsButton({});
 
     // Blueprint switcher toolbar.
     var sel = qs("#wfBlueprintSelect");

--- a/assets/web/workflows.js
+++ b/assets/web/workflows.js
@@ -632,7 +632,7 @@
   function openDialog(opts) {
     if (!_dialogOverlay) {
       _dialogOverlay = el("div", "wf-dialog-overlay cg-modal-overlay hidden");
-      _dialogOverlay.appendChild(el("div", "wf-dialog"));
+      _dialogOverlay.appendChild(el("div", "wf-dialog cg-modal-card"));
       document.body.appendChild(_dialogOverlay);
     }
     var overlay = _dialogOverlay;

--- a/tests/test_overview_frontend_source.py
+++ b/tests/test_overview_frontend_source.py
@@ -100,12 +100,12 @@ def test_metadata_screenspace_clustering():
 
 
 def test_hidden_utility_class_defined():
-    """overview.css must define the generic `.hidden` utility (CSS toggle
-    completeness, agents/CODE-REVIEW.md): the moved Convergence/Metadata
-    satellites toggle `.hidden` on their status banners and controls, and on
-    Studio that rule came from studio.css — which this page doesn't load.
-    Without it the "analysis running"/"data changed" banners render always."""
-    css = (_WEB / "overview.css").read_text(encoding="utf-8")
+    """tokens.css must define the generic `.hidden` utility (CSS toggle
+    completeness, agents/CODE-REVIEW.md): the Convergence/Metadata satellites
+    toggle `.hidden` on their status banners and controls, and every app page
+    (this one included) gets the rule from tokens.css. Without it the
+    "analysis running"/"data changed" banners render always."""
+    css = (_WEB / "tokens.css").read_text(encoding="utf-8")
     assert re.search(r"^\.hidden \{\n  display: none !important;", css, re.MULTILINE)
 
 

--- a/tests/test_overview_frontend_source.py
+++ b/tests/test_overview_frontend_source.py
@@ -74,7 +74,9 @@ def test_hub_wires_shared_chrome_buttons():
     the buttons; each surface wires them — a missed call means dead chrome)."""
     hub = (_WEB / "overview.js").read_text(encoding="utf-8")
     assert "initThemeToggle()" in hub
-    assert "openSettingsModal" in hub
+    # Settings wiring goes through settings-modal.js's shared helper, which
+    # owns the #settingsBtn lookup.
+    assert "wireSettingsButton" in hub
 
 
 def test_hub_reads_metadata_cluster_setting_from_sheet_payload():

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -81,21 +81,22 @@ def test_on_cancel_generate_aborts_and_posts_intake_cancel():
 
 
 def test_studio_uses_shared_ndjson_reader():
-    """The shared NDJSON helper lives in utils.js (also used by Composer) and is
-    reused by the sheet/intake/reel readers (the three sites used to duplicate
-    the loop); Studio must not grow a local copy back."""
+    """The shared NDJSON streaming helpers live in utils.js (also used by
+    Composer/Transcripts/Overview); Studio must not grow a local copy back."""
     utils_src = (_WEB / "utils.js").read_text(encoding="utf-8")
     assert "var readNDJSONStream = function (response, onLine)" in utils_src
     # response.body guard
     assert "if (!response.body" in utils_src
+    assert "var apiPostNDJSON = function (path, body, opts)" in utils_src
     src = _studio_js()
     # The duplicated raw .getReader() blocks should be gone (only the utils.js
     # helper calls it).
     assert "response.body.getReader()" not in src
-    # Used by all three streaming endpoints.
-    assert "readNDJSONStream(response, handleLine).then(finishBranch)" in src
-    assert "readNDJSONStream(response, handleIntakeLine).then(finishBranch)" in src
-    assert "readNDJSONStream(response, handleLine).then(finish)" in src
+    # All three streaming endpoints go through the fetch+drain helper.
+    assert 'apiPostNDJSON("api/generate", genBody' in src
+    assert '"api/generate-intake"' in src
+    assert "onLine: handleIntakeLine" in src
+    assert "apiPostNDJSON(endpoint, reelBody, { onLine: handleLine })" in src
 
 
 def test_sheet_branch_catch_marks_failures():

--- a/tests/test_workflows_frontend_source.py
+++ b/tests/test_workflows_frontend_source.py
@@ -46,8 +46,9 @@ def test_hub_wires_topnav_chrome():
     them (they appear but do nothing otherwise)."""
     src = _workflows_js()
     assert "initThemeToggle(" in src
-    assert "#settingsBtn" in src
-    assert "openSettingsModal(" in src
+    # Settings wiring goes through settings-modal.js's shared helper, which
+    # owns the #settingsBtn lookup.
+    assert "wireSettingsButton(" in src
 
 
 def test_start_overlay_treats_workflows_as_video_tool():


### PR DESCRIPTION
## Summary

Thirteen commits that collapse duplicated frontend patterns into the shared modules (`utils.js`, `settings-modal.js`, `tokens.css`), leading with one real correctness fix.

- **Composer treated HTTP errors as success**: its local `apiGet`/`apiSend` (and composer-markers' `fetchJson`) skipped the `r.ok` check. Composer now uses the shared helpers, which gain `apiPatch` and an envelope-aware rejection carrying the server's `error` text + `.status` — so messages like "An export is already running" still reach toasts.
- `apiPostNDJSON` converges the 7 copies of the streaming-fetch prologue (studio sheet/intake/reels, composer, transcripts clip-marks/embed-subtitles, overview-reports — which now branches on `.status === 409` instead of a sentinel Error).
- New `utils.js` helpers fold repeated page code: `clipgenWheelToHorizontal` (3 byte-identical listeners), `get/setStoredUIMapEntry` (5 sites incl. the byte-identical `persistVideoTime` twins), `clipgenPickParticipant` (3 hash>stored precedence ladders), `clipgenPartForGlobal` (3 multi-part timeline forks; composer passes `startKey: "offset"`).
- `wireSettingsButton` (settings-modal.js) replaces six hand-rolled `#settingsBtn` listeners with four different guard styles — Studio's was unguarded; its `onApply` folds each page's identical onSave/onReset pair.
- Overview: tab activate/deactivate guards become a `tabHook` loop; the two raw `setInterval` pollers in Reports move onto `createPoller` (gaining real visibility pause).
- CSS: the per-severity ladder moves to a `--sev` custom-property indirection in `tokens.css` (~90 lines across five page stylesheets → one 8-line ladder); `.hidden` and a new `.cg-modal-card` dialog shell also move to `tokens.css` (gallery/viewer keep local copies — exports strip tokens.css; transcripts' divergent `.modal-content` intentionally not adopted).
- Screenspace: the two param gatherers get a suffix-aware reader trio (~90 `(qs("#id"+sfx)||{}).value` reads become `num("id", default)`); structurally unifying the gatherers is deliberately deferred.

## Test plan

- [x] Full `uv run --extra dev pytest -c tests/pytest.ini` green (three source-guard tests updated to the new contracts: studio NDJSON reader, workflows/overview settings wiring, `.hidden` home)
- [x] `node --check` on every touched JS file
- [x] [/ui-check](agents/skills/ui-check/SKILL.md): six pages load headless with zero pageerrors/request failures; screenshots reviewed — Studio severity pills/dots, Screenspace top-issue dots (both painted via the new `--sev` ladder), Composer cuts + marker lanes (the migrated API client), Overview metadata, Transcripts segments, Workflows canvas
- [x] Manual: open the Screenspace region-name modal, Workflows dialog, and Studio confirm dialog once to eyeball the `.cg-modal-card` shell (the smoke can't open modals); Studio confirm card intentionally gains the shared border + `--shadow-xl`
