### PR TITLE
fix(screenspace): do not pick the Latin OCR model for Chinese+Latin

### DIFF
--- a/source/screenspace_ocr.py
+++ b/source/screenspace_ocr.py
@@ -62,7 +62,13 @@ def _resolve_ocr_model(languages: list[str] | None) -> str:
         raise ValueError(f"Unsupported OCR language(s): {unknown}")
     models = {_OCR_LANG_TO_MODEL[lang] for lang in langs}
     if models == {_OCR_MODEL_DEFAULT, "latin"}:
-        return "latin"  # the latin model covers English glyphs too
+        # latin covers English glyphs, not the Chinese half of the default rec
+        # model. ["en", "de"] can share latin; ["zh", "de"] cannot.
+        default_langs = [
+            lang for lang in langs if _OCR_LANG_TO_MODEL[lang] == _OCR_MODEL_DEFAULT
+        ]
+        if default_langs and all(lang == "en" for lang in default_langs):
+            return "latin"
     if len(models) == 1:
         return next(iter(models))
     raise ValueError(f"OCR languages {langs} need incompatible recognition models")

--- a/tests/screenspace/test_text_numbers.py
+++ b/tests/screenspace/test_text_numbers.py
@@ -887,6 +887,11 @@ class TestResolveOcrModel:
         # The latin model covers English glyphs, so the mix is servable.
         assert screenspace._resolve_ocr_model(["en", "de"]) == "latin"
 
+    def test_chinese_plus_latin_is_incompatible(self):
+        # default covers Chinese+English; latin does not cover Chinese.
+        with pytest.raises(ValueError, match="incompatible"):
+            screenspace._resolve_ocr_model(["zh", "de"])
+
     def test_incompatible_mix_raises(self):
         with pytest.raises(ValueError, match="incompatible"):
             screenspace._resolve_ocr_model(["ja", "ko"])


### PR DESCRIPTION
## Summary

`_resolve_ocr_model` no longer treats every `{default, latin}` mix as English+Latin. `zh` shares the default rec model with `en`, so `["zh", "de"]` was resolving to the Latin-only model and silently dropping Chinese. The shortcut still applies when the default-side languages are all `en`.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/screenspace/test_text_numbers.py -k ResolveOcrModel`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`