### PR TITLE
fix(cli): keep the Windows installer working directory inside {app}

### DIFF
--- a/source/cli.py
+++ b/source/cli.py
@@ -899,8 +899,13 @@ def get_runtime_working_dir() -> str:
       and invalidate the signature.
     * a one-dir build (Windows/Linux) — the folder containing the payload
       directory. One-dir puts ``clipgen.exe`` *inside* ``clipgen/`` alongside
-      ``lib/``; the folder the user actually dragged somewhere is its
+      ``lib/``; the folder the user actually dragged out of the zip is its
       parent, so that is where they will drop ``credentials.json``.
+    * a one-dir *installer* copy — Inno Setup lands that same layout at
+      ``%LOCALAPPDATA%\\Programs\\clipgen``. Walking up one more level would
+      put cwd in ``Programs`` itself, so stay in ``{app}``. Detected by an
+      ``unins000.exe`` sibling (Inno's uninstaller) or a parent named
+      ``Programs``.
     * anything else — the executable's own directory.
     """
     if not getattr(sys, "frozen", False):
@@ -919,6 +924,13 @@ def get_runtime_working_dir() -> str:
     # of Contents/MacOS; the .app branch above handles it.)
     meipass = getattr(sys, "_MEIPASS", None)
     if meipass and Path(meipass).resolve().parent == exe_dir:
+        # Portable zip: .../clipgen/{clipgen.exe, lib/} → cwd is .../
+        # Inno installer: %LOCALAPPDATA%/Programs/clipgen/{clipgen.exe, lib/}
+        # → stay in {app}, not in Programs.
+        if (exe_dir / "unins000.exe").is_file() or exe_dir.parent.name.lower() == (
+            "programs"
+        ):
+            return str(exe_dir)
         return str(exe_dir.parent)
     return str(exe_dir)
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,5 +1,6 @@
 import os
 from argparse import Namespace
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -939,6 +940,34 @@ def test_frozen_onedir_resolves_beside_the_payload_folder(monkeypatch):
     monkeypatch.setattr("sys.executable", "/Users/me/Apps/clipgen/clipgen.exe")
     monkeypatch.setattr("sys._MEIPASS", "/Users/me/Apps/clipgen/lib", raising=False)
     assert cli.get_runtime_working_dir() == "/Users/me/Apps"
+
+
+def test_frozen_onedir_installer_keeps_cwd_in_app_dir(monkeypatch):
+    """Inno installs the one-dir layout under .../Programs/clipgen, not a zip."""
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr(
+        "sys.executable",
+        "/Users/me/AppData/Local/Programs/clipgen/clipgen.exe",
+    )
+    monkeypatch.setattr(
+        "sys._MEIPASS",
+        "/Users/me/AppData/Local/Programs/clipgen/lib",
+        raising=False,
+    )
+    assert cli.get_runtime_working_dir() == ("/Users/me/AppData/Local/Programs/clipgen")
+
+
+def test_frozen_onedir_uninstaller_marker_keeps_cwd_in_app_dir(monkeypatch, tmp_path):
+    app = tmp_path / "clipgen"
+    lib = app / "lib"
+    lib.mkdir(parents=True)
+    (app / "unins000.exe").write_bytes(b"")
+    exe = app / "clipgen.exe"
+    exe.write_bytes(b"")
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr("sys.executable", str(exe))
+    monkeypatch.setattr("sys._MEIPASS", str(lib), raising=False)
+    assert Path(cli.get_runtime_working_dir()) == app.resolve()
 
 
 def test_frozen_macos_app_wins_over_onedir_branch(monkeypatch):


### PR DESCRIPTION
## Summary

Installed Windows builds now use `{app}` as the working directory instead of `%LOCALAPPDATA%\\Programs`. The one-dir `exe` + `lib/` walk-up is correct for the portable zip, but Inno Setup puts that layout under `Programs\\clipgen`, so cwd became `Programs`. Detection is Inno's `unins000.exe` sibling or a parent named `Programs`.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_cli_args.py -k "frozen_onedir or frozen_macos_working or frozen_plain or frozen_onefile"`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`
- [ ] Launch an installed `clipgen.exe` and confirm the welcome line's working directory is the install folder, not `Programs`