### PR TITLE
fix(build): delete dropped Python trees on Windows installer upgrades

### DIFF
--- a/build/clipgen.iss
+++ b/build/clipgen.iss
@@ -45,6 +45,20 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 ; time ISCC runs (the zip step copies them in first), so they install too.
 Source: "..\dist\clipgen\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
 
+[InstallDelete]
+; Inno overlays {app} and does not remove files the new payload no longer
+; ships. Upgrades from before the RapidOCR / no-PyAV / in-tree-pHash work
+; would otherwise keep ~110 MB of imagehash/skimage/scipy plus easyocr/torch/av.
+Type: filesandordirs; Name: "{app}\lib\imagehash*"
+Type: filesandordirs; Name: "{app}\lib\skimage*"
+Type: filesandordirs; Name: "{app}\lib\scikit_image*"
+Type: filesandordirs; Name: "{app}\lib\scipy*"
+Type: filesandordirs; Name: "{app}\lib\pywt*"
+Type: filesandordirs; Name: "{app}\lib\PyWavelets*"
+Type: filesandordirs; Name: "{app}\lib\easyocr*"
+Type: filesandordirs; Name: "{app}\lib\torch*"
+Type: filesandordirs; Name: "{app}\lib\av*"
+
 [Icons]
 Name: "{autoprograms}\clipgen"; Filename: "{app}\clipgen.exe"
 Name: "{autodesktop}\clipgen"; Filename: "{app}\clipgen.exe"; Tasks: desktopicon

--- a/tests/test_dropped_dependencies.py
+++ b/tests/test_dropped_dependencies.py
@@ -33,3 +33,11 @@ def test_source_does_not_import_dropped_dependencies() -> None:
         "dropped dependencies imported again (see module docstring): "
         + "; ".join(offenders)
     )
+
+
+def test_windows_installer_deletes_dropped_packages_on_upgrade() -> None:
+    """Inno overlays {app}; without InstallDelete, old trees survive upgrades."""
+    iss = (ROOT / "build" / "clipgen.iss").read_text(encoding="utf-8")
+    assert "[InstallDelete]" in iss
+    for name in DROPPED:
+        assert f"{{app}}\\lib\\{name}*" in iss, name


### PR DESCRIPTION
## Summary

The Windows installer now has an `[InstallDelete]` section for packages removed in recent builds (`imagehash`, `skimage`, `scipy`, `pywt`, `easyocr`, `torch`, `av`). Inno overlays `{app}` on upgrade and otherwise leaves those trees in `lib`.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_dropped_dependencies.py`
- [x] `uv run ruff format --check && uv run ruff check --fix`
- [ ] Upgrade a pre-#712 Windows install and confirm `lib\\imagehash` / `lib\\skimage` are gone