### PR TITLE
fix(web): ignore Start overlay form hotkeys off the Open tab

### DIFF
--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -437,17 +437,21 @@
     // inModal + `when` so they fire only while the launcher owns the keyboard.
     if (window.ClipgenHotkeys) {
       var isOpen = function () { return state.open; };
+      // Spreadsheet/folder/confirm shortcuts target the Open pane. Gating only
+      // on state.open left G/E/I/Cmd+Enter live on About and Recent updates,
+      // where they mutated a hidden form or confirmed the workspace.
+      var isOpenForm = function () { return state.open && state.startTab === "open"; };
       ClipgenHotkeys.register([
         { id: "start.tabOpen",      inModal: true, when: isOpen, handler: function () { setStartTab("open"); } },
         { id: "start.tabAbout",     inModal: true, when: isOpen, handler: function () { setStartTab("about"); } },
         { id: "start.tabUpdates",   inModal: true, when: isOpen, handler: function () { setStartTab("updates"); } },
-        { id: "start.tabGoogle",    inModal: true, when: isOpen, handler: function () { setTab("google"); } },
-        { id: "start.tabExcel",     inModal: true, when: isOpen, handler: function () { setTab("excel"); } },
-        { id: "start.tabMindnode",  inModal: true, when: isOpen, handler: function () { setTab("mindnode"); } },
-        { id: "start.tabNone",      inModal: true, when: isOpen, handler: function () { setTab("none"); } },
-        { id: "start.browseInput",  inModal: true, when: isOpen, handler: function () { browseFolder("input"); } },
-        { id: "start.browseOutput", inModal: true, when: isOpen, handler: function () { browseFolder("output"); } },
-        { id: "start.confirm",      inModal: true, allowInInput: true, when: isOpen, handler: function () { confirm(); } }
+        { id: "start.tabGoogle",    inModal: true, when: isOpenForm, handler: function () { setTab("google"); } },
+        { id: "start.tabExcel",     inModal: true, when: isOpenForm, handler: function () { setTab("excel"); } },
+        { id: "start.tabMindnode",  inModal: true, when: isOpenForm, handler: function () { setTab("mindnode"); } },
+        { id: "start.tabNone",      inModal: true, when: isOpenForm, handler: function () { setTab("none"); } },
+        { id: "start.browseInput",  inModal: true, when: isOpenForm, handler: function () { browseFolder("input"); } },
+        { id: "start.browseOutput", inModal: true, when: isOpenForm, handler: function () { browseFolder("output"); } },
+        { id: "start.confirm",      inModal: true, allowInInput: true, when: isOpenForm, handler: function () { confirm(); } }
       ]);
     }
   }

--- a/tests/test_start_overlay_source.py
+++ b/tests/test_start_overlay_source.py
@@ -110,6 +110,38 @@ def test_overlay_always_opens_on_the_open_tab():
     )
 
 
+def _hotkey_register_block() -> str:
+    src = strip_comments(read("start-overlay.js"))
+    start = src.index("ClipgenHotkeys.register([")
+    return src[start : src.index("]);", start)]
+
+
+def _hotkey_entry(block: str, hid: str) -> str:
+    marker = f'id: "{hid}"'
+    i = block.index(marker)
+    nxt = block.find("{ id:", i + 1)
+    return block[i : nxt if nxt != -1 else len(block)]
+
+
+def test_form_hotkeys_require_the_open_tab():
+    """G/E/I/Cmd+Enter must not fire while About or Recent updates is showing."""
+    block = _hotkey_register_block()
+    for hid in (
+        "start.tabGoogle",
+        "start.tabExcel",
+        "start.tabMindnode",
+        "start.tabNone",
+        "start.browseInput",
+        "start.browseOutput",
+        "start.confirm",
+    ):
+        assert "isOpenForm" in _hotkey_entry(block, hid), hid
+    for hid in ("start.tabOpen", "start.tabAbout", "start.tabUpdates"):
+        entry = _hotkey_entry(block, hid)
+        assert "when: isOpen," in entry, hid
+        assert "isOpenForm" not in entry, hid
+
+
 def test_both_panels_ship_a_refresh_button():
     html = read("start-overlay.html")
     for role in ("google-refresh", "excel-refresh"):


### PR DESCRIPTION
## Summary

Spreadsheet, folder, and confirm shortcuts in the Start overlay now require the Open tab, not just the overlay being open. `G`/`E`/`I`/`O` and `Cmd+Enter` were firing on About and Recent updates and mutating (or confirming) the hidden workspace form. Top-level Open/About/Updates shortcuts stay overlay-wide.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_start_overlay_source.py`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`
- [x] Open the Start overlay, switch to About, press `E` / `I` / `Cmd+Enter` — the hidden form must not change or confirm