### PR TITLE
build(transcripts): drop PyAV by feeding whisper ffmpeg-decoded PCM

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -107,9 +107,9 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           set -euo pipefail
-          # cv2 and PyAV each bundle their own FFmpeg shared libraries, and
-          # THIRD-PARTY-LICENSES states each one's license explicitly. Those
-          # strings come from the wheels' build config, so a wheel bump can
+          # cv2 bundles its own FFmpeg shared libraries, and
+          # THIRD-PARTY-LICENSES states their license explicitly. Those
+          # strings come from the wheel's build config, so a wheel bump can
           # silently change them and leave us shipping a false notice — which
           # is a distribution problem, not a runtime one, so nothing else here
           # would catch it. Assert the recorded state instead.
@@ -134,7 +134,14 @@ jobs:
             echo "$1 → $got"
           }
           check_license "cv2" "GPL version 3 or later"
-          check_license "av"  "LGPL version 3 or later"
+          # PyAV was overridden out of the dependency tree (its wheel carried a
+          # third FFmpeg; transcription feeds whisper ffmpeg-decoded ndarrays
+          # instead). Its LGPL notice section is gone from THIRD-PARTY-LICENSES,
+          # so its dylibs sneaking back into the bundle would ship unattributed.
+          if find dist/clipgen.app -type d \( -name "av" -o -name "av.libs" \) | grep -q .; then
+            echo "::error::PyAV is back in the bundle; restore its THIRD-PARTY-LICENSES sections."
+            exit 1
+          fi
 
       - name: Verify bundled ffmpeg features (Windows)
         if: matrix.os == 'windows-latest'

--- a/agents/skills/debug/SKILL.md
+++ b/agents/skills/debug/SKILL.md
@@ -22,7 +22,7 @@
 
 8. **DBus errors in logs** — harmless. They come from Chrome attempting DBus connections in headless environments. Ignore them.
 
-9. **`objc[...] Class AVFFrameReceiver/AVFAudioReceiver is implemented in both ...` on macOS** — harmless. Both `opencv-python-headless` (cv2, Screenspace) and `av` (PyAV, pulled in by `faster-whisper` for Transcripts) bundle their own FFmpeg `libavdevice`, an AVFoundation capture-device library clipgen never uses; the ObjC runtime warns when both load in one process. `start_combined_server()` pre-loads both via `utils.preload_av_libs_quietly()` with native stderr silenced, so the combined web server stays quiet. A rare pure-CLI run that loads both libs may still print it — it's benign.
+9. **`objc[...] Class AVFFrameReceiver/AVFAudioReceiver is implemented in both ...` on macOS** — should no longer occur. It needed two FFmpeg `libavdevice` copies in one process, and PyAV (the second copy, formerly pulled in by `faster-whisper`) is no longer a dependency — transcription feeds whisper ffmpeg-decoded PCM instead (`transcripts._ensure_av_stub`). If it reappears, something reintroduced `av`; the warning itself is benign. `start_combined_server()` still pre-loads cv2 via `utils.preload_vision_libs_quietly()` with native stderr silenced.
 
 ## Development / debugging
 

--- a/build/THIRD-PARTY-LICENSES
+++ b/build/THIRD-PARTY-LICENSES
@@ -31,8 +31,6 @@ omegaconf                   2.3.1      BSD-3-Clause
 antlr4-python3-runtime      4.9.3      BSD-3-Clause
 NumPy                       2.4.3      BSD-3-Clause
 SciPy                       1.17.1     BSD-3-Clause
-PyAV (av)                   17.0.0     BSD-3-Clause
-  FFmpeg (bundled in av)      8.0        LGPL-3.0-or-later
 pywebview                   6.2.1      BSD-3-Clause
 ImageHash                   4.3.2      BSD-2-Clause
 scikit-image                0.26.0     BSD-3-Clause (+ BSD-2-Clause, MIT)
@@ -270,7 +268,7 @@ BSD-3-CLAUSE LICENSE
 
 The following components are licensed under the BSD 3-Clause License:
   Flask, Werkzeug, Jinja2, MarkupSafe, NumPy, SciPy, scikit-image,
-  PyAV, pywebview, omegaconf, antlr4-python3-runtime
+  pywebview, omegaconf, antlr4-python3-runtime
 
 ---
 
@@ -511,43 +509,6 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----
-
-PyAV (av)
-Copyright (c) 2017 Mike Boers and PyAV contributors
-License: BSD-3-Clause
-
-The PyAV Python bindings are BSD-3-Clause. The wheel additionally bundles its
-own FFmpeg shared libraries, which are LGPL-3.0-or-later — see the
-LGPL-3.0-OR-LATER section below. These are distinct from both the cv2-bundled
-FFmpeg and the standalone ffmpeg/ffprobe executables.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
 
 ---
 
@@ -873,39 +834,6 @@ Copyright notices:
 
 
 ===============================================================================
-LGPL-3.0-OR-LATER (FFmpeg bundled inside PyAV)
-===============================================================================
-
-PyAV (the `av` package) bundles its own FFmpeg shared libraries inside
-av/.dylibs/ (av.libs/ on Linux).  These are built without --enable-gpl:
-avcodec_license() reports "LGPL version 3 or later", so they are
-LGPL-3.0-or-later.
-
-The bundled FFmpeg libraries are:
-  libavcodec, libavformat, libavfilter, libavutil, libavdevice,
-  libswresample, libswscale
-
-libx264 and libx265 are also present in that directory as transitive dynamic
-dependencies, but they are not compiled into FFmpeg -- were they enabled, the
-build would require --enable-gpl and avcodec_license() would report GPL.
-
-clipgen does not import `av` directly for media work.  faster-whisper does:
-faster_whisper/audio.py decodes the audio stream of a recording through PyAV
-before handing samples to Whisper.  These libraries are dynamically linked and
-unmodified, so the LGPL is satisfied by this notice plus the source pointers
-below; recipients may replace the libraries with their own build.
-
-Source code for FFmpeg is available at: https://ffmpeg.org/download.html
-Source code for the PyAV build (including its FFmpeg build configuration) is
-available at: https://github.com/PyAV-Org/PyAV
-
-The full text of the GNU Lesser General Public License version 3 is the GNU
-General Public License version 3 (reproduced in the GPL-3.0-OR-LATER section
-below) as supplemented by the additional permissions in the LGPL v3, available
-at: https://www.gnu.org/licenses/lgpl-3.0.html
-
-
-===============================================================================
 GPL-3.0-OR-LATER (FFmpeg bundled inside opencv-python-headless)
 ===============================================================================
 
@@ -988,9 +916,9 @@ third-party libraries compiled into these static builds are published by each
 provider at the URLs above.
 
 These executables are distinct from the FFmpeg *shared libraries* that arrive
-inside opencv-python-headless and PyAV (two sections back): those are linked
-into cv2.abi3.so and av respectively and loaded in-process. The executables
-here are separate GPL programs, pinned and verified by clipgen's own build.
+inside opencv-python-headless (the previous section): those are linked into
+cv2.abi3.so and loaded in-process. The executables here are separate GPL
+programs, pinned and verified by clipgen's own build.
 
 The full text of the GNU General Public License version 3 follows.
 

--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -92,6 +92,13 @@ excludes = [
     "pytest", "_pytest", "py", "pluggy", "iniconfig",
     # Other unused transitive dependencies
     "matplotlib", "IPython", "notebook", "jupyter",
+    # PyAV. Overridden out of the dependency tree (pyproject.toml), so it is
+    # not in the build venv either — this entry documents that on purpose:
+    # faster_whisper imports av at module scope but never calls it on the
+    # ndarray input path clipgen uses, and transcripts._ensure_av_stub()
+    # satisfies the import at runtime. Its wheel would re-add a second ~40 MB
+    # FFmpeg beside the vendored ffmpeg/ffprobe binaries below.
+    "av",
 ]
 
 # Bundled ffmpeg/ffprobe: pinned static GPL builds, fetched by
@@ -166,7 +173,7 @@ pyz = PYZ(a.pure)
 _strip = sys.platform == "darwin"
 
 # One-dir, not one-file. One-file re-extracts the whole archive to a *new* temp
-# directory on every launch, so every large dylib (cv2, av, onnxruntime) loads cold —
+# directory on every launch, so every large dylib (cv2, onnxruntime) loads cold —
 # no OS page cache, and macOS re-validates each code signature from scratch.
 # Measured double-click to first HTTP response: 17.6 s one-file vs 1.1 s one-dir.
 # PyInstaller also deprecated one-file + windowed on macOS ("clashes with macOS's

--- a/plans/LICENSE-PLAN.md
+++ b/plans/LICENSE-PLAN.md
@@ -59,18 +59,24 @@ short of rebuilding OpenCV — and state the position accurately:
    clipgen's files is relicensed), published at github.com/henedl/clipgen
 3. Provide source pointers for FFmpeg, x264, x265, and the opencv-python build
 4. Guard against silent drift: `build-binaries.yml` asserts the `libavcodec license:` string of
-   both the cv2- and PyAV-bundled FFmpeg on every macOS build, so a wheel bump that changes
-   either one fails CI instead of leaving a false notice in the artifact
+   the cv2-bundled FFmpeg on every macOS build, so a wheel bump that changes it fails CI instead
+   of leaving a false notice in the artifact (it also asserts PyAV stays *out* of the bundle,
+   since its notice sections were removed — see below)
 
-### PyAV and FFmpeg (decided 2026-08-15)
+### PyAV and FFmpeg (decided 2026-08-15; superseded 2026-08-16)
 
-PyAV (`av`, a hard dependency of faster-whisper) bundles a *third* FFmpeg in `av/.dylibs/`. Its
-`avcodec_license()` reports **LGPL version 3 or later** — here the "x264/x265 present but not
-linked" reading is actually correct, since enabling them would have required `--enable-gpl`.
+PyAV (`av`, a hard dependency of faster-whisper) bundled a *third* FFmpeg in `av/.dylibs/`. Its
+`avcodec_license()` reported **LGPL version 3 or later** — here the "x264/x265 present but not
+linked" reading was actually correct, since enabling them would have required `--enable-gpl`.
+The 2026-08-15 decision was to attribute it under a new LGPL-3.0-or-later section.
 
-**Decision:** attribute it under a new LGPL-3.0-or-later section. Dynamic linking of unmodified
-LGPL libraries is satisfied by notice + source pointers + the recipient's ability to relink, so
-no further obligation attaches. It is a documentation item, not a compliance problem.
+**Superseded:** PyAV is no longer shipped at all. faster-whisper only calls `av` to decode
+path inputs; `transcripts.py` now feeds `transcribe()` ndarrays decoded by the pinned ffmpeg
+(`video.decode_audio_pcm`) and stubs the module-scope `import av`
+(`transcripts._ensure_av_stub`), so the dependency is overridden out in `pyproject.toml`
+(~45 MB mac / ~69 MB Windows). The PyAV BSD entry and the whole LGPL-3.0-or-later section were
+removed from `build/THIRD-PARTY-LICENSES`, and `build-binaries.yml` now fails if `av` dylibs
+reappear in the bundle unattributed.
 
 ### Bundled ffmpeg/ffprobe executables (decided 2026-08-03)
 
@@ -121,18 +127,14 @@ of re-deriving it.
   - Does anything else in `cv2/` regress with FFmpeg off (`imgcodecs` keeps its own `libavif`)?
   - Is it moot by the time it is picked up, if #1260 lands first?
 
-- **Take PyAV off the decode path** (note only — a consistency change, not a licensing fix).
-  `source/transcripts.py` passes a **path** to `WhisperModel.transcribe()`, so PyAV's FFmpeg
-  demuxes and decodes every recording we transcribe — a third FFmpeg doing real work on user
-  media, none of it pinned or verified by our build. `transcribe()` also accepts an
-  `np.ndarray`, so decoding with the pinned ffmpeg (`-f f32le -ac 1 -ar 16000 -`) would route all
-  media through the one binary we control, and would delete the non-default-audio-track
-  workaround in `transcribe_video()` (which exists only because faster-whisper always reads the
-  container's first audio stream — `-map 0:a:N` solves it directly). Caveats: no bundle-size win
-  (`av` still ships and is still imported — `faster_whisper/__init__.py` imports it
-  transitively at module load, so it cannot be excluded), we would own the 16 kHz mono float32
-  resampling, and it materializes the whole audio array (~230 MB/hour, matching what
-  faster-whisper's own `decode_audio` already does).
+- [x] **Take PyAV off the decode path** — Done 2026-08-16, and it went further than this note
+  anticipated: the "cannot be excluded" caveat was wrong. `faster_whisper/audio.py` imports `av`
+  at module scope but only *calls* it inside `decode_audio()`, so an empty stub module
+  (`transcripts._ensure_av_stub`) satisfies the import and `av` is overridden out of the
+  dependency tree entirely (a ~45 MB mac / ~69 MB Windows bundle-size win on top of the
+  consistency one). `video.decode_audio_pcm` decodes with the pinned ffmpeg
+  (`-map 0:a:N -ac 1 -ar 16000 -f f32le`), which also deleted the non-default-audio-track
+  demux workaround in `transcribe_video()`.
 
 - **Full transitive-dependency attribution sweep.** Step 5 covered direct dependencies only. The
   bundle contains a long tail of unlisted transitives (onnxruntime, tokenizers, huggingface-hub,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "flask>=3.0.0",
     "werkzeug>=3.0.0",
     "faster-whisper>=1.2.0",
-    "av>=11.0.0",
     "opencv-python-headless>=4.8.0",
     "numpy>=1.26.0",
     "Pillow>=10.0.0",
@@ -64,7 +63,15 @@ required-version = ">=0.11.0"
 # opencv-python-headless, which provides every cv2 API rapidocr uses.
 # Without this override uv would install both wheels into the same cv2/
 # tree, where they clobber each other file-by-file.
-override-dependencies = ["opencv-python ; sys_platform == 'never'"]
+override-dependencies = [
+    "opencv-python ; sys_platform == 'never'",
+    # faster-whisper declares av (PyAV) but only calls it inside decode_audio(),
+    # which clipgen never reaches: transcripts.py feeds transcribe() ndarrays
+    # decoded by the ffmpeg CLI and stubs the module-scope `import av`
+    # (transcripts._ensure_av_stub). Overriding it out drops PyAV's bundled
+    # second FFmpeg (~45 MB of wheel dylibs on macOS, ~69 MB on Windows).
+    "av ; sys_platform == 'never'",
+]
 
 [tool.ty.environment]
 # ty auto-detects a module root only when it is literally named `src`

--- a/source/server.py
+++ b/source/server.py
@@ -4286,7 +4286,6 @@ class LiveServer:
 # console so a terminal launch narrates the cold start too.
 _BOOT_MESSAGES = {
     "starting": "Starting clipgen…",
-    "video_libs": "Loading video engine…",
     "vision_libs": "Loading computer-vision libraries…",
     "workspace": "Preparing workspace…",
     "interface": "Building the interface…",
@@ -4497,12 +4496,10 @@ def serve_combined_app(
     def build() -> None:
         try:
             # Preload first, under the stderr suppressor, before the blueprint
-            # imports below pull cv2 themselves (and before faster-whisper pulls
-            # av) — see preload_av_libs_quietly for why order matters.
-            utils.preload_av_libs_quietly(
-                on_phase=lambda lib: set_phase(
-                    "video_libs" if lib == "av" else "vision_libs"
-                )
+            # imports below pull cv2 themselves — see preload_vision_libs_quietly
+            # for why order matters.
+            utils.preload_vision_libs_quietly(
+                on_phase=lambda lib: set_phase("vision_libs")
             )
             set_phase("workspace")
             # Reclaim orphaned scratch files (atomic-write .tmp siblings, reel

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -45,6 +45,7 @@ import re
 import sys
 import threading
 import time
+import types
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -267,6 +268,21 @@ def _confirm_model_download(model_name: str) -> bool:
     return False
 
 
+def _ensure_av_stub() -> None:
+    """Make ``import faster_whisper`` work without PyAV installed.
+
+    ``faster_whisper/audio.py`` does ``import av`` at module scope but only
+    *calls* it inside ``decode_audio()``, which clipgen never reaches: every
+    ``transcribe()`` call gets a 16 kHz float32 ndarray decoded by the ffmpeg
+    CLI (``video.decode_audio_pcm``). PyAV is overridden out of the dependency
+    tree in ``pyproject.toml`` because its wheel bundles a second ~40 MB FFmpeg
+    clipgen has no use for, so an empty module satisfies the import. Guarded by
+    a smoke test in tests/test_transcripts.py so a faster-whisper bump that
+    starts *using* ``av`` at import time fails loudly there, not here.
+    """
+    sys.modules.setdefault("av", types.ModuleType("av"))
+
+
 def _resolve_transcribe_device() -> str:
     """Return the device string to hand ``WhisperModel``.
 
@@ -326,6 +342,7 @@ def _load_model(model_name: str | None = None) -> Any:
         profiling.count("transcribe.model_cache.miss")
 
         try:
+            _ensure_av_stub()
             from faster_whisper import WhisperModel
         except ImportError:
             utils.error_print(
@@ -573,30 +590,28 @@ def transcribe_video(
 
     lang = language or config.TRANSCRIBE_LANGUAGE
 
-    # faster-whisper's decoder always reads the container's first audio stream —
-    # there is no index parameter — so a non-default track has to be demuxed to
-    # its own file first. Track 0 keeps the raw video path (byte-identical to the
-    # pre-track-picker behaviour); the extraction is the same cached, locked one
-    # the browser's per-track volume mixer uses.
-    audio_source = str(video_path)
-    if idx > 0:
-        extracted = video_mod.extract_audio_track(video_path, idx)
-        if extracted is None:
-            # Never fall back to track 0 — that would silently transcribe the
-            # wrong audio, which reads as "clipgen is broken", not "it failed".
-            utils.warning_print(
-                f"Could not extract audio track {idx + 1} from "
-                f"{Path(video_path).name} — skipping transcription."
-            )
-            return None
-        audio_source = str(extracted)
+    # Decode the selected stream to PCM ourselves (ffmpeg CLI, ``-map 0:a:N``)
+    # instead of handing faster-whisper the path: its own decoder is PyAV,
+    # which is deliberately not installed (see _ensure_av_stub), and it can
+    # only read the container's first audio stream anyway.
+    audio_source = video_mod.decode_audio_pcm(str(video_path), idx)
+    if audio_source is None:
+        # Never fall back to another track — that would silently transcribe the
+        # wrong audio, which reads as "clipgen is broken", not "it failed".
+        utils.warning_print(
+            f"Could not decode audio track {idx + 1} from "
+            f"{Path(video_path).name} — skipping transcription."
+        )
+        return None
+    if _is_cancelled():
+        raise _TranscriptionCancelled
 
     try:
         transcribe_kwargs = _build_transcribe_kwargs(
             language=lang, initial_prompt=prompt
         )
-        # Not a free call: faster-whisper loads the audio, extracts features and
-        # runs VAD + language detection *eagerly* here, then hands back a lazy
+        # Not a free call: faster-whisper extracts features and runs VAD +
+        # language detection *eagerly* here, then hands back a lazy
         # generator. That is why info.duration_after_vad is already populated
         # below. Without this span the TRANSCRIBE_VAD_* knobs — the ones
         # PERFORMANCE.md calls "the big win" — are the one thing the transcribe

--- a/source/utils.py
+++ b/source/utils.py
@@ -64,35 +64,25 @@ def suppress_native_stderr():
         os.close(saved_fd)
 
 
-_av_libs_preloaded = False
+_vision_libs_preloaded = False
 
 
-def preload_av_libs_quietly(on_phase: Callable[[str], None] | None = None) -> None:
-    """Import ``av`` and ``cv2`` once, early, with native stderr silenced.
+def preload_vision_libs_quietly(on_phase: Callable[[str], None] | None = None) -> None:
+    """Import ``cv2`` once, early, with native stderr silenced.
 
-    Both wheels bundle their own FFmpeg ``libavdevice`` (an AVFoundation
-    capture-device library clipgen never uses). On macOS, whichever loads
-    *second* makes the ObjC runtime print a "Class AVFFrameReceiver is
-    implemented in both ..." duplicate-class warning. Pre-loading both here
-    under :func:`suppress_native_stderr` means later lazy ``import cv2`` /
-    ``import av`` calls find them already resident (no second dlopen, no
-    warning). Idempotent; either import missing is a no-op.
-
-    *on_phase* is called with ``"av"`` / ``"cv2"`` before each import — each
-    can take ~10s of disk I/O on a cold machine, and the server's boot page
-    narrates which one it is waiting on.
+    The wheel's dylibs can emit native noise on load, and the import can take
+    ~10s of disk I/O on a cold machine — pre-loading here under
+    :func:`suppress_native_stderr` means later lazy ``import cv2`` calls find
+    it already resident, and the server's boot page can narrate the wait
+    (*on_phase* is called with ``"cv2"`` before the import). Idempotent; a
+    missing install is a no-op. This used to preload PyAV too, whose bundled
+    ``libavdevice`` duplicated cv2's and tripped a macOS duplicate-ObjC-class
+    warning — PyAV is no longer a dependency (see transcripts._ensure_av_stub).
     """
-    global _av_libs_preloaded
-    if _av_libs_preloaded:
+    global _vision_libs_preloaded
+    if _vision_libs_preloaded:
         return
-    _av_libs_preloaded = True
-    if on_phase is not None:
-        on_phase("av")
-    with suppress_native_stderr():
-        try:
-            import av  # noqa: F401
-        except ImportError:
-            pass
+    _vision_libs_preloaded = True
     if on_phase is not None:
         on_phase("cv2")
     with suppress_native_stderr():

--- a/source/video.py
+++ b/source/video.py
@@ -15,7 +15,10 @@ import threading
 from collections import Counter
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
 
 import config
 import files
@@ -1999,6 +2002,66 @@ def extract_audio_track(filepath: str, audio_index: int) -> Path | None:
             _prune_stale_audio_tracks(cache_dir, digest, mtime_ns)
             return out_path
         return None
+
+
+def decode_audio_pcm(filepath: str, audio_index: int = 0) -> "np.ndarray | None":
+    """Decode one audio stream to 16 kHz mono float32 PCM for transcription.
+
+    Whisper consumes exactly this shape as an ndarray, which keeps PyAV out of
+    the dependency tree: faster-whisper only calls ``av`` to decode *path*
+    inputs, and ``-map 0:a:<index>`` selects the stream directly, so a
+    non-default track no longer needs a demux-to-temp-file round trip either.
+    Returns a writable ``np.ndarray`` (float32), or ``None`` on any failure —
+    including an empty stream, since zero samples would only fail later and
+    less legibly inside the model. ~4 MB per audio-minute; the transient
+    bytes→array copy briefly doubles that, matching what faster-whisper's own
+    ``decode_audio`` peaked at.
+    """
+    if config.DEBUGGING:
+        return None
+    import numpy as np  # deferred: keep video.py cheap for non-transcribe CLI paths
+
+    cmd = [
+        "ffmpeg",
+        "-nostdin",
+        "-v",
+        "error",
+        "-i",
+        filepath,
+        "-map",
+        f"0:a:{audio_index}",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-f",
+        "f32le",
+        "pipe:1",
+    ]
+    try:
+        with profiling.span("transcribe.decode_audio"):
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                # Audio-only decode runs far faster than realtime, but it does
+                # scale with session length — bound it loosely so a wedged
+                # ffmpeg can't pin a transcription worker forever.
+                timeout=900,
+            )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        utils.verbose_print(f"PCM decode failed for {filepath}: {exc}")
+        return None
+    if result.returncode != 0 or not result.stdout:
+        stderr_tail = result.stderr.decode("utf-8", "replace").strip()[-300:]
+        utils.verbose_print(
+            f"PCM decode failed for {filepath} "
+            f"(exit {result.returncode}): {stderr_tail or 'no output'}"
+        )
+        return None
+    # bytearray copy: frombuffer over immutable bytes yields a read-only array,
+    # and the model must be free to operate on a writable waveform.
+    return np.frombuffer(bytearray(result.stdout), dtype=np.float32)
 
 
 def _delete_quietly(path: Path) -> None:

--- a/tests/test_boot_dispatcher.py
+++ b/tests/test_boot_dispatcher.py
@@ -119,7 +119,7 @@ def test_serve_combined_app_raises_on_build_failure(monkeypatch):
     def _exit_build(**kwargs: Any) -> Any:
         raise SystemExit(1)
 
-    monkeypatch.setattr(utils, "preload_av_libs_quietly", lambda **kwargs: None)
+    monkeypatch.setattr(utils, "preload_vision_libs_quietly", lambda **kwargs: None)
     monkeypatch.setattr(utils, "sweep_stale_temp_artifacts", lambda: None)
     monkeypatch.setattr(server, "build_combined_app", _exit_build)
 
@@ -136,7 +136,7 @@ def test_serve_combined_app_returns_before_build_completes(monkeypatch):
         release.wait(timeout=10)
         return _fake_app
 
-    monkeypatch.setattr(utils, "preload_av_libs_quietly", lambda **kwargs: None)
+    monkeypatch.setattr(utils, "preload_vision_libs_quietly", lambda **kwargs: None)
     monkeypatch.setattr(utils, "sweep_stale_temp_artifacts", lambda: None)
     monkeypatch.setattr(server, "build_combined_app", _slow_build)
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -694,9 +694,8 @@ def test_licenses_flag_prints_the_notice_and_exits(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "THIRD-PARTY SOFTWARE NOTICES AND LICENSES" in out
     # Attribution for the copyleft components is the whole point of the file;
-    # a notice that lost its GPL/LGPL sections would still pass a length check.
+    # a notice that lost its GPL sections would still pass a length check.
     assert "GNU GENERAL PUBLIC LICENSE" in out
-    assert "LGPL-3.0-OR-LATER" in out
 
 
 def test_licenses_flag_fails_loudly_when_the_notice_is_missing(

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -244,7 +244,6 @@ def test_license_notice_is_tracked_and_bundled() -> None:
     for heading in (
         "GPL-3.0-OR-LATER (bundled ffmpeg and ffprobe executables)",
         "GPL-3.0-OR-LATER (FFmpeg bundled inside opencv-python-headless)",
-        "LGPL-3.0-OR-LATER (FFmpeg bundled inside PyAV)",
         "MOZILLA PUBLIC LICENSE 2.0",
     ):
         assert heading in text, f"THIRD-PARTY-LICENSES lost its {heading!r} section"

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -402,6 +402,13 @@ def whisper_probe(monkeypatch, tmp_path):
         "probe_video_properties",
         lambda _p: {"audio_codec": "aac", "audio_tracks": [{"index": 0}]},
     )
+    import numpy as np
+
+    monkeypatch.setattr(
+        video_mod,
+        "decode_audio_pcm",
+        lambda _path, _idx=0: np.zeros(16000, dtype=np.float32),
+    )
     src = tmp_path / "study_P01.mp4"
     src.write_bytes(b"stub")
 
@@ -440,7 +447,10 @@ def test_transcribe_flushes_on_cancel(whisper_probe):
 
     def cancelled():
         state["n"] += 1
-        return state["n"] > 3
+        # Four pre-loop checks (before/after model load, after PCM decode,
+        # after prepare) — trip on the first between-segments check so the
+        # cancel lands mid-loop, where the finally-flush is what's under test.
+        return state["n"] > 4
 
     with pytest.raises(transcripts._TranscriptionCancelled):
         whisper_probe(_fake_model(segs, per_segment_delay=0.01), cancel_flag=cancelled)

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -1014,7 +1014,7 @@ def test_combined_server_forces_non_interactive(monkeypatch):
         return [b"ok"]
 
     monkeypatch.setattr(utils, "NO_INPUT_MODE", False)
-    monkeypatch.setattr(utils, "preload_av_libs_quietly", lambda **kwargs: None)
+    monkeypatch.setattr(utils, "preload_vision_libs_quietly", lambda **kwargs: None)
     monkeypatch.setattr(utils, "sweep_stale_temp_artifacts", lambda: None)
     monkeypatch.setattr(server, "build_combined_app", lambda **kwargs: _fake_app)
 

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import config
@@ -13,6 +14,10 @@ from transcripts import TranscriptResult, TranscriptSegment
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
+
+# One second of silence in the exact shape video.decode_audio_pcm hands the
+# model: 16 kHz mono float32.
+_FAKE_AUDIO = np.zeros(16000, dtype=np.float32)
 
 
 def _sample_result(source="study_P01.mp4") -> TranscriptResult:
@@ -310,6 +315,8 @@ class TestBuildTranscribeKwargs:
 
 class TestTranscribeVideoWhisperKwargs:
     def test_transcribe_passes_kwargs_to_model(self, monkeypatch):
+        import video as video_mod
+
         captured: dict = {}
 
         class FakeSeg:
@@ -321,13 +328,16 @@ class TestTranscribeVideoWhisperKwargs:
             language = "en"
 
         class FakeModel:
-            def transcribe(self, path: str, **kwargs):
+            def transcribe(self, audio, **kwargs):
                 captured.update(kwargs)
                 return iter([FakeSeg()]), FakeInfo()
 
         monkeypatch.setattr(config, "DEBUGGING", False)
         monkeypatch.setattr(
             transcripts, "_load_model", lambda model_name=None: FakeModel()
+        )
+        monkeypatch.setattr(
+            video_mod, "decode_audio_pcm", lambda _path, _idx=0: _FAKE_AUDIO
         )
         monkeypatch.setattr(config, "TRANSCRIBE_VAD_FILTER", True)
         monkeypatch.setattr(config, "TRANSCRIBE_HALLUCINATION_SILENCE_THRESHOLD", 0.0)
@@ -395,8 +405,8 @@ def _multitrack_probe(*labels):
 
 
 class TestTranscribeVideoAudioTrack:
-    """faster-whisper always decodes stream 0, so a non-default track has to be
-    demuxed first. These pin which path actually reaches the model."""
+    """The selected stream is decoded to PCM by video.decode_audio_pcm
+    (``-map 0:a:N``). These pin which stream actually reaches the model."""
 
     def _install_model(self, monkeypatch):
         captured: dict = {}
@@ -410,8 +420,8 @@ class TestTranscribeVideoAudioTrack:
             language = "en"
 
         class FakeModel:
-            def transcribe(self, path: str, **_kwargs):
-                captured["path"] = path
+            def transcribe(self, audio, **_kwargs):
+                captured["audio"] = audio
                 return iter([FakeSeg()]), FakeInfo()
 
         monkeypatch.setattr(config, "DEBUGGING", False)
@@ -420,78 +430,77 @@ class TestTranscribeVideoAudioTrack:
         )
         return captured
 
-    def test_track_zero_passes_the_video_path_and_never_extracts(self, monkeypatch):
+    @staticmethod
+    def _install_decode(monkeypatch):
+        import video as video_mod
+
+        calls: list = []
+        monkeypatch.setattr(
+            video_mod,
+            "decode_audio_pcm",
+            lambda path, idx=0: calls.append((path, idx)) or _FAKE_AUDIO,
+        )
+        return calls
+
+    def test_track_zero_decodes_stream_zero(self, monkeypatch):
         import video as video_mod
 
         captured = self._install_model(monkeypatch)
+        calls = self._install_decode(monkeypatch)
         monkeypatch.setattr(
             video_mod, "probe_video_properties", _multitrack_probe("Mic", "System")
-        )
-        monkeypatch.setattr(
-            video_mod,
-            "extract_audio_track",
-            lambda *_a: pytest.fail("track 0 must not be extracted"),
         )
 
         result = transcripts.transcribe_video("/fake/video.mp4", audio_index=0)
         assert result is not None
-        assert captured["path"] == "/fake/video.mp4"
-        # The extracted .m4a is a cache artifact; source_file stays the video.
+        assert calls == [("/fake/video.mp4", 0)]
+        assert captured["audio"] is _FAKE_AUDIO
+        # The PCM array is transient; source_file stays the video.
         assert result["source_file"] == "/fake/video.mp4"
 
-    def test_nonzero_track_transcribes_the_extracted_audio(self, monkeypatch, tmp_path):
+    def test_nonzero_track_decodes_that_stream(self, monkeypatch):
         import video as video_mod
 
         captured = self._install_model(monkeypatch)
-        extracted = tmp_path / "track1.m4a"
-        extracted.write_bytes(b"x")
-        calls: list = []
+        calls = self._install_decode(monkeypatch)
         monkeypatch.setattr(
             video_mod, "probe_video_properties", _multitrack_probe("System", "Mic")
-        )
-        monkeypatch.setattr(
-            video_mod,
-            "extract_audio_track",
-            lambda path, idx: calls.append((path, idx)) or extracted,
         )
 
         result = transcripts.transcribe_video("/fake/video.mp4", audio_index=1)
         assert result is not None
         assert calls == [("/fake/video.mp4", 1)]
-        assert captured["path"] == str(extracted)
+        assert captured["audio"] is _FAKE_AUDIO
         assert result["source_file"] == "/fake/video.mp4"
 
-    def test_auto_detects_the_speech_track(self, monkeypatch, tmp_path):
+    def test_auto_detects_the_speech_track(self, monkeypatch):
         import video as video_mod
 
         captured = self._install_model(monkeypatch)
-        extracted = tmp_path / "track1.m4a"
-        extracted.write_bytes(b"x")
+        calls = self._install_decode(monkeypatch)
         monkeypatch.setattr(
             video_mod,
             "probe_video_properties",
             _multitrack_probe("System Audio", "Participant Mic"),
         )
-        monkeypatch.setattr(
-            video_mod, "extract_audio_track", lambda _path, _idx: extracted
-        )
 
         result = transcripts.transcribe_video("/fake/video.mp4")
         assert result is not None
-        assert captured["path"] == str(extracted)
+        assert calls == [("/fake/video.mp4", 1)]
+        assert captured["audio"] is _FAKE_AUDIO
 
-    def test_failed_extraction_fails_loudly(self, monkeypatch, capsys):
-        """Never fall back to track 0 — that transcribes the wrong audio."""
+    def test_failed_decode_fails_loudly(self, monkeypatch, capsys):
+        """Never fall back to another track — that transcribes the wrong audio."""
         import video as video_mod
 
         self._install_model(monkeypatch)
         monkeypatch.setattr(
             video_mod, "probe_video_properties", _multitrack_probe("System", "Mic")
         )
-        monkeypatch.setattr(video_mod, "extract_audio_track", lambda _path, _idx: None)
+        monkeypatch.setattr(video_mod, "decode_audio_pcm", lambda _path, _idx=0: None)
 
         assert transcripts.transcribe_video("/fake/video.mp4", audio_index=1) is None
-        assert "Could not extract audio track 2" in capsys.readouterr().out
+        assert "Could not decode audio track 2" in capsys.readouterr().out
 
     def test_out_of_range_track_returns_none_without_loading_model(
         self, monkeypatch, capsys
@@ -1019,6 +1028,9 @@ class TestTranscriptWorker:
             lambda *_a, **_k: {"duration": 100.0, "audio_codec": "aac"},
         )
         monkeypatch.setattr(
+            video_mod, "decode_audio_pcm", lambda _path, _idx=0: _FAKE_AUDIO
+        )
+        monkeypatch.setattr(
             transcripts, "load_transcripts_manifest", lambda: {"corrections": []}
         )
 
@@ -1454,6 +1466,8 @@ class TestIsWhisperModelCached:
         import inspect
         import re
 
+        # av is deliberately not installed; the package import needs the stub.
+        transcripts._ensure_av_stub()
         import faster_whisper.utils as fwu
 
         for m in transcripts.WHISPER_MODELS:
@@ -1465,6 +1479,30 @@ class TestIsWhisperModelCached:
         assert match, "download_model no longer builds a literal allow_patterns"
         theirs = set(re.findall(r'"([^"]+)"', match.group(1)))
         assert theirs == set(transcripts._WHISPER_ALLOW_PATTERNS)
+
+
+def test_faster_whisper_imports_with_av_stub_only():
+    """The PyAV-free import contract, pinned from both ends.
+
+    PyAV is overridden out of the dependency tree (pyproject.toml): its wheel
+    bundles a second ~40 MB FFmpeg, and faster-whisper only calls ``av`` to
+    decode *path* inputs while clipgen always passes ffmpeg-decoded ndarrays.
+    Two ways this can silently rot, both caught here: the real ``av``
+    distribution reappearing (reinstating it must be a deliberate change —
+    it drags licensing sections of build/THIRD-PARTY-LICENSES and the
+    clipgen.spec exclude back with it), and a faster-whisper upgrade that
+    starts *executing* ``av`` at import time, which the empty stub module
+    cannot satisfy.
+    """
+    import importlib.metadata
+
+    with pytest.raises(importlib.metadata.PackageNotFoundError):
+        importlib.metadata.distribution("av")
+
+    transcripts._ensure_av_stub()
+    import faster_whisper
+
+    assert hasattr(faster_whisper, "WhisperModel")
 
 
 class TestConfirmModelDownload:
@@ -1517,6 +1555,7 @@ class TestConfirmModelDownload:
         monkeypatch.setattr(utils, "read_user_input", lambda _p: "n")
         monkeypatch.setattr(transcripts, "_cached_model", None)
         monkeypatch.setattr(transcripts, "_cached_model_name", None)
+        transcripts._ensure_av_stub()  # av is deliberately not installed
         import faster_whisper
 
         monkeypatch.setattr(

--- a/tests/test_utils_timestamps.py
+++ b/tests/test_utils_timestamps.py
@@ -272,6 +272,11 @@ def test_normalize_track_language_covers_every_whisper_language():
     """The table exists to serve transcription output, so a Whisper code that
     silently degrades to "und" is the exact bug this function was added to fix.
     Skips rather than fails where faster-whisper is not installed."""
+    import transcripts
+
+    # av is deliberately not installed (pyproject override); without the stub
+    # the package import fails and importorskip would silently drop this test.
+    transcripts._ensure_av_stub()
     pytest = __import__("pytest")
     tokenizer = pytest.importorskip("faster_whisper.tokenizer")
     unmapped = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.12"
 
 [manifest]
-overrides = [{ name = "opencv-python", marker = "sys_platform == 'never'" }]
+overrides = [
+    { name = "av", marker = "sys_platform == 'never'" },
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -47,24 +50,6 @@ name = "av"
 version = "17.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/eb/abca886df3a091bc406feb5ff71b4c4f426beaae6b71b9697264ce8c7211/av-17.0.0.tar.gz", hash = "sha256:c53685df73775a8763c375c7b2d62a6cb149d992a26a4b098204da42ade8c3df", size = 4410769, upload-time = "2026-03-14T14:38:45.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/fb/55e3b5b5d1fc61466292f26fbcbabafa2642f378dc48875f8f554591e1a4/av-17.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ed4013fac77c309a4a68141dcf6148f1821bb1073a36d4289379762a6372f711", size = 23238424, upload-time = "2026-03-14T14:38:05.856Z" },
-    { url = "https://files.pythonhosted.org/packages/52/03/9ace1acc08bc9ae38c14bf3a4b1360e995e4d999d1d33c2cbd7c9e77582a/av-17.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:e44b6c83e9f3be9f79ee87d0b77a27cea9a9cd67bd630362c86b7e56a748dfbb", size = 18709043, upload-time = "2026-03-14T14:38:08.288Z" },
-    { url = "https://files.pythonhosted.org/packages/00/c0/637721f3cd5bb8bd16105a1a08efd781fc12f449931bdb3a4d0cfd63fa55/av-17.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b440da6ac47da0629d509316f24bcd858f33158dbdd0f1b7293d71e99beb26de", size = 34018780, upload-time = "2026-03-14T14:38:10.45Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/59/d19bc3257dd985d55337d7f0414c019414b97e16cd3690ebf9941a847543/av-17.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1060cba85f97f4a337311169d92c0b5e143452cfa5ca0e65fa499d7955e8592e", size = 36358757, upload-time = "2026-03-14T14:38:13.092Z" },
-    { url = "https://files.pythonhosted.org/packages/52/6c/a1f4f2677bae6f2ade7a8a18e90ebdcf70690c9b1c4e40e118aa30fa313f/av-17.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:deda202e6021cfc7ba3e816897760ec5431309d59a4da1f75df3c0e9413d71e7", size = 35195281, upload-time = "2026-03-14T14:38:15.789Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ea/52b0fc6f69432c7bf3f5fbe6f707113650aa40a1a05b9096ffc2bba4f77d/av-17.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffaf266a1a9c2148072de0a4b5ae98061465178d2cfaa69ee089761149342974", size = 37444817, upload-time = "2026-03-14T14:38:18.563Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ad/d2172966282cb8f146c13b6be7416efefde74186460c5e1708ddfc13dba6/av-17.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:45a35a40b2875bf2f98de7c952d74d960f92f319734e6d28e03b4c62a49e6f49", size = 28888553, upload-time = "2026-03-14T14:38:21.223Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/bb/c5a4c4172c514d631fb506e6366b503576b8c7f29809cf42aca73e28ff01/av-17.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:3d32e9b5c5bbcb872a0b6917b352a1db8a42142237826c9b49a36d5dbd9e9c26", size = 21916910, upload-time = "2026-03-14T14:38:23.706Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8e/c40ac08e63f79387c59f6ecc38f47d4c942b549130eee579ec1a91f6a291/av-17.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:d13250fb4b4522e9a6bec32da082556d5f257110ea223758151375748d9bbe25", size = 23483029, upload-time = "2026-03-14T14:38:25.758Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/fb/b4419494bfc249163ec393c613966d66db7e95c76da3345711cd115a79df/av-17.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:dbb56aa3b7ae72451d1bf6e9d37c7d83d39b97af712f73583ff419fbf08fc237", size = 18920446, upload-time = "2026-03-14T14:38:27.905Z" },
-    { url = "https://files.pythonhosted.org/packages/30/62/c2306d91602ddad2c56106f21dcb334fd51d5ea2e952f7fa025bb8aa39fc/av-17.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a213ac9e83b7ab12c2e9f277a09cac8e9d85cf0883efdab7a87a60e2e4e48879", size = 37477266, upload-time = "2026-03-14T14:38:30.404Z" },
-    { url = "https://files.pythonhosted.org/packages/28/cd/c8510a9607886785c0b3ca019d503e888c3757529be42a7287fe2bfa92d5/av-17.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:e15c88bb0921f9435bcc5a27a0863dba571a80ad5e1389c4fcf2073833bb4a74", size = 39572988, upload-time = "2026-03-14T14:38:32.984Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/2d/207d9361e25b5abec9be335bbab4df6b6b838e2214be4b374f4cfb285427/av-17.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:096cfd1e9fc896506726c7c42aaf9b370e78c2f257cde4d6ddb6c889bfcc49ec", size = 38399591, upload-time = "2026-03-14T14:38:35.465Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ca/307740c6aa2980966bf11383ffcb04bacc5b13f3d268ab4cfb274ad6f793/av-17.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3649ab3d2c7f58049ded1a36e100c0d8fd529cf258f41dd88678ba824034d8c9", size = 40590681, upload-time = "2026-03-14T14:38:38.269Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f2/6fdb26d0651adf409864cb2a0d60da107e467d3d1aabc94b234ead54324a/av-17.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e5002271ab2135b551d980c2db8f3299d452e3b9d3633f24f6bb57fffe91cd10", size = 29216337, upload-time = "2026-03-14T14:38:40.83Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0a/0896b829a39b5669a2d811e1a79598de661693685cd62b31f11d0c18e65b/av-17.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dba98603fc4665b4f750de86fbaf6c0cfaece970671a9b529e0e3d1711e8367e", size = 22071058, upload-time = "2026-03-14T14:38:43.663Z" },
-]
 
 [[package]]
 name = "blinker"
@@ -240,7 +225,6 @@ name = "clipgen"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "av" },
     { name = "faster-whisper" },
     { name = "flask" },
     { name = "gspread" },
@@ -269,7 +253,6 @@ ui = [
 
 [package.metadata]
 requires-dist = [
-    { name = "av", specifier = ">=11.0.0" },
     { name = "faster-whisper", specifier = ">=1.2.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "gspread", specifier = ">=3.7.0" },
@@ -429,7 +412,7 @@ name = "faster-whisper"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av" },
+    { name = "av", marker = "sys_platform == 'never'" },
     { name = "ctranslate2" },
     { name = "huggingface-hub" },
     { name = "onnxruntime" },


### PR DESCRIPTION
## Summary

faster-whisper only calls PyAV inside `decode_audio()`, which ndarray input never reaches — so `av` existed solely to decode paths our vendored ffmpeg can already decode. Overriding it out of the dependency tree drops ~45 MB of bundled second-FFmpeg dylibs from the macOS bundle (~69 MB on Windows).

- `video.decode_audio_pcm()`: ffmpeg CLI `-map 0:a:N -ac 1 -ar 16000 -f f32le`, replacing the non-default-track demux-to-temp-file workaround in `transcribe_video()`
- `transcripts._ensure_av_stub()`: empty module satisfies faster_whisper's module-scope `import av`; a tripwire test pins the contract from both ends (real `av` reappearing, or a faster-whisper bump that executes `av` at import time)
- `pyproject.toml`: `av` removed, `override-dependencies` entry added (same pattern as opencv-python); `clipgen.spec` excludes `av` defensively
- `preload_av_libs_quietly` → `preload_vision_libs_quietly` (cv2 only) — the duplicate-libavdevice ObjC warning needed two FFmpeg copies in one process
- `THIRD-PARTY-LICENSES`: PyAV entry + LGPL-3.0-or-later section removed; `build-binaries.yml` now asserts `av` stays *out* of the bundle instead of asserting its license string; `plans/LICENSE-PLAN.md` updated

## Test plan

- [x] `ruff format --check` + `ruff check` + `ty check` clean; full suite 3297 passed
- [x] End-to-end: real whisper (`tiny`) on a synthesized two-audio-track video — speech track transcribed via explicit index, tone track yields no segments, `av` stub active, `av` absent from the venv
- [x] Manual transcript run (maintainer)
- [x] `build-binaries` workflow dispatch on this branch — both legs green, av-absence guard passed (run 31969452396); artifacts: macOS 251→232 MB, Windows 583→537 MB vs previous build
