### PR TITLE
fix(web): switch Start overlay to Open when restoring a recent

### DIFF
--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -1405,6 +1405,10 @@
 
   function restoreProject(project) {
     if (!project) return;
+    // The left rail is visible on every top-level tab. Filling Open-pane
+    // fields while About/Updates is showing reads as a dead click; switch
+    // first so the restored values are actually on screen.
+    setStartTab("open");
     // Picking a recent project is an explicit authoring act — confirming after
     // it should write that project's name, not fall back to "leave alone".
     state.projectNameAuthored = true;

--- a/tests/test_start_overlay_source.py
+++ b/tests/test_start_overlay_source.py
@@ -151,6 +151,14 @@ def test_load_status_rerenders_about_when_that_tab_is_showing():
     assert "renderAbout()" in body
 
 
+def test_restore_project_switches_to_the_open_tab():
+    """Rail recents stay visible on About; a click must reveal the Open form."""
+    src = strip_comments(read("start-overlay.js"))
+    body = src[src.index("function restoreProject") :]
+    body = body[: body.index("\n  function ")]
+    assert 'setStartTab("open")' in body
+
+
 def test_both_panels_ship_a_refresh_button():
     html = read("start-overlay.html")
     for role in ("google-refresh", "excel-refresh"):


### PR DESCRIPTION
## Summary

Clicking a recent project in the Start overlay rail now switches to the Open tab before filling the form. The rail stays visible on About and Recent updates, so a restore that only wrote hidden fields looked like a dead click.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_start_overlay_source.py`
- [x] `uv run ruff format --check && uv run ruff check --fix`
- [ ] Open About, click a recent in the rail — the Open pane should appear with that project's folders and sheet