### PR TITLE
fix(screenspace): match text searches inside whole-line OCR readings

### DIFF
--- a/source/screenspace_ocr.py
+++ b/source/screenspace_ocr.py
@@ -92,6 +92,12 @@ def _build_ocr_reader(model: str) -> Any:
 
     params: dict[str, Any] = {
         "Global.log_level": "error",
+        # RapidOCR silently drops readings scoring below Global.text_score
+        # (default 0.5) before clipgen ever sees them — a pre-filter EasyOCR
+        # never had, and one the user-facing confidence slider cannot reach
+        # (lowering the slider below 0.5 would change nothing). Near-zero here
+        # makes clipgen's own ocr_confidence_threshold the single gate.
+        "Global.text_score": 0.05,
         # Each pooled engine owns a private onnxruntime session; cap intra-op
         # threads so pool_size × threads cannot oversubscribe the CPU.
         "EngineConfig.onnxruntime.intra_op_num_threads": max(
@@ -332,6 +338,33 @@ def _ocr_region_readings(
     return readings
 
 
+def _fuzzy_match_ratio(needle: str, haystack: str) -> float:
+    """Best fuzzy ratio of *needle* against *haystack* or any span of it.
+
+    PP-OCR's detector returns whole lines as single readings (a WoW chat line,
+    a full sentence), where EasyOCR segmented into word-group boxes. Scoring
+    the search string against the entire reading punishes exactly the case the
+    tool exists for — a short target inside a longer line scores ~0.6 even on
+    a perfect read — so a reading longer than the search is scored by its
+    best same-length window instead ("does this text appear", not "is this
+    text the whole reading"). The plain two-string ratio still applies when
+    the search is at least as long as the reading.
+    """
+    if not needle or len(needle) >= len(haystack):
+        return difflib.SequenceMatcher(None, needle, haystack).ratio()
+    if needle in haystack:
+        return 1.0
+    # SequenceMatcher caches its second sequence, so the constant needle goes
+    # there and each window is set_seq1 (ratio() is symmetric).
+    matcher = difflib.SequenceMatcher(None, "", needle)
+    best = 0.0
+    for i in range(len(haystack) - len(needle) + 1):
+        matcher.set_seq1(haystack[i : i + len(needle)])
+        ratio = matcher.ratio()
+        best = max(best, ratio)
+    return best
+
+
 def _score_text_readings(
     readings: list[Any], params: dict[str, Any]
 ) -> tuple[bool, dict[str, Any]]:
@@ -339,7 +372,8 @@ def _score_text_readings(
 
     ``fuzzy_ratio`` is the calibration scalar; ``text_found``/``confidence`` carry
     the best-matching reading for the strip tooltip. ``passed`` is the fuzzy
-    match at the current threshold.
+    match at the current threshold. Matching is substring-aware — see
+    :func:`_fuzzy_match_ratio`.
     """
     search_string = params.get("search_string", "")
     fuzzy_threshold = params.get(
@@ -359,7 +393,7 @@ def _score_text_readings(
         if conf < ocr_min_conf:
             continue
         ocr_cmp = _normalize_ocr_text(text, ocr_normalize)
-        ratio = difflib.SequenceMatcher(None, search_cmp, ocr_cmp).ratio()
+        ratio = _fuzzy_match_ratio(search_cmp, ocr_cmp)
         if ratio > best_ratio:
             best_ratio = ratio
             best_text = text

--- a/tests/screenspace/test_text_numbers.py
+++ b/tests/screenspace/test_text_numbers.py
@@ -805,6 +805,46 @@ class TestScoreOcrReadings:
         assert detail["number_found"] == 1234.0  # 3.5 and -12 rejected outright
 
 
+class TestFuzzyMatchRatio:
+    def test_search_inside_whole_line_reading_is_full_match(self):
+        # PP-OCR's detector returns whole chat lines; a single-word search must
+        # match a line containing it (plain two-string ratio scored ~0.4 here
+        # and silently killed every chatbox search — the WoW regression).
+        readings = [(None, "Your Stamina increases by 1.", 0.98)]
+        params = {"search_string": "Stamina", "fuzzy_threshold": 0.75}
+        passed, detail = screenspace._score_text_readings(readings, params)
+        assert passed is True
+        assert detail["fuzzy_ratio"] == 1.0
+        assert detail["text_found"] == "Your Stamina increases by 1."
+
+    def test_windowed_match_tolerates_misreads(self):
+        # "Derense" for "Defense" — one glyph off inside a long line still
+        # clears a moderate threshold via the best same-length window.
+        readings = [(None, "Your skill in Derense has increased to 18.", 0.97)]
+        params = {"search_string": "Defense", "fuzzy_threshold": 0.75}
+        passed, detail = screenspace._score_text_readings(readings, params)
+        assert passed is True
+        assert detail["fuzzy_ratio"] >= 0.8
+
+    def test_search_longer_than_reading_uses_plain_ratio(self):
+        readings = [(None, "Save", 0.9)]
+        params = {"search_string": "Save changes now?", "fuzzy_threshold": 0.9}
+        passed, detail = screenspace._score_text_readings(readings, params)
+        assert passed is False
+        assert detail["fuzzy_ratio"] < 0.5
+
+    def test_empty_search_never_matches_via_windowing(self):
+        # An empty needle must not degenerate into ratio("", "") == 1.0.
+        assert screenspace_ocr._fuzzy_match_ratio("", "anything") == 0.0
+
+    def test_unrelated_text_still_scores_low(self):
+        readings = [(None, "You loot 2 Copper", 0.99)]
+        params = {"search_string": "Ironforge", "fuzzy_threshold": 0.75}
+        passed, detail = screenspace._score_text_readings(readings, params)
+        assert passed is False
+        assert detail["fuzzy_ratio"] < 0.6
+
+
 class TestReadingsFromResult:
     def test_empty_result_maps_to_no_readings(self):
         empty = SimpleNamespace(boxes=None, txts=None, scores=None)


### PR DESCRIPTION
## Summary

Fixes the WoW-chatbox regression found in post-swap manual testing. A parameter/preprocessing sweep on the real footage (36 variant combinations) proved recognition was never the problem — every chat line read at 0.94–1.00 confidence at every setting. The regression is a scoring artifact: PP-OCR's detector returns **whole lines** as single readings where easyocr segmented into word-group boxes, so a single-word search like `Stamina` scored ~0.4 against `"Your Stamina increases by 1."` and could never clear the 0.75 threshold.

- `_fuzzy_match_ratio`: readings longer than the search are scored by their best same-length window (exact-substring fast path) — "does this text appear in the region", not "is this text the whole reading". No engine or preprocessing changes needed.
- Engine construction pins `Global.text_score` near zero: RapidOCR was silently discarding sub-0.5 readings before clipgen ever saw them — a pre-filter the user-facing confidence slider could never reach below. clipgen's own `ocr_confidence_threshold` is now the single confidence gate.

## Test plan

- [x] `/check` green (ruff, ty, full suite; 5 new scorer pins incl. the Stamina case, misread-tolerant windowing, empty-search guard, and an unrelated-text negative)
- [x] End-to-end on the reporting footage via the production `scan_text` path: `Stamina` and `Ironforge` were 0 events before, **17 events each at fuzzy_ratio 1.0** after; calibration pins re-score from cached readings
- [ ] Maintainer re-check on the WoW region (existing pins should flip to hits without re-running OCR)