### PR TITLE
fix(workflows): fail Transcribe when decode or the model returns nothing

### DIFF
--- a/source/workflows.py
+++ b/source/workflows.py
@@ -264,6 +264,18 @@ def _exec_transcribe(
     # ("audio_track_contains"), not an index.
 
     result: Any = None
+    if not paths:
+        return {
+            "transcript": {
+                "segments": [],
+                "language": lang or "",
+                "source_file": "",
+                "model": "",
+                "source": src,
+            },
+            "segments": {"segments": [], "source": src},
+            "__note__": "No video wired",
+        }
     if len(paths) >= 2:
         timeline = video.build_source_timeline(paths)
         if timeline is not None:
@@ -273,7 +285,7 @@ def _exec_transcribe(
                 language=lang,
                 cancel_flag=ctx.cancel_flag,
             )
-    elif paths:
+    else:
         result = transcripts.transcribe_video(
             paths[0],
             model_name=model_name,
@@ -282,12 +294,9 @@ def _exec_transcribe(
         )
 
     if result is None:
-        result = {
-            "segments": [],
-            "language": lang or "",
-            "source_file": paths[0] if paths else "",
-            "model": "",
-        }
+        # Decode/model failure used to become a successful empty transcript, so
+        # Find-word and summaries ran on silence with no error on the node.
+        raise RuntimeError("Could not transcribe the wired video")
     transcript_val = dict(result)
     transcript_val["source"] = src
     return {

--- a/tests/test_workflows_executors.py
+++ b/tests/test_workflows_executors.py
@@ -111,6 +111,25 @@ def test_transcribe_returns_segments_and_carries_source(tmp_path, monkeypatch):
     assert out["segments"]["source"] is src
 
 
+def test_transcribe_notes_when_nothing_wired(tmp_path):
+    out = _run("transcribe", _ctx(tmp_path), {}, {})
+    assert out["transcript"]["segments"] == []
+    assert "wire" in out["__note__"].lower()
+
+
+def test_transcribe_raises_when_decode_fails(tmp_path, monkeypatch):
+    import transcripts
+
+    monkeypatch.setattr(transcripts, "transcribe_video", lambda *a, **k: None)
+    src = {"participant": "P01", "video_paths": [str(tmp_path / "study_P01.mp4")]}
+    try:
+        _run("transcribe", _ctx(tmp_path), {"video": src}, {})
+    except RuntimeError as exc:
+        assert "transcribe" in str(exc).lower()
+    else:
+        raise AssertionError("decode failure must fail the node, not return empty")
+
+
 # ---- Thinking (Ollama) ----
 
 


### PR DESCRIPTION
## Summary

The Workflows Transcribe node now fails when `transcribe_video` / `transcribe_timeline` returns `None` (decode or model failure) instead of completing with empty segments. Downstream Find-word and summary nodes were running on silence. A node with no video wired still completes with a `__note__`, like Make Clips.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_workflows_executors.py -k transcribe`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`
- [ ] In Workflows, wire a missing/unreadable video into Transcribe — the node should fail, not succeed with zero segments