### PR TITLE
test: add real-ffmpeg I/O tests, UI journeys, and test-selection policy

### DIFF
--- a/agents/skills/test/SKILL.md
+++ b/agents/skills/test/SKILL.md
@@ -19,6 +19,39 @@ uv run --extra dev pytest -c tests/pytest.ini -k "test_batch"
 - `make_clip(**overrides)` — builds a minimal clip record dict; pass keyword args to override any field
 - `fake_sheet_meta()` — returns a mock sheet metadata object
 
+## Choosing what kind of test to write
+
+Pick one kind and write it in the right place; do not mix kinds in one file.
+
+| Kind | Example | Default `/check`? |
+|---|---|---|
+| **Ratchet** | `test_frontend_satellite_wiring.py`, `test_packaging.py`, `test_shared_constants.py` | yes, must stay fast |
+| **Domain** | `test_utils_timestamps.py` | yes |
+| **API** | `test_studio_api.py` route + JSON under mocks | yes |
+| **I/O** | real `process_clips` cut of a 2s `testsrc` in `test_pipeline_io.py` | yes, max three, `skipif` no ffmpeg |
+| **Journey** | Studio generate → artifact appears | no, `tests/ui/` only |
+
+Teaching copies: domain → `tests/test_utils_timestamps.py`; API → a *small* test in
+`tests/test_studio_api.py` (not the whole file); journey → `tests/ui/test_ui_smoke.py`
++ `tests/ui/_ui_states.py`.
+
+Selection rules:
+
+- **Source scans are frozen.** No new `assert "<code>" in src` unless the bug is
+  "this symbol vanished" — and then prefer a shrink-only allowlist (`KNOWN_DEAD` in
+  `tests/test_js_dead_functions.py` is the pattern). A frontend test pins a **rule**
+  or a **shipped bug**, never a spelling.
+- The only additive-by-default rule is the existing one below: every new CLI mode,
+  flag, or selector gets at least one smoke test.
+- Bug was "page booted but the click did nothing" → add a journey in
+  `tests/ui/test_ui_journeys.py`, and only if the journey list is still ≤ 5.
+- Bug was "ffmpeg produced garbage / succeeded with partial output" → add an I/O
+  test in `tests/test_pipeline_io.py`, not another mocked argv assert. Check
+  `tests/test_clip_pipeline.py` first; the silent-wrong reel class is already
+  locked under mocks there.
+- Do not add pytest markers (`unit` / `integration`). The `tests/ui/` directory
+  split is the slow-path marker.
+
 ## CLI test pattern
 
 CLI argument tests use a local `_args(**overrides)` helper that builds a full argparse namespace with defaults, then overrides specific keys. Look for this pattern in `tests/test_cli_args.py` and `tests/test_cli_modes.py` when adding new flag tests.
@@ -37,3 +70,9 @@ you added shows up in `--durations=20`, work through
 repo minutes of CI (waits whose release never fires, per-item regex over a whole corpus,
 uncached scan helpers, real production poll intervals) and how to fix one without quietly
 turning the test into a no-op.
+
+For a faster local inner loop (not a CI change — `pytest-xdist` stays out of `pyproject.toml`):
+
+```
+uv run --extra dev --with pytest-xdist pytest -c tests/pytest.ini -n auto
+```

--- a/agents/skills/ui-check/SKILL.md
+++ b/agents/skills/ui-check/SKILL.md
@@ -1,7 +1,10 @@
 # clipgen-ui-check — Headless page smoke, screenshots, and in-page probing
 
 Boots the real combined server against a generated fixture project, loads all six
-pages in headless Chromium, and fails on any uncaught error. Use it after touching
+pages in headless Chromium, and fails on any uncaught error. It also runs five
+click-through journeys (`tests/ui/test_ui_journeys.py`): Studio generate,
+Screenspace result-row seek, Transcripts segment seek, settings persistence, and
+opening the fixture workbook through the Start overlay. Use it after touching
 anything in `assets/web/` — it is the runtime confirmation that used to be "ask the
 human to open the page".
 
@@ -37,14 +40,15 @@ CLIPGEN_UI_CHECK=1 uv run --extra dev --extra ui pytest -c tests/pytest.ini \
   tests/ui -p no:randomly -q
 ```
 
-`-p no:randomly` because shuffling six independent page loads buys nothing and
-makes failure output harder to read. Cold run ~35 s (ffmpeg encodes the fixture
-videos once), warm ~20 s.
+`-p no:randomly` because shuffling independent page loads buys nothing and
+makes failure output harder to read. Cold run ~45 s (ffmpeg encodes the fixture
+videos once), warm ~30 s — the boot smoke plus the five journeys.
 
 ## 3. Inspect — actually look at the screenshots
 
 ```
 .context/ui-check/screenshots/{studio,screenspace,transcripts,workflows,composer,overview}.png
+.context/ui-check/screenshots/journey-{generate,screenspace,transcripts,settings,start-overlay}.png
 .context/ui-check/ui-report.json
 ```
 
@@ -53,8 +57,9 @@ at the UI** rather than trusting the exit code. What you are checking for:
 
 - Does the page show real content, or an empty state? The fixture project has 6
   observations, 2 participants with video, 4 transcript segments, 2 Screenspace
-  events, 1 Composer cut and 1 Workflows blueprint. A zero-state screenshot means
-  the seeding in `tests/ui/_ui_fixtures.py` drifted, even though the test passed.
+  events plus 1 completed Screenspace task, 1 Composer cut and 1 Workflows
+  blueprint. A zero-state screenshot means the seeding in
+  `tests/ui/_ui_fixtures.py` drifted, even though the test passed.
 - Does your change look right — spacing, alignment, colors, truncation?
 
 `ui-report.json` holds the non-fatal detail that never reaches stdout: XHR 404s
@@ -129,11 +134,12 @@ Two honest limits, worth knowing before you read the output:
 - **Never** add `tests/ui` to `/check` or to `.github/workflows/`. It needs a
   browser, a fixture encode and ~20 s; `/check` must stay fast and hermetic.
 - **Never** remove `ui` from `norecursedirs` in `tests/pytest.ini`, or the
-  `CLIPGEN_UI_CHECK` gate in `test_ui_smoke.py`. They are two independent locks
-  and both are deliberate.
+  `CLIPGEN_UI_CHECK` gates in `test_ui_smoke.py` / `test_ui_journeys.py`. They
+  are two independent locks and both are deliberate.
 - `tests/test_frontend_syntax.py` (the `node --check` gate) is **not** part of this
   suite and *does* belong in `/check`. Don't move it here.
-- This is not an interaction crawl. It loads pages; it does not click through them.
+- This is not an interaction crawl. The journey list is capped at five until a
+  real shipped bug earns a sixth (`agents/skills/test/SKILL.md` has the policy).
   Feel, motion, drag behaviour and real-media playback still need a human.
 
 ## Housekeeping

--- a/plans/TEST-SUITE-PLAN.md
+++ b/plans/TEST-SUITE-PLAN.md
@@ -77,18 +77,18 @@ in `tests/test_studio_api.py` (not the whole 4.5k-line file); journey →
 Update [agents/skills/test/SKILL.md](../agents/skills/test/SKILL.md) so agents
 stop defaulting to "another mocked route test" and "another `in src` pin."
 
-- [ ] Add the taxonomy table above (kinds, where they live, `/check` or not).
-- [ ] Add the source-scan freeze: no new `assert "<code>" in src` unless the
+- [x] Add the taxonomy table above (kinds, where they live, `/check` or not).
+- [x] Add the source-scan freeze: no new `assert "<code>" in src` unless the
       bug is a vanished symbol; prefer `KNOWN_DEAD`-style shrink-only lists.
-- [ ] Add: every new CLI mode / flag / selector still needs a smoke test
+- [x] Add: every new CLI mode / flag / selector still needs a smoke test
       (existing rule). That is the *only* additive-by-default rule.
-- [ ] Add: if the bug was "page booted but the click did nothing," add a
+- [x] Add: if the bug was "page booted but the click did nothing," add a
       journey — only if the journey list is still ≤ 5.
-- [ ] Add: if the bug was "ffmpeg produced garbage / success-with-partial,"
+- [x] Add: if the bug was "ffmpeg produced garbage / success-with-partial,"
       add an I/O test, not another mocked argv assert. Check
       `test_clip_pipeline.py` first; the silent-wrong reel class is already
       locked under mocks.
-- [ ] Add optional local speed tip (not a CI change):
+- [x] Add optional local speed tip (not a CI change):
 
 ```bash
 uv run --extra dev --with pytest-xdist pytest -c tests/pytest.ini -n auto

--- a/plans/TEST-SUITE-PLAN.md
+++ b/plans/TEST-SUITE-PLAN.md
@@ -114,13 +114,13 @@ Reuse `make_clip` from `tests/conftest.py`. Point the clip at the encoded file
 via the same `{study}_{participant}.mp4` contract `files` expects. Set
 `config.OUTPUT_DIR` to `tmp_path`, `CLIP_PARALLEL_WORKERS = 1`.
 
-- [ ] **Cut:** `pipeline.process_clips([clip], output_format="clip")` returns
+- [x] **Cut:** `pipeline.process_clips([clip], output_format="clip")` returns
       count 1, the output `.mp4` exists and is non-empty, and
       `video.get_file_duration` is in range for the requested window (a 2s
       source, ~1s cut).
-- [ ] **Screenshot:** same setup, `output_format="screen"`, output `.png`
+- [x] **Screenshot:** same setup, `output_format="screen"`, output `.png`
       exists and `PIL.Image.open` can read it (dimensions > 0).
-- [ ] **Reel of two cuts:** two adjacent windows on the same 2s source,
+- [x] **Reel of two cuts:** two adjacent windows on the same 2s source,
       `pipeline.process_reel(...)`. Assert the reel path exists, duration is
       roughly the sum of the windows (not one window), and a mocked-False
       second cut does **not** produce a reel file (locks the silent-wrong

--- a/plans/archive/TEST-SUITE-PLAN.md
+++ b/plans/archive/TEST-SUITE-PLAN.md
@@ -1,7 +1,7 @@
 # Test suite evolution plan
 
-> **Status: not started.** Do not rebuild the suite. Evolve it in place. Keep this
-> file's checkboxes current as work lands.
+> **Status: Done** (phases 1–3 shipped; phase 4 remains optional and unstarted).
+> Journey #2 shipped adapted — see the note on its checkbox.
 
 **Goal:** Buy confidence that researcher paths still work, without slowing `/check`.
 
@@ -160,7 +160,7 @@ as `PAGES` in `_ui_pages.py`).
 
 Cap: these five, no more, until a real shipped bug is a sixth.
 
-- [ ] **Studio generate.** Open Studio (`#sheetGrid tbody tr` already ready).
+- [x] **Studio generate.** Open Studio (`#sheetGrid tbody tr` already ready).
       Select one valid timestamp cell (`.valid-ts`), get it into the artifact
       work area (`#artifactsList` / `#artifactsCount`), click `#generateBtn`,
       wait until the spinner (`#artifactsSpinner`) is gone and the list has
@@ -169,21 +169,26 @@ Cap: these five, no more, until a real shipped bug is a sixth.
       of job/stream timing, drive the same click path but assert on a
       completion signal the page already exposes (progress snapshot / queue
       item class) rather than adding a `data-testid`.
-- [ ] **Screenspace seek-to-event.** Open Screenspace `#P01` (player already
-      has `src`). Click a seeded event on the timeline (fixture already seeds
-      2 events). Assert `video.currentTime` is within ~0.5s of that event's
-      timestamp. **Do not** start a detector scan (OpenCV/OCR would dominate
-      the run).
-- [ ] **Transcripts seek-to-segment.** Open Transcripts `#P01`. Click
+- [x] **Screenspace seek-to-event.** *Shipped adapted:* the seeded events
+      render nowhere as written (the timeline is a canvas that only draws
+      tasks, and the fixture seeded none), and Screenspace seeks never touch
+      `video.currentTime` (`loadFrame` pauses the video and moves only the
+      playhead state). The fixture now seeds one **completed** task (safe:
+      SSE/polling only start for queued/running/paused) with `ui-evt-1`
+      attached; the journey clicks the task, then a `.result-row`, and
+      asserts the playhead (`#timestampInput`) landed on 2.0s. Still no
+      detector scan.
+- [x] **Transcripts seek-to-segment.** Open Transcripts `#P01`. Click
       `#segmentList .segment-row` (already the readiness selector). Assert
-      player time matches the segment's start.
-- [ ] **Settings persist.** Open settings via `window.openSettingsModal`
+      player time matches the segment's start. (Shipped against the row's
+      `.segment-timestamp` child — row-level clicks are deliberately a no-op.)
+- [x] **Settings persist.** Open settings via `window.openSettingsModal`
       (already in `GLOBAL_OVERLAYS`). Change one durable setting that the
       fixture does not depend on (e.g. a numeric pad or a theme-adjacent
       toggle that round-trips through `/api/settings`). Reload Studio. Re-open
       settings. Assert the value stuck. Do not use `localStorage` as the
       assertion if the product persists through the settings file.
-- [ ] **Start overlay → Studio rows.** Needs a context **without**
+- [x] **Start overlay → Studio rows.** Needs a context **without**
       `clipgen.startOverlayDismissed` (today `tests/ui/_ui_session.py`
       `build_init_script` always sets it). Add a parameter or a second
       factory so this one test can see the overlay. Pick the fixture workbook

--- a/tests/test_pipeline_io.py
+++ b/tests/test_pipeline_io.py
@@ -1,0 +1,144 @@
+"""Real-ffmpeg I/O tests: the pipeline must write usable media, not just argv.
+
+Everything else in the default suite mocks ``run_ffmpeg`` and asserts arguments;
+these three prove the end of the pipe — a cut clip a player can open, a readable
+screenshot, and a reel that is the sum of its parts (or, on a failed part, no
+reel at all — the silent-short-reel class, locked here on the *real* concat path;
+the mock-only version lives in ``test_clip_pipeline.py``).
+
+Deliberately capped at three (see ``agents/skills/test/SKILL.md``): titlecards
+(machine-dependent ``drawtext``), OCR, Whisper, remux (already covered by
+``test_container_seekability.py``), and padding/format/worker combinatorics all
+stay mocked elsewhere.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+from PIL import Image
+
+import config
+import pipeline
+import video
+
+
+def _have_ffmpeg() -> bool:
+    return shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+
+
+requires_ffmpeg = pytest.mark.skipif(
+    not _have_ffmpeg(), reason="needs real ffmpeg/ffprobe to cut media"
+)
+
+
+def _encode(path) -> None:
+    """Encode a 2 s testsrc clip; keyframe every second so short cuts stay tight."""
+    command = ["ffmpeg", "-y", "-v", "error"]
+    command += ["-f", "lavfi", "-i", "testsrc=duration=2:size=160x120:rate=15"]
+    command += ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"]
+    command += ["-f", "mp4", str(path)]
+    subprocess.run(command, check=True, capture_output=True)
+
+
+@pytest.fixture(scope="module")
+def source_dir(tmp_path_factory):
+    """One shared 2 s source at the ``{study}_{participant}.mp4`` contract path."""
+    if not _have_ffmpeg():
+        pytest.skip("needs real ffmpeg/ffprobe")
+    directory = tmp_path_factory.mktemp("io_input")
+    _encode(directory / "study_P01.mp4")
+    return directory
+
+
+@pytest.fixture
+def output_dir(monkeypatch, source_dir, tmp_path):
+    """Point the pipeline at the shared source and a fresh output dir."""
+    out = tmp_path / "out"
+    out.mkdir()
+    monkeypatch.setattr(config, "INPUT_DIR", str(source_dir), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(out), raising=False)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 1)
+    # Keep Rich progress/spinner rendering out of the test output.
+    monkeypatch.setattr(pipeline.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(pipeline.utils, "use_progress", lambda: False)
+    return out
+
+
+@requires_ffmpeg
+def test_cut_writes_playable_clip(make_clip, output_dir):
+    clip = make_clip(value="0:00-0:01")
+
+    generated, records = pipeline.process_clips(
+        [clip], output_format="clip", titlecards_enabled=False
+    )
+
+    assert generated == 1
+    assert len(records) == 1
+    outputs = list(output_dir.glob("*.mp4"))
+    assert len(outputs) == 1
+    assert outputs[0].stat().st_size > 0
+    # A ~1 s window from a 2 s source; stream copy may run to the next keyframe,
+    # and get_file_duration rounds to whole seconds. None would mean unprobeable.
+    duration = video.get_file_duration(str(outputs[0]))
+    assert duration is not None and 1 <= duration <= 2
+
+
+@requires_ffmpeg
+def test_screenshot_is_a_readable_image(make_clip, output_dir):
+    clip = make_clip(value="0:01-0:02")  # screenshots key off the start time only
+
+    generated, _records = pipeline.process_clips(
+        [clip], output_format="screen", titlecards_enabled=False
+    )
+
+    assert generated == 1
+    outputs = list(output_dir.glob("*.png"))
+    assert len(outputs) == 1
+    with Image.open(outputs[0]) as image:
+        assert image.width > 0 and image.height > 0
+
+
+@requires_ffmpeg
+def test_reel_concatenates_both_windows_or_writes_nothing(
+    monkeypatch, make_clip, output_dir
+):
+    def _clips():
+        return [
+            make_clip(row=3, value="0:00-0:01"),
+            make_clip(row=4, value="0:01-0:02"),
+        ]
+
+    # Failed second cut: no reel file may exist afterwards. With one worker the
+    # part cuts run in clip order, so failing the second call is deterministic.
+    with monkeypatch.context() as patch:
+        calls: list[str] = []
+        real_run_ffmpeg = video.run_ffmpeg
+
+        def fail_second_cut(**kwargs):
+            calls.append(kwargs["output_file"])
+            if len(calls) == 2:
+                return False
+            return real_run_ffmpeg(**kwargs)
+
+        patch.setattr(pipeline.video, "run_ffmpeg", fail_second_cut)
+        errors: list[tuple] = []
+        patch.setattr(pipeline.utils, "error_print", lambda *a, **_k: errors.append(a))
+
+        generated, records = pipeline.process_reel(_clips(), titlecards_enabled=False)
+
+        assert generated == 0
+        assert records == []
+        assert any("Reel aborted" in e[0] for e in errors)
+        # The successful first part was unlinked and its reservation released.
+        assert list(output_dir.iterdir()) == []
+
+    # Clean run: the reel is roughly the sum of both windows, not one of them.
+    generated, records = pipeline.process_reel(_clips(), titlecards_enabled=False)
+
+    assert generated == 1
+    assert len(records) == 1
+    reel_path = output_dir / "study_reel.mp4"
+    assert reel_path.is_file() and reel_path.stat().st_size > 0
+    duration = video.get_file_duration(str(reel_path))
+    assert duration is not None and 2 <= duration <= 3

--- a/tests/ui/_ui_fixtures.py
+++ b/tests/ui/_ui_fixtures.py
@@ -344,10 +344,36 @@ def _seed_screenspace() -> None:
                     "source_height": 240,
                 }
             },
-            # Empty on purpose: an active task makes the page open an SSE stream,
-            # which both defeats any settle heuristic and risks hanging teardown
-            # on the server's connection-thread join.
-            "tasks": [],
+            # Completed only, never queued/running/paused: an *active* task makes
+            # the page open an SSE stream, which both defeats any settle heuristic
+            # and risks hanging teardown on the server's connection-thread join.
+            # A completed task starts neither SSE nor the fallback poller (both
+            # gate on queued/running/paused) and restore_tasks keeps it verbatim,
+            # so the journeys can click it and read real results.
+            "tasks": [
+                {
+                    "id": "ss-ui-task-1",
+                    "type": "change",
+                    "name": "Change · toolbar",
+                    "participant": "P01",
+                    "source_video": f"{STUDY}_P01.mp4",
+                    "video_paths": [str(INPUT_DIR / f"{STUDY}_P01.mp4")],
+                    "region": "toolbar",
+                    # Pixel-space copy of the normalized region above (320×240).
+                    "region_coords": {"x": 16, "y": 12, "w": 128, "h": 48},
+                    "parameters": {},
+                    "status": "completed",
+                    "progress": 1.0,
+                    "priority": 100,
+                    "result": [
+                        {"timestamp": 2.0, "magnitude": 0.62},
+                        {"timestamp": 3.5, "magnitude": 0.47},
+                    ],
+                    "error": None,
+                    "created_at": "2026-01-05T12:00:00+00:00",
+                    "completed_at": "2026-01-05T12:01:00+00:00",
+                },
+            ],
             "events": [
                 {
                     "id": "ui-evt-1",
@@ -360,7 +386,10 @@ def _seed_screenspace() -> None:
                     "confidence": 0.82,
                     "metadata": {},
                     "excluded": False,
-                    "task_id": "",
+                    # Attached to the completed task so its results view and the
+                    # event agree; ui-evt-2 stays detached (it belongs to P02, and
+                    # a task is per-participant).
+                    "task_id": "ss-ui-task-1",
                     "region": "toolbar",
                 },
                 {

--- a/tests/ui/_ui_session.py
+++ b/tests/ui/_ui_session.py
@@ -58,13 +58,24 @@ class Session:
     origin: str
 
 
-def build_init_script(theme: str = "dark") -> str:
-    """JS run before any page script, in every context this module creates."""
+def build_init_script(theme: str = "dark", *, dismiss_start: bool = True) -> str:
+    """JS run before any page script, in every context this module creates.
+
+    ``dismiss_start=False`` leaves the start-overlay dismissal key unset so the
+    journey that drives the overlay's own UI sees its real ``close()`` semantics.
+    (The overlay still never auto-opens in this harness — ``shouldAutoOpen``
+    bails on ``sheet_loaded`` — so every other context keeps the pin.)
+    """
     if theme not in THEMES:
         raise ValueError(f"theme must be one of {THEMES}, got {theme!r}")
+    dismiss = (
+        " sessionStorage.setItem('clipgen.startOverlayDismissed', '1');"
+        if dismiss_start
+        else ""
+    )
     return (
         "try {"
-        " sessionStorage.setItem('clipgen.startOverlayDismissed', '1');"
+        f"{dismiss}"
         f" localStorage.setItem('clipgen-theme', '{theme}');"
         "} catch (e) {}"
         "window.CLIPGEN_DEV_TOKEN_TWEAK = false;"
@@ -76,6 +87,7 @@ def new_context(
     *,
     viewport: dict[str, int] | None = None,
     theme: str = "dark",
+    dismiss_start: bool = True,
 ) -> Any:
     """Build the one Chromium context shape every UI tool should use.
 
@@ -92,7 +104,7 @@ def new_context(
         timezone_id="UTC",
         color_scheme="light" if theme == "light" else "dark",
     )
-    context.add_init_script(build_init_script(theme))
+    context.add_init_script(build_init_script(theme, dismiss_start=dismiss_start))
     return context
 
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -71,31 +71,44 @@ def live_server(ui_env: None) -> Iterator[_ui_server.LiveServer]:
 
 
 @pytest.fixture(scope="session")
-def browser_context(live_server: _ui_server.LiveServer) -> Iterator[Any]:
-    """A Chromium context with the blocking start overlay pre-dismissed.
+def browser(live_server: _ui_server.LiveServer) -> Iterator[Any]:
+    """One Chromium instance for the whole session.
 
-    The context arguments live in ``_ui_session.new_context`` so this fixture and
-    ``shot.py`` cannot drift apart again — they had already, on locale/timezone.
+    Split from ``browser_context`` so a test that needs a differently-configured
+    context (the start-overlay journey runs without the dismissal pin) can build
+    its own via ``_ui_session.new_context`` without launching a second browser.
+    Depends on ``live_server`` purely for teardown order: LIFO guarantees the
+    browser closes before the server socket does.
     """
     try:
         playwright = _ui_browser.sync_playwright()().start()
     except _ui_fixtures.UiUnavailable as exc:
         pytest.skip(str(exc))
-    browser = None
-    context = None
+    launched = None
     try:
-        browser = playwright.chromium.launch(
+        launched = playwright.chromium.launch(
             executable_path=str(_ui_browser.resolve_chromium()),
             headless=True,
             args=_ui_browser.LAUNCH_ARGS,
         )
-        context = _ui_session.new_context(browser)
-        yield context
+        yield launched
     except _ui_fixtures.UiUnavailable as exc:
         pytest.skip(str(exc))
     finally:
-        if context is not None:
-            context.close()
-        if browser is not None:
-            browser.close()
+        if launched is not None:
+            launched.close()
         playwright.stop()
+
+
+@pytest.fixture(scope="session")
+def browser_context(browser: Any) -> Iterator[Any]:
+    """A Chromium context with the blocking start overlay pre-dismissed.
+
+    The context arguments live in ``_ui_session.new_context`` so this fixture and
+    ``shot.py`` cannot drift apart again — they had already, on locale/timezone.
+    """
+    context = _ui_session.new_context(browser)
+    try:
+        yield context
+    finally:
+        context.close()

--- a/tests/ui/test_ui_journeys.py
+++ b/tests/ui/test_ui_journeys.py
@@ -1,0 +1,276 @@
+"""Five click-through journeys: click → API → DOM must still hang together.
+
+The boot smoke (``test_ui_smoke.py``) proves the curtain goes up; it clicks
+nothing. Each journey here drives one researcher path through the page's own
+UI — real clicks on live selectors, never internal render calls — and asserts
+both the journey's DOM contract and ``log.fatal``. Capped at five until a real
+shipped bug earns a sixth (see ``plans/TEST-SUITE-PLAN.md`` /
+``agents/skills/test/SKILL.md``).
+
+Same double opt-in as the smoke: ``norecursedirs`` excludes the directory and
+the module gate below refuses to run without ``CLIPGEN_UI_CHECK=1``.
+"""
+
+import json
+import os
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+if os.environ.get("CLIPGEN_UI_CHECK") != "1":
+    pytest.skip(
+        "The UI journey harness is opt-in. Run the /ui-check skill, or:\n"
+        "  CLIPGEN_UI_CHECK=1 uv run --extra dev --extra ui pytest "
+        "-c tests/pytest.ini tests/ui -p no:randomly",
+        allow_module_level=True,
+    )
+
+import _ui_fixtures
+import _ui_pages
+import _ui_session
+import _ui_states
+from _ui_pages import PageLog
+from _ui_server import LiveServer
+
+import config
+
+pytestmark = pytest.mark.ui
+
+# The live selectors each journey leans on, in one place for the same honesty as
+# ``PAGES`` in ``_ui_pages.py``: this table is the part most likely to rot on a
+# redesign, and a rename should be a one-line fix here rather than a dig.
+SELECTORS = {
+    "studio-cell": '#sheetGrid .ts-cell.valid-ts[data-row="6"][data-participant="P01"]',
+    "studio-generate": "#generateBtn",
+    "studio-card-success": "#artifactsList .queue-card.queue-card-success",
+    "studio-card-fail": "#artifactsList .queue-card.queue-card-fail",
+    # The spinner is `.active`-class-toggled (display:none base), never removed.
+    "studio-spinner-idle": "#artifactsSpinner:not(.active)",
+    "studio-status-open": "#statusOverlay:not(.hidden)",
+    "ss-task-card": "#taskList .task-card",
+    "ss-result-row": "#resultsList .result-row",
+    # Row-level clicks are a no-op; only the timestamp/text children seek.
+    "ts-segment-seek": '#segmentList .segment-row[data-index="1"] .segment-timestamp',
+    "settings-input": '.settings-row[data-setting="WEBP_QUALITY"] .settings-control input',
+    "settings-status": ".settings-save-status",
+    "start-tab-excel": '#startOverlay .sheet-card__tab[data-tab="excel"]',
+    "start-picker-trigger": '[data-role="excel-picker-trigger"]',
+    "start-picker-option": '[data-role="excel-picker-menu"] .sheet-picker__option',
+    "start-confirm": '[data-role="confirm"]',
+}
+
+_WAIT_MS = 15_000
+# The generate journey cuts a real ~3 s clip through ffmpeg; give it headroom.
+_GENERATE_MS = 30_000
+
+
+def _overlay(name: str) -> _ui_states.Overlay:
+    return next(o for o in _ui_states.GLOBAL_OVERLAYS if o.name == name)
+
+
+def _fatal_message(name: str, log: PageLog, shot_name: str) -> str:
+    return _ui_pages.format_failure(
+        name,
+        log,
+        str((_ui_fixtures.SHOT_DIR / f"{shot_name}.png").resolve()),
+        str(_ui_fixtures.REPORT_PATH.resolve()),
+    )
+
+
+@contextmanager
+def _journey(
+    context: Any, live_server: LiveServer, page_name: str, shot_name: str
+) -> Iterator[tuple[Any, PageLog]]:
+    """Open one page with listeners wired; screenshot even on failure.
+
+    A broken journey is exactly the one worth looking at, so the capture runs in
+    the ``finally`` — same contract as the smoke.
+    """
+    log = PageLog()
+    page = context.new_page()
+    _ui_pages.wire_listeners(page, log)
+    try:
+        _ui_pages.open_and_settle(page, live_server.origin, page_name, log)
+        yield page, log
+    finally:
+        try:
+            shot = _ui_fixtures.SHOT_DIR / f"{shot_name}.png"
+            page.screenshot(path=str(shot), full_page=True)
+        except Exception as exc:  # pragma: no cover - capture is best-effort
+            log.console_errors.append(f"screenshot failed: {exc}")
+        page.close()
+
+
+def test_studio_generate_produces_an_artifact(
+    live_server: LiveServer, browser_context: Any
+) -> None:
+    """Queue one valid cell, click Generate, and watch a real clip land.
+
+    Row 6 is P01 ``0:01-0:04`` — a 3 s cut of the 20 s fixture. A plain click is
+    load-bearing: Shift/right-click route the cell to the reel queue instead.
+    """
+    with _journey(browser_context, live_server, "studio", "journey-generate") as (
+        page,
+        log,
+    ):
+        page.click(SELECTORS["studio-cell"])
+        page.wait_for_selector(
+            SELECTORS["studio-generate"] + ":not([disabled])", timeout=_WAIT_MS
+        )
+        page.click(SELECTORS["studio-generate"])
+        # Terminal signals, strongest first: the "Done" status modal, then the
+        # per-card success class, then the title spinner going idle.
+        page.wait_for_selector(SELECTORS["studio-status-open"], timeout=_GENERATE_MS)
+        assert page.locator("#statusTitle").inner_text() == "Done"
+        page.wait_for_selector(SELECTORS["studio-card-success"], timeout=_WAIT_MS)
+        page.wait_for_selector(
+            SELECTORS["studio-spinner-idle"], state="attached", timeout=_WAIT_MS
+        )
+        assert page.locator(SELECTORS["studio-card-fail"]).count() == 0
+    assert not log.fatal, _fatal_message("studio-generate", log, "journey-generate")
+
+
+def test_screenspace_result_row_seeks_playhead(
+    live_server: LiveServer, browser_context: Any
+) -> None:
+    """Select the seeded completed task, click its first result, land on 2.0 s.
+
+    The assertion is the playhead state (``#timestampInput``), not
+    ``video.currentTime``: Screenspace's ``loadFrame`` pauses the video and
+    shows a still frame — the ``<video>`` element deliberately does not move.
+    """
+    with _journey(
+        browser_context, live_server, "screenspace", "journey-screenspace"
+    ) as (
+        page,
+        log,
+    ):
+        page.click(SELECTORS["ss-task-card"])
+        page.wait_for_selector(SELECTORS["ss-result-row"], timeout=_WAIT_MS)
+        page.locator(SELECTORS["ss-result-row"]).first.click()
+        page.wait_for_function(
+            "() => ((document.querySelector('#timestampInput') || {}).value || '')"
+            ".indexOf('0:02') === 0",
+            timeout=_WAIT_MS,
+        )
+    assert not log.fatal, _fatal_message("screenspace-seek", log, "journey-screenspace")
+
+
+def test_transcripts_segment_click_seeks_video(
+    live_server: LiveServer, browser_context: Any
+) -> None:
+    """Click segment 1's timestamp (start 2.5 s) and watch the player follow.
+
+    Segment 0 starts at 0.0, indistinguishable from boot state. The seek
+    coalescer also starts playback, so the tolerance absorbs a little drift and
+    the video is paused before the screenshot.
+    """
+    with _journey(
+        browser_context, live_server, "transcripts", "journey-transcripts"
+    ) as (
+        page,
+        log,
+    ):
+        page.click(SELECTORS["ts-segment-seek"])
+        page.wait_for_function(
+            "() => { const v = document.querySelector('#videoPlayer');"
+            " return !!v && Math.abs(v.currentTime - 2.5) < 0.75; }",
+            timeout=_WAIT_MS,
+        )
+        page.evaluate("() => document.querySelector('#videoPlayer').pause()")
+    assert not log.fatal, _fatal_message("transcripts-seek", log, "journey-transcripts")
+
+
+def test_settings_change_persists_across_reload(
+    live_server: LiveServer, browser_context: Any
+) -> None:
+    """Change WEBP_QUALITY in the modal, reload Studio, and find it stuck.
+
+    WEBP_QUALITY is the durable setting nothing else depends on: no server-side
+    capability probe (unlike the format/titlecard settings) and no effect on the
+    fixture. The file under the output dir is the real store — only non-default
+    values are written — so it is asserted alongside the reopened modal.
+    """
+    settings_path = _ui_fixtures.OUTPUT_DIR / config.STUDIO_SETTINGS_FILENAME
+    try:
+        with _journey(browser_context, live_server, "studio", "journey-settings") as (
+            page,
+            log,
+        ):
+            result = _ui_states.enter_overlay(page, _overlay("settings"))
+            assert result.reached, result.detail
+            field = page.locator(SELECTORS["settings-input"])
+            field.fill("55")
+            field.dispatch_event("change")
+            page.wait_for_function(
+                "() => (document.querySelector('.settings-save-status') || {})"
+                ".textContent === 'Saved'",
+                timeout=_WAIT_MS,
+            )
+            saved = json.loads(settings_path.read_text(encoding="utf-8"))
+            assert saved.get("WEBP_QUALITY") == 55
+
+            page.reload(wait_until="domcontentloaded")
+            page.wait_for_selector("#sheetGrid tbody tr", timeout=_WAIT_MS)
+            result = _ui_states.enter_overlay(page, _overlay("settings"))
+            assert result.reached, result.detail
+            assert page.locator(SELECTORS["settings-input"]).input_value() == "55"
+        assert not log.fatal, _fatal_message(
+            "settings-persist", log, "journey-settings"
+        )
+    finally:
+        # config is a live module global in the shared server process; put the
+        # default back so the rest of the session never sees the override.
+        request = urllib.request.Request(
+            live_server.origin + "/api/settings",
+            data=json.dumps({"settings": {"WEBP_QUALITY": 80}}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="PUT",
+        )
+        urllib.request.urlopen(request, timeout=10).read()
+
+
+def test_start_overlay_opens_the_fixture_workbook(
+    live_server: LiveServer, browser: Any
+) -> None:
+    """Pick the fixture workbook through the overlay's own UI, land on the grid.
+
+    Runs in its own context without the dismissal pin so the overlay behaves as
+    shipped. It still never auto-opens here (``shouldAutoOpen`` bails on
+    ``sheet_loaded``), so it is opened through its public opener like every
+    overlay state. The seeded recents rail is six fabricated dead projects —
+    the journey goes through the Excel picker, not the rail.
+    """
+    context = _ui_session.new_context(browser, dismiss_start=False)
+    try:
+        with _journey(context, live_server, "studio", "journey-start-overlay") as (
+            page,
+            log,
+        ):
+            result = _ui_states.enter_overlay(page, _overlay("start"))
+            assert result.reached, result.detail
+            page.click(SELECTORS["start-tab-excel"])
+            page.click(SELECTORS["start-picker-trigger"])
+            option = page.locator(SELECTORS["start-picker-option"]).first
+            option.wait_for(state="visible", timeout=_WAIT_MS)
+            assert (option.get_attribute("data-path") or "").endswith(
+                f"{_ui_fixtures.STUDY}.xlsx"
+            )
+            option.click()
+            page.wait_for_selector(
+                SELECTORS["start-confirm"] + ":not([disabled])", timeout=_WAIT_MS
+            )
+            # confirm() ends in window.location.reload() on success.
+            with page.expect_navigation(
+                wait_until="domcontentloaded", timeout=_GENERATE_MS
+            ):
+                page.click(SELECTORS["start-confirm"])
+            page.wait_for_selector("#sheetGrid tbody tr", timeout=_WAIT_MS)
+        assert not log.fatal, _fatal_message(
+            "start-overlay", log, "journey-start-overlay"
+        )
+    finally:
+        context.close()


### PR DESCRIPTION
## Summary

Executes the test suite evolution plan (now archived as done): buy confidence that researcher paths still produce working media and UI, without slowing `/check`.

- `agents/skills/test/SKILL.md` gains the test-kind taxonomy (ratchet/domain/API/I/O/journey), the source-scan freeze, and journey/I/O selection rules.
- `tests/test_pipeline_io.py`: three real-ffmpeg tests in the default suite (`skipif` without ffmpeg, <1 s total) — clip cut, screenshot, and reel concat including the abort-on-failed-part path on the real concat code.
- `tests/ui/test_ui_journeys.py`: five click-through journeys in the opt-in `/ui-check` harness (Studio generate, Screenspace result-row seek via a newly seeded completed task, Transcripts segment seek, settings persistence, Start-overlay workbook open), plus harness plumbing (`dismiss_start` opt-out, a session `browser` fixture).

## Test plan

- [x] `/check` green after each commit: ruff format + lint, ty, full suite (2775 passed, ~25 s)
- [x] `tests/test_pipeline_io.py` under `--durations=20`: no outliers (0.84 s for the file)
- [x] [/ui-check](agents/skills/ui-check/SKILL.md): 16 tests pass (boot smoke + 5 journeys), journey screenshots reviewed
- [ ] Journeys on a machine without a Playwright Chromium cache (should skip with install instructions)