### PR TITLE
fix(video): use two-stage seek when the container start_time is nonzero

### DIFF
--- a/source/video.py
+++ b/source/video.py
@@ -173,22 +173,48 @@ def _resolved_path_and_mtime(filepath: str) -> tuple[str, int] | None:
 
 
 def accurate_seek_args(timestamp_seconds: float) -> list[str]:
-    """Return the pre-input ``-ss`` args for a frame-accurate seek.
+    """Return the pre-input ``-ss`` args for a frame-accurate seek on t=0 media.
 
-    A single pre-input ``-ss`` is frame-accurate whenever the output is
-    decoded (rawvideo/MJPEG — every caller here): ffmpeg seeks the demuxer to
-    the nearest keyframe at or before the target, then decodes and discards
-    up to the exact frame internally. The old two-stage idiom (pre-input
-    ``-ss`` to ``target - 2s`` plus a post-input ``-ss 2``) predates that
-    behavior and decoded ~2 s of extra frames per call for a bit-identical
-    result — measured 135 → 90 ms per frame extraction on 1440p/GOP-2s, with
-    identical output on every timestamp × GOP profile tried
-    (``test_single_seek_matches_two_stage_seek_exactly`` keeps ffmpeg honest).
+    A single pre-input ``-ss`` is frame-accurate on MP4/MOV (container
+    ``start_time`` 0) whenever the output is decoded (rawvideo/MJPEG — every
+    caller here): ffmpeg seeks the demuxer to the nearest keyframe at or before
+    the target, then decodes and discards up to the exact frame internally.
+    MPEG-TS and similar containers with a non-zero ``start_time`` need
+    :func:`accurate_seek_pre_post` instead — pre-input ``-ss`` is in stream
+    time there and lands on the wrong frame (or none).
     Never valid for stream copy, which cannot decode-and-discard.
     """
-    if timestamp_seconds <= 0:
-        return []
-    return ["-ss", str(timestamp_seconds)]
+    pre, _post = accurate_seek_pre_post(timestamp_seconds)
+    return pre
+
+
+def accurate_seek_pre_post(
+    timestamp_seconds: float, *, container_start: float = 0.0
+) -> tuple[list[str], list[str]]:
+    """Return ``(pre_input, post_input)`` ``-ss`` args for a decoded seek.
+
+    Zero ``container_start`` (typical MP4): one pre-input ``-ss``. Non-zero
+    (MPEG-TS): the old two-stage idiom — pre-input to ``target - 2s`` plus
+    post-input ``-ss 2``, or post-input only below 2s — which is frame-accurate
+    because post-input ``-ss`` counts decoded media, not stream timestamps.
+    """
+    ts = max(0.0, timestamp_seconds)
+    if container_start <= 1e-6:
+        return (["-ss", str(ts)] if ts > 0 else [], [])
+    if ts > 2.0:
+        return (["-ss", f"{ts - 2.0:.6g}"], ["-ss", "2.0"])
+    return ([], ["-ss", str(ts)] if ts > 0 else [])
+
+
+def _container_start_seconds(filepath: str) -> float:
+    """Format ``start_time`` from the properties cache, or 0 if unknown."""
+    props = probe_video_properties(filepath)
+    if not props:
+        return 0.0
+    try:
+        return max(0.0, float(props.get("start_time") or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _ffmpeg_install_guidance_lines() -> list[str]:
@@ -1179,10 +1205,10 @@ def extract_thumbnail_bytes(
 ) -> bytes | None:
     """Extract a small JPEG thumbnail frame from a video at *start_seconds*.
 
-    Frame-accurate: the pre-input ``-ss`` decodes-and-discards from the
-    nearest prior keyframe (see :func:`accurate_seek_args`), so the returned
-    thumbnail matches the requested timestamp instead of snapping to the
-    keyframe. Returns raw JPEG bytes on success or ``None`` on any failure.
+    Frame-accurate: :func:`accurate_seek_pre_post` chooses a single pre-input
+    ``-ss`` on t=0 media, or the two-stage idiom when the container's
+    ``start_time`` is non-zero (MPEG-TS). Returns raw JPEG bytes on success
+    or ``None`` on any failure.
     """
     if config.DEBUGGING:
         config.debug_ic(input_file, start_seconds, width)
@@ -1191,10 +1217,15 @@ def extract_thumbnail_bytes(
     if not Path(input_file).is_file():
         return None
 
+    pre, post = accurate_seek_pre_post(
+        max(0.0, start_seconds),
+        container_start=_container_start_seconds(input_file),
+    )
     cmd = _ffmpeg_cmd(
-        *accurate_seek_args(max(0.0, start_seconds)),
+        *pre,
         "-i",
         input_file,
+        *post,
         "-vframes",
         "1",
         "-vf",
@@ -1723,6 +1754,7 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
             "fps": 30.0,
             "duration": 300.0,
             "nb_frames": 9000,
+            "start_time": 0.0,
         }
         # In DEBUGGING mode the file may not exist on disk; fall back to a
         # synthetic key so callers still get a cached result.
@@ -1753,7 +1785,7 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         "-show_entries",
         "stream_tags=title,language,handler_name",
         "-show_entries",
-        "format=duration",
+        "format=duration,start_time",
         "-of",
         "json",
         filepath,
@@ -1852,11 +1884,18 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
 
     # Duration from format-level metadata (more reliable than stream-level)
     fmt_duration = 0.0
+    fmt_start = 0.0
     fmt = data.get("format", {})
     try:
         fmt_duration = float(fmt.get("duration", 0))
     except (ValueError, TypeError):
         pass
+    try:
+        raw_start = fmt.get("start_time")
+        if raw_start not in (None, "N/A", ""):
+            fmt_start = max(0.0, float(raw_start))
+    except (ValueError, TypeError):
+        fmt_start = 0.0
     # Fallback: compute from frame count and fps
     if fmt_duration <= 0 and nb_frames > 0 and fps > 0:
         fmt_duration = nb_frames / fps
@@ -1875,6 +1914,7 @@ def probe_video_properties(filepath: str) -> dict[str, Any] | None:
         "fps": fps,
         "duration": fmt_duration,
         "nb_frames": nb_frames,
+        "start_time": fmt_start,
     }
     _video_properties_cache[key] = result
     if fmt_duration > 0:
@@ -2472,10 +2512,10 @@ def extract_frame_at_timestamp(
 ) -> Any | None:
     """Extract a single video frame at the given timestamp via ffmpeg.
 
-    Frame-accurate: the pre-input ``-ss`` decodes-and-discards from the
-    nearest prior keyframe (see :func:`accurate_seek_args`), so the returned
-    frame is the one at ``timestamp_seconds`` rather than the keyframe.
-    Returns a BGR numpy array (H x W x 3) or None if extraction fails.
+    Frame-accurate: :func:`accurate_seek_pre_post` chooses a single pre-input
+    ``-ss`` on t=0 media, or the two-stage idiom when the container's
+    ``start_time`` is non-zero (MPEG-TS). Returns a BGR numpy array
+    (H x W x 3) or None if extraction fails.
     Requires ffprobe to determine resolution and ffmpeg to decode the frame.
     """
     if config.DEBUGGING:
@@ -2488,11 +2528,19 @@ def extract_frame_at_timestamp(
         return None
 
     width, height = props["width"], props["height"]
+    try:
+        container_start = max(0.0, float(props.get("start_time") or 0.0))
+    except (TypeError, ValueError):
+        container_start = 0.0
+    pre, post = accurate_seek_pre_post(
+        max(0.0, timestamp_seconds), container_start=container_start
+    )
     cmd = [
         "ffmpeg",
-        *accurate_seek_args(max(0.0, timestamp_seconds)),
+        *pre,
         "-i",
         video_path,
+        *post,
         "-frames:v",
         "1",
         "-pix_fmt",

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -350,7 +350,32 @@ def test_probe_video_properties_parses_output(monkeypatch, tmp_path):
         "fps": 0.0,
         "duration": 0.0,
         "nb_frames": 0,
+        "start_time": 0.0,
     }
+
+
+def test_probe_video_properties_parses_container_start_time(monkeypatch, tmp_path):
+    video._video_properties_cache.clear()
+    clip = tmp_path / "clip.ts"
+    clip.write_bytes(b"x")
+    fake_json = json.dumps(
+        {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "mpeg2video",
+                    "width": 160,
+                    "height": 120,
+                }
+            ],
+            "format": {"duration": "8.0", "start_time": "11.4"},
+        }
+    )
+    monkeypatch.setattr(video.subprocess, "check_output", lambda _cmd, **_kw: fake_json)
+    result = video.probe_video_properties(str(clip))
+    assert result is not None
+    assert result["start_time"] == 11.4
+    assert result["duration"] == 8.0
 
 
 def test_probe_video_properties_multiple_audio_tracks(monkeypatch, tmp_path):
@@ -1394,6 +1419,27 @@ def test_accurate_seek_args_is_a_single_pre_input_seek():
     assert video.accurate_seek_args(0.5) == ["-ss", "0.5"]
 
 
+def test_accurate_seek_pre_post_zero_start_is_single_pre_input():
+    assert video.accurate_seek_pre_post(12.345) == (["-ss", "12.345"], [])
+    assert video.accurate_seek_pre_post(0.0) == ([], [])
+    assert video.accurate_seek_pre_post(0.5, container_start=0.0) == (
+        ["-ss", "0.5"],
+        [],
+    )
+
+
+def test_accurate_seek_pre_post_nonzero_start_uses_two_stage():
+    """MPEG-TS start_time ≠ 0: post-input -ss counts decoded media."""
+    assert video.accurate_seek_pre_post(0.5, container_start=11.4) == (
+        [],
+        ["-ss", "0.5"],
+    )
+    assert video.accurate_seek_pre_post(3.7, container_start=11.4) == (
+        ["-ss", "1.7"],
+        ["-ss", "2.0"],
+    )
+
+
 # ---- two-stage seek wiring in extract_frame_at_timestamp ----
 
 
@@ -1425,6 +1471,29 @@ def test_extract_frame_at_timestamp_seeks_before_input_only(monkeypatch):
     i_idx = cmd.index("-i")
     assert cmd[:i_idx][-2:] == ["-ss", "12.5"], "expected pre-input seek"
     assert "-ss" not in cmd[i_idx + 2 :], "post-input seek is the obsolete split"
+
+
+def test_extract_frame_at_timestamp_two_stage_when_start_time_nonzero(monkeypatch):
+    monkeypatch.setattr(
+        video,
+        "probe_video_properties",
+        lambda _: {
+            "width": 320,
+            "height": 240,
+            "fps": 30.0,
+            "duration": 60.0,
+            "start_time": 11.4,
+        },
+    )
+    captured: dict = {}
+    monkeypatch.setattr(video.subprocess, "run", _captured_run(captured))
+
+    video.extract_frame_at_timestamp("/fake.ts", 0.5)
+    cmd = captured["cmd"]
+    i_idx = cmd.index("-i")
+    assert "-ss" not in cmd[:i_idx]
+    assert cmd[i_idx + 1 : i_idx + 3] == ["/fake.ts", "-ss"]
+    assert cmd[i_idx + 3] == "0.5"
 
 
 # ---- two-stage seek + float ts in extract_thumbnail_bytes ----


### PR DESCRIPTION
## Summary

Frame extraction now uses the two-stage (or post-input) seek when ffprobe reports a non-zero container `start_time`. A single pre-input `-ss` is still used for typical MP4. MPEG-TS streams were landing on the wrong frame or returning nothing.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_video_commands.py tests/test_pipeline_io.py`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`
- [ ] Open a `.ts` recording in Studio/Screenspace and confirm thumbnails match the requested time