### PR TITLE
perf(web): cut per-item listeners on Overview and Studio intake

### DIFF
--- a/agents/skills/profile/SKILL.md
+++ b/agents/skills/profile/SKILL.md
@@ -40,7 +40,8 @@ Frontend (via `CLIPGEN_CONFIG.profiling`): `poll.<page>.<name>` per poller tick,
 `studio.renderGrid`, `transcripts.renderSegments`/`renderPartialSegments`,
 `screenspace.renderResults`/`renderChunk`/`renderTimeline`, `composer.renderTimeline`,
 `viewer.renderList`, `workflows.renderAllNodes`, `gallery.renderGrid`,
-`overview.renderMetadata`/`renderConvergence`, and a `longtask` observer for
+`overview.renderMetadata`/`computeMetadata`/`renderConvergence`/`computeConvergence`,
+and a `longtask` observer for
 main-thread stalls >50 ms. To add a span, follow the hooks' pattern: accumulate
 into locals and flush once per scan/tick — **never** call `profiling.add` /
 `performance.mark` per frame.

--- a/agents/skills/profile/SKILL.md
+++ b/agents/skills/profile/SKILL.md
@@ -37,7 +37,7 @@ fallback), `workflows.run` / `workflows.node <type>` / `workflows.batch_child` /
 `workflows.batch_wall` (`WORKFLOWS_BATCH_WORKERS` effective parallelism, same
 ratio as the clip pools).
 Frontend (via `CLIPGEN_CONFIG.profiling`): `poll.<page>.<name>` per poller tick,
-`studio.renderGrid`, `transcripts.renderSegments`/`renderPartialSegments`,
+`studio.renderGrid`/`renderIntakeCards`, `transcripts.renderSegments`/`renderPartialSegments`,
 `screenspace.renderResults`/`renderChunk`/`renderTimeline`, `composer.renderTimeline`,
 `viewer.renderList`, `workflows.renderAllNodes`, `gallery.renderGrid`,
 `overview.renderMetadata`/`computeMetadata`/`renderConvergence`/`computeConvergence`,

--- a/agents/skills/profile/SKILL.md
+++ b/agents/skills/profile/SKILL.md
@@ -37,7 +37,7 @@ fallback), `workflows.run` / `workflows.node <type>` / `workflows.batch_child` /
 `workflows.batch_wall` (`WORKFLOWS_BATCH_WORKERS` effective parallelism, same
 ratio as the clip pools).
 Frontend (via `CLIPGEN_CONFIG.profiling`): `poll.<page>.<name>` per poller tick,
-`studio.renderGrid`/`renderIntakeCards`, `transcripts.renderSegments`/`renderPartialSegments`,
+`studio.renderGrid`/`renderIntakeCards`/`renderQueue`, `transcripts.renderSegments`/`renderPartialSegments`,
 `screenspace.renderResults`/`renderChunk`/`renderTimeline`, `composer.renderTimeline`,
 `viewer.renderList`, `workflows.renderAllNodes`, `gallery.renderGrid`,
 `overview.renderMetadata`/`computeMetadata`/`renderConvergence`/`computeConvergence`,

--- a/assets/web/overview-convergence.js
+++ b/assets/web/overview-convergence.js
@@ -391,13 +391,26 @@
     var sorted = events.slice().sort(function (a, b) { return a.start - b.start; });
 
     var qualifying = [];
+    var left = 0;
     for (var i = 0; i < sorted.length; i++) {
       var center = sorted[i].start;
+      var windowStart = center - windowSec;
+      var windowEnd = center + windowSec;
+      // Events are sorted by start, so the left edge of the ±W window only
+      // moves forward. Advance past intervals that ended before windowStart;
+      // a long-lived interval (started early, still overlapping) holds left.
+      while (
+        left < sorted.length &&
+        sorted[left].start < windowStart &&
+        sorted[left].end < windowStart
+      ) {
+        left++;
+      }
       var seen = {};
-      for (var j = 0; j < sorted.length; j++) {
-        if (sorted[j].start > center + windowSec) break;
-        if (sorted[j].end < center - windowSec && sorted[j].start < center - windowSec) continue;
-        if (sorted[j].start <= center + windowSec && sorted[j].end >= center - windowSec) {
+      for (var j = left; j < sorted.length; j++) {
+        if (sorted[j].start > windowEnd) break;
+        if (sorted[j].end < windowStart && sorted[j].start < windowStart) continue;
+        if (sorted[j].start <= windowEnd && sorted[j].end >= windowStart) {
           seen[sorted[j].participant] = true;
         }
       }
@@ -502,9 +515,11 @@
     // at first activation would go stale and misplace sheet events on the timeline.
     cvState.baselines = getState().convergenceBaselines || {};
     clearSelection();
-    collectAllEvents();
-    populateEventTypeChips();
-    applyFilters();
+    clipgenPerf.span("overview.computeConvergence", function () {
+      collectAllEvents();
+      populateEventTypeChips();
+      applyFilters();
+    });
     render();
     // collectAllEvents just refreshed _snapshot to the current version, so
     // checkStaleness will clear the paint on the subheader Refresh button.
@@ -808,14 +823,13 @@
       clusters: swimClusters,
       durationSec: duration,
       subRowH: SUB_ROW_H,
-      onEventHover: function (idx, ev, hover) {
+      onEventHover: function (idx, ev, hover, marker) {
         clearTimeout(_cvHoverDebounce);
         if (!hover) { cvHideFramePreview(); return; }
         var origEv = ev._ref;
         if (!origEv) return;
         _cvHoverDebounce = setTimeout(function () {
-          var marker = swimLane.querySelectorAll(".cg-swim-event")[idx];
-          if (marker) cvShowFramePreview(marker, origEv);
+          if (marker && marker.isConnected) cvShowFramePreview(marker, origEv);
         }, 60);
       },
       onEventClick: function (idx, ev, mouseEv) {

--- a/assets/web/overview-metadata.js
+++ b/assets/web/overview-metadata.js
@@ -1944,9 +1944,11 @@
   // --- Core lifecycle ---
 
   function refresh() {
-    mdState.cache = computeAllStats(mdState.filterParticipants);
-    // Stamp _searchId onto cache entries before rendering so tagged rows carry it.
-    buildSearchIndex(mdState.cache);
+    clipgenPerf.span("overview.computeMetadata", function () {
+      mdState.cache = computeAllStats(mdState.filterParticipants);
+      // Stamp _searchId onto cache entries before rendering so tagged rows carry it.
+      buildSearchIndex(mdState.cache);
+    });
     renderAll(mdState.cache);
     takeSnapshot();
     // takeSnapshot just moved us to the current version, so this clears any

--- a/assets/web/primitives.js
+++ b/assets/web/primitives.js
@@ -155,6 +155,7 @@
       (events || []).forEach(function (e) {
         if (e && typeof e.count === "number" && e.count > max) max = e.count;
       });
+      var frag = document.createDocumentFragment();
       (events || []).forEach(function (e, idx) {
         if (!e || typeof e.t !== "number") return;
         var bar = document.createElement("div");
@@ -180,22 +181,45 @@
           ? "color-mix(in oklch, " + e.color + " " + Math.round(alpha * 100) + "%, transparent)"
           : fmtHue(hue, 0.7, 0.16, alpha);
         bar.dataset.idx = idx;
-        if (typeof opts.onBarMouseEnter === "function") {
-          bar.addEventListener("mouseenter", function () { opts.onBarMouseEnter(idx); });
-        }
-        if (typeof opts.onBarMouseLeave === "function") {
-          bar.addEventListener("mouseleave", function () { opts.onBarMouseLeave(idx); });
-        }
-        if (typeof opts.onBarClick === "function") {
-          bar.addEventListener("click", function (ev) { opts.onBarClick(idx, ev); });
-        }
-        track.appendChild(bar);
+        frag.appendChild(bar);
       });
+      track.appendChild(frag);
       if (marker != null) {
         var mk = document.createElement("div");
         mk.className = "density-timeline-marker";
         mk.style.left = "calc(" + (marker * 100) + "% - 1px)";
         track.appendChild(mk);
+      }
+    }
+
+    // Same shape as createSwimLane: three listeners on the track, not three
+    // per bar. mouseenter doesn't bubble, so hover uses mouseover/out.
+    function bindDelegates() {
+      if (typeof opts.onBarMouseEnter === "function" || typeof opts.onBarMouseLeave === "function") {
+        track.addEventListener("mouseover", function (ev) {
+          var bar = ev.target.closest(".density-timeline-bar");
+          if (!bar || !track.contains(bar)) return;
+          if (ev.relatedTarget && bar.contains(ev.relatedTarget)) return;
+          var idx = parseInt(bar.dataset.idx, 10);
+          if (isNaN(idx) || typeof opts.onBarMouseEnter !== "function") return;
+          opts.onBarMouseEnter(idx);
+        });
+        track.addEventListener("mouseout", function (ev) {
+          var bar = ev.target.closest(".density-timeline-bar");
+          if (!bar || !track.contains(bar)) return;
+          if (ev.relatedTarget && bar.contains(ev.relatedTarget)) return;
+          if (typeof opts.onBarMouseLeave !== "function") return;
+          opts.onBarMouseLeave();
+        });
+      }
+      if (typeof opts.onBarClick === "function") {
+        track.addEventListener("click", function (ev) {
+          var bar = ev.target.closest(".density-timeline-bar");
+          if (!bar || !track.contains(bar)) return;
+          var idx = parseInt(bar.dataset.idx, 10);
+          if (isNaN(idx)) return;
+          opts.onBarClick(idx, ev);
+        });
       }
     }
 
@@ -222,6 +246,7 @@
       }
     };
 
+    bindDelegates();
     renderTicks(opts.durationSec, opts.tickCount);
     renderBars(opts.events, opts.marker);
     return wrap;

--- a/assets/web/primitives.js
+++ b/assets/web/primitives.js
@@ -344,6 +344,8 @@
       var existing = wrap.querySelectorAll(".cg-swim-cluster-band, .cg-swim-cluster-connector");
       for (var i = 0; i < existing.length; i++) existing[i].remove();
       state.clusterEls = [];
+      var axisFrag = document.createDocumentFragment();
+      var laneFrag = document.createDocumentFragment();
       state.clusters.forEach(function (cl, idx) {
         var hue = cl.hue != null ? cl.hue : 220;
         var leftPct = cl.t0 * 100;
@@ -355,7 +357,7 @@
         axisBand.style.width = widthPct + "%";
         axisBand.style.setProperty("--cg-cluster-hue", hue);
         axisBand.dataset.clusterIdx = idx;
-        axis.appendChild(axisBand);
+        axisFrag.appendChild(axisBand);
 
         var laneBand = document.createElement("div");
         laneBand.className = "cg-swim-cluster-band cg-swim-cluster-lanes";
@@ -363,20 +365,18 @@
         laneBand.style.width = widthPct + "%";
         laneBand.style.setProperty("--cg-cluster-hue", hue);
         laneBand.dataset.clusterIdx = idx;
-        lanes.appendChild(laneBand);
+        laneFrag.appendChild(laneBand);
 
         var connector = document.createElement("div");
         connector.className = "cg-swim-cluster-connector";
         connector.style.left = (((cl.t0 + cl.t1) / 2) * 100) + "%";
         connector.style.setProperty("--cg-cluster-hue", hue);
-        lanes.appendChild(connector);
+        laneFrag.appendChild(connector);
 
-        if (typeof opts.onClusterClick === "function") {
-          axisBand.addEventListener("click", function (ev) { opts.onClusterClick(idx, cl, ev); });
-          laneBand.addEventListener("click", function (ev) { opts.onClusterClick(idx, cl, ev); });
-        }
         state.clusterEls.push({ axis: axisBand, lane: laneBand, connector: connector });
       });
+      axis.appendChild(axisFrag);
+      lanes.appendChild(laneFrag);
     }
 
     function renderLaneSeparators() {
@@ -404,13 +404,20 @@
     function renderEvents() {
       var existing = lanes.querySelectorAll(".cg-swim-event");
       for (var i = 0; i < existing.length; i++) existing[i].remove();
-      state.eventEls = [];
+      // Sparse, indexed by events[] so getEventsForParticipant / setHovered
+      // address by event idx rather than packed render order.
+      state.eventEls = new Array(state.events.length);
       var subH = effectiveSubRowH();
       var sCount = state.sources.length;
       var defaultSource = state.sources[0];
+      var pIndex = {};
+      for (var pi = 0; pi < state.participants.length; pi++) {
+        pIndex[state.participants[pi]] = pi;
+      }
+      var frag = document.createDocumentFragment();
       state.events.forEach(function (e, idx) {
-        var pIdx = state.participants.indexOf(e.p);
-        if (pIdx < 0) return;
+        var pIdx = pIndex[e.p];
+        if (pIdx == null) return;
         var sIdx = state.sources.indexOf(e.source || defaultSource);
         if (sIdx < 0) sIdx = 0;
         var hue = resolveHue(e.label, e.hue);
@@ -445,16 +452,52 @@
         marker.dataset.idx = idx;
         marker.dataset.participant = e.p;
         marker.dataset.sourceIdx = sIdx;
-        if (typeof opts.onEventHover === "function") {
-          marker.addEventListener("mouseenter", function () { opts.onEventHover(idx, e, true); });
-          marker.addEventListener("mouseleave", function () { opts.onEventHover(idx, e, false); });
-        }
-        if (typeof opts.onEventClick === "function") {
-          marker.addEventListener("click", function (ev) { opts.onEventClick(idx, e, ev); });
-        }
-        lanes.appendChild(marker);
-        state.eventEls.push(marker);
+        frag.appendChild(marker);
+        state.eventEls[idx] = marker;
       });
+      lanes.appendChild(frag);
+    }
+
+    // Hover/click on thousands of markers via three listeners on the wrap, not
+    // three per marker. mouseenter doesn't bubble, so hover uses mouseover/out
+    // with a relatedTarget guard. Bound once — renderEvents only replaces nodes.
+    function bindDelegates() {
+      if (typeof opts.onEventHover === "function") {
+        lanes.addEventListener("mouseover", function (ev) {
+          var marker = ev.target.closest(".cg-swim-event");
+          if (!marker || !lanes.contains(marker)) return;
+          if (ev.relatedTarget && marker.contains(ev.relatedTarget)) return;
+          var idx = parseInt(marker.dataset.idx, 10);
+          if (isNaN(idx) || !state.events[idx]) return;
+          opts.onEventHover(idx, state.events[idx], true, marker);
+        });
+        lanes.addEventListener("mouseout", function (ev) {
+          var marker = ev.target.closest(".cg-swim-event");
+          if (!marker || !lanes.contains(marker)) return;
+          if (ev.relatedTarget && marker.contains(ev.relatedTarget)) return;
+          var idx = parseInt(marker.dataset.idx, 10);
+          if (isNaN(idx) || !state.events[idx]) return;
+          opts.onEventHover(idx, state.events[idx], false, marker);
+        });
+      }
+      if (typeof opts.onEventClick === "function" || typeof opts.onClusterClick === "function") {
+        wrap.addEventListener("click", function (ev) {
+          var marker = ev.target.closest(".cg-swim-event");
+          if (marker && wrap.contains(marker) && typeof opts.onEventClick === "function") {
+            var midx = parseInt(marker.dataset.idx, 10);
+            if (!isNaN(midx) && state.events[midx]) {
+              opts.onEventClick(midx, state.events[midx], ev, marker);
+            }
+            return;
+          }
+          if (typeof opts.onClusterClick !== "function") return;
+          var band = ev.target.closest(".cg-swim-cluster-band");
+          if (!band || !wrap.contains(band)) return;
+          var cidx = parseInt(band.dataset.clusterIdx, 10);
+          if (isNaN(cidx) || !state.clusters[cidx]) return;
+          opts.onClusterClick(cidx, state.clusters[cidx], ev);
+        });
+      }
     }
 
     function renderLabels() {
@@ -492,6 +535,7 @@
 
     wrap.setHovered = function (idx) {
       state.eventEls.forEach(function (el, i) {
+        if (!el) return;
         if (idx == null || idx === -1) {
           el.classList.remove("is-hover", "is-dim");
         } else if (i === idx) {
@@ -531,7 +575,7 @@
     wrap.getEventsForParticipant = function (pid) {
       var out = [];
       for (var i = 0; i < state.events.length; i++) {
-        if (state.events[i].p === pid) out.push(state.eventEls[i]);
+        if (state.events[i].p === pid && state.eventEls[i]) out.push(state.eventEls[i]);
       }
       return out;
     };
@@ -539,7 +583,8 @@
       var out = [];
       for (var i = 0; i < state.events.length; i++) {
         if (state.events[i].p === pid &&
-            state.sources.indexOf(state.events[i].source) === sourceIdx) {
+            state.sources.indexOf(state.events[i].source) === sourceIdx &&
+            state.eventEls[i]) {
           out.push(state.eventEls[i]);
         }
       }
@@ -551,6 +596,7 @@
       return w / d;
     };
 
+    bindDelegates();
     renderAll();
     return wrap;
   }

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -25,6 +25,7 @@
     findIntakeInQueue = STUDIO.findIntakeInQueue,
     findOverlappingData = STUDIO.findOverlappingData,
     intakeAddItem = STUDIO.intakeAddItem,
+    intakeAddItems = STUDIO.intakeAddItems,
     intakeToggleItem = STUDIO.intakeToggleItem,
     renderArtifactQueue = STUDIO.renderArtifactQueue,
     renderReelQueue = STUDIO.renderReelQueue,
@@ -755,13 +756,19 @@
     var addAllBtn = qs(cfg.addAllBtnSel);
     if (addAllBtn) {
       addAllBtn.addEventListener("click", function () {
-        cfg.filtered().forEach(function (c) { cfg.addToArtifacts(c); });
+        var clusters = cfg.filtered();
+        var items = [];
+        for (var i = 0; i < clusters.length; i++) items.push(cfg.clusterToItem(clusters[i]));
+        intakeAddItems(state.artifactQueue, items, renderArtifactQueue);
       });
     }
     var reelAllBtn = qs(cfg.reelAllBtnSel);
     if (reelAllBtn) {
       reelAllBtn.addEventListener("click", function () {
-        cfg.filtered().forEach(function (c) { cfg.addToReel(c); });
+        var clusters = cfg.filtered();
+        var items = [];
+        for (var i = 0; i < clusters.length; i++) items.push(cfg.clusterToItem(clusters[i]));
+        intakeAddItems(state.reelQueue, items, renderReelQueue);
       });
     }
     var thresholdInput = qs(cfg.thresholdSel);

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -450,18 +450,20 @@
   };
 
   function renderIntakeCards(cfg, items) {
+    return clipgenPerf.span("studio.renderIntakeCards", function () {
+      renderIntakeCardsImpl(cfg, items);
+    });
+  }
+
+  function renderIntakeCardsImpl(cfg, items) {
     var container = qs(cfg.cardsSel);
     container.innerHTML = "";
+    var frag = document.createDocumentFragment();
     items.forEach(function (c, idx) {
       var card = el("div", "queue-card intake-queue-card" + (cfg.cardClass ? " " + cfg.cardClass : ""));
       card.style.setProperty("--cg-card-hue", cfg.cardHue(c));
       card.dataset[cfg.idxAttr] = idx;
       card.setAttribute("draggable", "true");
-      card.addEventListener("dragstart", function (ev) {
-        ev.dataTransfer.setData("application/json", JSON.stringify(cfg.clusterToItem(c)));
-        ev.dataTransfer.effectAllowed = "copyMove";
-        setCardDragImage(ev, this);
-      });
 
       var thumb = buildQueueCardThumb(card, {
         participant: c.participant,
@@ -523,8 +525,9 @@
           .join("\n");
       }
 
-      container.appendChild(card);
+      frag.appendChild(card);
     });
+    container.appendChild(frag);
     attachQueueScrubbers(container);
     refreshIntakeCardStates();
     // Re-renders wipe the hub's keyboard-cursor outline; repaint it.
@@ -694,6 +697,16 @@
       if (!cluster) return;
       if (e.shiftKey) cfg.toggleReel(cluster);
       else cfg.toggleArtifacts(cluster);
+    });
+
+    cards.addEventListener("dragstart", function (ev) {
+      var card = ev.target.closest(cfg.cardSel);
+      if (!card) return;
+      var cluster = cfg.filtered()[parseInt(card.dataset[cfg.idxAttr], 10)];
+      if (!cluster) return;
+      ev.dataTransfer.setData("application/json", JSON.stringify(cfg.clusterToItem(cluster)));
+      ev.dataTransfer.effectAllowed = "copyMove";
+      setCardDragImage(ev, card);
     });
 
     // Right-click to dismiss

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -217,12 +217,23 @@
 
   // Idempotent add (used by "Add all" and drag-drop) vs. toggle (used by single
   // card click) — same split as addToQueue vs. toggleArtifactCell for cells.
-  function intakeAddItem(queue, item, renderFn) {
+  // Batch form renders once; calling add-all as N× intakeAddItem rebuilt the
+  // whole queue on every push (400 cards → ~1s longtask, tens of thousands of
+  // detached listeners).
+  function intakeAddItems(queue, items, renderFn) {
     var locked = queue === state.artifactQueue ? isArtifactQueueLocked() : isReelQueueLocked();
     if (locked) return;
-    if (findIntakeInQueue(queue, item) >= 0) return;
-    queue.push(item);
-    renderFn();
+    var added = false;
+    for (var i = 0; i < items.length; i++) {
+      if (!items[i] || findIntakeInQueue(queue, items[i]) >= 0) continue;
+      queue.push(items[i]);
+      added = true;
+    }
+    if (added) renderFn();
+  }
+
+  function intakeAddItem(queue, item, renderFn) {
+    intakeAddItems(queue, [item], renderFn);
   }
 
   function intakeToggleItem(queue, item, renderFn) {
@@ -2416,7 +2427,7 @@
       }
     }
     if (added) {
-      renderFn();
+      if (renderFn) renderFn();
       if (info.row) updateSingleCellClass(info.participant, info.row);
     }
   }
@@ -2831,7 +2842,8 @@
       if (isArtifactQueueLocked()) return;
       if (info.source === "reel-stash" || info.source === "artifact-stash") {
         for (var i = 0; i < info.items.length; i++)
-          addToQueue(state.artifactQueue, info.items[i], renderArtifactQueue);
+          addToQueue(state.artifactQueue, info.items[i], null);
+        renderArtifactQueue();
         return;
       }
       if (isIntakeSource(info.source)) {
@@ -2848,7 +2860,8 @@
       if (isReelQueueLocked()) return;
       if (info.source === "reel-stash" || info.source === "artifact-stash") {
         for (var i = 0; i < info.items.length; i++)
-          addToQueue(state.reelQueue, info.items[i], renderReelQueue);
+          addToQueue(state.reelQueue, info.items[i], null);
+        renderReelQueue();
         return;
       }
       if (isIntakeSource(info.source)) {
@@ -3040,38 +3053,13 @@
       "queue-card" + (cfg.isReel ? " reel-card" : "") + (isIntake ? " queue-card-intake" : ""),
     );
     if (cfg.isReel) card.setAttribute("data-reel-idx", idx);
+    card.setAttribute("data-queue-idx", idx);
     card.setAttribute("data-participant", item.participant);
     card.setAttribute("data-row", isIntake ? "" : item.row);
     if (isIntake) card.setAttribute("data-source", item.source);
     if (!isIntake && item.severity) card.setAttribute("data-severity", item.severity);
     card.setAttribute("data-seg-idx", segIdx);
     if (!ctx.locked) card.setAttribute("draggable", "true");
-
-    if (cfg.attachDragstart && !ctx.locked) {
-      card.addEventListener("dragstart", function (ev) {
-        var data = {
-          participant: item.participant,
-          desc: item.desc,
-          start: item.start,
-          end: item.end,
-          source: isIntake ? item.source : "artifact",
-        };
-        if (!isIntake) {
-          data.row = item.row;
-          data.timestamp = item.timestamp;
-          data.severity = item.severity;
-          data.segIdx = item.segIdx;
-          data.segTotal = item.segTotal;
-        } else {
-          data.event_type = item.event_type;
-          data.event_ids = item.event_ids;
-          data.mark_ids = item.mark_ids;
-        }
-        ev.dataTransfer.setData("application/json", JSON.stringify(data));
-        ev.dataTransfer.effectAllowed = "copyMove";
-        setCardDragImage(ev, this);
-      });
-    }
 
     var thumb = buildQueueCardThumb(card, {
       participant: item.participant,
@@ -3118,38 +3106,18 @@
     var removeBtn = el("button", "queue-card-remove");
     removeBtn.innerHTML = iconHTML("x-mark");
     removeBtn.title = "Remove";
-    if (!ctx.locked) {
-      removeBtn.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        var card = this.closest(".queue-card");
-        var commit = function () {
-          // Resolve by identity, not the captured idx: while the exit animation
-          // plays, an earlier card's removal can re-render and shift indices.
-          var q = state[cfg.queueKey];
-          var ix = q.indexOf(item);
-          if (ix < 0) return;
-          var removed = q.splice(ix, 1)[0];
-          if (removed.row) delete state.cellResults[cellKey(removed.participant, removed.row)];
-          ctx.render();
-          if (removed.row) updateSingleCellClass(removed.participant, removed.row);
-        };
-        if (card && window.ClipgenMotion) ClipgenMotion.animateOut(card, "delete").then(commit);
-        else commit();
-      });
-    }
     card.appendChild(removeBtn);
-
-    if (!isIntake) {
-      card.addEventListener("mouseenter", function () {
-        highlightGridHeaders(item.participant, item.row);
-      });
-      card.addEventListener("mouseleave", clearGridHighlights);
-    }
 
     return card;
   }
 
   function renderQueue(cfg) {
+    return clipgenPerf.span("studio.renderQueue", function () {
+      renderQueueImpl(cfg);
+    });
+  }
+
+  function renderQueueImpl(cfg) {
     clearGridHighlights();
     var list = qs(cfg.listSel);
     var q = state[cfg.queueKey];
@@ -3171,10 +3139,12 @@
       renderQueue(cfg);
     };
     var totalDur = 0;
+    var frag = document.createDocumentFragment();
     for (var i = 0; i < n; i++) {
       totalDur += q[i].end - q[i].start;
-      list.appendChild(buildQueueCard(q[i], i, cfg, { locked: locked, render: render }));
+      frag.appendChild(buildQueueCard(q[i], i, cfg, { locked: locked, render: render }));
     }
+    list.appendChild(frag);
     if (cfg.durationSel) qs(cfg.durationSel).textContent = formatDuration(totalDur);
     applyCardStates(list);
     attachQueueScrubbers(list);
@@ -3187,6 +3157,85 @@
 
   function renderReelQueue() {
     renderQueue(REEL_QUEUE);
+  }
+
+  // One listener set per queue list, not per card. Must run once at boot —
+  // never from renderQueue (CODE-REVIEW.md listener-cleanup rule).
+  function bindQueueList(cfg) {
+    var list = qs(cfg.listSel);
+    if (!list) return;
+
+    if (cfg.attachDragstart) {
+      list.addEventListener("dragstart", function (ev) {
+        if (cfg.isLocked()) {
+          ev.preventDefault();
+          return;
+        }
+        var card = ev.target.closest(".queue-card");
+        if (!card || !list.contains(card)) return;
+        var idx = parseInt(card.getAttribute("data-queue-idx"), 10);
+        var item = state[cfg.queueKey][idx];
+        if (!item) return;
+        var isIntake = isIntakeSource(item.source);
+        var data = {
+          participant: item.participant,
+          desc: item.desc,
+          start: item.start,
+          end: item.end,
+          source: isIntake ? item.source : "artifact",
+        };
+        if (!isIntake) {
+          data.row = item.row;
+          data.timestamp = item.timestamp;
+          data.severity = item.severity;
+          data.segIdx = item.segIdx;
+          data.segTotal = item.segTotal;
+        } else {
+          data.event_type = item.event_type;
+          data.event_ids = item.event_ids;
+          data.mark_ids = item.mark_ids;
+        }
+        ev.dataTransfer.setData("application/json", JSON.stringify(data));
+        ev.dataTransfer.effectAllowed = "copyMove";
+        setCardDragImage(ev, card);
+      });
+    }
+
+    list.addEventListener("click", function (ev) {
+      var btn = ev.target.closest(".queue-card-remove");
+      if (!btn || !list.contains(btn)) return;
+      if (cfg.isLocked()) return;
+      ev.stopPropagation();
+      var card = btn.closest(".queue-card");
+      if (!card) return;
+      var idx = parseInt(card.getAttribute("data-queue-idx"), 10);
+      var item = state[cfg.queueKey][idx];
+      if (!item) return;
+      var commit = function () {
+        // Resolve by identity, not the captured idx: while the exit animation
+        // plays, an earlier card's removal can re-render and shift indices.
+        var q = state[cfg.queueKey];
+        var ix = q.indexOf(item);
+        if (ix < 0) return;
+        var removed = q.splice(ix, 1)[0];
+        if (removed.row) delete state.cellResults[cellKey(removed.participant, removed.row)];
+        renderQueue(cfg);
+        if (removed.row) updateSingleCellClass(removed.participant, removed.row);
+      };
+      if (window.ClipgenMotion) ClipgenMotion.animateOut(card, "delete").then(commit);
+      else commit();
+    });
+
+    list.addEventListener("mouseover", function (ev) {
+      var card = ev.target.closest(".queue-card");
+      if (!card || !list.contains(card)) return;
+      if (card.classList.contains("queue-card-intake") || !card.getAttribute("data-row")) {
+        clearGridHighlights();
+        return;
+      }
+      highlightGridHeaders(card.getAttribute("data-participant"), parseInt(card.getAttribute("data-row"), 10));
+    });
+    list.addEventListener("mouseleave", clearGridHighlights);
   }
 
   // ---- Stashes (carved into studio-stash.js) ----
@@ -3245,8 +3294,9 @@
 
     qs("#addToReelBtn").addEventListener("click", function () {
       for (var i = 0; i < state.artifactQueue.length; i++) {
-        addToQueue(state.reelQueue, state.artifactQueue[i], renderReelQueue);
+        addToQueue(state.reelQueue, state.artifactQueue[i], null);
       }
+      renderReelQueue();
     });
 
     qs("#clearReelBtn").addEventListener("click", clearReel);
@@ -4776,6 +4826,8 @@
     initWheelScroll();
     bindDragGate();
     bindReelReorder();
+    bindQueueList(ARTIFACT_QUEUE);
+    bindQueueList(REEL_QUEUE);
     bindButtons();
     updateArtifactActions();
     updateReelActions();
@@ -4836,6 +4888,7 @@
   STUDIO.findIntakeInQueue = findIntakeInQueue;
   STUDIO.findOverlappingData = findOverlappingData;
   STUDIO.intakeAddItem = intakeAddItem;
+  STUDIO.intakeAddItems = intakeAddItems;
   STUDIO.intakeToggleItem = intakeToggleItem;
   STUDIO.isIntakeSource = isIntakeSource;
   STUDIO.isArtifactQueueLocked = isArtifactQueueLocked;

--- a/tests/test_primitives_source.py
+++ b/tests/test_primitives_source.py
@@ -1,0 +1,18 @@
+"""Source locks for shared UI primitives.
+
+The Overview swim lane used to bind mouseenter/leave/click on every marker.
+On a 200×12 sheet that was 7,592 listeners (three per event). Delegation on
+the wrap is the fix; this test keeps the per-marker path from coming back.
+"""
+
+from _frontend_source import read
+
+
+def test_swim_lane_does_not_bind_per_marker_listeners() -> None:
+    src = read("primitives.js")
+    start = src.index("function renderEvents()")
+    end = src.index("function bindDelegates()", start)
+    body = src[start:end]
+    assert "addEventListener" not in body
+    assert "document.createDocumentFragment" in body
+    assert "function bindDelegates()" in src

--- a/tests/test_primitives_source.py
+++ b/tests/test_primitives_source.py
@@ -1,8 +1,10 @@
 """Source locks for shared UI primitives.
 
 The Overview swim lane used to bind mouseenter/leave/click on every marker.
-On a 200×12 sheet that was 7,592 listeners (three per event). Delegation on
-the wrap is the fix; this test keeps the per-marker path from coming back.
+On a 200×12 sheet that was 7,592 listeners (three per event). The Studio
+intake density timeline had the same shape (1,200 listeners on 400 bars).
+Delegation on the wrap/track is the fix; these tests keep the per-item
+path from coming back.
 """
 
 from _frontend_source import read
@@ -16,3 +18,12 @@ def test_swim_lane_does_not_bind_per_marker_listeners() -> None:
     assert "addEventListener" not in body
     assert "document.createDocumentFragment" in body
     assert "function bindDelegates()" in src
+
+
+def test_density_timeline_does_not_bind_per_bar_listeners() -> None:
+    src = read("primitives.js")
+    start = src.index("function renderBars(")
+    end = src.index("function bindDelegates()", start)
+    body = src[start:end]
+    assert "addEventListener" not in body
+    assert "document.createDocumentFragment" in body

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -262,3 +262,37 @@ def test_intake_queued_state_covers_every_panel():
     # Scoped per panel: every card also carries the shared .intake-queue-card,
     # so an unscoped query would index one panel's cards against another's list.
     assert "panel.cardsSel" in sweep and "panel.cardSel" in sweep
+
+
+def test_intake_add_all_batches_queue_render() -> None:
+    """Add-all used to call addToArtifacts per cluster, and each call rendered
+    the whole queue. 400 intake cards was a ~1s longtask and ~30k listeners."""
+    src = _studio_js()
+    assert "function intakeAddItems(queue, items, renderFn)" in src
+    start = src.index("function initIntakePanel(")
+    body = src[start : src.index("\n  function ", start + 1)]
+    assert "intakeAddItems(state.artifactQueue, items, renderArtifactQueue)" in body
+    assert "intakeAddItems(state.reelQueue, items, renderReelQueue)" in body
+    assert "cfg.filtered().forEach" not in body
+
+
+def test_queue_cards_do_not_bind_per_card_listeners() -> None:
+    """Artifact/reel cards used to attach dragstart, remove-click, and hover
+    on every card. Delegation lives on bindQueueList; render just stamps idx."""
+    src = _studio_js()
+    start = src.index("function buildQueueCard(")
+    end = src.index("function renderQueue(", start)
+    body = src[start:end]
+    # The only per-card listener left is the rare Composer-trim badge.
+    assert body.count("addEventListener") == 1
+    assert "intake-trim-badge" in body
+    assert "data-queue-idx" in body
+    assert "function bindQueueList(cfg)" in src
+    impl = src[
+        src.index("function renderQueueImpl(") : src.index("function renderArtifactQueue(")
+    ]
+    assert "document.createDocumentFragment" in impl
+    bind_start = src.index("function bindQueueList(")
+    bind = src[bind_start : src.index("\n  function ", bind_start + 1)]
+    assert "queue-card-remove" in bind
+    assert "dragstart" in bind

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -289,7 +289,9 @@ def test_queue_cards_do_not_bind_per_card_listeners() -> None:
     assert "data-queue-idx" in body
     assert "function bindQueueList(cfg)" in src
     impl = src[
-        src.index("function renderQueueImpl(") : src.index("function renderArtifactQueue(")
+        src.index("function renderQueueImpl(") : src.index(
+            "function renderArtifactQueue("
+        )
     ]
     assert "document.createDocumentFragment" in impl
     bind_start = src.index("function bindQueueList(")


### PR DESCRIPTION
## Summary
- Overview swim lanes bound mouseenter/leave/click on every marker. On a 200×12 sheet that was 7,592 listeners; one wrap/lanes delegate plus a fragment insert drops it to 384.
- Studio intake did the same for density bars (3×400) and card `dragstart`. Delegating those on the track/container brings the intake tab from 1,835 listeners down to ~250.
- Add all to Artifacts called `intakeAddItem` per cluster, and each call rebuilt the whole queue. 400 cards was a 996ms longtask and ~30k leftover listeners. One `intakeAddItems` pass plus delegated queue-card events lands at ~10ms / ~1,450 listeners.

## Test plan
- [x] Overview → Convergence on a large sheet: hover/click swim-lane markers and cluster callouts still highlight and select.
- [x] Studio → Screenspace Intake with many unclustered events: density-bar hover/click, card click/shift-click, drag onto Artifacts/Reel, right-click dismiss.
- [x] Add all to Artifacts (and Add all to Reel) with a large intake list: one paint, cards appear in the queue, in-queue highlight on intake cards, remove and drag still work.
- [x] Sheet tab still behaves (grid drag, artifact/reel queues) after the queue-list delegation change.
