### PR TITLE
ci: require japan and korean OCR rec models in the frozen bundle

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -166,8 +166,10 @@ jobs:
           # and the vendored non-default recognition models must both ship.
           find dist/clipgen.app -path "*rapidocr*" -name "*.onnx" | grep -q . \
             || { echo "::error::bundle lacks rapidocr's default models"; exit 1; }
-          find dist/clipgen.app -path "*ocr_models/latin_rec.onnx" | grep -q . \
-            || { echo "::error::bundle lacks the vendored OCR rec models"; exit 1; }
+          for rec in latin_rec.onnx japan_rec.onnx korean_rec.onnx; do
+            find dist/clipgen.app -path "*ocr_models/$rec" | grep -q . \
+              || { echo "::error::bundle lacks the vendored OCR rec model $rec"; exit 1; }
+          done
 
       - name: Verify no in-process FFmpeg libraries (macOS)
         if: matrix.os == 'macos-latest'
@@ -256,8 +258,10 @@ jobs:
           if (-not $ocr) {
             throw "bundle lacks rapidocr's default models"
           }
-          if (-not (Test-Path "dist/clipgen/lib/ocr_models/latin_rec.onnx")) {
-            throw "bundle lacks the vendored OCR rec models"
+          foreach ($rec in @("latin_rec.onnx", "japan_rec.onnx", "korean_rec.onnx")) {
+            if (-not (Test-Path "dist/clipgen/lib/ocr_models/$rec")) {
+              throw "bundle lacks the vendored OCR rec model $rec"
+            }
           }
 
       - name: Smoke-launch the frozen exe (Windows)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -135,6 +135,15 @@ def test_spec_advertises_macos_14_minimum() -> None:
     assert '"LSMinimumSystemVersion": "11.0"' not in spec_text
 
 
+def test_ci_verifies_all_vendored_ocr_models() -> None:
+    """Post-build smoke must require japan/korean rec, not only latin."""
+    yml = (_ROOT / ".github" / "workflows" / "build-binaries.yml").read_text(
+        encoding="utf-8"
+    )
+    for name in ("latin_rec.onnx", "japan_rec.onnx", "korean_rec.onnx"):
+        assert name in yml, name
+
+
 def test_spec_never_strips_or_packs_on_windows() -> None:
     """``strip``/``upx`` must stay macOS-only, or Windows ships a dead exe.
 


### PR DESCRIPTION
## Summary

macOS and Windows post-build smoke now require `japan_rec.onnx` and `korean_rec.onnx` next to `latin_rec.onnx`. Checking only latin let a bundle missing the other rec models pass CI and then fail offline OCR.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini tests/test_packaging.py`
- [x] `uv run ruff format --check && uv run ruff check --fix`