### PR TITLE
perf(screenspace): cut per-frame CV cost in color, attention, and template

### DIFF
--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -1223,6 +1223,15 @@ def compute_spectral_residual(gray: np.ndarray) -> np.ndarray:
     complex temporaries), recovering the phase term as ``z/|z|`` from the
     magnitude already in hand rather than through ``angle`` + a complex ``exp``.
     Agreement between the branches is ~1e-6 and is asserted in the tests.
+
+    **This function is repeatable, not bit-reproducible.** ``cv2.dft`` returns
+    results differing by ~1 ulp between two identical calls on some OpenCV
+    builds — reproducibly so on Linux CI, never observed on macOS — so tests
+    over the cv2 branch (and over anything downstream of it, such as
+    :func:`compute_saliency_map`) must assert closeness, not ``array_equal``.
+    Irrelevant downstream: the attention scan thresholds peak *distances* at
+    0.15, and the half-scale surround in :func:`compute_color_contrast` already
+    moves the composed map ~6 orders of magnitude more than this.
     """
     f32 = gray.astype(np.float32)
     if _dft_friendly(f32.shape[:2]):

--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -472,6 +472,45 @@ def color_matches(
     return matched, conf
 
 
+def _channel_runs(flags: np.ndarray) -> tuple[tuple[int, int], ...]:
+    """Contiguous ``(lo, hi)`` index runs of a 256-entry boolean table."""
+    idx = np.flatnonzero(flags)
+    if idx.size == 0:
+        return ()
+    breaks = np.flatnonzero(np.diff(idx) > 1)
+    starts = np.concatenate(([idx[0]], idx[breaks + 1]))
+    ends = np.concatenate((idx[breaks], [idx[-1]]))
+    return tuple(zip(starts.tolist(), ends.tolist()))
+
+
+@functools.cache
+def _hsv_match_bands(
+    h: float, s: float, v: float, tol_h: float, tol_s: float, tol_v: float
+) -> tuple[tuple[tuple[int, int, int], tuple[int, int, int]], ...]:
+    """``cv2.inRange`` (lower, upper) HSV bands equivalent to the per-pixel test.
+
+    Each of the three per-channel predicates depends only on that channel's
+    ``uint8`` value, so evaluating the *same float32 expressions* over all 256
+    possible values yields exact membership tables — the bands below are those
+    tables, not an approximation of them. Hue wraparound splits into two bands;
+    everything else is one. Empty result means no pixel value can match.
+
+    Cached per (target, tolerance): constant for a whole scan, and bounded by
+    the number of distinct color configurations a user has set up.
+    """
+    vals = np.arange(256, dtype=np.float32)
+    hue_diff = np.abs(vals - h)
+    hue_ok = np.minimum(hue_diff, 180.0 - hue_diff) <= tol_h
+    sat_ok = np.abs(vals - s) <= tol_s
+    val_ok = np.abs(vals - v) <= tol_v
+    return tuple(
+        ((h_lo, s_lo, v_lo), (h_hi, s_hi, v_hi))
+        for h_lo, h_hi in _channel_runs(hue_ok)
+        for s_lo, s_hi in _channel_runs(sat_ok)
+        for v_lo, v_hi in _channel_runs(val_ok)
+    )
+
+
 def color_present(
     region_pixels: np.ndarray,
     target_color: dict[str, float],
@@ -496,15 +535,24 @@ def color_present(
     if region_pixels.size == 0:
         return False, 0.0
     hsv = cv2.cvtColor(region_pixels, cv2.COLOR_BGR2HSV)
-    h = hsv[..., 0].astype(np.float32)
-    s = hsv[..., 1].astype(np.float32)
-    v = hsv[..., 2].astype(np.float32)
-    hue_diff = np.abs(h - float(target_color["h"]))
-    hue_dist = np.minimum(hue_diff, 180.0 - hue_diff)
+    # Integer band tests on the uint8 HSV rather than three full-size float32
+    # casts and comparisons: identical mask (see _hsv_match_bands), ~12x faster,
+    # and no ~25 MB of per-frame temporaries at 1080p — this path deliberately
+    # runs at full resolution, so it is the hottest per-pixel routine here.
+    bands = _hsv_match_bands(
+        float(target_color["h"]),
+        float(target_color["s"]),
+        float(target_color["v"]),
+        float(tolerance["h"]),
+        float(tolerance["s"]),
+        float(tolerance["v"]),
+    )
+    hits: np.ndarray | None = None
+    for lower, upper in bands:
+        band = cv2.inRange(hsv, np.array(lower, np.uint8), np.array(upper, np.uint8))
+        hits = band if hits is None else cv2.bitwise_or(hits, band)
     match = (
-        (hue_dist <= tolerance["h"])
-        & (np.abs(s - float(target_color["s"])) <= tolerance["s"])
-        & (np.abs(v - float(target_color["v"])) <= tolerance["v"])
+        hits.astype(bool) if hits is not None else np.zeros(hsv.shape[:2], dtype=bool)
     )
     # Shaped regions: only pixels inside the polygon count, in both the match
     # numerator and the coverage denominator. A mask emptied by extreme downscale
@@ -670,8 +718,9 @@ def compute_phash(
     Mirrors ``imagehash.phash`` (grayscale → 32×32 → 2D DCT → top-left 8×8 →
     median threshold) natively in cv2, skipping the per-frame BGR→RGB +
     ``PIL.Image`` round-trip that dominates this hot scan-callback path.
-    Callers that already hold the unblurred grayscale (scan_similarity's
-    static-skip check) pass it as *gray* to skip the second conversion.
+    Callers that already hold the unblurred grayscale (every scan whose
+    static-skip check converts the frame) pass it as *gray* to skip the
+    second conversion.
     """
     import imagehash
 
@@ -788,9 +837,16 @@ def _match_template_prepared(
     prepared: _PreparedTemplate,
     threshold: float,
     nms_overlap: float,
+    corr: np.ndarray | None = None,
 ) -> list[dict[str, Any]]:
-    """Match a frame against an already-prepared template payload."""
-    result = _template_correlation_map(frame, prepared)
+    """Match a frame against an already-prepared template payload.
+
+    Callers that already computed this frame's correlation map (to read its
+    threshold-independent peak) pass it as *corr* — the map is the single most
+    expensive op in the tool and recomputing it here doubled the cost of every
+    passing frame.
+    """
+    result = _template_correlation_map(frame, prepared) if corr is None else corr
     if result is None:
         return []
     tmpl_gray, _gray_mask, _degenerate = prepared
@@ -851,6 +907,7 @@ def match_template(
     mask: np.ndarray | None = None,
     *,
     prepared: _PreparedTemplate | None = None,
+    corr: np.ndarray | None = None,
 ) -> list[dict[str, Any]]:
     """Find all locations where template appears in frame.
 
@@ -861,6 +918,8 @@ def match_template(
 
     Across many frames with one template, build *prepared* once via
     :func:`_prepare_template` to skip the per-call blur and grayscale conversion.
+    A caller that already holds this frame's correlation map (from
+    :func:`_template_correlation_map`) passes it as *corr* to skip recomputing it.
 
     Returns:
         ``{x, y, w, h, score}`` dicts for each match above *threshold*.
@@ -872,7 +931,7 @@ def match_template(
 
     if prepared is None:
         prepared = _prepare_template(template, mask)
-    return _match_template_prepared(frame, prepared, threshold, nms_overlap)
+    return _match_template_prepared(frame, prepared, threshold, nms_overlap, corr)
 
 
 def flow_downscale(
@@ -1138,18 +1197,57 @@ def _merge_timestamp_spans(
 # per-frame map feeds the same grid/heatmap pipeline as flow/change.
 
 
+@functools.cache
+def _dft_friendly(shape: tuple[int, int]) -> bool:
+    """Whether ``cv2.dft`` is the faster transform for this frame shape.
+
+    cv2's DFT is fastest on sizes that factor into 2/3/5 and is markedly
+    *slower* than numpy on awkward ones — measured on this project's benchmark
+    frames: 0.163 ms vs 0.400 ms at 144x256, but 4.021 ms vs 1.254 ms at
+    151x257. The attention working dim pins only the longest axis to 256; the
+    other follows the source aspect ratio and can land on a prime, so the fast
+    path is gated rather than unconditional.
+    """
+    return all(cv2.getOptimalDFTSize(n) == n for n in shape)
+
+
 def compute_spectral_residual(gray: np.ndarray) -> np.ndarray:
     """Spectral-residual saliency (Hou & Zhang 2007), float32 in [0, 1].
 
     The log-amplitude spectrum minus its local average isolates the
     "unexpected" frequency content; recombining it with the original phase
     highlights the spatial locations responsible for it.
+
+    Two transforms, same math: on DFT-friendly shapes cv2 runs it in float32
+    (the numpy branch promotes to complex128 and allocates four more full-size
+    complex temporaries), recovering the phase term as ``z/|z|`` from the
+    magnitude already in hand rather than through ``angle`` + a complex ``exp``.
+    Agreement between the branches is ~1e-6 and is asserted in the tests.
     """
-    fft = np.fft.fft2(gray.astype(np.float32))
-    log_amp = np.log1p(np.abs(fft)).astype(np.float32)
-    phase = np.angle(fft)
-    residual = log_amp - cv2.blur(log_amp, (3, 3))
-    sal = np.abs(np.fft.ifft2(np.exp(residual) * np.exp(1j * phase))) ** 2
+    f32 = gray.astype(np.float32)
+    if _dft_friendly(f32.shape[:2]):
+        spectrum = cv2.dft(f32, flags=cv2.DFT_COMPLEX_OUTPUT)
+        real, imag = spectrum[:, :, 0], spectrum[:, :, 1]
+        mag = cv2.magnitude(real, imag)
+        log_amp = np.log1p(mag)
+        residual = log_amp - cv2.blur(log_amp, (3, 3))
+        scale = np.exp(residual)
+        unit = np.divide(scale, mag, out=np.zeros_like(scale), where=mag > 0)
+        out_real = real * unit
+        out_imag = imag * unit
+        # A zero coefficient (uniform frame) has no direction; the numpy branch
+        # reads angle(0) as 0, i.e. a unit vector of 1+0j. Match that.
+        flat = mag <= 0
+        np.copyto(out_real, scale, where=flat)
+        np.copyto(out_imag, np.float32(0.0), where=flat)
+        inverse = cv2.idft(cv2.merge([out_real, out_imag]), flags=cv2.DFT_SCALE)
+        sal = inverse[:, :, 0] ** 2 + inverse[:, :, 1] ** 2
+    else:
+        fft = np.fft.fft2(f32)
+        log_amp = np.log1p(np.abs(fft)).astype(np.float32)
+        phase = np.angle(fft)
+        residual = log_amp - cv2.blur(log_amp, (3, 3))
+        sal = np.abs(np.fft.ifft2(np.exp(residual) * np.exp(1j * phase))) ** 2
     sal = cv2.GaussianBlur(sal.astype(np.float32), (9, 9), 2.5)
     peak = float(sal.max())
     return sal / peak if peak > 0 else sal
@@ -1160,12 +1258,32 @@ def compute_color_contrast(bgr: np.ndarray) -> np.ndarray:
 
     Sum over L/a/b of |channel − wide Gaussian blur of channel|: bright/colored
     elements that differ from their surround score high regardless of hue.
+
+    The surround is deliberately computed at **half scale**. Its sigma is
+    ``max_dim / 8``, which on a float32 input asks OpenCV for a ~8σ+1 tap
+    kernel — wider than the image itself at the attention working dim, and 66%
+    of the whole attention callback. Halving the resolution costs 5x less
+    (3.22 ms → 0.61 ms per frame) and moves the normalized map by at most
+    0.012; a blur that broad is smooth enough that the downscale loses nothing
+    it was measuring. Blurring the interleaved 3-channel Lab in one call is the
+    obvious alternative and was measured *slower* (3.66 ms) — the kernel width
+    is the cost, not the call count.
     """
     lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB).astype(np.float32)
-    sigma = max(3.0, max(lab.shape[:2]) / 8.0)
-    contrast = np.zeros(lab.shape[:2], dtype=np.float32)
-    for ch in cv2.split(lab):
-        contrast += np.abs(ch - cv2.GaussianBlur(ch, (0, 0), sigma))
+    height, width = lab.shape[:2]
+    sigma = max(3.0, max(height, width) / 8.0)
+    small = cv2.resize(
+        lab,
+        (max(1, width // 2), max(1, height // 2)),
+        interpolation=cv2.INTER_AREA,
+    )
+    surround = cv2.resize(
+        cv2.GaussianBlur(small, (0, 0), sigma / 2.0),
+        (width, height),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    diff = cv2.absdiff(lab, surround)
+    contrast = diff[:, :, 0] + diff[:, :, 1] + diff[:, :, 2]
     peak = float(contrast.max())
     return contrast / peak if peak > 0 else contrast
 

--- a/source/screenspace_scans.py
+++ b/source/screenspace_scans.py
@@ -1148,7 +1148,7 @@ def scan_inactivity(
             return None
         prev_skip_gray[0] = curr_gray
 
-        curr_hash = compute_phash(pixels)
+        curr_hash = compute_phash(pixels, gray=curr_gray)
 
         if prev_hash[0] is not None:
             dist = int(curr_hash - prev_hash[0])
@@ -1459,7 +1459,7 @@ def scan_boundaries(
                     on_progress((ts - start_seconds) / total_range)
                 return None
             prev_skip_gray[0] = curr_gray
-            curr_hash = compute_phash(pixels)
+            curr_hash = compute_phash(pixels, gray=curr_gray)
             if prev_hash[0] is not None:
                 dist = int(curr_hash - prev_hash[0])
                 within_gap = (

--- a/source/screenspace_tools.py
+++ b/source/screenspace_tools.py
@@ -713,6 +713,7 @@ class TemplateTool(AnalysisTool):
             threshold=threshold,
             mask=scaled_mask,
             prepared=prepared,
+            corr=corr,
         )
         # Shaped region: the match still runs full-frame (template ignores the
         # rect for rect regions too), but the polygon acts as a detection

--- a/tests/screenspace/test_attention.py
+++ b/tests/screenspace/test_attention.py
@@ -19,14 +19,18 @@ def _bright_patch_frame(w=160, h=120, px=120, py=80, size=20):
 
 
 class TestSpectralResidual:
-    def test_shape_range_and_determinism(self):
+    def test_shape_range_and_repeatability(self):
         gray = np.random.RandomState(3).randint(0, 255, (90, 120), dtype=np.uint8)
         sal_a = screenspace.compute_spectral_residual(gray)
         sal_b = screenspace.compute_spectral_residual(gray.copy())
         assert sal_a.shape == gray.shape
         assert sal_a.dtype == np.float32
         assert float(sal_a.min()) >= 0.0 and float(sal_a.max()) <= 1.0
-        assert np.array_equal(sal_a, sal_b)
+        # Repeatable to float32 noise rather than bit-identical: cv2.dft is not
+        # bit-reproducible across calls on every OpenCV build (see
+        # compute_spectral_residual). Anything that actually broke the transform
+        # would move the map by orders of magnitude more than this.
+        assert np.allclose(sal_a, sal_b, rtol=0, atol=1e-6)
 
     def test_flat_frame_does_not_crash(self):
         gray = np.full((60, 80), 128, dtype=np.uint8)
@@ -179,7 +183,13 @@ class TestChannels:
         with_face_on, _ = screenspace.compute_saliency_map(
             frame, None, center_bias=0.0, include_face=True
         )
-        assert np.array_equal(with_face_off, with_face_on)
+        # Closeness, not bit-equality: cv2.dft is not bit-reproducible call to
+        # call on every OpenCV build (Linux CI produced 1-ulp differences at
+        # float32 where macOS produced none), and the two maps here are two
+        # independent computations of the same math. The regression this guards
+        # -- a zeros-only face channel joining the denominator -- scales the
+        # whole map by 3/4, so it sits ~7 orders of magnitude above this bound.
+        assert np.allclose(with_face_off, with_face_on, rtol=0, atol=1e-6)
 
 
 class TestSaliencyMap:

--- a/tests/screenspace/test_attention.py
+++ b/tests/screenspace/test_attention.py
@@ -1,10 +1,13 @@
 """Tests for the Attention tool: saliency primitives, scan, heatmaps, events."""
 
+import cv2
 import numpy as np
+import pytest
 
 import config
 import screenspace
 import screenspace_frames
+import screenspace_primitives
 import screenspace_scans
 
 
@@ -32,7 +35,84 @@ class TestSpectralResidual:
         assert np.all(np.isfinite(sal))
 
 
+def _numpy_spectral_residual(gray):
+    """The complex128 numpy transform, as the cv2.dft path's oracle."""
+    fft = np.fft.fft2(gray.astype(np.float32))
+    log_amp = np.log1p(np.abs(fft)).astype(np.float32)
+    phase = np.angle(fft)
+    residual = log_amp - cv2.blur(log_amp, (3, 3))
+    sal = np.abs(np.fft.ifft2(np.exp(residual) * np.exp(1j * phase))) ** 2
+    sal = cv2.GaussianBlur(sal.astype(np.float32), (9, 9), 2.5)
+    peak = float(sal.max())
+    return sal / peak if peak > 0 else sal
+
+
+class TestSpectralResidualTransforms:
+    """cv2.dft is a faster transform of the same math, not different math."""
+
+    @pytest.mark.parametrize("shape", [(144, 256), (90, 120), (64, 64)])
+    def test_dft_path_agrees_with_numpy(self, shape):
+        assert screenspace_primitives._dft_friendly(shape)
+        gray = np.random.RandomState(7).randint(0, 256, shape, dtype=np.uint8)
+        assert np.allclose(
+            screenspace.compute_spectral_residual(gray),
+            _numpy_spectral_residual(gray),
+            atol=1e-5,
+        )
+
+    def test_uniform_frame_agrees_with_numpy(self):
+        # Every AC coefficient is exactly zero here, so the dft path's
+        # "no direction" fallback (angle(0) == 0) is the whole result.
+        for fill in (0, 7, 255):
+            gray = np.full((64, 64), fill, dtype=np.uint8)
+            assert np.allclose(
+                screenspace.compute_spectral_residual(gray),
+                _numpy_spectral_residual(gray),
+                atol=1e-5,
+            )
+
+    def test_prime_dimensions_take_the_numpy_fallback(self):
+        # cv2.dft is several times *slower* than numpy on these, so the gate
+        # must reject them; the fallback is then bit-identical by definition.
+        assert not screenspace_primitives._dft_friendly((151, 257))
+        gray = np.random.RandomState(9).randint(0, 256, (151, 257), dtype=np.uint8)
+        assert np.array_equal(
+            screenspace.compute_spectral_residual(gray),
+            _numpy_spectral_residual(gray),
+        )
+
+    def test_gate_accepts_only_2_3_5_smooth_sizes(self):
+        assert screenspace_primitives._dft_friendly((120, 160))
+        assert not screenspace_primitives._dft_friendly((139, 256))
+
+
 class TestChannels:
+    def test_color_contrast_surround_is_half_scale(self):
+        # The surround blur is deliberately computed at half resolution (see
+        # compute_color_contrast); pin it so it is not "corrected" back to the
+        # full-scale kernel, which cost 5x more for a <=0.012 map difference.
+        frame = _bright_patch_frame()
+        lab = cv2.cvtColor(frame, cv2.COLOR_BGR2LAB).astype(np.float32)
+        height, width = lab.shape[:2]
+        sigma = max(3.0, max(height, width) / 8.0)
+        small = cv2.resize(lab, (width // 2, height // 2), interpolation=cv2.INTER_AREA)
+        surround = cv2.resize(
+            cv2.GaussianBlur(small, (0, 0), sigma / 2.0),
+            (width, height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        diff = cv2.absdiff(lab, surround)
+        expected = diff[:, :, 0] + diff[:, :, 1] + diff[:, :, 2]
+        expected /= float(expected.max())
+        assert np.array_equal(screenspace.compute_color_contrast(frame), expected)
+
+    def test_color_contrast_handles_single_pixel_frame(self):
+        contrast = screenspace.compute_color_contrast(
+            np.full((1, 1, 3), 200, dtype=np.uint8)
+        )
+        assert contrast.shape == (1, 1)
+        assert np.all(np.isfinite(contrast))
+
     def test_color_contrast_highlights_patch(self):
         frame = _bright_patch_frame()
         contrast = screenspace.compute_color_contrast(frame)

--- a/tests/screenspace/test_attention.py
+++ b/tests/screenspace/test_attention.py
@@ -188,7 +188,8 @@ class TestChannels:
         # float32 where macOS produced none), and the two maps here are two
         # independent computations of the same math. The regression this guards
         # -- a zeros-only face channel joining the denominator -- scales the
-        # whole map by 3/4, so it sits ~7 orders of magnitude above this bound.
+        # whole map by 3/4: measured at 1.25e-1, five orders of magnitude above
+        # this bound, against an observed wobble of 6.0e-8.
         assert np.allclose(with_face_off, with_face_on, rtol=0, atol=1e-6)
 
 

--- a/tests/screenspace/test_color.py
+++ b/tests/screenspace/test_color.py
@@ -1,9 +1,11 @@
 """Tests for region extraction and colour primitives."""
 
+import cv2
 import numpy as np
 import pytest
 
 import screenspace
+import screenspace_primitives
 from _ss_helpers import _gray_with_red_patch
 
 
@@ -189,3 +191,117 @@ class TestColorPresent:
         matched, coverage = screenspace.color_present(region, self.target, self.tol)
         assert not matched
         assert coverage == 0.0
+
+
+def _float32_match_mask(region_pixels, target_color, tolerance):
+    """The per-pixel float32 test ``color_present`` used before the band rewrite.
+
+    Kept verbatim as the oracle: the integer-band path is a speedup, so it must
+    agree *exactly*, not approximately.
+    """
+    hsv = cv2.cvtColor(region_pixels, cv2.COLOR_BGR2HSV)
+    h = hsv[..., 0].astype(np.float32)
+    s = hsv[..., 1].astype(np.float32)
+    v = hsv[..., 2].astype(np.float32)
+    hue_diff = np.abs(h - float(target_color["h"]))
+    hue_dist = np.minimum(hue_diff, 180.0 - hue_diff)
+    return (
+        (hue_dist <= tolerance["h"])
+        & (np.abs(s - float(target_color["s"])) <= tolerance["s"])
+        & (np.abs(v - float(target_color["v"])) <= tolerance["v"])
+    )
+
+
+def _reference_color_present(
+    region_pixels, target_color, tolerance, min_coverage=0.0, mask=None
+):
+    """``color_present`` semantics on top of the float32 oracle mask."""
+    if region_pixels.size == 0:
+        return False, 0.0
+    match = _float32_match_mask(region_pixels, target_color, tolerance)
+    if mask is not None and not np.any(mask):
+        mask = None
+    denom = match.size
+    if mask is not None:
+        match &= mask > 0
+        denom = int(np.count_nonzero(mask))
+    count = int(np.count_nonzero(match))
+    coverage = count / denom if denom else 0.0
+    matched = count > 0 if min_coverage <= 0 else coverage >= min_coverage
+    return matched, float(coverage)
+
+
+class TestColorPresentBands:
+    """The uint8 ``cv2.inRange`` bands must reproduce the float32 test exactly."""
+
+    @pytest.mark.parametrize("hue", [0.0, 5.0, 90.0, 175.5, 179.0])
+    @pytest.mark.parametrize("tol_hue", [0.0, 10.0, 89.0, 90.0, 95.0])
+    @pytest.mark.parametrize("sat_val", [0.0, 7.5, 128.0, 255.0])
+    @pytest.mark.parametrize("tol_sat_val", [0.0, 0.5, 60.0, 255.0])
+    def test_matches_float32_oracle(self, hue, tol_hue, sat_val, tol_sat_val):
+        region = np.random.RandomState(11).randint(0, 256, (24, 32, 3), dtype=np.uint8)
+        target = {"h": hue, "s": sat_val, "v": sat_val}
+        tol = {"h": tol_hue, "s": tol_sat_val, "v": tol_sat_val}
+        assert screenspace.color_present(
+            region, target, tol
+        ) == _reference_color_present(region, target, tol)
+
+    def test_matches_oracle_with_mask_and_min_coverage(self):
+        region = np.random.RandomState(5).randint(0, 256, (40, 40, 3), dtype=np.uint8)
+        mask = np.zeros((40, 40), dtype=np.uint8)
+        mask[5:20, 5:20] = 255
+        target = {"h": 90.0, "s": 128.0, "v": 128.0}
+        tol = {"h": 20.0, "s": 80.0, "v": 80.0}
+        for min_coverage in (0.0, 0.05, 0.9):
+            assert screenspace.color_present(
+                region, target, tol, min_coverage, mask
+            ) == _reference_color_present(region, target, tol, min_coverage, mask)
+
+    def test_empty_mask_falls_back_to_full_rect(self):
+        region = _gray_with_red_patch(10)
+        empty = np.zeros(region.shape[:2], dtype=np.uint8)
+        target = {"h": 0.0, "s": 255.0, "v": 139.0}
+        tol = {"h": 10.0, "s": 60.0, "v": 60.0}
+        assert screenspace.color_present(
+            region, target, tol, 0.0, empty
+        ) == screenspace.color_present(region, target, tol)
+
+    def test_uniform_frames_agree_with_oracle(self):
+        target = {"h": 60.0, "s": 200.0, "v": 200.0}
+        tol = {"h": 15.0, "s": 40.0, "v": 40.0}
+        for fill in (0, 128, 255):
+            region = np.full((16, 16, 3), fill, dtype=np.uint8)
+            assert screenspace.color_present(
+                region, target, tol
+            ) == _reference_color_present(region, target, tol)
+
+    def test_impossible_tolerance_yields_no_bands(self):
+        # Nothing can match a saturation 300 apart from any uint8 value.
+        assert (
+            screenspace_primitives._hsv_match_bands(90.0, 300.0, 128.0, 10.0, 5.0, 60.0)
+            == ()
+        )
+        region = np.random.RandomState(2).randint(0, 256, (8, 8, 3), dtype=np.uint8)
+        matched, coverage = screenspace.color_present(
+            region,
+            {"h": 90.0, "s": 300.0, "v": 128.0},
+            {"h": 10.0, "s": 5.0, "v": 60.0},
+        )
+        assert not matched
+        assert coverage == 0.0
+
+    def test_hue_wraparound_splits_into_two_bands(self):
+        bands = screenspace_primitives._hsv_match_bands(
+            2.0, 128.0, 128.0, 5.0, 255.0, 255.0
+        )
+        assert len(bands) == 2
+        hue_ranges = sorted((lower[0], upper[0]) for lower, upper in bands)
+        assert hue_ranges[0][0] == 0
+        assert hue_ranges[-1][1] == 255
+
+    def test_wide_hue_tolerance_is_a_single_band(self):
+        bands = screenspace_primitives._hsv_match_bands(
+            90.0, 128.0, 128.0, 90.0, 255.0, 255.0
+        )
+        assert len(bands) == 1
+        assert bands[0][0][0] == 0 and bands[0][1][0] == 255

--- a/tests/screenspace/test_multitool_scoring.py
+++ b/tests/screenspace/test_multitool_scoring.py
@@ -311,7 +311,7 @@ class TestScanBoundaries:
         monkeypatch.setattr(
             screenspace_scans,
             "compute_phash",
-            lambda f: _FakeHash(int(f.reshape(-1)[0])),
+            lambda f, gray=None: _FakeHash(int(f.reshape(-1)[0])),
         )
 
         def fake_scan(video_path, interval_seconds, callback, **kwargs):
@@ -602,7 +602,9 @@ class TestScanBoundariesSceneHybrid:
             lambda a, b: 1.0 if a["tag"] == b["tag"] else 0.0,
         )
         monkeypatch.setattr(
-            screenspace_scans, "compute_phash", lambda f: _FakeHash(int(f[0, 1, 0]))
+            screenspace_scans,
+            "compute_phash",
+            lambda f, gray=None: _FakeHash(int(f[0, 1, 0])),
         )
 
         def fake_scan(video_path, interval_seconds, callback, **kwargs):

--- a/tests/screenspace/test_static_gating.py
+++ b/tests/screenspace/test_static_gating.py
@@ -114,9 +114,12 @@ class TestInactivityStaticGate:
         calls = [0]
         real_phash = screenspace_primitives.compute_phash
 
-        def counting_phash(px):
+        def counting_phash(px, gray=None):
             calls[0] += 1
-            return real_phash(px)
+            # The scan's static-gate gray is handed straight to compute_phash;
+            # a caller that stopped passing it would silently reconvert.
+            assert gray is not None
+            return real_phash(px, gray=gray)
 
         _feed_region(monkeypatch, seq)
         monkeypatch.setattr(screenspace_scans, "compute_phash", counting_phash)
@@ -149,9 +152,12 @@ class TestBoundariesStaticGate:
         calls = [0]
         real_phash = screenspace_primitives.compute_phash
 
-        def counting_phash(px):
+        def counting_phash(px, gray=None):
             calls[0] += 1
-            return real_phash(px)
+            # The scan's static-gate gray is handed straight to compute_phash;
+            # a caller that stopped passing it would silently reconvert.
+            assert gray is not None
+            return real_phash(px, gray=gray)
 
         _feed_full(monkeypatch, seq)
         monkeypatch.setattr(screenspace_scans, "compute_phash", counting_phash)

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -6,7 +6,9 @@ import config
 import screenspace
 import screenspace_frames
 import screenspace_heatmap
+import screenspace_primitives
 import screenspace_scans
+import screenspace_tools
 from _ss_helpers import _make_icon, _make_icon_frame
 
 
@@ -47,6 +49,45 @@ class TestMatchTemplate:
         template = frame[30:60, 80:140].copy()
         results = screenspace.match_template(frame, template, threshold=0.9, mask=None)
         assert len(results) >= 1
+
+
+class TestCorrelationMapReuse:
+    """The correlation map is the most expensive op here; compute it once."""
+
+    @staticmethod
+    def _frame_and_template():
+        rng = np.random.RandomState(42)
+        frame = rng.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        return frame, frame[30:60, 80:140].copy()
+
+    def test_supplied_corr_gives_the_same_matches(self):
+        frame, template = self._frame_and_template()
+        prepared = screenspace_primitives._prepare_template(template, None)
+        corr = screenspace_primitives._template_correlation_map(frame, prepared)
+        assert screenspace.match_template(
+            frame, template, threshold=0.9, prepared=prepared, corr=corr
+        ) == screenspace.match_template(frame, template, threshold=0.9)
+
+    def test_tool_check_frame_computes_the_map_once(self, monkeypatch):
+        frame, template = self._frame_and_template()
+        calls = []
+        real = screenspace_primitives._template_correlation_map
+
+        def counting(frame_arg, prepared):
+            calls.append(1)
+            return real(frame_arg, prepared)
+
+        monkeypatch.setattr(
+            screenspace_primitives, "_template_correlation_map", counting
+        )
+        monkeypatch.setattr(screenspace_tools, "_template_correlation_map", counting)
+        params = {"template_image": template, "threshold": 0.9}
+        matched, details = screenspace_tools.TemplateTool().check_frame(
+            frame, None, {"x": 0, "y": 0, "w": 200, "h": 100}, params
+        )
+        assert matched
+        assert details["match_count"] >= 1
+        assert len(calls) == 1
 
 
 class TestPrepareTemplateMask:


### PR DESCRIPTION
## Summary

Ran the `--profile` harness from #700 across every Screenspace scan tool; three were never touched by that pass and were the most expensive per-frame work in the engine. `color_present` now builds its match mask from `cv2.inRange` bands derived by evaluating the existing float32 predicates over all 256 uint8 values (exact, not approximate — 9216/9216 parameter combinations produce a bit-identical mask), `compute_spectral_residual` uses `cv2.dft` gated on `cv2.getOptimalDFTSize` (it is 3x *slower* than numpy on prime dimensions, so awkward shapes keep the numpy body), `compute_color_contrast` computes its `sigma = max_dim/8` surround blur at half scale, and `TemplateTool.check_frame` stops recomputing a correlation map it already holds. Also applied #700's `compute_phash(gray=)` fix to the two call sites it missed.

Measured on testsrc 1280x720, 962 sampled frames, `--ss-interval 0.1`, two runs each; `scan.decode_wait` is the control and does not move.

| tool | `scan.callback` before | after | |
|---|---|---|---|
| color (presence) | 4.83 / 4.90 s | 1.43 / 1.47 s | **-70%** |
| attention | 5.54 / 5.55 s | 2.16 / 2.19 s | **-61%** |
| inactivity | 1.77 / 1.80 s | 1.71 / 1.70 s | -4% |
| similarity (control) | 2.07 / 2.06 s | 2.00 / 2.03 s | unmoved |
| change (control) | 0.86 / 0.85 s | 0.85 / 0.87 s | unmoved |

⚠️ The half-scale contrast blur is the one change that can alter output: it moves the normalized saliency map by at most 0.012, and on adversarial testsrc 7/600 frames moved the peak by more than half the shift threshold — so emitted attention *shift events* can differ on frames with near-tied peaks. Everything else is exact or agrees to float32 noise (~5e-7).

⚠️ `compute_spectral_residual` is now repeatable but **not bit-reproducible**: `cv2.dft` returns ~1-ulp differences between two identical calls on some OpenCV builds (reproducibly on Linux CI, never on macOS over 200 repeats). Two attention tests that asserted `array_equal` across independent computations now assert closeness instead; the bound sits between the measured wobble (6.0e-8) and the regression they guard (1.25e-1). Reverting just the `cv2.dft` change would restore bit-reproducibility and cost ~18% of the attention win (2.16 s → ~2.8 s) — say the word if that trade is worth it.

## Test plan

- [x] `/check` green — ruff format, ruff check, ty, full pytest suite
- [x] Exact-equality tests, not tolerance: 400-case `color_present` sweep against the old float32 expression kept as the oracle; `cv2.dft` vs numpy agreement plus a prime-dimension fallback case; a call-counting test on the template map that fails at 2
- [x] Before/after `--profile` runs above, two each, reproduced, with `scan.decode_wait` as an unmoved control
- [x] Six-page headless smoke via `shot.py --perf` (no frontend changes here, but clean: zero long tasks, nav 41–126 ms)
- [ ] **Attention not yet eyeballed on real footage.** The benchmark is synthetic `testsrc`, whose high-frequency pattern is the worst case for near-tied saliency peaks; a heatmap comparison on a real screen recording would confirm the half-scale blur is invisible in practice.

No `build/VERSION` bump — `perf:`, not `feat:`.

