### PR TITLE
fix(build): advertise macOS 14 as the app minimum

### DIFF
--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -242,7 +242,10 @@ if sys.platform == "darwin":
             "CFBundleShortVersionString": _version,
             "CFBundleVersion": _version,
             "NSHighResolutionCapable": True,
-            "LSMinimumSystemVersion": "11.0",
+            # onnxruntime and numpy ship macosx_14_0 wheels; the self-built
+            # OpenCV wheel is MACOSX_DEPLOYMENT_TARGET=13.0. Advertising 11
+            # let Gatekeeper install on 11–13, then import failed at launch.
+            "LSMinimumSystemVersion": "14.0",
             # macOS raises a "find devices on your local network?" prompt on
             # first launch because the app binds a TCP socket (the UI is served
             # over loopback to the embedded webview). Without this key the

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -128,6 +128,13 @@ def test_spec_guards_and_upx_excludes_the_vendored_tools() -> None:
     )
 
 
+def test_spec_advertises_macos_14_minimum() -> None:
+    """Wheels in the lockfile are macosx_14_0; 11.0 was a false Gatekeeper floor."""
+    spec_text = (_ROOT / "build" / "clipgen.spec").read_text(encoding="utf-8")
+    assert '"LSMinimumSystemVersion": "14.0"' in spec_text
+    assert '"LSMinimumSystemVersion": "11.0"' not in spec_text
+
+
 def test_spec_never_strips_or_packs_on_windows() -> None:
     """``strip``/``upx`` must stay macOS-only, or Windows ships a dead exe.
 


### PR DESCRIPTION
## Summary

The macOS bundle's `LSMinimumSystemVersion` is now 14.0. It still said 11.0, but onnxruntime/numpy wheels are `macosx_14_0` and the self-built OpenCV wheel targets 13, so 11–13 could install then crash at launch.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_packaging.py`
- [x] `uv run ruff format --check && uv run ruff check --fix && uv run ty check`