### PR TITLE
build(macos): compile OpenCV without FFmpeg to make the DMG GPL-free

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -188,10 +188,18 @@ jobs:
             echo "::error::cv2 ships bundled dylibs — the no-FFmpeg self-built wheel was not used."
             exit 1
           fi
-          if find dist/clipgen.app -type f \
-            \( -name "libav*.dylib" -o -name "libsw*.dylib" \
+          # Exact FFmpeg family names, not a libav*/libsw* glob: Pillow ships
+          # libavif (the BSD AV1 *image* codec, no FFmpeg relation), which a
+          # glob would flag — it did, on this guard's first green-wheel run.
+          offenders="$(find dist/clipgen.app -type f \
+            \( -name "libavcodec*.dylib" -o -name "libavformat*.dylib" \
+               -o -name "libavutil*.dylib" -o -name "libavdevice*.dylib" \
+               -o -name "libavfilter*.dylib" -o -name "libswscale*.dylib" \
+               -o -name "libswresample*.dylib" -o -name "libpostproc*.dylib" \
                -o -name "libx264*.dylib" -o -name "libx265*.dylib" \) \
-            ! -path "*/bin/*" | grep -q .; then
+            ! -path "*/bin/*")"
+          if [ -n "$offenders" ]; then
+            printf '%s\n' "$offenders"
             echo "::error::FFmpeg/x264/x265 shared libraries found outside bin/;"
             echo "::error::the macOS app is conveyed as MIT and must not link GPL code."
             exit 1

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -55,9 +55,14 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        # uv sync --locked (not `uv pip install .`) so the env exactly matches
+        # uv.lock, and every later `uv run` in this workflow passes --no-sync.
+        # A plain `uv run` re-syncs the project env against the lock first,
+        # which would silently replace the force-reinstalled no-FFmpeg cv2
+        # wheel (below) with the official GPL-tainted one from PyPI — the
+        # pre-PyInstaller assert caught exactly that on the first CI run.
         run: |
-          uv venv
-          uv pip install .
+          uv sync --locked
           uv pip install pyinstaller==6.19.0
 
       # The official opencv-python-headless macOS arm64 wheels bundle a
@@ -108,8 +113,10 @@ jobs:
           set -euo pipefail
           uv pip install --force-reinstall --no-deps build/opencv-wheel/opencv_python_headless-*.whl
           # Fail here, before PyInstaller, if the wheel somehow carries FFmpeg
-          # (e.g. a cached wheel built before a flag change).
-          uv run python -c "import cv2; bi = cv2.getBuildInformation(); \
+          # (e.g. a cached wheel built before a flag change). Deliberately
+          # .venv/bin/python, not `uv run python`: a syncing uv run would
+          # reinstall the official wheel from the lock and defeat this step.
+          .venv/bin/python -c "import cv2; bi = cv2.getBuildInformation(); \
             assert 'FFMPEG' not in bi, 'self-built cv2 unexpectedly enables FFMPEG'; \
             print('cv2', cv2.__version__, '- no FFmpeg')"
           if find .venv -type d -name ".dylibs" -path "*cv2*" | grep -q .; then
@@ -124,11 +131,14 @@ jobs:
 
       - name: Fetch pinned vendor files (ffmpeg + OCR models)
         # Idempotent: a cache hit makes this a hash-check no-op. The spec
-        # refuses to build without these files.
-        run: uv run build/fetch_binaries.py
+        # refuses to build without these files. --no-sync: see Install
+        # dependencies.
+        run: uv run --no-sync build/fetch_binaries.py
 
       - name: Build executable
-        run: uv run pyinstaller --clean --noconfirm build/clipgen.spec
+        # --no-sync: a syncing uv run would swap the no-FFmpeg cv2 back to the
+        # official GPL wheel right before bundling (see Install dependencies).
+        run: uv run --no-sync pyinstaller --clean --noconfirm build/clipgen.spec
 
       - name: Verify bundled ffmpeg features (macOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -60,6 +60,62 @@ jobs:
           uv pip install .
           uv pip install pyinstaller==6.19.0
 
+      # The official opencv-python-headless macOS arm64 wheels bundle a
+      # GPL-3-configured Homebrew FFmpeg (upstream bug opencv/opencv-python#1260,
+      # open as of 2026-08-16), which would force the whole DMG to be conveyed
+      # GPL-3.0-or-later. The dylibs cannot be stripped post-hoc, so the macOS
+      # leg rebuilds the same version from its published sdist with FFmpeg off:
+      # zero bundled dylibs (Apple system frameworks only), all image codecs
+      # static in-tree, and −76 MB unpacked. clipgen never uses cv2's video I/O.
+      # Research + local repro recipe: plans/OPENCV-SELF-COMPILE-PLAN.md.
+      - name: Restore no-FFmpeg OpenCV wheel (macOS)
+        if: matrix.os == 'macos-latest'
+        id: opencv-wheel
+        uses: actions/cache@v6
+        with:
+          path: build/opencv-wheel
+          # Bump the trailing -v1 to force a rebuild without a version change.
+          key: opencv-noffmpeg-4.14.0.94-cp312-macos13-arm64-v1
+
+      - name: Build OpenCV without FFmpeg (macOS, cache miss)
+        if: matrix.os == 'macos-latest' && steps.opencv-wheel.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          # ~2 min on 12 cores locally; expect ~10 min on the 3-vCPU runner.
+          # The sdist's PEP 517 backend fetches cmake itself; no brew needed.
+          curl -fsSL -o /tmp/opencv-sdist.tar.gz \
+            "https://files.pythonhosted.org/packages/67/8a/51ff1c6287be0b6cd3070cf095875da4ff7d6eda38507e6ada5608786a78/opencv_python_headless-4.14.0.94.tar.gz"
+          echo "4afa2ea1214453648be88259f035712454faa9039b686de7753569ba8eec1577  /tmp/opencv-sdist.tar.gz" \
+            | shasum -a 256 -c
+          tar -xzf /tmp/opencv-sdist.tar.gz -C /tmp
+          mkdir -p build/opencv-wheel
+          # MACOSX_DEPLOYMENT_TARGET matches the official wheel's macosx_13_0
+          # floor. The CXXFLAGS -isystem works around CommandLineTools installs
+          # that ship no toolchain libc++ headers (harmless under full Xcode,
+          # where the SDK copy matches the toolchain).
+          env ENABLE_HEADLESS=1 \
+              CMAKE_ARGS="-DWITH_FFMPEG=OFF -DPYTHON3_LIMITED_API=ON" \
+              MACOSX_DEPLOYMENT_TARGET=13.0 \
+              CMAKE_BUILD_PARALLEL_LEVEL="$(sysctl -n hw.ncpu)" \
+              CXXFLAGS="-isystem $(xcrun --show-sdk-path)/usr/include/c++/v1" \
+            uv build --wheel --python 3.12 \
+              --out-dir build/opencv-wheel /tmp/opencv_python_headless-4.14.0.94
+          ls -la build/opencv-wheel
+
+      - name: Install the no-FFmpeg OpenCV wheel (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          set -euo pipefail
+          uv pip install --force-reinstall --no-deps build/opencv-wheel/opencv_python_headless-*.whl
+          # Fail here, before PyInstaller, if the wheel somehow carries FFmpeg
+          # (e.g. a cached wheel built before a flag change).
+          uv run python -c "import cv2; bi = cv2.getBuildInformation(); \
+            assert 'FFMPEG' not in bi, 'self-built cv2 unexpectedly enables FFMPEG'; \
+            print('cv2', cv2.__version__, '- no FFmpeg')"
+          if find .venv -type d -name ".dylibs" -path "*cv2*" | grep -q .; then
+            echo "::error::self-built cv2 wheel still bundles dylibs"; exit 1
+          fi
+
       - name: Cache pinned vendor files (ffmpeg + OCR models)
         uses: actions/cache@v6
         with:
@@ -103,37 +159,34 @@ jobs:
           find dist/clipgen.app -path "*ocr_models/latin_rec.onnx" | grep -q . \
             || { echo "::error::bundle lacks the vendored OCR rec models"; exit 1; }
 
-      - name: Verify bundled FFmpeg library licenses (macOS)
+      - name: Verify no in-process FFmpeg libraries (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           set -euo pipefail
-          # cv2 bundles its own FFmpeg shared libraries, and
-          # THIRD-PARTY-LICENSES states their license explicitly. Those
-          # strings come from the wheel's build config, so a wheel bump can
-          # silently change them and leave us shipping a false notice — which
-          # is a distribution problem, not a runtime one, so nothing else here
-          # would catch it. Assert the recorded state instead.
-          #
-          # cv2's GPLv3 is upstream bug opencv/opencv-python#1260 (macOS arm64
-          # skips the GPL-stripping step). When they fix it this check fails,
-          # which is the point: update the notice rather than let it go stale.
-          check_license() {
-            # BUNDLE renames dot-directories (cv2/.dylibs -> cv2/__dot__dylibs)
-            # and leaves symlinks elsewhere, so match both spellings and only
-            # real files.
-            lib="$(find dist/clipgen.app -type f \
-              \( -path "*$1/.dylibs/*" -o -path "*$1/__dot__dylibs/*" \) \
-              -name "libavcodec*.dylib" | head -1)"
-            test -n "$lib" || { echo "::error::no libavcodec found under $1"; exit 1; }
-            got="$(strings -a "$lib" | grep -m1 -o "libavcodec license: .*" || true)"
-            if [ "$got" != "libavcodec license: $2" ]; then
-              echo "::error::$1 FFmpeg license changed: expected '$2', got '${got:-<none>}'."
-              echo "::error::Update the FFmpeg sections of build/THIRD-PARTY-LICENSES to match."
-              exit 1
-            fi
-            echo "$1 → $got"
-          }
-          check_license "cv2" "GPL version 3 or later"
+          # cv2 is self-built with -DWITH_FFMPEG=OFF (wheel step above), so the
+          # only GPL FFmpeg allowed in the bundle is the pinned ffmpeg/ffprobe
+          # executables under bin/ — separate programs, mere aggregation, and
+          # THIRD-PARTY-LICENSES says exactly that. Any FFmpeg *library* in the
+          # bundle would be loaded in-process and silently turn the DMG's
+          # licensing text false, so fail the build instead. This also catches
+          # the official GPL-tainted wheel (opencv/opencv-python#1260) leaking
+          # back in via a dependency-resolution change.
+          # BUNDLE renames dot-directories (cv2/.dylibs -> cv2/__dot__dylibs),
+          # so match both spellings.
+          if find dist/clipgen.app \( -type d -o -type l \) \
+            \( -name ".dylibs" -o -name "__dot__dylibs" \) -path "*cv2*" | grep -q .; then
+            echo "::error::cv2 ships bundled dylibs — the no-FFmpeg self-built wheel was not used."
+            exit 1
+          fi
+          if find dist/clipgen.app -type f \
+            \( -name "libav*.dylib" -o -name "libsw*.dylib" \
+               -o -name "libx264*.dylib" -o -name "libx265*.dylib" \) \
+            ! -path "*/bin/*" | grep -q .; then
+            echo "::error::FFmpeg/x264/x265 shared libraries found outside bin/;"
+            echo "::error::the macOS app is conveyed as MIT and must not link GPL code."
+            exit 1
+          fi
+          echo "no in-process FFmpeg libraries in the bundle"
           # PyAV was overridden out of the dependency tree (its wheel carried a
           # third FFmpeg; transcription feeds whisper ffmpeg-decoded ndarrays
           # instead). Its LGPL notice section is gone from THIRD-PARTY-LICENSES,
@@ -239,13 +292,12 @@ jobs:
 
           LICENSING
 
-          clipgen's own source code is MIT-licensed and lives at
-          https://github.com/henedl/clipgen. This macOS app bundles GPL-3.0-or-later
-          software (the ffmpeg/ffprobe executables, and the FFmpeg libraries that
-          ship inside OpenCV), so the app as distributed is conveyed to you under
-          the GNU General Public License version 3 or later. See the
-          THIRD-PARTY-LICENSES file next to this one for the full notices and for
-          where to get the corresponding source code. You can also print it with:
+          clipgen is MIT-licensed and lives at https://github.com/henedl/clipgen.
+          The bundled ffmpeg and ffprobe executables are GPL-3.0-or-later free
+          software that clipgen runs strictly as separate programs, so they do
+          not change the license of the app itself. See the THIRD-PARTY-LICENSES
+          file next to this one for the full notices and for where to get the
+          corresponding source code. You can also print it with:
 
               /Applications/clipgen.app/Contents/MacOS/clipgen --licenses
 

--- a/build/THIRD-PARTY-LICENSES
+++ b/build/THIRD-PARTY-LICENSES
@@ -21,8 +21,9 @@ colorlog                    6.12.0     MIT
 six                         1.17.0     MIT
 pyobjc-core                 12.2.1     MIT (macOS only)
 pyobjc-framework-Cocoa      12.2.1     MIT (macOS only)
-opencv-python-headless      4.13.0     MIT (bindings) + Apache 2.0 (OpenCV)
-  FFmpeg (bundled in cv2)     7.1.1      GPL-3.0-or-later (macOS; LGPL on Windows)
+opencv-python-headless      4.14.0     MIT (bindings) + Apache 2.0 (OpenCV)
+  FFmpeg DLL (in cv2)         8.x        LGPL-2.1 (Windows zip only; the macOS
+                                         cv2 is self-built without FFmpeg)
 Flask                       3.1.3      BSD-3-Clause
 Werkzeug                    3.1.6      BSD-3-Clause
 Jinja2                      3.1.6      BSD-3-Clause
@@ -834,55 +835,488 @@ Copyright notices:
 
 
 ===============================================================================
-GPL-3.0-OR-LATER (FFmpeg bundled inside opencv-python-headless)
+LGPL-2.1 (FFmpeg DLL bundled in the Windows opencv-python-headless wheel)
 ===============================================================================
 
-IMPORTANT -- this supersedes an earlier claim in this file that the FFmpeg
-libraries bundled with opencv-python-headless are LGPL-2.1.  They are not, on
-macOS.  Verified against the exact pinned wheel (opencv-python-headless
-4.13.0.92), cv2/.dylibs/libavcodec.61.19.101.dylib reports:
+The official opencv-python-headless Windows wheel ships a separately compiled
+FFmpeg wrapper DLL (opencv_videoio_ffmpeg*.dll) inside the cv2 directory. It
+is built without --enable-gpl and is licensed LGPL-2.1; it ships in the
+Windows zip and installer.
 
-  libavcodec license: GPL version 3 or later
-  configuration: --enable-gpl --enable-version3 --enable-libx264 --enable-libx265
-
-The upstream project confirms this is an unintended side effect of building
-against Homebrew's FFmpeg: opencv-python's macOS arm64 workflow never sets
-CONFIG_PATH, so the GPL-stripping step in its travis_config.sh does not run.
-See https://github.com/opencv/opencv-python/issues/1260 (acknowledged upstream
-2026-08-14; note that the wheel's own LICENSE-3RD-PARTY.txt and README still
-misstate the license as LGPL-2.1).
-
-Scope: this affects the macOS build only.  opencv-python's Linux wheels
-configure FFmpeg without --enable-gpl, and the Windows build uses a separately
-compiled LGPL opencv_videoio_ffmpeg DLL.
-
-The affected libraries are:
-  libavcodec, libavformat, libavutil, libavdevice, libswscale,
-  and the codec libraries they link: libx264, libx265, libdav1d,
-  librav1e, libSvtAv1Enc
-
-clipgen does not call cv2.VideoCapture or any other FFmpeg-backed cv2
-function -- video decoding uses the bundled ffmpeg executable via subprocess
-(see the next section).  The libraries are present only because cv2.abi3.so
-lists them as load-time dependencies; they cannot be removed without rebuilding
-OpenCV with -DWITH_FFMPEG=OFF.  Note that non-use does not change the license:
-the GPL obligation follows from linking and distribution, not from invocation.
-
-Consequence: because these GPL-3.0-or-later libraries are loaded into the
-clipgen process, the macOS binary distribution as a whole is conveyed under the
-GNU General Public License version 3 or later.  clipgen's own source code
-remains MIT-licensed (MIT is GPL-compatible; no relicensing of clipgen's files
-is required or implied), and the source is published at
-https://github.com/henedl/clipgen.
+The macOS app contains no FFmpeg libraries inside cv2 at all: the official
+macOS arm64 wheels bundle a GPL-3-configured Homebrew FFmpeg by mistake
+(https://github.com/opencv/opencv-python/issues/1260, acknowledged upstream
+2026-08-14), so clipgen's macOS build compiles opencv-python-headless from its
+published sdist with -DWITH_FFMPEG=OFF instead. The resulting cv2 links only
+Apple system frameworks, and CI fails the build if any FFmpeg library ever
+appears in the app outside bin/. clipgen never calls cv2's video I/O on any
+platform; video decoding uses the bundled ffmpeg executable via subprocess
+(next section).
 
 Source code for FFmpeg is available at: https://ffmpeg.org/download.html
-Source code for the opencv-python build (including FFmpeg build configuration)
-is available at: https://github.com/opencv/opencv-python
-Source code for x264 is available at: https://www.videolan.org/developers/x264.html
-Source code for x265 is available at: https://bitbucket.org/multicoreware/x265_git
+Build configuration for the wrapper DLL and for the opencv-python wheels:
+https://github.com/opencv/opencv-python
 
-The full text of the GNU General Public License version 3 is reproduced in the
-next section.
+The full text of the GNU Lesser General Public License version 2.1 follows.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
 
 
 ===============================================================================
@@ -894,10 +1328,10 @@ clipgen ships standalone ffmpeg and ffprobe executables under <bundle>/bin/
 Windows folder). They are full-featured static builds compiled with
 --enable-gpl and --enable-version3, which makes the executables
 GPL-3.0-or-later. clipgen invokes them strictly as separate subprocesses
-("mere aggregation" in GPL terms), so on their own they would not place the
-rest of the distribution under the GPL. (On macOS the opencv-bundled FFmpeg
-libraries do, independently -- see the previous section.) clipgen's own source
-code remains MIT-licensed in all cases.
+("mere aggregation" in GPL terms), so they do not place the rest of the
+distribution under the GPL. clipgen's own source code remains MIT-licensed,
+and no GPL library is loaded into the clipgen process on any platform (the
+macOS cv2 is self-built without FFmpeg -- see the previous section).
 
 Exact builds (pinned by SHA256 in build/fetch_binaries.py, which also records
 this provenance):
@@ -915,10 +1349,11 @@ https://git.ffmpeg.org/ffmpeg.git. Sources and build configuration for the
 third-party libraries compiled into these static builds are published by each
 provider at the URLs above.
 
-These executables are distinct from the FFmpeg *shared libraries* that arrive
-inside opencv-python-headless (the previous section): those are linked into
-cv2.abi3.so and loaded in-process. The executables here are separate GPL
-programs, pinned and verified by clipgen's own build.
+These executables are the only GPL FFmpeg in the distribution. They are
+distinct from the LGPL FFmpeg wrapper DLL inside the Windows cv2 (the
+previous section): that DLL is loaded in-process by cv2, while the
+executables here are separate GPL programs, pinned and verified by clipgen's
+own build.
 
 The full text of the GNU General Public License version 3 follows.
 

--- a/plans/DROP-OPENCV-PLAN.md
+++ b/plans/DROP-OPENCV-PLAN.md
@@ -1,0 +1,195 @@
+# Drop OpenCV Plan
+
+**Status: unscheduled, optional future work package.** Investigated 2026-08-16; recorded so a
+future session inherits the evidence instead of re-deriving it. The near-term route is the
+self-compiled `WITH_FFMPEG=OFF` wheel — researched and de-risked the same day, see
+[OPENCV-SELF-COMPILE-PLAN.md](OPENCV-SELF-COMPILE-PLAN.md) — which fixes the license (and −76 MB
+of the bundle) for ~1/8 the effort but keeps cv2's remaining size, cold import, and CI guard
+burden.
+
+## Context
+
+The macOS arm64 `opencv-python-headless` wheel bundles GPL-3 ffmpeg dylibs
+(opencv/opencv-python#1260), forcing the DMG to be conveyed GPL-3.0-or-later; the dylibs cannot
+be stripped post-hoc ([LICENSE-PLAN.md](LICENSE-PLAN.md) has the three reasons). This plan is the
+other escape route: remove the cv2 dependency entirely by reimplementing its used surface on
+packages already in the tree — numpy, Pillow, scipy + scikit-image (SSIM already comes from
+skimage), shapely + pyclipper (already rapidocr deps). **No new dependencies.**
+
+Verdict from the investigation: **feasible, ~13–16 focused sessions across 6 PRs.** Payoff beyond
+the license: −120 MB unpacked bundle (`cv2/` is 120 MB, 75 MB of it dylibs), the ~10 s cv2 cold
+import gone (`utils.preload_vision_libs_quietly` deleted), and the build-binaries.yml license
+guard + upstream-bug exposure eliminated permanently on all platforms.
+
+### Findings the plan rests on
+
+- **clipgen's own cv2 use is Screenspace-only**: 12 modules, 66 distinct symbols; hot spots
+  `screenspace_primitives.py` (82 refs) and `screenspace_preview.py` (105 refs, mostly cosmetic
+  drawing/colormap/resize). No `cv2.VideoCapture` anywhere — decoding is ffmpeg-piped, so the
+  bundled ffmpeg is 100% dead weight. Only three genuinely hard algorithms: Farneback optical
+  flow, masked `TM_CCOEFF_NORMED` template matching, and Canny — plus the Haar face cascade,
+  which is default-off and already degrades to zeros on OpenCV 5 wheels.
+- **RapidOCR is the hidden blocker**: it imports cv2 at module scope in 10 modules (~28 symbols
+  incl. `findContours`, `minAreaRect`/`boxPoints`, `warpPerspective`). Verified in its installed
+  sources (3.9.2): the DB postprocess consumes only the *derived box* through shapely/pyclipper it
+  already ships, and `score_mode="fast"` (the default) scores the box, not the raw contour — so
+  `findContours` can return **unordered per-blob boundary pixels** (`skimage.measure.label` +
+  label-minus-erosion) and `minAreaRect` is `shapely.oriented_envelope`. No Suzuki–Abe contour
+  tracer needed. This is the load-bearing simplification of the whole plan.
+- **Perf-critical sites with documented cv2 wins** that must be benchmarked, not assumed:
+  `mean_gray_diff` (`cv2.norm NORM_L1` fused, exact-equality test), `color_present`'s `inRange`
+  band path (~12× note vs float32 numpy), `_area_resize` (~14× note on the phash path).
+- **Tests holding verbatim cv2 oracles** that must be rewritten in lockstep:
+  `tests/screenspace/test_static_gating.py`, `test_color.py`, `test_change_similarity.py`,
+  `test_attention.py`, `test_template.py`, plus PNG-decode helpers in `tests/test_screenspace_api.py`
+  and `tests/test_screenspace_preview.py`.
+
+## Architecture
+
+Two new modules (both added to `pyproject.toml [tool.setuptools] py-modules`):
+
+1. **`source/imageops.py`** — clipgen's native primitive layer, BGR uint8 ndarrays in/out (no
+   call-site data-model churn):
+   - Conversions `bgr_to_gray/hsv/lab`, `hsv_to_bgr` as **cv2-bit-exact uint8 fixed-point
+     formulas** (H∈[0,180], cv2 Lab constants) — HSV targets persist in user manifests, so
+     bit-exactness is non-negotiable. Frozen golden tests from literals captured off cv2 4.13
+     while it is still installed; the tests never import cv2.
+   - `resize` via PIL (AREA→`Image.BOX`, LINEAR/NEAREST/CUBIC→BILINEAR/NEAREST/BICUBIC);
+     `area_resize_fast` via the numpy reshape-mean trick for integer ratios (expected to *beat*
+     cv2's two-pass trick on the phash path).
+   - `gaussian_blur` with cv2's sigma-from-ksize derivation (`0.3*((k-1)*0.5-1)+0.8`) on
+     `scipy.ndimage.gaussian_filter1d` separable passes, `mode="mirror"` (= BORDER_REFLECT_101);
+     `box_blur` via `uniform_filter`.
+   - Pixel ops: `absdiff` via uint8 `np.maximum(a-b, b-a)` (no dtype promotion), `mean_abs_diff`
+     (integer sum ÷ size in double, preserving the exact-equality contract), `in_range`,
+     threshold, bitwise, normalize, min_max_loc, cart_to_polar/magnitude, copy_make_border.
+   - Morphology via `scipy.ndimage` min/max filters; `fill_poly`/line/rectangle/ellipse/
+     arrowed_line/put_text via PIL.ImageDraw; `disk_splat` with a cached boolean disk mask and
+     **set-not-accumulate assignment** (the heatmap's "last draw wins" replay semantics are
+     load-bearing, radius is a constant `acc_size//16`).
+   - Frozen bit-identical `JET_LUT` (256×3 uint8 literal captured from `cv2.applyColorMap`);
+     PNG/JPEG codecs via PIL (keep `_write_png`'s OSError semantics); 3-D HSV histogram
+     replicating `calcHist` bin edges + Pearson correlation (= HISTCMP_CORREL);
+     `dct2` = `scipy.fft.dctn(type=2, norm="ortho")` (≡ `cv2.dct`).
+   - Algorithms: `canny` (skimage.feature.canny), `clahe` (`skimage.exposure.equalize_adapthist`,
+     8×8-tile-equivalent kernel), `match_template_masked` (Padfield masked ZNCC on
+     `scipy.fft.rfft2`; `mask=None` reduces to standard ZNCC ≡ TM_CCOEFF_NORMED),
+     `tile_flow` (see hard algorithms), spectral-residual internals on scipy `fft2`/complex64.
+
+2. **`source/cv2_shim.py`** — cv2-namespace adapter exclusively for rapidocr (~28 symbols),
+   delegating to `imageops` wherever the computation exists ("one computation, one
+   implementation"); owns the perspective/contour/minAreaRect pieces clipgen itself never needs
+   (`getPerspectiveTransform` = 8-unknown `np.linalg.solve`; `warpPerspective` via
+   `scipy.ndimage.map_coordinates` `mode="nearest"` = BORDER_REPLICATE, more faithful than PIL's
+   black fill for rotated text-crop rectification; `findContours` returning `(N,1,2)` int32
+   boundary-pixel arrays in cv2's `(x,y)` order; `minAreaRect`/`boxPoints` via shapely, converted
+   to cv2's `((cx,cy),(w,h),angle)` tuple — note rapidocr's `get_mini_boxes` reads
+   `min(rect[1])`; mask-aware 4-tuple `mean`; saturating `add`; rotate, polylines, imwrite).
+
+   **Injection**: `screenspace_ocr._ensure_cv2_stub()` — direct analogue of
+   `transcripts._ensure_av_stub` — does `sys.modules.setdefault("cv2", cv2_shim)` immediately
+   before the lazy `from rapidocr import ...` in `_build_ocr_reader`. `setdefault` means a dev
+   venv with a real cv2 keeps working during the transition; once opencv leaves `uv.lock` the
+   shim always wins. No file is ever named `cv2.py`, so nothing shadows a real install. The shim's
+   module `__getattr__` raises a named error (`"cv2 shim: rapidocr needs '<name>'"`) on rapidocr
+   drift. The `[tool.uv]` override `"opencv-python ; sys_platform == 'never'"` **stays** —
+   rapidocr still declares it; only `opencv-python-headless` leaves `[project] dependencies`.
+
+## Phases (each a separate green PR; cv2 stays installed until Phase 6)
+
+1. **`imageops.py` core + golden tests + baseline benchmarks** (2–3 sessions). No call-site
+   changes. Record cv2 perf baselines (profile skill) while cv2 is still importable.
+2. **Mechanical migrations** (2): `screenspace_server.py` (imdecode/imencode),
+   `screenspace_frames.py` (resize clamp), `screenspace_scans.py`, `screenspace_tools.py`,
+   `screenspace_heatmap.py` entirely, `screenspace_preview.py`'s ~100 cosmetic refs (the
+   Farneback/Canny preview sites migrate with the primitives in Phase 4), `cli.py`
+   `_ss_hex_to_hsv`. Retarget test monkeypatches (`screenspace_heatmap.cv2.imencode` →
+   `imageops.encode_png`) and PNG-decode helpers to PIL.
+3. **Primitives hot paths** (2–3): `mean_gray_diff`, `color_present`/`_hsv_match_bands` (band
+   architecture kept verbatim), blurs, `_frame_diff_mask`, phash (`area_resize_fast` + `dct2`),
+   scene fingerprint (hist + Pearson + canny; numbers change — safe, references are recomputed
+   per scan, never persisted), `region_mask_for`. Rewrite the cv2 oracles in lockstep —
+   exact-equality contracts in `test_static_gating`/`test_color` are *preserved* (integer
+   arithmetic on both sides). Benchmark loop against Phase 1 baselines.
+4. **Hard algorithms + attention** (3):
+   - **Template**: Padfield masked ZNCC, mask support kept (alpha-masked templates are a real
+     product feature with dedicated degenerate handling). Scores drift in the third decimal,
+     ranking preserved; NMS/candidate-cap/degeneracy handling untouched.
+   - **Flow**: replace Farneback with `tile_flow` — per-tile phase correlation (windowed
+     cross-power spectrum via one batched 3-D FFT over the ~16×16 grid tiles, argmax + parabolic
+     refinement). The dense Farneback field is only ever reduced to per-tile grid aggregates
+     (`compute_optical_flow` → mean magnitude, dominant angle, `flow_grid`), so this is
+     deterministic, ~80 lines, and likely *faster*. skimage's `optical_flow_ilk`/`tvl1` were
+     evaluated and rejected: hundreds of ms to seconds per pair at 256², per-frame-scan poison.
+   - **Attention**: delete the cv2 dft branch (+`_dft_friendly`); the existing numpy
+     spectral-residual branch is the surviving implementation, moved to scipy fft2/complex64.
+     Lab center-surround on `imageops.bgr_to_lab`. **Drop the face channel end-to-end**: code
+     (`_get_face_cascade`, `compute_face_saliency`, weights), config keys
+     (`SCREENSPACE_ATTENTION_WEIGHT_FACE`/`_FACE_CHANNEL`), the `paramAttnWFace` slider
+     (screenspace.html/js + model-view map), and the CascadeClassifier tests.
+5. **OCR + shim** (2–3): CLAHE swap in `_preprocess_for_ocr`; `cv2_shim.py` with per-symbol unit
+   tests; a guard test importing all 10 cv2-importing rapidocr modules under the shim (fails
+   loudly on an unshimmed import-time symbol); an integration test instantiating rapidocr's
+   `DBPostProcess` directly on a synthetic probability map (no ONNX) asserting box corners within
+   1–2 px. **Manual gate before Phase 6**: run the Text tool on real fixture footage with cv2
+   uninstalled, diff readings against a cv2 baseline run.
+6. **Cut-over + build/CI/license** (1–2): drop the dep from `pyproject.toml`; delete
+   `utils.preload_vision_libs_quietly` + its server call + boot-page "cv2" phase; `clipgen.spec`
+   `excludes += ["cv2"]` (a stray dev-machine opencv can never leak into the bundle); invert the
+   build-binaries.yml guard — fail if any `cv2/` directory or non-`bin/` `libav*` dylib appears
+   in the bundle (same shape as the existing PyAV guard); remove the OpenCV/FFmpeg-dylib GPL
+   sections from `build/THIRD-PARTY-LICENSES` (the pinned ffmpeg/ffprobe *executables* section
+   stays); DMG licensing text back to MIT-app + GPL-aggregated-executables; update
+   [LICENSE-PLAN.md](LICENSE-PLAN.md) (supersede the OpenCV decision, close the #1260-tracking
+   and self-compile items as moot); add `tests/test_no_cv2.py` (greps `source/` for cv2 imports
+   allowlisting the shim, asserts `import screenspace` leaves no real `"cv2"` in `sys.modules`);
+   sweep docs (AGENTS/ARCHITECTURE/PERFORMANCE cv2 mentions, `screenspace.py` docstring).
+
+## User-visible behavior changes (accepted; no compat layers per the hard rule)
+
+- **Flow tool**: magnitude scale changes (per-tile displacement vs Farneback per-pixel mean) —
+  saved Flow thresholds need re-calibration via the existing calibration UI.
+- **Template tool**: scores drift in the third decimal; ranking preserved.
+- **Attention tool**: loses the optional face channel (default-off, already broken on OpenCV 5).
+- **Scene/OCR**: fingerprint numbers change (self-healing, recomputed per scan); CLAHE output
+  visually differs slightly.
+
+## Performance strategy
+
+Baseline before Phase 1 with the profile skill; re-measure per phase. Acceptance gate:
+end-to-end scan wall-clock per tool on the fixture within ~+15% of the cv2 baseline (keyframe
+decode dominates all tools, bounding the blast radius). Expectations: `mean_gray_diff` 2–5×
+slower in isolation but sub-ms at working sizes; `color_present` target ≤3× with an integer
+channel-decomposed HSV-test reformulation held in reserve (never materializes the HSV image);
+phash resize expected to win; tile_flow expected to win; template FFT ≈ parity; OCR shim cost is
+noise next to ONNX inference. Side benefits to record: ~10 s cold start drop, one fewer native
+thread pool under `SCREENSPACE_PARALLEL_WORKERS`.
+
+## Top risks
+
+1. **Per-frame perf regression on the scan core** → baselines first, +15% gate, uint8
+   reformulations in reserve.
+2. **OCR box-quality regression through the shim** → boundary-pixels + `oriented_envelope` is
+   ±0.5 px of cv2 geometrically; synthetic DBPostProcess test + mandatory real-footage diff.
+3. **Saved thresholds invalidated by number drift** (flow, template) → accepted; users
+   re-calibrate; scene references self-heal.
+4. **rapidocr drift outgrowing the shim** → existing `<4` pin, import-coverage guard, named
+   `__getattr__` errors.
+5. **Convention mismatch leaking into persisted state** (HSV in manifests, region masks) →
+   bit-exact conversions with frozen goldens; fill_poly tolerance confined to ±1 px.
+
+## Recommended shape if picked up
+
+Land Phases 1–3 unconditionally (pure wins, low risk, exact-equality preserved), then a go/no-go
+on Phases 4–6 with the Phase 3 benchmarks in hand. Phases 1–3 also stand alone as prep that
+makes a later full drop cheap, even if the self-compile route lands first for the license.
+
+## Verification
+
+- Per phase: the /check pipeline (ruff format + lint, ty, full test suite).
+- Phase 1/3: benchmark script vs recorded cv2 baselines (profile skill).
+- Phase 4: synthetic-translation flow-recovery tests; planted-icon template property tests.
+- Phase 5: DBPostProcess synthetic-map test; manual Text-tool diff on real footage, cv2
+  uninstalled.
+- Phase 6: `tests/test_no_cv2.py`; /ui-check across all six pages; a full desktop build
+  confirming no `cv2/` in the bundle and the inverted CI guard passing.

--- a/plans/LICENSE-PLAN.md
+++ b/plans/LICENSE-PLAN.md
@@ -6,7 +6,16 @@ clipgen bundles 20+ third-party libraries into a PyInstaller binary. All license
 
 ## Architectural decisions
 
-### OpenCV and FFmpeg (decided 2026-04-04, **corrected 2026-08-15**)
+### OpenCV and FFmpeg (decided 2026-04-04, corrected 2026-08-15; **superseded 2026-08-16**)
+
+> **Superseded:** the macOS build now compiles `opencv-python-headless` 4.14.0.94 from its
+> published sdist with `-DWITH_FFMPEG=OFF` (research: [OPENCV-SELF-COMPILE-PLAN.md](OPENCV-SELF-COMPILE-PLAN.md)),
+> so the DMG carries **no** FFmpeg libraries inside cv2 and is conveyed MIT again, with GPL
+> applying only to the aggregated ffmpeg/ffprobe executables. The GPL-FFmpeg-inside-opencv
+> section of `build/THIRD-PARTY-LICENSES` was replaced by an LGPL-2.1 section covering the
+> Windows wheel's `opencv_videoio_ffmpeg` DLL, and the CI guard inverted: it now fails if any
+> `cv2/.dylibs` or FFmpeg/x264/x265 dylib appears in the bundle outside `bin/`. The analysis
+> below is kept for the record of *why* the official arm64 wheel cannot be shipped.
 
 > **The original decision rested on a false premise.** It claimed opencv-python builds FFmpeg as
 > LGPL-2.1 "without `--enable-gpl`", with `libx264`/`libx265` present but "not compiled into
@@ -111,21 +120,24 @@ The desktop builds ship pinned full-GPL static ffmpeg/ffprobe executables under 
 None of these are scheduled. They are recorded so the next session inherits the evidence instead
 of re-deriving it.
 
-- **Track upstream opencv-python#1260.** The cheapest resolution: when a release lands whose
-  macOS arm64 wheel reports LGPL, pin to it and revert the GPL sections of
-  `build/THIRD-PARTY-LICENSES`. The CI license guard will fail on that build, which is the
-  intended signal. No ETA — the issue was acknowledged 2026-08-14 and is unfixed.
+- **Track upstream opencv-python#1260.** No longer load-bearing: the macOS build compiles its
+  own FFmpeg-free cv2 regardless. If upstream fixes the wheel, the only optional simplification
+  is deleting the wheel-build CI steps and going back to the official wheel — the inverted
+  license guard stays valid either way (it would then verify the fixed wheel). Weigh that
+  against the self-built wheel's other wins (−76 MB unpacked, no 93-dylib brew chain).
 
-- **Self-compiled OpenCV (needs research before anyone commits to it).**
-  `CMAKE_ARGS="-DWITH_FFMPEG=OFF" ENABLE_HEADLESS=1` against the published sdist is the *only*
-  route that actually removes the GPL dylibs, since they cannot be deleted post-hoc (see the
-  three reasons above). It would also drop ~29 MB of the 120 MB `cv2/` tree, all of it dead
-  weight — clipgen never calls cv2's video I/O. Open questions:
-  - Does the sdist build clean on macOS arm64? The route is documented by upstream but far less
-    exercised than the git-clone path.
-  - What does a 20 min–2 h OpenCV compile do to the macOS build job's wall-clock and caching?
-  - Does anything else in `cv2/` regress with FFmpeg off (`imgcodecs` keeps its own `libavif`)?
-  - Is it moot by the time it is picked up, if #1260 lands first?
+- [x] **Self-compiled OpenCV — researched, de-risked, and implemented 2026-08-16**, see
+  [OPENCV-SELF-COMPILE-PLAN.md](OPENCV-SELF-COMPILE-PLAN.md) for the full evidence. Every open
+  question answered empirically on macOS arm64: the sdist builds clean in **122 s** locally
+  (~8–15 min on a standard CI runner, cacheable); requires a pin bump to 4.14.0.94 (4.13.x
+  published no sdists); the result has **zero** bundled dylibs (Apple frameworks only, codecs
+  static in-tree — the win is −76 MB unpacked, not the ~29 MB guessed here) and passes the full
+  clipgen test suite (3302 tests). The macOS CI leg now builds and caches the wheel;
+  see the superseded-decision note above for what changed where.
+
+- **Remove cv2 entirely (reimplement its used surface)** — investigated 2026-08-16, feasible
+  with no new dependencies but ~8× the effort of the self-compile; recorded as an optional
+  future work package in [DROP-OPENCV-PLAN.md](DROP-OPENCV-PLAN.md).
 
 - [x] **Take PyAV off the decode path** — Done 2026-08-16, and it went further than this note
   anticipated: the "cannot be excluded" caveat was wrong. `faster_whisper/audio.py` imports `av`

--- a/plans/OPENCV-SELF-COMPILE-PLAN.md
+++ b/plans/OPENCV-SELF-COMPILE-PLAN.md
@@ -101,8 +101,11 @@ while the bundle ships Python 3.12; retag with `wheel tags` if that ever matters
      `uv sync --locked` once and uses `uv run --no-sync` for every later invocation
      (fetch_binaries, pyinstaller); the assert runs via `.venv/bin/python` directly.
 - [x] **Inverted license guard** ("Verify no in-process FFmpeg libraries"): fails on any
-   `cv2/.dylibs`/`__dot__dylibs` in the .app, or any `libav*`/`libsw*`/`libx264*`/`libx265*`
-   dylib outside `bin/` (the PyAV-absence guard rides along unchanged).
+   `cv2/.dylibs`/`__dot__dylibs` in the .app, or any FFmpeg-family dylib
+   (libavcodec/format/util/device/filter, libswscale/swresample/postproc, libx264/x265)
+   outside `bin/`, printing the offenders. The names are enumerated, not a `libav*` glob —
+   Pillow ships `libavif` (the BSD AV1 *image* codec, no FFmpeg relation), and the glob
+   flagged it on the guard's first run against a good bundle. PyAV-absence guard unchanged.
 - [x] **License text**: the `GPL-3.0-OR-LATER (FFmpeg bundled inside opencv-python-headless)`
    section of `build/THIRD-PARTY-LICENSES` was replaced by
    `LGPL-2.1 (FFmpeg DLL bundled in the Windows opencv-python-headless wheel)` with the full

--- a/plans/OPENCV-SELF-COMPILE-PLAN.md
+++ b/plans/OPENCV-SELF-COMPILE-PLAN.md
@@ -95,6 +95,11 @@ while the bundle ships Python 3.12; retag with `wheel tags` if that ever matters
    - `uv pip install --force-reinstall --no-deps <wheel>`, then assert `FFMPEG` is absent from
      `cv2.getBuildInformation()` and no `cv2/.dylibs` exists in site-packages — before
      PyInstaller runs, so a bad cached wheel fails fast.
+   - **Gotcha (caught by that assert on the first CI run):** a plain `uv run` re-syncs the
+     project env against `uv.lock` before running, which reinstalls the *official* GPL wheel
+     from PyPI over the force-reinstalled one. The workflow therefore installs with
+     `uv sync --locked` once and uses `uv run --no-sync` for every later invocation
+     (fetch_binaries, pyinstaller); the assert runs via `.venv/bin/python` directly.
 - [x] **Inverted license guard** ("Verify no in-process FFmpeg libraries"): fails on any
    `cv2/.dylibs`/`__dot__dylibs` in the .app, or any `libav*`/`libsw*`/`libx264*`/`libx265*`
    dylib outside `bin/` (the PyAV-absence guard rides along unchanged).

--- a/plans/OPENCV-SELF-COMPILE-PLAN.md
+++ b/plans/OPENCV-SELF-COMPILE-PLAN.md
@@ -1,0 +1,121 @@
+# OpenCV Self-Compile Plan (WITH_FFMPEG=OFF)
+
+**Status: researched, de-risked, and implemented 2026-08-16** (all steps in "Implementation
+steps" below are done). All findings were verified empirically on macOS arm64 (M4 Pro,
+macOS 15). This resolves the "needs research before anyone commits to it" open item in
+[LICENSE-PLAN.md](LICENSE-PLAN.md). The heavier alternative (removing cv2 entirely) is
+[DROP-OPENCV-PLAN.md](DROP-OPENCV-PLAN.md).
+
+## Context
+
+The official `opencv-python-headless` macOS arm64 wheels bundle GPL-3-configured FFmpeg dylibs
+(upstream bug opencv/opencv-python#1260), forcing the DMG to be conveyed GPL-3.0-or-later. The
+dylibs cannot be stripped post-hoc. Building the published sdist ourselves with FFmpeg disabled
+is the only route that removes them while keeping cv2.
+
+## Research results
+
+Every LICENSE-PLAN open question, answered:
+
+1. **Does the sdist build clean on macOS arm64? Yes — in 122 seconds.**
+
+   ```bash
+   env ENABLE_HEADLESS=1 \
+       CMAKE_ARGS="-DWITH_FFMPEG=OFF -DPYTHON3_LIMITED_API=ON" \
+       CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu) \
+       uv build --wheel --python 3.12 --out-dir dist .   # from the unpacked sdist
+   ```
+
+   No brew packages, no preinstalled cmake needed — the sdist's custom PEP 517 backend
+   auto-installs the cmake PyPI wheel; scikit-build falls back to Unix Makefiles when ninja is
+   absent. 122 s wall-clock at `-j12` on an M4 Pro (the old "20 min–2 h" estimate was off by an
+   order of magnitude: the build compiles ~750 translation units, not all of OpenCV's history).
+
+   Two caveats found:
+   - **The pinned 4.13.0.92 has no sdist.** 4.13.x published wheels only; the nearest 4.x with an
+     sdist is **4.14.0.94** (2026-07-29). Self-compiling therefore means a pin bump. The full
+     clipgen test suite (3302 tests, incl. every exact-equality cv2 oracle) passes on 4.14.0.94,
+     so the bump is behaviorally free for clipgen's usage.
+   - **A broken CommandLineTools install fails with `fatal error: 'string' file not found`.**
+     CLT 26.3 on the dev machine ships no `CommandLineTools/usr/include/c++/v1`; clang lists that
+     nonexistent dir and never falls back to the SDK copy. Workaround (harmless elsewhere):
+     `CXXFLAGS="-isystem $(xcrun --show-sdk-path)/usr/include/c++/v1"`. GitHub-hosted runners run
+     full Xcode and should not hit this, but keep the flag in the build step — it costs nothing.
+
+2. **CI wall-clock: ~8–15 min uncached, seconds cached.** 122 s locally on 12 cores; standard
+   `macos-latest` arm64 runners are M1 with 3 vCPUs, so expect roughly 4–6× that. Acceptable even
+   on every build; with `actions/cache` keyed on (opencv version, CMAKE_ARGS, deployment target,
+   python tag) a rebuild only happens on a pin bump or cache eviction.
+
+3. **Nothing clipgen uses regresses with FFmpeg off.** Verified from the CMake summary and the
+   built wheel:
+   - Media I/O all **static in-tree**: build-libjpeg-turbo, libpng, libwebp, libtiff, openjp2,
+     OpenEXR, zlib. PNG round-trip verified. (`AVIF: NO` — the official wheel's avif came from
+     brew dylibs; clipgen encodes only PNG/JPEG via cv2, GIFs via PIL.)
+   - Video I/O = AVFoundation only (clipgen never uses cv2 video I/O anyway).
+   - `cv2.data.haarcascades` present (attention face channel unaffected).
+   - `uv run pytest`: **3302 passed** against the self-built wheel.
+
+4. **Is it moot (upstream fix)? Not yet.** #1260 is open, acknowledged 2026-08-14, no fix
+   commits on the repo (last commit 2026-07-28), no milestone. The maintainer intends to rebuild
+   macOS FFmpeg without brew and to re-audit Linux; Windows is already a separately built LGPL
+   DLL. If a fixed wheel ships, this plan's CI step can be deleted again — the inverse license
+   guard (below) stays valid either way.
+
+**Measured wins** (self-built vs official 4.14.0.94 arm64 wheel):
+
+| | official | self-built |
+|---|---|---|
+| wheel size | 46.5 MB | **14 MB** |
+| unpacked `cv2/` | 120 MB | **44 MB** (−76 MB in the DMG payload) |
+| bundled dylibs | 93 (75 MB, incl. GPL ffmpeg/x264/x265, gnutls, glib, …) | **0** — `otool -L` shows Apple system frameworks only |
+| license of the artifact | forces GPL-3.0-or-later conveyance | **no GPL code at all** |
+| `import cv2` (warm) | multi-second dylib chain | 0.36 s |
+
+The wheel tags as `cp312-cp312` via `uv build` (the PEP 517 path doesn't pass
+`--py-limited-api`), but the extension itself is `cv2.abi3.so` (Limited API: YES). Irrelevant
+while the bundle ships Python 3.12; retag with `wheel tags` if that ever matters.
+
+## Implementation steps (one small PR) — all landed 2026-08-16
+
+- [x] **Bump `opencv-python-headless` to `>=4.14.0.94,<5`** in `pyproject.toml`/`uv.lock` (all
+   platforms — Windows keeps the official wheel with its separately built LGPL
+   `opencv_videoio_ffmpeg` DLL; the `opencv-python ; sys_platform == 'never'` override is
+   untouched).
+- [x] **Wheel-build steps in the macOS job of `.github/workflows/build-binaries.yml`**, before
+   PyInstaller:
+   - `actions/cache` keyed `opencv-noffmpeg-4.14.0.94-cp312-macos13-arm64-v1`
+     (bump `-v1` to force a rebuild without a version change).
+   - On miss: download the sdist from PyPI (sha256-pinned), build with
+     `ENABLE_HEADLESS=1 CMAKE_ARGS="-DWITH_FFMPEG=OFF -DPYTHON3_LIMITED_API=ON"
+     MACOSX_DEPLOYMENT_TARGET=13.0 CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)
+     CXXFLAGS="-isystem $(xcrun --show-sdk-path)/usr/include/c++/v1"` via
+     `uv build --wheel` (13.0 matches the official wheel's deployment floor; the CXXFLAGS is
+     the CLT-quirk belt-and-braces).
+   - `uv pip install --force-reinstall --no-deps <wheel>`, then assert `FFMPEG` is absent from
+     `cv2.getBuildInformation()` and no `cv2/.dylibs` exists in site-packages — before
+     PyInstaller runs, so a bad cached wheel fails fast.
+- [x] **Inverted license guard** ("Verify no in-process FFmpeg libraries"): fails on any
+   `cv2/.dylibs`/`__dot__dylibs` in the .app, or any `libav*`/`libsw*`/`libx264*`/`libx265*`
+   dylib outside `bin/` (the PyAV-absence guard rides along unchanged).
+- [x] **License text**: the `GPL-3.0-OR-LATER (FFmpeg bundled inside opencv-python-headless)`
+   section of `build/THIRD-PARTY-LICENSES` was replaced by
+   `LGPL-2.1 (FFmpeg DLL bundled in the Windows opencv-python-headless wheel)` with the full
+   LGPL-2.1 text (previously a gap — the Windows DLL was mentioned but its license text never
+   included); the executables section and summary table updated; the DMG INSTALL.txt LICENSING
+   text conveys the app as MIT with GPL only on the aggregated executables. Heading assertions
+   in `tests/test_packaging.py` updated, plus a negative assertion that the GPL-inside-cv2
+   section stays gone.
+- [x] **Docs**: OpenCV decision in [LICENSE-PLAN.md](LICENSE-PLAN.md) marked superseded.
+   Local-dev caveat: dev venvs still install the official (GPL-tainted on macOS) wheel from
+   PyPI — fine, GPL obligations attach to distribution, and clipgen distributes only the
+   CI-built DMG.
+
+## Non-goals / notes
+
+- Local dev builds of the wheel are possible with the recipe above but not required; the license
+  concern is distribution-only.
+- Staying on 4.x (not 5.0.0.93, which also has an sdist) keeps `CascadeClassifier` and avoids
+  the OpenCV 5 API churn the codebase currently tolerates but doesn't require.
+- If upstream fixes #1260, delete step 2 and keep steps 3–4 — the inverse guard then simply
+  verifies the fixed official wheel, and the pin follows the normal bump cadence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ dependencies = [
     "flask>=3.0.0",
     "werkzeug>=3.0.0",
     "faster-whisper>=1.2.0",
-    "opencv-python-headless>=4.8.0",
+    # 4.14.0.94 floor: the oldest 4.x that publishes an sdist, which the macOS
+    # CI leg builds with -DWITH_FFMPEG=OFF to keep GPL FFmpeg out of the DMG
+    # (plans/OPENCV-SELF-COMPILE-PLAN.md). <5 keeps CascadeClassifier and the
+    # 4.x API this codebase is tested against.
+    "opencv-python-headless>=4.14.0.94,<5",
     "numpy>=1.26.0",
     "Pillow>=10.0.0",
     "imagehash>=4.3.0",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -243,10 +243,17 @@ def test_license_notice_is_tracked_and_bundled() -> None:
     # accidentally-regenerated notice would still look plausible without them.
     for heading in (
         "GPL-3.0-OR-LATER (bundled ffmpeg and ffprobe executables)",
-        "GPL-3.0-OR-LATER (FFmpeg bundled inside opencv-python-headless)",
+        "LGPL-2.1 (FFmpeg DLL bundled in the Windows opencv-python-headless wheel)",
         "MOZILLA PUBLIC LICENSE 2.0",
     ):
         assert heading in text, f"THIRD-PARTY-LICENSES lost its {heading!r} section"
+    # The macOS cv2 is self-built with -DWITH_FFMPEG=OFF precisely so the DMG
+    # carries no in-process GPL code (plans/OPENCV-SELF-COMPILE-PLAN.md); a
+    # revived GPL-FFmpeg-inside-opencv section would mean that regressed.
+    assert "FFmpeg bundled inside opencv-python-headless" not in text, (
+        "THIRD-PARTY-LICENSES regrew the GPL-FFmpeg-inside-cv2 section; the "
+        "macOS build compiles cv2 without FFmpeg and the DMG is conveyed MIT"
+    )
 
 
 def test_license_notice_sections_are_well_formed() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ requires-dist = [
     { name = "imagehash", specifier = ">=4.3.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "onnxruntime", specifier = ">=1.24" },
-    { name = "opencv-python-headless", specifier = ">=4.8.0" },
+    { name = "opencv-python-headless", specifier = ">=4.14.0.94,<5" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "playwright", marker = "extra == 'ui'", specifier = ">=1.55" },
@@ -984,20 +984,21 @@ sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c
 
 [[package]]
 name = "opencv-python-headless"
-version = "4.13.0.92"
+version = "4.14.0.94"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/67/8a/51ff1c6287be0b6cd3070cf095875da4ff7d6eda38507e6ada5608786a78/opencv_python_headless-4.14.0.94.tar.gz", hash = "sha256:4afa2ea1214453648be88259f035712454faa9039b686de7753569ba8eec1577", size = 96405664, upload-time = "2026-07-28T19:23:48.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
-    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/56/12f9b05628cf4ab6aad54479b9124f7c1f2f92b6a4e47c071beb63d926a2/opencv_python_headless-4.14.0.94-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:bc7db37dc234f7bb3190a158fd9dd750357246fc7d8adb23698843ef721a993b", size = 46491231, upload-time = "2026-07-29T03:52:11.902Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/2f9c42466f62aa27e97aaf6c9d914008895ecde28013ba4beed7f541f593/opencv_python_headless-4.14.0.94-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1777f43c9fa064f54b916ad70d944b4fde0a644a17e49f04a966bb24a4b5f1e1", size = 33084176, upload-time = "2026-07-28T20:05:59.902Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/91/83c51e3fe000b5dfce4f3be5c5d320e07ebab5c1742abc4e45674503f90f/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:29714d7716dbfddf9fec20ffb878765e94ccaecd7d3ebd6750877420296e2dc5", size = 35405458, upload-time = "2026-07-28T19:19:29.997Z" },
+    { url = "https://files.pythonhosted.org/packages/de/06/14c8c5d331bc72738683a9b227966aceaa4c6d08752f33d64578aebcb6f8/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5e02669eac0ba67b2a22d7245af1e8ee1a2ef1185ee526a063d8f0555224bd52", size = 57534165, upload-time = "2026-07-28T19:19:52.742Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0e/0b98bd582582253f61c4506f9b465cf5a8aa7fa4f7237dd99e1b5151a159/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:97c6e818c6f71c0cfa214e12293b1d0266d679c38f4e086de08357c8ac6ece0d", size = 38104309, upload-time = "2026-07-28T19:20:08.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ce/7f538891722a4f06921419d55bac6f41729258d54442861edb2de0dbdf5e/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:211e581f5a4670acbbe08fff36a35e9946039d2eea28b80394632d036d1be527", size = 61960165, upload-time = "2026-07-28T19:20:33.074Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/91/ded03abad74d7264fa6bc7c923d7cade6f94a9023eeb372cfad54c2d0334/opencv_python_headless-4.14.0.94-cp37-abi3-win32.whl", hash = "sha256:f70296aa7ac9d7ade0d925c43fdc006c83e20a23f30e2f40f1b82c74a7a54460", size = 33030271, upload-time = "2026-07-28T18:32:39.447Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8d/db8673846ee53cbb5de4c2b4decc11cf733e203eb7d5146297869f69bd48/opencv_python_headless-4.14.0.94-cp37-abi3-win_amd64.whl", hash = "sha256:cbed65415b8f6a9541c705afe3e64795840524d0ff3bc58f507826284a1dc64b", size = 41028030, upload-time = "2026-07-28T18:32:36.724Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The official opencv-python-headless macOS arm64 wheels bundle a GPL-3-configured Homebrew FFmpeg, still unfixed as of 2026-08-16), which forced the whole DMG to be conveyed GPL-3.0-or-later. The macOS CI leg now compiles the same version from its published sdist with `-DWITH_FFMPEG=OFF` — zero bundled dylibs (Apple system frameworks only), all image codecs static in-tree — so the app is conveyed MIT again, with GPL applying only to the aggregated `bin/` ffmpeg/ffprobe executables. **Measured: the macOS artifact shrank 362 → 211 MB.**

- `pyproject.toml`/`uv.lock`: bump `opencv-python-headless` to `>=4.14.0.94,<5` — the oldest 4.x with a published sdist (4.13.x shipped wheels only)
- `build-binaries.yml`: sha256-pinned sdist download + `actions/cache`d `uv build` wheel step (9 min on the runner on cache miss, ~1 s restore on hit) + force-reinstall with an FFMPEG-absence assert **before** PyInstaller; deps install switches to `uv sync --locked` and later `uv run`s pass `--no-sync` — a plain `uv run` re-syncs against the lock and would silently reinstall the official GPL wheel (the assert caught exactly that on the first CI run); license guard inverted — fails, printing offenders, on any `cv2/.dylibs` or FFmpeg-family dylib (enumerated names, not `libav*` — Pillow's BSD `libavif` is a false-positive for the glob) outside `bin/`
- `build/THIRD-PARTY-LICENSES`: GPL-FFmpeg-inside-opencv section replaced by an LGPL-2.1 section for the Windows wheel's `opencv_videoio_ffmpeg` DLL, now with the full LGPL-2.1 text (previously mentioned but never included); DMG `INSTALL.txt` licensing text updated to match
- `plans/OPENCV-SELF-COMPILE-PLAN.md` records the research, repro recipe, and CI gotchas; `plans/DROP-OPENCV-PLAN.md` records the heavier remove-cv2-entirely alternative as unscheduled future work

Windows leg behavior unchanged apart from the wheel version bump (official wheel, separately built LGPL FFmpeg DLL).

## Test plan

- [x] Wheel built locally from the 4.14.0.94 sdist on macOS arm64 (122 s at -j12); `otool -L` shows Apple frameworks only, no `.dylibs/` dir, `getBuildInformation()` has no FFMPEG
- [x] Full test suite (3302 passed) against the self-built wheel, and again after the pin bump with the official 4.14.0.94 wheel
- [x] `/check`: ruff format + lint, ty, full suite green
- [x] `--licenses` prints the updated notice; section-structure test passes
- [x] Dispatched CI run [31974499745](https://github.com/henedl/clipgen/actions/runs/31974499745): both legs green — wheel step 9m01s uncached, cache saved, FFmpeg-absence assert and inverted bundle guard pass on the produced .app, DMG artifact 211 MB (previous dev build: 362 MB)