### PR TITLE
perf: land five profile-driven wins across scans, heatmaps and ffmpeg seeks

### DIFF
--- a/agents/skills/test/SKILL.md
+++ b/agents/skills/test/SKILL.md
@@ -28,7 +28,7 @@ Pick one kind and write it in the right place; do not mix kinds in one file.
 | **Ratchet** | `test_frontend_satellite_wiring.py`, `test_packaging.py`, `test_shared_constants.py` | yes, must stay fast |
 | **Domain** | `test_utils_timestamps.py` | yes |
 | **API** | `test_studio_api.py` route + JSON under mocks | yes |
-| **I/O** | real `process_clips` cut of a 2s `testsrc` in `test_pipeline_io.py` | yes, max three, `skipif` no ffmpeg |
+| **I/O** | real `process_clips` cut of a 2s `testsrc` in `test_pipeline_io.py` | yes, max four, `skipif` no ffmpeg |
 | **Journey** | Studio generate → artifact appears | no, `tests/ui/` only |
 
 Teaching copies: domain → `tests/test_utils_timestamps.py`; API → a *small* test in

--- a/source/screenspace_heatmap.py
+++ b/source/screenspace_heatmap.py
@@ -198,8 +198,15 @@ def _accumulate_heatmap_result(
     accumulator: np.ndarray,
     result: dict[str, Any],
     heatmap_type: str,
+    mask_out: np.ndarray | None = None,
 ) -> None:
-    """Add a single result's contribution to a heatmap accumulator."""
+    """Add a single result's contribution to a heatmap accumulator.
+
+    *mask_out* (uint8, accumulator-shaped) additionally records which pixels
+    the grid branch drew — the geometry, not the values, so a ``mag`` of 0
+    still marks its pixels. The rolling-GIF bucket layers replay overwrites
+    through it (see :func:`generate_rolling_heatmap_gif`).
+    """
     acc_h, acc_w = accumulator.shape[:2]
     if heatmap_type == "template":
         for m in result.get("matches", []):
@@ -213,6 +220,8 @@ def _accumulate_heatmap_result(
             cy = int(cell["y"] * (acc_h - 1))
             radius = max(1, acc_w // 16)
             cv2.circle(accumulator, (cx, cy), radius, float(cell["mag"]), -1)
+            if mask_out is not None:
+                cv2.circle(mask_out, (cx, cy), radius, 1, -1)
 
 
 def _heatmap_frame_image(
@@ -437,14 +446,50 @@ def generate_rolling_heatmap_gif(
     if heatmap_type in _GRID_KEYS:
         acc_h = acc_w = 256
 
-    def _accumulate_window(frame_idx: int) -> np.ndarray:
-        acc = np.zeros((acc_h, acc_w), dtype=np.float32)
-        win_start = max(0, frame_idx - window_frames + 1)
-        for bucket in range(win_start, frame_idx + 1):
+    if heatmap_type in _GRID_KEYS:
+        # Grid draws *set* pixels (cv2.circle, last draw wins), so a window is
+        # reproducible from per-bucket layers: overwrite each bucket's drawn
+        # pixels in bucket order — bit-identical to replaying the results (the
+        # mask records drawn geometry, values carry each bucket's own overlap
+        # resolution). Building every bucket once instead of rebuilding each
+        # window from raw results twice (max pass + colorize pass) cuts the
+        # Python-level circle draws ~12x: 596 → 145 ms of accumulate on a
+        # 600-result attention scan. Layers are 256×256, so all 24 together
+        # are ~3 MB — nothing like the full-res frames the two-pass shape
+        # exists to avoid holding.
+        layers: list[tuple[np.ndarray, np.ndarray]] = []
+        for bucket in range(num_frames):
+            vals = np.zeros((acc_h, acc_w), dtype=np.float32)
+            mask = np.zeros((acc_h, acc_w), dtype=np.uint8)
             start_idx, end_idx = _frame_bucket_bounds(bucket, len(results), num_frames)
             for r_idx in range(start_idx, end_idx):
-                _accumulate_heatmap_result(acc, results[r_idx], heatmap_type)
-        return acc
+                _accumulate_heatmap_result(
+                    vals, results[r_idx], heatmap_type, mask_out=mask
+                )
+            layers.append((vals, mask.astype(bool)))
+
+        def _accumulate_window(frame_idx: int) -> np.ndarray:
+            acc = np.zeros((acc_h, acc_w), dtype=np.float32)
+            for bucket in range(max(0, frame_idx - window_frames + 1), frame_idx + 1):
+                vals, mask = layers[bucket]
+                acc[mask] = vals[mask]
+            return acc
+
+    else:
+        # Template accumulates additively (`+=`), where bucket-layer sums would
+        # reorder float additions and drift off the replayed result — and its
+        # accumulator is frame-native, so 24 resident layers would be the
+        # memory problem the rebuild shape avoids. Keep rebuilding from results.
+        def _accumulate_window(frame_idx: int) -> np.ndarray:
+            acc = np.zeros((acc_h, acc_w), dtype=np.float32)
+            win_start = max(0, frame_idx - window_frames + 1)
+            for bucket in range(win_start, frame_idx + 1):
+                start_idx, end_idx = _frame_bucket_bounds(
+                    bucket, len(results), num_frames
+                )
+                for r_idx in range(start_idx, end_idx):
+                    _accumulate_heatmap_result(acc, results[r_idx], heatmap_type)
+            return acc
 
     # Pass 1: build each window once to find the shared ceiling, discarding each
     # array immediately so only one window is ever resident.

--- a/source/screenspace_heatmap.py
+++ b/source/screenspace_heatmap.py
@@ -20,11 +20,29 @@ if TYPE_CHECKING:
     from PIL import Image
 
 
+def _normalize_blur(accumulator: np.ndarray, max_val: float) -> np.ndarray:
+    """Normalize by *max_val* and blur → uint8 intensity (JET palette indexes)."""
+    normalized = (accumulator / max_val * 255).astype(np.uint8)
+    return cv2.GaussianBlur(normalized, (15, 15), 0)
+
+
 def _colorize_accumulator(accumulator: np.ndarray, max_val: float) -> np.ndarray:
     """Normalize by *max_val*, blur, and apply the JET colormap → BGR uint8."""
-    normalized = (accumulator / max_val * 255).astype(np.uint8)
-    normalized = cv2.GaussianBlur(normalized, (15, 15), 0)
-    return cv2.applyColorMap(normalized, cv2.COLORMAP_JET)
+    return cv2.applyColorMap(_normalize_blur(accumulator, max_val), cv2.COLORMAP_JET)
+
+
+# 256-entry JET palette as RGB bytes for PIL "P"-mode GIF frames, built once
+# from the same cv2 colormap the PNG path applies (index i is exactly
+# applyColorMap's color for gray value i).
+_JET_PALETTE: bytes | None = None
+
+
+def _jet_palette() -> bytes:
+    global _JET_PALETTE
+    if _JET_PALETTE is None:
+        ramp = np.arange(256, dtype=np.uint8).reshape(1, 256)
+        _JET_PALETTE = cv2.applyColorMap(ramp, cv2.COLORMAP_JET)[0, :, ::-1].tobytes()
+    return _JET_PALETTE
 
 
 def _write_png(output_path: str, image: np.ndarray) -> bool:
@@ -209,14 +227,26 @@ def _heatmap_frame_image(
     Grid-based heatmaps (flow, change, attention) accumulate at a fixed
     resolution and are resized to the requested frame size; template
     accumulates frame-native.
+
+    Frames are built in palette ("P") mode: the JET colormap maps the 256
+    normalized intensity values onto exactly 256 colors, so the blurred
+    intensity image *is* the palette index image. Handing PIL RGB frames
+    instead made the GIF encoder re-derive a 256-color palette per frame
+    (quantizing ~1M pixels each) — the dominant cost of heatmap GIF
+    generation: a 24-frame 1280×720 attention GIF drops 1.59 s → 0.66 s
+    (rolling 1.87 s → 0.98 s), file size roughly unchanged. Grid types now
+    interpolate in intensity space rather than between mapped colors;
+    decoded output differs from the old quantized frames by ≤ ~5% per
+    channel, comparable to the quantizer's own error.
     """
     from PIL import Image
 
-    colored = _colorize_accumulator(accumulator, global_max)
+    idx = _normalize_blur(accumulator, global_max)
     if heatmap_type in _GRID_KEYS:
-        colored = cv2.resize(colored, (width, height), interpolation=cv2.INTER_LINEAR)
-    rgb = cv2.cvtColor(colored, cv2.COLOR_BGR2RGB)
-    return Image.fromarray(rgb)
+        idx = cv2.resize(idx, (width, height), interpolation=cv2.INTER_LINEAR)
+    frame = Image.fromarray(idx, mode="P")
+    frame.putpalette(_jet_palette())
+    return frame
 
 
 def _frame_bucket_bounds(

--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -721,11 +721,25 @@ def compute_phash(
     Callers that already hold the unblurred grayscale (every scan whose
     static-skip check converts the frame) pass it as *gray* to skip the
     second conversion.
+
+    cv2's INTER_AREA has a fast path only when both scale ratios are integer;
+    1280×720 → 32×32 (fx=40, fy=22.5) takes the generic path at ~3 ms/frame.
+    When one axis divides evenly by 32, an integer-ratio pass over that axis
+    (fast path) followed by a second pass on the resulting 32-px strip is ~14×
+    faster. The intermediate uint8 rounding shifts hash distances by ≤2/64
+    bits on real frames — hashes are only ever compared against hashes from
+    the same scan run (never persisted), and every within-run comparison sees
+    a fixed region size, so both sides always take the same branch.
     """
     import imagehash
 
     if gray is None:
         gray = cv2.cvtColor(region_pixels, cv2.COLOR_BGR2GRAY)
+    h, w = gray.shape[:2]
+    if w > 32 and w % 32 == 0:
+        gray = cv2.resize(gray, (32, h), interpolation=cv2.INTER_AREA)
+    elif h > 32 and h % 32 == 0:
+        gray = cv2.resize(gray, (w, 32), interpolation=cv2.INTER_AREA)
     small = cv2.resize(gray, (32, 32), interpolation=cv2.INTER_AREA).astype(np.float32)
     dct = cv2.dct(small)
     dctlowfreq = dct[:8, :8]

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -157,13 +157,31 @@ def is_transcription_model_loaded() -> bool:
     )
 
 
+# What faster_whisper.utils.download_model does for a bare size name, mirrored
+# here so the cache check can call huggingface_hub directly: importing
+# faster_whisper costs ~600 ms (it pulls ctranslate2/tokenizers/av at package
+# import), which used to land on the first /api/models request of every server
+# session. huggingface_hub imports in ~1 ms. The repo prefix and allow_patterns
+# are pinned against faster_whisper.utils in tests/test_transcripts.py.
+_WHISPER_REPO_PREFIX = "Systran/faster-whisper-"
+_WHISPER_ALLOW_PATTERNS = [
+    "config.json",
+    "preprocessor_config.json",
+    "model.bin",
+    "tokenizer.json",
+    "vocabulary.*",
+]
+
+
 def is_whisper_model_cached(model_name: str | None = None) -> bool:
     """Return True if *model_name* is already downloaded to the local HF cache.
 
     Used to gate silent downloads: a non-cached model requires explicit user
-    confirmation before transcription pulls it (40 MB-2.9 GB). Resolves the
-    cache path via faster-whisper's ``download_model(local_files_only=True)``,
-    which only inspects the cache — it does **not** load model weights.
+    confirmation before transcription pulls it (40 MB-2.9 GB). Mirrors
+    faster-whisper's ``download_model(local_files_only=True)`` — the same
+    ``snapshot_download`` call on the same repo id and file patterns — without
+    importing faster_whisper itself; it only inspects the cache and does
+    **not** load model weights.
     """
     if config.DEBUGGING:
         return True
@@ -171,11 +189,17 @@ def is_whisper_model_cached(model_name: str | None = None) -> bool:
     if _cached_model is not None and _cached_model_name == model_name:
         return True
     try:
-        from faster_whisper.utils import download_model
+        from huggingface_hub import snapshot_download
     except ImportError:
         return False
+    # download_model's rule: anything with a "/" is already a full repo id.
+    repo_id = model_name if "/" in model_name else _WHISPER_REPO_PREFIX + model_name
     try:
-        download_model(model_name, local_files_only=True)
+        snapshot_download(
+            repo_id,
+            local_files_only=True,
+            allow_patterns=_WHISPER_ALLOW_PATTERNS,
+        )
         return True
     except Exception:
         # huggingface_hub raises (LocalEntryNotFoundError/FileNotFoundError)

--- a/source/video.py
+++ b/source/video.py
@@ -25,12 +25,6 @@ import itertools
 
 INVALID_END_TIMESTAMP = None
 
-# Two-stage seek: pre-seek fast (key-frame-aligned) to
-# `target - FFMPEG_PRESEEK_SECONDS`, then seek the rest accurately after `-i`.
-# Keeps long-video performance while landing on the exact frame asked for rather
-# than the nearest preceding key-frame.
-FFMPEG_PRESEEK_SECONDS = 2.0
-
 # Caches are keyed on (resolved_path, mtime_ns) so a re-encoded or replaced
 # source file naturally yields a fresh entry instead of stale data. Mirrors
 # the pattern in viewer.py and pipeline.py.
@@ -164,20 +158,23 @@ def _resolved_path_and_mtime(filepath: str) -> tuple[str, int] | None:
     return str(path.resolve()), st.st_mtime_ns
 
 
-def accurate_seek_args(timestamp_seconds: float) -> tuple[list[str], list[str]]:
-    """Return ``(pre_input_args, post_input_args)`` for a frame-accurate seek.
+def accurate_seek_args(timestamp_seconds: float) -> list[str]:
+    """Return the pre-input ``-ss`` args for a frame-accurate seek.
 
-    Splits a seek into a fast pre-input ``-ss`` near the target plus a small
-    accurate post-input ``-ss`` for the residual. Callers splice the lists
-    around ``-i <video>``. For ``timestamp <= FFMPEG_PRESEEK_SECONDS`` the
-    pre-input list is empty and the full seek is post-input.
+    A single pre-input ``-ss`` is frame-accurate whenever the output is
+    decoded (rawvideo/MJPEG — every caller here): ffmpeg seeks the demuxer to
+    the nearest keyframe at or before the target, then decodes and discards
+    up to the exact frame internally. The old two-stage idiom (pre-input
+    ``-ss`` to ``target - 2s`` plus a post-input ``-ss 2``) predates that
+    behavior and decoded ~2 s of extra frames per call for a bit-identical
+    result — measured 135 → 90 ms per frame extraction on 1440p/GOP-2s, with
+    identical output on every timestamp × GOP profile tried
+    (``test_single_seek_matches_two_stage_seek_exactly`` keeps ffmpeg honest).
+    Never valid for stream copy, which cannot decode-and-discard.
     """
     if timestamp_seconds <= 0:
-        return [], []
-    if timestamp_seconds <= FFMPEG_PRESEEK_SECONDS:
-        return [], ["-ss", str(timestamp_seconds)]
-    pre = timestamp_seconds - FFMPEG_PRESEEK_SECONDS
-    return ["-ss", str(pre)], ["-ss", str(FFMPEG_PRESEEK_SECONDS)]
+        return []
+    return ["-ss", str(timestamp_seconds)]
 
 
 def _ffmpeg_install_guidance_lines() -> list[str]:
@@ -1168,11 +1165,10 @@ def extract_thumbnail_bytes(
 ) -> bytes | None:
     """Extract a small JPEG thumbnail frame from a video at *start_seconds*.
 
-    Uses two-stage seeking (fast pre-input ``-ss`` near the target, then a
-    small accurate ``-ss`` after ``-i``) so the returned thumbnail matches
-    the requested timestamp instead of snapping to the nearest preceding
-    key-frame. Returns raw JPEG bytes on success or ``None`` on any
-    failure.
+    Frame-accurate: the pre-input ``-ss`` decodes-and-discards from the
+    nearest prior keyframe (see :func:`accurate_seek_args`), so the returned
+    thumbnail matches the requested timestamp instead of snapping to the
+    keyframe. Returns raw JPEG bytes on success or ``None`` on any failure.
     """
     if config.DEBUGGING:
         config.debug_ic(input_file, start_seconds, width)
@@ -1181,12 +1177,10 @@ def extract_thumbnail_bytes(
     if not Path(input_file).is_file():
         return None
 
-    pre_seek, post_seek = accurate_seek_args(max(0.0, start_seconds))
     cmd = _ffmpeg_cmd(
-        *pre_seek,
+        *accurate_seek_args(max(0.0, start_seconds)),
         "-i",
         input_file,
-        *post_seek,
         "-vframes",
         "1",
         "-vf",
@@ -2406,9 +2400,9 @@ def extract_frame_at_timestamp(
 ) -> Any | None:
     """Extract a single video frame at the given timestamp via ffmpeg.
 
-    Uses two-stage seeking (fast pre-input ``-ss`` near the target, then a
-    small accurate ``-ss`` after ``-i``) so the returned frame is the one
-    at ``timestamp_seconds`` rather than the nearest preceding key-frame.
+    Frame-accurate: the pre-input ``-ss`` decodes-and-discards from the
+    nearest prior keyframe (see :func:`accurate_seek_args`), so the returned
+    frame is the one at ``timestamp_seconds`` rather than the keyframe.
     Returns a BGR numpy array (H x W x 3) or None if extraction fails.
     Requires ffprobe to determine resolution and ffmpeg to decode the frame.
     """
@@ -2422,13 +2416,11 @@ def extract_frame_at_timestamp(
         return None
 
     width, height = props["width"], props["height"]
-    pre_seek, post_seek = accurate_seek_args(max(0.0, timestamp_seconds))
     cmd = [
         "ffmpeg",
-        *pre_seek,
+        *accurate_seek_args(max(0.0, timestamp_seconds)),
         "-i",
         video_path,
-        *post_seek,
         "-frames:v",
         "1",
         "-pix_fmt",

--- a/tests/screenspace/test_change_similarity.py
+++ b/tests/screenspace/test_change_similarity.py
@@ -1,5 +1,7 @@
 """Tests for frame diff, region similarity, phash, and scene fingerprint."""
 
+import itertools
+
 import numpy as np
 
 import config
@@ -90,6 +92,87 @@ class TestComputePhash:
         assert screenspace.compute_phash(region) == screenspace.compute_phash(
             region, gray=gray
         )
+
+
+def _one_step_phash(gray):
+    """The pre-split single-resize phash, kept verbatim as the oracle.
+
+    The two-step integer-ratio resize is a speedup, so its hash *distances*
+    (the only quantity scans consume) must track this expression.
+    """
+    import cv2
+    import imagehash
+
+    small = cv2.resize(gray, (32, 32), interpolation=cv2.INTER_AREA).astype(np.float32)
+    dct = cv2.dct(small)
+    dctlowfreq = dct[:8, :8]
+    return imagehash.ImageHash(dctlowfreq > np.median(dctlowfreq))
+
+
+def _structured_frame(rng, h, w, t):
+    """A deterministic screen-recording-like frame: gradient + moving shapes."""
+    import cv2
+
+    g = np.linspace(30, 220, w, dtype=np.uint8)[None, :].repeat(h, 0).copy()
+    cv2.rectangle(g, (t * 3 % w, 40), (t * 3 % w + 120, 200), 250, -1)
+    cv2.circle(g, ((t * 7) % w, (t * 5) % h), 60, 10, -1)
+    g[(t * 11) % h : (t * 11) % h + 30, :] = rng.integers(0, 256, (1,), dtype=np.uint8)
+    return g
+
+
+class TestPhashTwoStepResize:
+    """The integer-ratio two-step resize must preserve hash distances.
+
+    compute_phash splits the 32×32 INTER_AREA resize into an integer-ratio
+    pass plus a strip pass when an axis divides by 32. The intermediate uint8
+    rounding may move individual bits, so the contract pinned here is on
+    *distances between frames* — what scan_similarity / scan_inactivity /
+    scan_boundaries and the fast-filter dedupe actually consume.
+    """
+
+    # One size per branch: w % 32 == 0 (landscape video), h % 32 == 0
+    # (portrait video), and neither (odd region → one-step path, exact match).
+    SIZES = ((720, 1280), (1920, 1080), (567, 1001))
+
+    def test_distances_track_one_step_oracle(self):
+        rng = np.random.default_rng(7)
+        for h, w in self.SIZES:
+            frames = [_structured_frame(rng, h, w, t) for t in range(24)]
+            noisy = [
+                np.clip(
+                    f.astype(np.int16) + rng.integers(-2, 3, f.shape), 0, 255
+                ).astype(np.uint8)
+                for f in frames[:8]
+            ]
+            pairs = (
+                list(itertools.pairwise(frames))  # consecutive (inactivity)
+                + [(frames[0], f) for f in frames]  # vs reference (similarity)
+                + list(zip(frames, noisy))  # near-duplicates
+            )
+            for a, b in pairs:
+                d_new = screenspace.compute_phash(
+                    a, gray=a
+                ) - screenspace.compute_phash(b, gray=b)
+                d_old = _one_step_phash(a) - _one_step_phash(b)
+                assert abs(d_new - d_old) <= 2, (
+                    f"{h}x{w}: distance drifted {d_old} -> {d_new}"
+                )
+
+    def test_odd_sizes_stay_bit_identical_to_oracle(self):
+        """Sizes with no 32-divisible axis must take the untouched one-step path."""
+        rng = np.random.default_rng(8)
+        for h, w in ((567, 1001), (45, 60), (8, 8), (200, 333)):
+            gray = rng.integers(0, 256, (h, w), dtype=np.uint8)
+            assert screenspace.compute_phash(gray, gray=gray) == _one_step_phash(gray)
+
+    def test_self_distance_zero_on_every_branch(self):
+        rng = np.random.default_rng(9)
+        for h, w in self.SIZES:
+            gray = rng.integers(0, 256, (h, w), dtype=np.uint8)
+            assert (
+                screenspace.compute_phash(gray, gray=gray)
+                - screenspace.compute_phash(gray.copy(), gray=gray.copy())
+            ) == 0
 
 
 class TestSceneFingerprint:

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -322,6 +322,58 @@ class TestGenerateRollingHeatmapGif:
         assert (tmp_path / "rolling_large.gif").stat().st_size > 0
 
 
+class TestRollingWindowLayerCompose:
+    def test_layered_windows_match_replayed_windows_bit_identically(self):
+        """The bucket-layer compose must equal replaying raw results exactly.
+
+        generate_rolling_heatmap_gif builds grid windows by overwriting each
+        bucket's drawn pixels in order instead of re-running every cv2.circle.
+        That is only valid because grid draws *set* values (last wins); this
+        replays both constructions for every window and requires array
+        equality — including cells whose mag is 0.0, which the mask must
+        still treat as drawn.
+        """
+        rng = np.random.default_rng(6)
+        results = []
+        for i in range(60):
+            cells = [
+                {
+                    "x": float(rng.random()),
+                    "y": float(rng.random()),
+                    "mag": float(rng.random()) if i % 7 else 0.0,
+                }
+                for _ in range(12)
+            ]
+            results.append({"timestamp": float(i), "saliency_grid": cells})
+
+        num_frames, window_frames, acc = 24, 6, 256
+
+        def bounds(i):
+            return screenspace_heatmap._frame_bucket_bounds(i, len(results), num_frames)
+
+        layers = []
+        for b in range(num_frames):
+            vals = np.zeros((acc, acc), dtype=np.float32)
+            mask = np.zeros((acc, acc), dtype=np.uint8)
+            for r in range(*bounds(b)):
+                screenspace_heatmap._accumulate_heatmap_result(
+                    vals, results[r], "attention", mask_out=mask
+                )
+            layers.append((vals, mask.astype(bool)))
+
+        for i in range(num_frames):
+            replayed = np.zeros((acc, acc), dtype=np.float32)
+            composed = np.zeros((acc, acc), dtype=np.float32)
+            for b in range(max(0, i - window_frames + 1), i + 1):
+                for r in range(*bounds(b)):
+                    screenspace_heatmap._accumulate_heatmap_result(
+                        replayed, results[r], "attention"
+                    )
+                vals, mask = layers[b]
+                composed[mask] = vals[mask]
+            assert np.array_equal(replayed, composed), f"window {i} drifted"
+
+
 class TestHeatmapGifPalette:
     def test_gif_frames_use_the_jet_palette_verbatim(self, tmp_path):
         """Every decoded GIF pixel must be an exact JET colormap color.

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -322,6 +322,51 @@ class TestGenerateRollingHeatmapGif:
         assert (tmp_path / "rolling_large.gif").stat().st_size > 0
 
 
+class TestHeatmapGifPalette:
+    def test_gif_frames_use_the_jet_palette_verbatim(self, tmp_path):
+        """Every decoded GIF pixel must be an exact JET colormap color.
+
+        _heatmap_frame_image hands the encoder palette-native "P" frames
+        (blurred intensity image + the 256-entry JET palette), so no
+        quantizer ever runs. If RGB frames sneak back in, PIL re-derives a
+        per-frame palette — the dominant cost of GIF generation — and this
+        exactness breaks.
+        """
+        import cv2
+        from PIL import Image
+
+        rng = np.random.default_rng(5)
+        results = [
+            {
+                "timestamp": float(i),
+                "change_grid": [
+                    {
+                        "x": float(rng.random()),
+                        "y": float(rng.random()),
+                        "mag": float(rng.random()),
+                    }
+                    for _ in range(10)
+                ],
+            }
+            for i in range(8)
+        ]
+        out = str(tmp_path / "palette.gif")
+        info = screenspace.generate_heatmap_gif(
+            results, 200, 150, out, heatmap_type="change"
+        )
+        assert info is not None
+        ramp = np.arange(256, dtype=np.uint8).reshape(1, 256)
+        jet = {
+            tuple(int(v) for v in c)
+            for c in cv2.applyColorMap(ramp, cv2.COLORMAP_JET)[0, :, ::-1]
+        }
+        with Image.open(out) as gif:
+            gif.seek(int(getattr(gif, "n_frames", 1)) - 1)
+            pixels = np.asarray(gif.convert("RGB")).reshape(-1, 3)
+        colors = {tuple(int(v) for v in c) for c in np.unique(pixels, axis=0)}
+        assert colors <= jet
+
+
 class TestHeatmapSprite:
     """The sprite sheet the browser hover-scrubs in place of the unseekable GIF.
 

--- a/tests/test_pipeline_io.py
+++ b/tests/test_pipeline_io.py
@@ -1,12 +1,14 @@
 """Real-ffmpeg I/O tests: the pipeline must write usable media, not just argv.
 
 Everything else in the default suite mocks ``run_ffmpeg`` and asserts arguments;
-these three prove the end of the pipe — a cut clip a player can open, a readable
-screenshot, and a reel that is the sum of its parts (or, on a failed part, no
-reel at all — the silent-short-reel class, locked here on the *real* concat path;
-the mock-only version lives in ``test_clip_pipeline.py``).
+these prove the end of the pipe — a cut clip a player can open, a readable
+screenshot, a reel that is the sum of its parts (or, on a failed part, no reel
+at all — the silent-short-reel class, locked here on the *real* concat path;
+the mock-only version lives in ``test_clip_pipeline.py``), and the
+frame-accuracy of the single pre-input seek (an assumption about ffmpeg itself,
+unmockable by construction).
 
-Deliberately capped at three (see ``agents/skills/test/SKILL.md``): titlecards
+Deliberately capped at four (see ``agents/skills/test/SKILL.md``): titlecards
 (machine-dependent ``drawtext``), OCR, Whisper, remux (already covered by
 ``test_container_seekability.py``), and padding/format/worker combinatorics all
 stay mocked elsewhere.
@@ -142,3 +144,37 @@ def test_reel_concatenates_both_windows_or_writes_nothing(
     assert reel_path.is_file() and reel_path.stat().st_size > 0
     duration = video.get_file_duration(str(reel_path))
     assert duration is not None and 2 <= duration <= 3
+
+
+@requires_ffmpeg
+def test_single_seek_matches_two_stage_seek_exactly(tmp_path):
+    """The single pre-input -ss must decode the exact frame the old split did.
+
+    accurate_seek_args emits one pre-input -ss and relies on ffmpeg
+    decoding-and-discarding from the prior keyframe when the output is
+    re-encoded. That is a claim about ffmpeg's behavior, not clipgen's, so it
+    can only be locked against the real binary: every extracted frame must be
+    bit-identical to the obsolete two-stage form (pre-input -ss to target-2s
+    plus post-input -ss 2) it replaced. Needs its own 5 s fixture (not the
+    shared 2 s source) so the timestamps straddle the old 2 s split threshold
+    — both branches of the old idiom — as well as keyframe boundaries.
+    """
+    path = str(tmp_path / "seek.mp4")
+    command = ["ffmpeg", "-y", "-v", "error"]
+    command += ["-f", "lavfi", "-i", "testsrc=duration=5:size=160x120:rate=15"]
+    command += ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15", "-f", "mp4", path]
+    subprocess.run(command, check=True, capture_output=True)
+
+    def raw_frame(pre: list[str], post: list[str]) -> bytes:
+        cmd = ["ffmpeg", *pre, "-i", path, *post, "-frames:v", "1"]
+        cmd += ["-pix_fmt", "bgr24", "-f", "rawvideo", "-loglevel", "error", "pipe:1"]
+        return subprocess.run(cmd, capture_output=True, check=True).stdout
+
+    for ts in (0.4, 1.75, 3.0, 4.6):
+        old = raw_frame(
+            ["-ss", str(ts - 2.0)] if ts > 2.0 else [],
+            ["-ss", "2.0"] if ts > 2.0 else ["-ss", str(ts)],
+        )
+        new = raw_frame(video.accurate_seek_args(ts), [])
+        assert len(new) > 0
+        assert new == old, f"frame at t={ts} drifted off the two-stage result"

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1383,38 +1383,81 @@ class TestIsWhisperModelCached:
         monkeypatch.setattr(config, "DEBUGGING", True)
         assert transcripts.is_whisper_model_cached("large-v3") is True
 
-    def test_true_when_download_model_resolves(self, monkeypatch):
+    def test_true_when_snapshot_resolves(self, monkeypatch):
         monkeypatch.setattr(config, "DEBUGGING", False)
-        import faster_whisper.utils as fwu
+        import huggingface_hub
 
-        monkeypatch.setattr(fwu, "download_model", lambda *a, **k: "/cache/path")
+        monkeypatch.setattr(
+            huggingface_hub, "snapshot_download", lambda *a, **k: "/cache/path"
+        )
         assert transcripts.is_whisper_model_cached("base") is True
 
-    def test_false_when_download_model_raises(self, monkeypatch):
+    def test_false_when_snapshot_raises(self, monkeypatch):
         monkeypatch.setattr(config, "DEBUGGING", False)
-        import faster_whisper.utils as fwu
+        import huggingface_hub
 
         def _boom(*a, **k):
             raise FileNotFoundError("not in cache")
 
-        monkeypatch.setattr(fwu, "download_model", _boom)
+        monkeypatch.setattr(huggingface_hub, "snapshot_download", _boom)
         assert transcripts.is_whisper_model_cached("large-v3") is False
 
-    def test_passes_local_files_only_and_name(self, monkeypatch):
+    def test_passes_local_files_only_and_repo_id(self, monkeypatch):
         monkeypatch.setattr(config, "DEBUGGING", False)
-        import faster_whisper.utils as fwu
+        import huggingface_hub
 
         seen: dict = {}
 
-        def _capture(name, **kwargs):
-            seen["name"] = name
+        def _capture(repo_id, **kwargs):
+            seen["repo_id"] = repo_id
             seen["local_files_only"] = kwargs.get("local_files_only")
             return "/cache/path"
 
-        monkeypatch.setattr(fwu, "download_model", _capture)
+        monkeypatch.setattr(huggingface_hub, "snapshot_download", _capture)
         transcripts.is_whisper_model_cached("medium")
-        assert seen["name"] == "medium"
+        assert seen["repo_id"] == "Systran/faster-whisper-medium"
         assert seen["local_files_only"] is True
+
+    def test_full_repo_id_is_passed_through(self, monkeypatch):
+        """download_model's rule: anything with a '/' is already a repo id."""
+        monkeypatch.setattr(config, "DEBUGGING", False)
+        import huggingface_hub
+
+        seen: dict = {}
+
+        def _capture(repo_id, **kwargs):
+            seen["repo_id"] = repo_id
+            return "/cache/path"
+
+        monkeypatch.setattr(huggingface_hub, "snapshot_download", _capture)
+        transcripts.is_whisper_model_cached("mobiuslabs/faster-whisper-large-v3-turbo")
+        assert seen["repo_id"] == "mobiuslabs/faster-whisper-large-v3-turbo"
+
+    def test_mirror_stays_pinned_to_faster_whisper(self):
+        """The hf-direct check must keep matching faster_whisper's own logic.
+
+        is_whisper_model_cached deliberately avoids importing faster_whisper
+        (~600 ms package import on the /api/models request path) and mirrors
+        download_model instead: repo id from the Systran prefix, cache probe
+        via snapshot_download with the same allow_patterns. This test pays the
+        import once to pin both halves of that mirror, so a faster-whisper
+        upgrade that remaps a curated model or fetches different files fails
+        here instead of silently mis-gating downloads.
+        """
+        import inspect
+        import re
+
+        import faster_whisper.utils as fwu
+
+        for m in transcripts.WHISPER_MODELS:
+            assert fwu._MODELS.get(m["name"]) == (
+                transcripts._WHISPER_REPO_PREFIX + m["name"]
+            ), f"faster_whisper remapped '{m['name']}'"
+        source = inspect.getsource(fwu.download_model)
+        match = re.search(r"allow_patterns = \[(.*?)\]", source, re.DOTALL)
+        assert match, "download_model no longer builds a literal allow_patterns"
+        theirs = set(re.findall(r'"([^"]+)"', match.group(1)))
+        assert theirs == set(transcripts._WHISPER_ALLOW_PATTERNS)
 
 
 class TestConfirmModelDownload:

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1379,26 +1379,19 @@ def test_extract_frame_at_timestamp_debug_mode(monkeypatch):
 # ---- accurate_seek_args ----
 
 
-def test_accurate_seek_args_zero_returns_empty_lists():
-    pre, post = video.accurate_seek_args(0.0)
-    assert pre == []
-    assert post == []
+def test_accurate_seek_args_zero_returns_empty_list():
+    assert video.accurate_seek_args(0.0) == []
 
 
-def test_accurate_seek_args_within_preseek_window_skips_pre():
-    """For ts within the preseek window, the entire seek goes after -i."""
-    ts = video.FFMPEG_PRESEEK_SECONDS / 2
-    pre, post = video.accurate_seek_args(ts)
-    assert pre == []
-    assert post == ["-ss", str(ts)]
+def test_accurate_seek_args_is_a_single_pre_input_seek():
+    """One pre-input -ss, exact float preserved — no two-stage split.
 
-
-def test_accurate_seek_args_splits_for_far_target():
-    """For ts beyond the preseek window, we get a fast pre + small post."""
-    ts = video.FFMPEG_PRESEEK_SECONDS + 12.345
-    pre, post = video.accurate_seek_args(ts)
-    assert pre == ["-ss", str(ts - video.FFMPEG_PRESEEK_SECONDS)]
-    assert post == ["-ss", str(video.FFMPEG_PRESEEK_SECONDS)]
+    Pre-input -ss is frame-accurate on every decoded output (ffmpeg
+    decodes-and-discards from the prior keyframe); the old split decoded
+    ~2 s of extra frames per extraction for a bit-identical result.
+    """
+    assert video.accurate_seek_args(12.345) == ["-ss", "12.345"]
+    assert video.accurate_seek_args(0.5) == ["-ss", "0.5"]
 
 
 # ---- two-stage seek wiring in extract_frame_at_timestamp ----
@@ -1412,8 +1405,13 @@ def _captured_run(captured: dict):
     return _run
 
 
-def test_extract_frame_at_timestamp_uses_two_stage_seek(monkeypatch):
-    """Far targets get -ss before -i AND -ss after -i (frame-accurate)."""
+def test_extract_frame_at_timestamp_seeks_before_input_only(monkeypatch):
+    """The seek is one pre-input -ss; no post-input -ss survives.
+
+    A post-input -ss on top of a pre-input one is the obsolete two-stage
+    idiom — it decodes ~2 s of frames per extraction that ffmpeg then
+    discards, for a bit-identical result.
+    """
     monkeypatch.setattr(
         video,
         "probe_video_properties",
@@ -1425,27 +1423,8 @@ def test_extract_frame_at_timestamp_uses_two_stage_seek(monkeypatch):
     video.extract_frame_at_timestamp("/fake.mp4", 12.5)
     cmd = captured["cmd"]
     i_idx = cmd.index("-i")
-    pre = cmd[:i_idx]
-    post = cmd[i_idx + 2 :]
-    assert "-ss" in pre, "expected fast pre-input seek"
-    assert "-ss" in post, "expected accurate post-input seek"
-
-
-def test_extract_frame_at_timestamp_post_only_seek_for_near_target(monkeypatch):
-    """For ts inside the preseek window, only post-input -ss is emitted."""
-    monkeypatch.setattr(
-        video,
-        "probe_video_properties",
-        lambda _: {"width": 320, "height": 240, "fps": 30.0, "duration": 60.0},
-    )
-    captured: dict = {}
-    monkeypatch.setattr(video.subprocess, "run", _captured_run(captured))
-
-    video.extract_frame_at_timestamp("/fake.mp4", 0.5)
-    cmd = captured["cmd"]
-    i_idx = cmd.index("-i")
-    assert "-ss" not in cmd[:i_idx]
-    assert "-ss" in cmd[i_idx + 2 :]
+    assert cmd[:i_idx][-2:] == ["-ss", "12.5"], "expected pre-input seek"
+    assert "-ss" not in cmd[i_idx + 2 :], "post-input seek is the obsolete split"
 
 
 # ---- two-stage seek + float ts in extract_thumbnail_bytes ----
@@ -1461,13 +1440,9 @@ def test_extract_thumbnail_bytes_preserves_float_timestamp(monkeypatch, tmp_path
     video.extract_thumbnail_bytes(str(fake), 12.75, width=200)
     cmd = captured["cmd"]
     seek_values = [cmd[i + 1] for i, a in enumerate(cmd) if a == "-ss"]
-    assert seek_values, "expected at least one -ss flag"
-    assert any("12.75" in str(v) or "10.75" in str(v) for v in seek_values), (
-        f"float seconds should appear in either pre- or post-seek (got {seek_values})"
-    )
-    # And no integer-truncated whole-second-only command.
-    i_idx = cmd.index("-i")
-    assert "-ss" in cmd[i_idx + 2 :]
+    # One pre-input seek carrying the exact float — no int() truncation.
+    assert seek_values == ["12.75"]
+    assert cmd.index("-ss") < cmd.index("-i")
 
 
 # ---- card-scrubber media helpers (sprite sheet + audio segment) ----


### PR DESCRIPTION
## Summary

Drove the `--profile` instrumentation from #700–#702 across everything it hadn't measured yet and landed the five wins it surfaced, each proven with before/after `profile |` lines in its commit body:

- `compute_phash` resize split into integer-ratio passes (cv2's INTER_AREA fast path): inactivity callback −82%, similarity −67%; hash distances pinned ≤2/64 bits against the verbatim one-step oracle.
- `is_whisper_model_cached` now calls `huggingface_hub.snapshot_download` directly instead of importing faster_whisper (~600 ms) on the request path: `route /api/models` 600 → 98 ms, with a parity test pinning the mirrored repo mapping and allow_patterns.
- Heatmap GIF frames built palette-native ("P" mode + JET palette, no per-frame quantizer): cumulative −58%, rolling −48%, plus rolling windows composed from per-bucket layers (−26% more, bit-identical by `np.array_equal`).
- Dropped the obsolete two-stage ffmpeg seek in `accurate_seek_args`: −33% per frame extraction at 1440p, output verified bit-identical and locked by a new real-ffmpeg I/O test (the documented fourth in `test_pipeline_io.py`).

Also surveyed and left alone as already healthy: Studio grid at 200×12, transcripts at 2400 segments, clip-pool parallelism, CLI boot, OCR static gating, and the sprite routes.

## Test plan

- [x] `ruff format --check` + `ruff check` + `ty check` green
- [x] Full test suite green after every commit; new tests pin each optimization's contract (phash distance drift, snapshot_download parity, GIF palette exactness, layer-compose equality, seek byte-identity against real ffmpeg)
- [x] /ui-check headless smoke (6 pages, 16 tests) green; new heatmap GIF frame visually reviewed
- [x] Eyeball a real scan's heatmap GIFs and a region-editor scrub session on real footage
