### PR TITLE
fix(web): refresh Start overlay About when /api/status lands

### DIFF
--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -1175,6 +1175,9 @@
     return apiGet("/api/status").then(function (s) {
       state.statusData = s;
       state.sheetLoaded = !!s.sheet_loaded;
+      // setStartTab("about") renders from statusData; if About is already
+      // visible when this lands, the panel would otherwise stay on v0.0.0.
+      if (state.startTab === "about") renderAbout();
       return s;
     });
   }

--- a/tests/test_start_overlay_source.py
+++ b/tests/test_start_overlay_source.py
@@ -142,6 +142,15 @@ def test_form_hotkeys_require_the_open_tab():
         assert "isOpenForm" not in entry, hid
 
 
+def test_load_status_rerenders_about_when_that_tab_is_showing():
+    """Opening About before /api/status resolves must not freeze v0.0.0."""
+    src = strip_comments(read("start-overlay.js"))
+    body = src[src.index("function loadStatus") :]
+    body = body[: body.index("\n  function ")]
+    assert 'startTab === "about"' in body
+    assert "renderAbout()" in body
+
+
 def test_both_panels_ship_a_refresh_button():
     html = read("start-overlay.html")
     for role in ("google-refresh", "excel-refresh"):


### PR DESCRIPTION
## Summary

`loadStatus()` now rerenders the About panel if that tab is already visible when `/api/status` returns. Opening About during the first fetch otherwise stayed on the `v0.0.0` fallback until the user left and came back.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_start_overlay_source.py`
- [x] `uv run ruff format --check && uv run ruff check --fix`
- [ ] Slow `/api/status`, open About before it resolves, then let it complete — version should update in place