### PR TITLE
perf(screenspace): share one grid accumulation across heatmap artifacts

### DIFF
--- a/agents/skills/profile/SKILL.md
+++ b/agents/skills/profile/SKILL.md
@@ -30,7 +30,8 @@ probes — the label `_parallel_probe` was measured without). `media_cache.*` an
 `sse.open <rule>` (streaming responses — see below), `transcribe.*`, `sheets.*`
 (Google via `_call_with_api_retry`; local `.xlsx` is `sheets.excel_load`),
 `pipeline.clip` / `pipeline.pool_wall`, `ocr.pool_wait` / `ocr.reader_build`,
-`heatmap.gif` / `heatmap.rolling` / `heatmap.gifs` (pair wall — see below),
+`heatmap.gif` / `heatmap.rolling` / `heatmap.gifs` (pair wall) /
+`heatmap.grid_layers` (shared grid accumulation — see below),
 `ollama.generate`, `titlecard.wrap` plus
 `titlecard.copy` / `titlecard.reencode` counts (the concat-demuxer vs filter
 fallback), `workflows.run` / `workflows.node <type>` / `workflows.batch_child` /
@@ -264,6 +265,14 @@ indicative; add `--full-chromium` when paint fidelity matters.
   touch GIF encode. `heatmap.gifs` is the pair wall (same ratio as
   `pipeline.clip ÷ pipeline.pool_wall`): near 2.0 means the cumulative and
   rolling encodes overlapped; near 1.0 means they ran back-to-back.
+- `heatmap.grid_layers` is the per-cell circle drawing for a grid tool
+  (flow/change/attention), hoisted out of the GIF pair so the PNG and both GIFs
+  share one pass instead of replaying the results four times. It is *outside*
+  `heatmap.gifs`, so a grid tool's post-scan cost is `grid_layers + gifs` — read
+  them together or the total looks like it halved when the work only moved.
+  Expect the pair wall to sit near 2.0 once it is hoisted: what was left in the
+  threads (numpy folds + PIL's encoder) parallelizes, whereas the circle loop
+  it replaced measured **0.82×** — slower in two threads than in one.
 - `ocr.pool_wait` is idle time blocked on a busy OCR engine — raise
   `SCREENSPACE_OCR_POOL_SIZE` only when this is large *and* `peak_rss` leaves
   headroom, since each Reader holds its own model copy.

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -138,7 +138,7 @@
       video.removeEventListener("loadedmetadata", onMeta);
       video.currentTime = localTime;
       applyPlaybackRate(); // load() reset the element to its default rate
-      if (resume) video.play();
+      if (resume) window.ClipgenVideoControls.safePlay(video);
     };
     video.addEventListener("loadedmetadata", onMeta);
   }
@@ -146,7 +146,7 @@
   function togglePlay() {
     var video = qs("#coVideo");
     if (!video || !video.src) return;
-    if (video.paused) video.play();
+    if (video.paused) window.ClipgenVideoControls.safePlay(video);
     else video.pause();
   }
 

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1768,7 +1768,7 @@
           var onMeta = function () {
             video.removeEventListener("loadedmetadata", onMeta);
             video.currentTime = 0.001;
-            video.play();
+            window.ClipgenVideoControls.safePlay(video);
           };
           video.addEventListener("loadedmetadata", onMeta);
           return;
@@ -1830,12 +1830,9 @@
     updateVideoButtons();
 
     applyPlaybackRate();
-    var playPromise = video.play();
-    if (playPromise && playPromise.then) {
-      playPromise.catch(function () {
-        pauseVideo();
-      });
-    }
+    // Rejection here means playback never started (autoplay policy, or a
+    // pause/seek landing first), so the button state must fall back.
+    window.ClipgenVideoControls.safePlay(video, pauseVideo);
   }
 
   function pauseVideo() {

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -134,7 +134,7 @@
     var onMeta = function () {
       v.removeEventListener("loadedmetadata", onMeta);
       v.currentTime = localTime;
-      if (autoplay) v.play();
+      if (autoplay) window.ClipgenVideoControls.safePlay(v);
     };
     v.addEventListener("loadedmetadata", onMeta);
   }
@@ -574,7 +574,7 @@
     if (section) section.classList.toggle("video-collapsed", state.videoCollapsed);
 
     qs("#videoPlayBtn").addEventListener("click", function () {
-      if (video.paused) video.play();
+      if (video.paused) window.ClipgenVideoControls.safePlay(video);
       else video.pause();
     });
     // Hover the mute button for a glassy 0–200% volume popover (click still
@@ -953,7 +953,7 @@
         },
         handler: function () {
           var v = qs("#videoPlayer");
-          if (v.paused) v.play();
+          if (v.paused) window.ClipgenVideoControls.safePlay(v);
           else v.pause();
         },
       },
@@ -1099,7 +1099,7 @@
     function (t) { seekVideo(t); },
     function (video, t) {
       video.currentTime = t;
-      if (video.paused) video.play();
+      if (video.paused) window.ClipgenVideoControls.safePlay(video);
     }
   );
 

--- a/assets/web/video-controls.js
+++ b/assets/web/video-controls.js
@@ -6,6 +6,7 @@
  * This module owns those shared bits.
  *
  * Public API on window.ClipgenVideoControls:
+ *   safePlay(videoEl, onRejected)     — play() whose promise is always handled.
  *   nextSpeed(speeds, current)        — next entry in the cycle (wraps around).
  *   applyPlaybackRate(videoEl, rate)  — set the playback rate without pitch
  *                                       preservation. The time-stretch filter is
@@ -19,6 +20,20 @@
  */
 (function () {
   "use strict";
+
+  // HTMLMediaElement.play() returns a promise that REJECTS whenever playback is
+  // interrupted before it starts — a pause() landing in the same tick, a new
+  // load(), a seek that swaps the source, or autoplay policy. Every one of those
+  // is normal here: seeking a clip and immediately pausing is a click away on
+  // Transcripts and Composer. Left unhandled the rejection surfaces as an
+  // uncaught page error ("The play() request was interrupted by a call to
+  // pause()"), which is noise in the console and a hard failure in /ui-check.
+  // Not every browser returns a promise, hence the duck-typing.
+  function safePlay(videoEl, onRejected) {
+    if (!videoEl) return;
+    var p = videoEl.play();
+    if (p && p.catch) p.catch(onRejected || function () {});
+  }
 
   function nextSpeed(speeds, current) {
     var idx = speeds.indexOf(current);
@@ -334,8 +349,7 @@
       forEachTrack(function (el) {
         if (el.readyState < 3) return; // HAVE_FUTURE_DATA — don't fight the buffer
         if (el.paused) {
-          var p = el.play();
-          if (p && p.catch) p.catch(function () {});
+          safePlay(el);
           return;
         }
         var delta = el.currentTime - video.currentTime; // + => audio ahead
@@ -538,6 +552,7 @@
   }
 
   window.ClipgenVideoControls = {
+    safePlay: safePlay,
     nextSpeed: nextSpeed,
     applyPlaybackRate: applyPlaybackRate,
     attachAudioPanel: attachAudioPanel,

--- a/assets/web/viewer.js
+++ b/assets/web/viewer.js
@@ -1849,7 +1849,11 @@
     }
     vid.muted = false;
     vid.controls = true;
-    vid.play();
+    // Exported viewers inline this file without video-controls.js, so the
+    // play() promise is handled here rather than via safePlay(). Clicking
+    // away from a preview interrupts the start and rejects it.
+    var playing = vid.play();
+    if (playing && playing.catch) playing.catch(function () {});
     if (_preview.overlay) _preview.overlay.classList.add("hidden");
     if (_preview.timeBadge) _preview.timeBadge.classList.add("hidden");
   }

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -174,9 +174,18 @@ def _participant_duration(participant: str) -> float | None:
 def api_participants() -> Any:
     """Participants with source videos, plus part timelines for stitched seeks."""
     participants: list[dict[str, Any]] = []
-    for p in files.resolve_participant_videos(_sheet_context):
-        if not p.get("has_video"):
-            continue
+    resolved = [
+        p
+        for p in files.resolve_participant_videos(_sheet_context)
+        if p.get("has_video")
+    ]
+    # Every entry below probes its parts for durations and its first part for
+    # resolution/fps. Serialized that is one ffprobe subprocess after another and
+    # the page cannot render until the last one returns — measured 1.06 s for a
+    # 24-participant study on local SSD, all of it ffprobe. Probe the whole set up
+    # front so the loop reads the caches instead.
+    video.prewarm_probes(vp for p in resolved for vp in p["video_paths"])
+    for p in resolved:
         parts = _participant_parts(p["video_paths"])
         # Resolution + fps for the subheader readout, probed from the first part —
         # stitched parts share one source setup. probe_video_properties returns None

--- a/source/screenspace.py
+++ b/source/screenspace.py
@@ -113,13 +113,17 @@ from screenspace_scans import (
     scan_text,
 )
 from screenspace_heatmap import (
+    GIF_FRAMES,
+    GridLayers,
     build_gif_sprite_bytes,
+    build_grid_layers,
     generate_attention_heatmap,
     generate_change_heatmap,
     generate_flow_heatmap,
     generate_heatmap_gif,
     generate_rolling_heatmap_gif,
     generate_template_heatmap,
+    grid_layer_count,
     sprite_grid,
 )
 from screenspace_tools import (

--- a/source/screenspace_heatmap.py
+++ b/source/screenspace_heatmap.py
@@ -77,6 +77,22 @@ _GRID_KEYS: dict[str, str] = {
     "attention": "saliency_grid",
 }
 
+# Accumulator edge for grid types. Fixed (not frame-native), which is what makes
+# holding one layer per GIF bucket cheap enough to share — see build_grid_layers.
+_GRID_ACC_SIZE = 256
+
+# Temporal buckets per animated GIF. Public because a caller prebuilding layers
+# must bucket them exactly as the generators do, or they are rejected as stale.
+GIF_FRAMES = 24
+
+# One GIF bucket's drawn values plus the mask of pixels it drew.
+GridLayers = list[tuple[np.ndarray, np.ndarray]]
+
+
+def grid_layer_count(results: list[dict[str, Any]]) -> int:
+    """Bucket count the GIF generators will use for *results*."""
+    return min(GIF_FRAMES, len(results))
+
 
 def generate_template_heatmap(
     results: list[dict[str, Any]],
@@ -106,25 +122,36 @@ def generate_template_heatmap(
     return output_path
 
 
+def _grid_accumulator(
+    results: list[dict[str, Any]],
+    heatmap_type: str,
+    layers: "GridLayers | None",
+) -> np.ndarray:
+    """Full-replay accumulator for a grid heatmap PNG, reusing *layers* if given."""
+    if layers:
+        return _fold_grid_layers(layers, len(layers) - 1)
+    accumulator = np.zeros((_GRID_ACC_SIZE, _GRID_ACC_SIZE), dtype=np.float32)
+    for r in results:
+        _accumulate_heatmap_result(accumulator, r, heatmap_type)
+    return accumulator
+
+
 def generate_flow_heatmap(
     results: list[dict[str, Any]],
     region_width: int,
     region_height: int,
     output_path: str,
+    layers: GridLayers | None = None,
 ) -> str | None:
     """Generate a heatmap PNG from accumulated optical flow magnitudes.
 
     Uses ``flow_grid`` data from each result to paint per-cell motion
     intensity across all frames.
+
+    *layers* is an optional prebuilt :func:`build_grid_layers` result covering
+    every result; folding it is equivalent to the replay below and skips it.
     """
-    acc_size = 256
-    accumulator = np.zeros((acc_size, acc_size), dtype=np.float32)
-    for r in results:
-        for cell in r.get("flow_grid", []):
-            cx = int(cell["x"] * (acc_size - 1))
-            cy = int(cell["y"] * (acc_size - 1))
-            radius = max(1, acc_size // 16)
-            cv2.circle(accumulator, (cx, cy), radius, float(cell["mag"]), -1)
+    accumulator = _grid_accumulator(results, "flow", layers)
 
     if accumulator.max() == 0:
         return None
@@ -143,16 +170,17 @@ def generate_change_heatmap(
     region_width: int,
     region_height: int,
     output_path: str,
+    layers: GridLayers | None = None,
 ) -> str | None:
     """Generate a heatmap PNG from accumulated per-frame change-mask grids.
 
     Uses ``change_grid`` data (downsampled change masks) from each result to
     paint where pixels changed most often across all detected change frames.
+
+    *layers* is an optional prebuilt :func:`build_grid_layers` result covering
+    every result; folding it is equivalent to the replay below and skips it.
     """
-    acc_size = 256
-    accumulator = np.zeros((acc_size, acc_size), dtype=np.float32)
-    for r in results:
-        _accumulate_heatmap_result(accumulator, r, "change")
+    accumulator = _grid_accumulator(results, "change", layers)
 
     if accumulator.max() == 0:
         return None
@@ -171,17 +199,18 @@ def generate_attention_heatmap(
     frame_width: int,
     frame_height: int,
     output_path: str,
+    layers: GridLayers | None = None,
 ) -> str | None:
     """Generate a heatmap PNG from accumulated per-frame saliency grids.
 
     Uses ``saliency_grid`` data (downsampled saliency maps, one per sampled
     frame) so heat reflects predicted attention dwell across the whole scan —
     the eye-tracking-style deliverable. Full-frame: sized to the video frame.
+
+    *layers* is an optional prebuilt :func:`build_grid_layers` result covering
+    every result; folding it is equivalent to the replay below and skips it.
     """
-    acc_size = 256
-    accumulator = np.zeros((acc_size, acc_size), dtype=np.float32)
-    for r in results:
-        _accumulate_heatmap_result(accumulator, r, "attention")
+    accumulator = _grid_accumulator(results, "attention", layers)
 
     if accumulator.max() == 0:
         return None
@@ -223,6 +252,54 @@ def _accumulate_heatmap_result(
             cv2.circle(accumulator, (cx, cy), radius, float(cell["mag"]), -1)
             if mask_out is not None:
                 cv2.circle(mask_out, (cx, cy), radius, 1, -1)
+
+
+def build_grid_layers(
+    results: list[dict[str, Any]],
+    heatmap_type: str,
+    num_frames: int,
+) -> GridLayers | None:
+    """Draw each temporal bucket's grid cells once, as ``(values, mask)`` layers.
+
+    Grid types (flow/change/attention) draw with ``cv2.circle``, which *sets*
+    rather than accumulates — so a bucket's layer plus the mask of pixels it
+    drew reproduces any replay of that bucket exactly (see
+    :func:`generate_rolling_heatmap_gif`, which has always relied on this).
+
+    The three artifacts a grid scan produces — the PNG, the cumulative GIF and
+    the rolling GIF — all replayed the same results independently, four full
+    passes of per-cell Python-level circle draws in total. Measured on a 962-
+    result 16×16-grid attention scan those passes are ~0.26 s *each*, and the
+    two GIF generators run concurrently, so they also spent that time fighting
+    over the GIL: overlapping them measured **slower** than running them back to
+    back (0.82×). Building the buckets once up front leaves only numpy folds and
+    PIL's encoder in the threads, which does parallelize (measured 1.45×).
+
+    Returns ``None`` for non-grid types (template accumulates additively and
+    frame-native; see :func:`generate_rolling_heatmap_gif`).
+    """
+    if heatmap_type not in _GRID_KEYS:
+        return None
+    layers: GridLayers = []
+    for bucket in range(max(1, num_frames)):
+        vals = np.zeros((_GRID_ACC_SIZE, _GRID_ACC_SIZE), dtype=np.float32)
+        mask = np.zeros((_GRID_ACC_SIZE, _GRID_ACC_SIZE), dtype=np.uint8)
+        start_idx, end_idx = _frame_bucket_bounds(bucket, len(results), num_frames)
+        for r_idx in range(start_idx, end_idx):
+            _accumulate_heatmap_result(
+                vals, results[r_idx], heatmap_type, mask_out=mask
+            )
+        layers.append((vals, mask.astype(bool)))
+    return layers
+
+
+def _fold_grid_layers(layers: GridLayers, upto: int) -> np.ndarray:
+    """Replay buckets ``0..upto`` onto one accumulator (last draw wins per pixel)."""
+    acc = np.zeros((_GRID_ACC_SIZE, _GRID_ACC_SIZE), dtype=np.float32)
+    for bucket in range(upto + 1):
+        vals, mask = layers[bucket]
+        acc[mask] = vals[mask]
+    return acc
 
 
 def _heatmap_frame_image(
@@ -373,14 +450,19 @@ def generate_heatmap_gif(
     height: int,
     output_path: str,
     heatmap_type: str = "template",
-    num_frames: int = 24,
+    num_frames: int = GIF_FRAMES,
     frame_duration_ms: int = 120,
+    layers: GridLayers | None = None,
 ) -> dict[str, Any] | None:
     """Generate an animated GIF showing heatmap accumulation over time.
 
     Divides *results* into *num_frames* temporal buckets, progressively
     accumulates heatmap data, and writes frames as an animated GIF. Returns the
     :func:`_save_animation` descriptor, or ``None`` when there is nothing to draw.
+
+    *layers* is an optional prebuilt :func:`build_grid_layers` result covering the
+    same buckets, which replaces both replays below with numpy folds. Grid types
+    only; ignored for template.
     """
     if not results:
         return None
@@ -391,14 +473,21 @@ def generate_heatmap_gif(
 
     acc_h, acc_w = height, width
     if heatmap_type in _GRID_KEYS:
-        acc_h = acc_w = 256
+        acc_h = acc_w = _GRID_ACC_SIZE
+    if heatmap_type not in _GRID_KEYS or (
+        layers is not None and len(layers) != num_frames
+    ):
+        layers = None
 
     # Pass 1: find the shared ceiling. Accumulation is monotonic, so the final
     # state already carries the global max — no per-frame snapshots needed.
-    accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
-    for r in results:
-        _accumulate_heatmap_result(accumulator, r, heatmap_type)
-    global_max = float(accumulator.max())
+    if layers is not None:
+        global_max = float(_fold_grid_layers(layers, num_frames - 1).max())
+    else:
+        accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
+        for r in results:
+            _accumulate_heatmap_result(accumulator, r, heatmap_type)
+        global_max = float(accumulator.max())
     if global_max == 0:
         return None
 
@@ -409,9 +498,15 @@ def generate_heatmap_gif(
     accumulator = np.zeros((acc_h, acc_w), dtype=np.float32)
     frames: list[Image.Image] = []
     for frame_idx in range(num_frames):
-        start_idx, end_idx = _frame_bucket_bounds(frame_idx, len(results), num_frames)
-        for r_idx in range(start_idx, end_idx):
-            _accumulate_heatmap_result(accumulator, results[r_idx], heatmap_type)
+        if layers is not None:
+            vals, mask = layers[frame_idx]
+            accumulator[mask] = vals[mask]
+        else:
+            start_idx, end_idx = _frame_bucket_bounds(
+                frame_idx, len(results), num_frames
+            )
+            for r_idx in range(start_idx, end_idx):
+                _accumulate_heatmap_result(accumulator, results[r_idx], heatmap_type)
         frames.append(
             _heatmap_frame_image(accumulator, global_max, heatmap_type, width, height)
         )
@@ -426,9 +521,10 @@ def generate_rolling_heatmap_gif(
     height: int,
     output_path: str,
     heatmap_type: str = "template",
-    num_frames: int = 24,
+    num_frames: int = GIF_FRAMES,
     window_frames: int = 6,
     frame_duration_ms: int = 120,
+    layers: GridLayers | None = None,
 ) -> dict[str, Any] | None:
     """Generate an animated GIF showing a sliding-window heatmap over time.
 
@@ -447,7 +543,7 @@ def generate_rolling_heatmap_gif(
     window_frames = max(1, window_frames)
     acc_h, acc_w = height, width
     if heatmap_type in _GRID_KEYS:
-        acc_h = acc_w = 256
+        acc_h = acc_w = _GRID_ACC_SIZE
 
     if heatmap_type in _GRID_KEYS:
         # Grid draws *set* pixels (cv2.circle, last draw wins), so a window is
@@ -459,22 +555,17 @@ def generate_rolling_heatmap_gif(
         # Python-level circle draws ~12x: 596 → 145 ms of accumulate on a
         # 600-result attention scan. Layers are 256×256, so all 24 together
         # are ~3 MB — nothing like the full-res frames the two-pass shape
-        # exists to avoid holding.
-        layers: list[tuple[np.ndarray, np.ndarray]] = []
-        for bucket in range(num_frames):
-            vals = np.zeros((acc_h, acc_w), dtype=np.float32)
-            mask = np.zeros((acc_h, acc_w), dtype=np.uint8)
-            start_idx, end_idx = _frame_bucket_bounds(bucket, len(results), num_frames)
-            for r_idx in range(start_idx, end_idx):
-                _accumulate_heatmap_result(
-                    vals, results[r_idx], heatmap_type, mask_out=mask
-                )
-            layers.append((vals, mask.astype(bool)))
+        # exists to avoid holding. The caller can hand the same layers to the
+        # cumulative GIF and the PNG (build_grid_layers), dropping the build
+        # here too.
+        if layers is None or len(layers) != num_frames:
+            layers = build_grid_layers(results, heatmap_type, num_frames) or []
+        bucket_layers = layers
 
         def _accumulate_window(frame_idx: int) -> np.ndarray:
             acc = np.zeros((acc_h, acc_w), dtype=np.float32)
             for bucket in range(max(0, frame_idx - window_frames + 1), frame_idx + 1):
-                vals, mask = layers[bucket]
+                vals, mask = bucket_layers[bucket]
                 acc[mask] = vals[mask]
             return acc
 

--- a/source/screenspace_worker.py
+++ b/source/screenspace_worker.py
@@ -21,6 +21,9 @@ import utils
 import video
 from screenspace_tools import TOOLS
 from screenspace_heatmap import (
+    GridLayers,
+    build_grid_layers,
+    grid_layer_count,
     generate_attention_heatmap,
     generate_change_heatmap,
     generate_flow_heatmap,
@@ -537,6 +540,7 @@ class ScreenspaceWorker:
         heatmap_type: str,
         *,
         rolling: bool,
+        layers: GridLayers | None = None,
     ) -> dict[str, Any]:
         """Write the cumulative (and optionally rolling-window) heatmap GIFs.
 
@@ -562,6 +566,7 @@ class ScreenspaceWorker:
                         height,
                         gif_path,
                         heatmap_type=heatmap_type,
+                        layers=layers,
                     )
                     roll_f = pool.submit(
                         generate_rolling_heatmap_gif,
@@ -571,6 +576,7 @@ class ScreenspaceWorker:
                         roll_path,
                         heatmap_type=heatmap_type,
                         window_frames=config.SCREENSPACE_HEATMAP_ROLLING_WINDOW,
+                        layers=layers,
                     )
                     gif = gif_f.result()
                     roll = roll_f.result()
@@ -585,6 +591,7 @@ class ScreenspaceWorker:
                     height,
                     gif_path,
                     heatmap_type=heatmap_type,
+                    layers=layers,
                 )
                 attachments.update(_heatmap_gif_attachments(gif, "heatmap_gif"))
         return attachments
@@ -617,6 +624,12 @@ class ScreenspaceWorker:
         heatmap_path = str(
             Path(utils.get_effective_output_dir()) / f"heatmap_{task_id}.png"
         )
+        # The PNG and both GIFs replay the same per-cell circle draws. For grid
+        # tools (flow/change/attention) that is the dominant post-scan cost and
+        # it anti-parallelizes inside the GIF pool, so draw the buckets once here
+        # and hand the layers to all three (see build_grid_layers).
+        with profiling.span("heatmap.grid_layers"):
+            layers = build_grid_layers(results, task_type, grid_layer_count(results))
         if task_type == "template":
             props = video.probe_video_properties(video_paths[0])
             fw = props.get("width", 1920) if props else 1920
@@ -638,13 +651,13 @@ class ScreenspaceWorker:
             fw = props.get("width", 1920) if props else 1920
             fh = props.get("height", 1080) if props else 1080
             hp = _published_name(
-                generate_attention_heatmap(results, fw, fh, heatmap_path)
+                generate_attention_heatmap(results, fw, fh, heatmap_path, layers=layers)
             )
             if hp:
                 attachments["heatmap"] = hp
             attachments.update(
                 self._write_heatmap_gifs(
-                    task_id, results, fw, fh, "attention", rolling=True
+                    task_id, results, fw, fh, "attention", rolling=True, layers=layers
                 )
             )
         elif task_type in ("flow", "change"):
@@ -652,17 +665,25 @@ class ScreenspaceWorker:
             rh = region_coords.get("h", 256)
             if task_type == "flow":
                 hp = _published_name(
-                    generate_flow_heatmap(results, rw, rh, heatmap_path)
+                    generate_flow_heatmap(results, rw, rh, heatmap_path, layers=layers)
                 )
             else:
                 hp = _published_name(
-                    generate_change_heatmap(results, rw, rh, heatmap_path)
+                    generate_change_heatmap(
+                        results, rw, rh, heatmap_path, layers=layers
+                    )
                 )
             if hp:
                 attachments["heatmap"] = hp
             attachments.update(
                 self._write_heatmap_gifs(
-                    task_id, results, rw, rh, task_type, rolling=task_type == "change"
+                    task_id,
+                    results,
+                    rw,
+                    rh,
+                    task_type,
+                    rolling=task_type == "change",
+                    layers=layers,
                 )
             )
         return attachments

--- a/source/video.py
+++ b/source/video.py
@@ -13,9 +13,8 @@ import sys
 import tempfile
 import threading
 from collections import Counter
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from pathlib import Path
-from collections.abc import Iterable
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/source/video.py
+++ b/source/video.py
@@ -15,6 +15,7 @@ import threading
 from collections import Counter
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from collections.abc import Iterable
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -1633,18 +1634,58 @@ def _parallel_probe(items: list[str], probe_fn: Callable[[str], Any]) -> list[An
     ``(resolved_path, mtime_ns)``, the paths in one call are distinct, and a
     duplicate concurrent probe of the same file is idempotent — both threads
     write the same value under the same key. Fewer than 2 items skips the pool.
+
+    Every ``probe_fn`` passed here reads container headers (duration, stream
+    properties) rather than decoding, so the width is set by how many ffprobe
+    processes can wait on I/O at once, not by core count. Measured on 24 files:
+    1 worker 0.97 s, 4 workers 0.25 s, 8 workers 0.14 s, 12 workers 0.13 s — the
+    curve is flat past 8, which is where the cap sits. A decoding probe
+    (``probe_max_keyframe_gap``) would want a CPU-shaped cap instead; it does not
+    come through here.
     """
     if len(items) < 2:
         return [probe_fn(item) for item in items]
 
     results: list[Any] = [None] * len(items)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(4, len(items))) as pool:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(items))) as pool:
         future_to_idx = {
             pool.submit(probe_fn, item): idx for idx, item in enumerate(items)
         }
         for future in concurrent.futures.as_completed(future_to_idx):
             results[future_to_idx[future]] = future.result()
     return results
+
+
+def prewarm_probes(paths: Iterable[str]) -> None:
+    """Probe *paths* in parallel so later per-file lookups are cache hits.
+
+    For callers that walk a participant list and probe each entry inside the
+    loop: the loop stays sequential and readable, but the ffprobe subprocesses it
+    would have serialized are already paid for. Properties are what get probed
+    because ``get_file_duration`` reads its answer out of the properties cache,
+    so one probe per file warms both.
+
+    Duplicates are collapsed, and probe failures are swallowed here — a file that
+    cannot be probed simply stays uncached and its caller re-probes it and
+    handles the ``None`` as it always did. Prewarming must never be the thing
+    that fails a request.
+    """
+    unique = list(dict.fromkeys(str(p) for p in paths))
+    if len(unique) < 2:
+        return
+
+    def _quiet(path: str) -> None:
+        try:
+            probe_video_properties(path)
+        except Exception as exc:
+            # Deliberately broad. probe_video_properties already handles the
+            # failures it expects and returns None; anything reaching here is
+            # unexpected, and the correct response is still to leave the file
+            # uncached — the caller re-probes it and handles None as it always
+            # did. Raising would turn a slow page into a broken one.
+            utils.verbose_print(f"Could not prewarm probe for {path}: {exc}")
+
+    _parallel_probe(unique, _quiet)
 
 
 def build_source_timeline(paths: list[str]) -> list[tuple[str, int, int]] | None:

--- a/tests/screenspace/test_attention.py
+++ b/tests/screenspace/test_attention.py
@@ -7,6 +7,7 @@ import pytest
 import config
 import screenspace
 import screenspace_frames
+import screenspace_heatmap
 import screenspace_primitives
 import screenspace_scans
 
@@ -416,6 +417,30 @@ def _grid_results(n=8):
     ]
 
 
+def _varied_grid_results(n):
+    """Per-frame results whose grids overlap and *differ* frame to frame.
+
+    ``_grid_results`` repeats one grid, so every draw order produces the same
+    pixels — useless for proving that bucketed layers replay in the right order.
+    These cells move and change magnitude, so an out-of-order fold shows up.
+    """
+    rng = np.random.RandomState(11)
+    results = []
+    for i in range(n):
+        cells = [
+            {
+                "x": round(float((gx + 0.5) / 8), 3),
+                "y": round(float((gy + 0.5) / 8), 3),
+                "mag": round(float(rng.rand()), 3),
+            }
+            for gy in range(8)
+            for gx in range(8)
+            if rng.rand() > 0.3
+        ]
+        results.append({"timestamp": float(i), "saliency_grid": cells})
+    return results
+
+
 class TestAttentionHeatmap:
     def test_static_png_generated(self, tmp_path):
         out = str(tmp_path / "heatmap.png")
@@ -443,6 +468,94 @@ class TestAttentionHeatmap:
         )
         assert cum_info is not None and cum_info["path"] == cum
         assert roll_info is not None and roll_info["path"] == roll
+
+
+class TestSharedGridLayers:
+    """The prebuilt-layers fast path must be byte-identical to replaying results.
+
+    The worker draws each GIF bucket's grid cells once and hands the layers to
+    the PNG and both GIFs instead of letting all three replay the results
+    (measured 2.84 s → 1.23 s of post-scan work on a 962-result attention scan).
+    That is only sound because ``cv2.circle`` sets rather than accumulates, so
+    equality here is exact — a tolerance would hide exactly the drift this
+    guards.
+    """
+
+    def _artifacts(self, tmp_path, results, tag, layers):
+        import screenspace_heatmap
+
+        png = tmp_path / f"{tag}.png"
+        cum = tmp_path / f"{tag}_cum.gif"
+        roll = tmp_path / f"{tag}_roll.gif"
+        screenspace.generate_attention_heatmap(
+            results, 320, 240, str(png), layers=layers
+        )
+        screenspace_heatmap.generate_heatmap_gif(
+            results, 320, 240, str(cum), heatmap_type="attention", layers=layers
+        )
+        screenspace_heatmap.generate_rolling_heatmap_gif(
+            results,
+            320,
+            240,
+            str(roll),
+            heatmap_type="attention",
+            window_frames=3,
+            layers=layers,
+        )
+        return [p.read_bytes() if p.exists() else None for p in (png, cum, roll)]
+
+    @pytest.mark.parametrize("count", [1, 2, 8, 37])
+    def test_layers_path_is_byte_identical_to_replay(self, tmp_path, count):
+        results = _varied_grid_results(count)
+        layers = screenspace.build_grid_layers(
+            results, "attention", screenspace.grid_layer_count(results)
+        )
+        replayed = self._artifacts(tmp_path, results, "replay", None)
+        shared = self._artifacts(tmp_path, results, "shared", layers)
+        assert replayed[0] is not None  # the PNG always lands
+        assert shared == replayed
+
+    def test_layer_count_matches_gif_buckets(self):
+        assert (
+            screenspace.grid_layer_count(_grid_results(100)) == screenspace.GIF_FRAMES
+        )
+        assert screenspace.grid_layer_count(_grid_results(5)) == 5
+
+    def test_layers_tile_every_result(self):
+        """Folding all buckets equals a full replay — the PNG depends on it."""
+        results = _varied_grid_results(37)
+        layers = screenspace.build_grid_layers(
+            results, "attention", screenspace.grid_layer_count(results)
+        )
+        assert layers is not None
+        drawn = np.zeros((256, 256), dtype=bool)
+        for _vals, mask in layers:
+            drawn |= mask
+        replay = np.zeros((256, 256), dtype=np.float32)
+        for r in results:
+            screenspace_heatmap._accumulate_heatmap_result(replay, r, "attention")
+        assert np.array_equal(
+            screenspace_heatmap._fold_grid_layers(layers, len(layers) - 1), replay
+        )
+        assert drawn.any()
+
+    def test_non_grid_type_has_no_layers(self):
+        """Template accumulates additively and frame-native — never bucketed."""
+        assert screenspace.build_grid_layers([{"matches": []}], "template", 4) is None
+
+    def test_stale_layers_are_rejected_not_trusted(self, tmp_path):
+        """A layer set bucketed for a different result count must not be used."""
+        results = _varied_grid_results(24)
+        wrong = screenspace.build_grid_layers(results[:6], "attention", 6)
+        out = tmp_path / "cum.gif"
+        ref = tmp_path / "ref.gif"
+        screenspace_heatmap.generate_heatmap_gif(
+            results, 320, 240, str(out), heatmap_type="attention", layers=wrong
+        )
+        screenspace_heatmap.generate_heatmap_gif(
+            results, 320, 240, str(ref), heatmap_type="attention"
+        )
+        assert out.read_bytes() == ref.read_bytes()
 
 
 class TestAttentionEvents:

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -8,6 +8,7 @@ setup. Combined-app registration (topnav-visible ``/composer/`` + the
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -88,6 +89,48 @@ def test_participants_reports_parts_and_total(co_client):
     # to skip the badge rather than marking every participant.
     assert p["in_sheet"] is False
     assert body["has_sheet"] is False
+
+
+def test_participants_prewarms_probes_before_the_loop(co_client, monkeypatch):
+    """Every part is probed in one batch, not one ffprobe per participant.
+
+    The per-entry probes are cache reads; serialized cold they measured 1.06 s
+    for a 24-participant study and the page cannot render until the last one
+    returns. Asserting the prewarm *saw every part path* is the invariant —
+    timing it here would just measure the mock.
+    """
+    seen: list[list[str]] = []
+    monkeypatch.setattr(video, "prewarm_probes", lambda paths: seen.append(list(paths)))
+
+    body = co_client.get("/composer/api/participants").get_json()
+    (p,) = body["participants"]
+
+    assert len(seen) == 1, "prewarm must run once for the whole list, not per entry"
+    assert [Path(path).name for path in seen[0]] == [
+        part["name"] for part in p["parts"]
+    ]
+
+
+def test_prewarm_probes_dedupes_and_never_raises(monkeypatch):
+    """Prewarming is pure optimization: it dedupes, and a failure is not an error.
+
+    A path that cannot be probed simply stays uncached — the caller re-probes it
+    and handles ``None`` as it always did. Raising here would turn a slow page
+    into a broken one.
+    """
+    calls: list[str] = []
+
+    def boom(path):
+        calls.append(path)
+        raise OSError("unprobeable")
+
+    monkeypatch.setattr(video, "probe_video_properties", boom)
+    # One path is already as fast as it gets, so the pool is skipped entirely.
+    video.prewarm_probes(["/only.mp4"])
+    assert calls == []
+
+    video.prewarm_probes(["/a.mp4", "/a.mp4", "/b.mp4"])
+    assert sorted(calls) == ["/a.mp4", "/b.mp4"]
 
 
 def test_participants_reports_audio_tracks(co_client, monkeypatch):

--- a/tests/test_media_play_frontend_source.py
+++ b/tests/test_media_play_frontend_source.py
@@ -1,0 +1,92 @@
+"""Source-level guard: every ``play()`` on a media element handles its promise.
+
+``HTMLMediaElement.play()`` returns a promise that *rejects* whenever playback
+is interrupted before it starts — a ``pause()`` in the same tick, a ``load()``,
+a source-swapping seek, or autoplay policy. All of those are ordinary here
+(clicking a transcript segment and immediately pausing is one gesture), but an
+unhandled rejection surfaces as an uncaught page error, which is console noise
+for users and a hard failure in ``/ui-check``.
+
+Six of the twelve call sites had drifted into calling it bare, so the contract
+is pinned here rather than left to review: go through
+``ClipgenVideoControls.safePlay`` (video-controls.js), or handle the promise
+inline on the pages that cannot load that module.
+"""
+
+import re
+
+from _frontend_source import WEB, read
+
+# Files that may call play() bare on their own line, and why. Both attach a
+# handler within two lines, which the assertion below verifies rather than
+# trusts — an allowlist entry buys a *local* handler, not an exemption.
+#
+# gallery.js and viewer.js are inlined into exported standalone viewers, which
+# ship without video-controls.js, so they cannot reach safePlay().
+INLINE_HANDLER_ALLOWLIST = {
+    "gallery.js",
+    "viewer.js",
+    "video-controls.js",  # defines safePlay(); its own mix path needs both arms
+}
+
+# `.play()` on anything, ignoring the definition inside safePlay's own comment.
+_PLAY_RE = re.compile(r"\.play\(\)")
+
+
+def _js_files():
+    return sorted(p for p in WEB.glob("*.js"))
+
+
+def _handled_within(src: str, idx: int) -> bool:
+    """Is the play() at *idx* followed by promise handling within two lines?"""
+    tail = src[idx:].split("\n")[:3]
+    return any(".then(" in line or ".catch(" in line for line in tail)
+
+
+def test_every_play_call_handles_its_promise():
+    offenders = []
+    for path in _js_files():
+        src = path.read_text(encoding="utf-8")
+        for match in _PLAY_RE.finditer(src):
+            line_start = src.rfind("\n", 0, match.start()) + 1
+            line = src[line_start : src.find("\n", match.start())]
+            if line.lstrip().startswith(("*", "//")):
+                continue  # prose in a comment, not a call
+            if path.name in INLINE_HANDLER_ALLOWLIST:
+                if not _handled_within(src, line_start):
+                    offenders.append(
+                        f"{path.name}: allowlisted but unhandled -> {line.strip()}"
+                    )
+                continue
+            offenders.append(f"{path.name}: {line.strip()}")
+    assert not offenders, (
+        "play() promises must be handled — call "
+        "window.ClipgenVideoControls.safePlay(el[, onRejected]) instead:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_safeplay_is_exported_and_defensive():
+    src = read("video-controls.js")
+    assert "safePlay: safePlay," in src, "safePlay must be on the public API"
+    body = src[src.index("function safePlay(") : src.index("function nextSpeed(")]
+    # A missing element must be a no-op, and a browser returning no promise
+    # (or a rejection with no caller handler) must not throw either.
+    assert "if (!videoEl) return;" in body
+    assert "p && p.catch" in body
+
+
+def test_pages_that_use_safeplay_load_video_controls():
+    """safePlay is only reachable on pages that actually load the module."""
+    users = {
+        path.name.split("-")[0].split(".")[0]
+        for path in _js_files()
+        if "ClipgenVideoControls.safePlay" in path.read_text(encoding="utf-8")
+    }
+    assert users, "expected the shared helper to have callers"
+    for page in users:
+        markup = read(f"{page}.html")
+        assert "video-controls.js" in markup, (
+            f"{page}.js calls safePlay but {page}.html does not load "
+            "video-controls.js — it would throw at runtime"
+        )


### PR DESCRIPTION
## Summary

Profiled the backend with `--profile` and fixed the two hot spots it surfaced, plus one bug `/ui-check` was already failing on.

- **Screenspace grid heatmaps** — the PNG, cumulative GIF and rolling GIF each replayed the same per-cell `cv2.circle` draws, four full passes; and because the two GIF generators share a 2-thread pool, that loop measured **0.82×**, i.e. overlapping them was *slower* than sequential. `build_grid_layers()` draws each bucket once and hands the layers to all three, leaving only numpy folds and PIL's encoder in the threads (which does parallelize, 1.45×). Output is **byte-identical** — `cv2.circle` sets rather than accumulates, the same property the rolling GIF already relied on.
- **`GET /composer/api/participants`** — probed every part serially inside the loop and the page could not render until the last ffprobe returned. `video.prewarm_probes()` warms the caches up front via the existing `_parallel_probe`, whose cap moves 4 → 8 (header reads, so the width is I/O wait, not cores; measured flat past 8).
- **`fix(web)`** — six of twelve `play()` call sites ignored the returned promise, so an interrupted start became an uncaught page error; they now route through `ClipgenVideoControls.safePlay()`.

```
attention scan, 962 results, 1280x720, end-to-end
  master 5.12s / 5.05s          branch 3.70s / 3.35s
  heatmap.gifs        2.584s -> grid_layers 0.371s + gifs 0.812s
  scan.callback       1.866s -> 1.821s   (control, unmoved)

GET /composer/api/participants, 24 participants, cold
  master 0.977s / 1.003s        branch 0.339s / 0.159s
```

## Test plan

- [x] `/check` green — ruff format + lint, ty, 3352 tests (+13)
- [x] Heatmap artifacts hashed against `master` (`git stash`): PNG + both GIFs byte-identical across attention/change/flow and 1/2/8/37-result edge cases
- [x] Every perf number above reproduced twice, master vs branch, with `scan.callback` as an unmoved control
- [x] `/ui-check` — **16 passed**, was 15 passed / 1 failed; `test_transcripts_segment_click_seeks_video` failed identically on `master` before this branch. Screenshots reviewed.
- [x] New tests mutation-checked: reversing the layer fold, deleting the prewarm call, and reintroducing a bare `play()` each fail them
- [x] Confirmed the `play()` guard is not masking a broken player — after a seek the element reports `paused: false` and advances 3.40s -> 4.10s in 700ms
- [x] Not verified: real-media playback feel and multi-part participants — the benchmark inputs are synthetic `testsrc`, and Composer's stitched timeline was exercised only through the fixture

No `build/VERSION` bump: `perf:` / `fix:` per `agents/CONTRIBUTING.md`.