### PR TITLE
fix(screenspace): reject incompatible OCR language pairs at task create

### DIFF
--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -2669,6 +2669,12 @@ def _coerce_ocr_controls(params: dict[str, Any], *, context: str = "") -> None:
             raise ValueError(
                 f"{context}languages must be a non-empty list drawn from {valid}"
             )
+        # Known codes can still need two rec models (ja+ko). Refuse here so
+        # the task never queues and fails mid-scan.
+        try:
+            screenspace._resolve_ocr_model([str(lang) for lang in langs])
+        except ValueError as exc:
+            raise ValueError(f"{context}{exc}") from exc
     if "ocr_confidence_threshold" not in params:
         return
     threshold = _coerce_float(

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -1117,6 +1117,23 @@ def test_create_ocr_task_accepts_known_language(client, monkeypatch):
     assert resp.get_json()["task"]["parameters"]["languages"] == ["de"]
 
 
+def test_create_ocr_task_rejects_incompatible_languages(client, monkeypatch):
+    """Each code can be known while the pair still needs two rec models."""
+    _create_region(client, "r")
+    _enable_video_task_setup(monkeypatch, "P01")
+    resp = client.post(
+        "/screenspace/api/tasks",
+        json={
+            "type": "text",
+            "participant": "P01",
+            "region": "r",
+            "parameters": {"search_string": "score", "languages": ["ja", "ko"]},
+        },
+    )
+    assert resp.status_code == 400
+    assert "incompatible" in resp.get_json()["error"]
+
+
 @pytest.mark.parametrize("task_type", ["template", "flow", "scene"])
 def test_create_task_new_types_accepted(client, task_type):
     """New phase-4 types pass type validation (fail at video, not type)."""


### PR DESCRIPTION
## Summary

`_coerce_ocr_controls` now calls `_resolve_ocr_model`, so mixes like `["ja", "ko"]` return HTTP 400 at task create/import instead of queuing and failing during the scan.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_screenspace_api.py -k "ocr_task_rejects or ocr_task_accepts_known"`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`