### PR TITLE
fix(studio): count artifacts, not cells, in the generate readout

### DIFF
--- a/assets/web/studio-generate.js
+++ b/assets/web/studio-generate.js
@@ -114,16 +114,25 @@
     var failReasons = [];
     var cancelled = false;
     var pending = (sheetItems.length > 0 ? 1 : 0) + (intakeItems.length > 0 ? 1 : 0);
-    var sheetCellTotal = 0;
-    var sheetCellsDone = 0;
+    // Everything below counts artifacts (one per queue card), never cells: a
+    // cell holding several timestamp pairs posts as one ref but produces one
+    // file per pair, and the readout must match the panel's card count.
+    var sheetArtifactTotal = sheetItems.length;
+    var sheetArtifactsDone = 0;
     var intakeDone = 0;
     var intakeTotal = intakeItems.length;
     var generateCardIndex = null;
+    updateGenerateProgress(0, sheetArtifactTotal + intakeTotal);
 
+    // Both branches feed one readout and one button fill. They share a unit now,
+    // so an intake-only run gets a real count instead of elapsed alone — which
+    // is also what a mid-run reload reattaches to from /api/job-status.
     function updateGenerateButtonProgress() {
-      var total = sheetCellTotal + intakeTotal;
+      var total = sheetArtifactTotal + intakeTotal;
       if (total <= 0) return;
-      setButtonProgress("generateBtn", (sheetCellsDone + intakeDone) / total);
+      var done = sheetArtifactsDone + intakeDone;
+      setButtonProgress("generateBtn", done / total);
+      updateGenerateProgress(done, total);
     }
 
     function finishBranch() {
@@ -179,15 +188,18 @@
 
     // Handle spreadsheet items via streaming api/generate
     if (sheetItems.length > 0) {
+      // One POST ref per cell, but tally how many cards each ref stands for so
+      // a returning line can advance the readout by that cell's artifacts.
       var cellsSeen = {};
       var cells = [];
+      var cardsPerCell = {};
       for (var si = 0; si < sheetItems.length; si++) {
         var ck = sheetItems[si].participant + "." + sheetItems[si].row;
         if (!cellsSeen[ck]) { cellsSeen[ck] = true; cells.push(ck); }
+        cardsPerCell[ck] = (cardsPerCell[ck] || 0) + 1;
       }
-      sheetCellTotal = cells.length;
+      var cellCounted = {};
       generateCardIndex = buildGenerateCardIndex(list);
-      updateGenerateProgress(0, sheetCellTotal);
 
       function handleLine(line) {
         var data;
@@ -202,9 +214,14 @@
           return;
         }
         if (!data.cell) return;
-        sheetCellsDone++;
-        updateGenerateProgress(sheetCellsDone, sheetCellTotal);
-        updateGenerateButtonProgress();
+        // At most one advance per cell: the server can emit both a result line
+        // and a trailing "No clip found" for the same ref when its casing
+        // differs from the sheet header, which would push done past total.
+        if (!cellCounted[data.cell]) {
+          cellCounted[data.cell] = true;
+          sheetArtifactsDone += cardsPerCell[data.cell] || 1;
+          updateGenerateButtonProgress();
+        }
         var cards = generateCardIndex[data.cell] || [];
         if (data.ok) {
           for (var ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], true);

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -1142,6 +1142,17 @@ body.panel-dragging #bottomPanel {
   }
 }
 
+/* Same trade, one step earlier: the mid-run "N / M artifacts · elapsed" readout
+ * and its spinner add ~215px to a row that only just fits at rest, so at typical
+ * column widths they pushed Generate / Stash / Clear off the end. The format and
+ * titlecard inputs configure the *next* run, so they are what gives way. */
+@container artifacts-toolbar (max-width: 920px) {
+  #artifactsToolbar:has(#generateProgress:not(.hidden)) #artifactFormat,
+  #artifactsToolbar:has(#generateProgress:not(.hidden)) #titlecardGroup {
+    display: none;
+  }
+}
+
 .bs-label {
   font-size: 12.5px;
   font-weight: 500;

--- a/assets/web/studio.html
+++ b/assets/web/studio.html
@@ -160,7 +160,8 @@
     <div id="artifactsArea" class="drop-area">
       <div class="bs-toolbar" id="artifactsToolbar">
         <span class="bs-label">Artifacts</span>
-        <span id="artifactsCount" class="bs-count cg-mono" data-tooltip="Cells queued for generation">(0)</span>
+        <!-- Empty-state text only; renderQueueImpl rewrites data-tooltip with the live artifact/cell tally. -->
+        <span id="artifactsCount" class="bs-count cg-mono" data-tooltip="Artifacts queued for generation">(0)</span>
         <!-- Intentional inline SVG (icon convention exception): animated loading spinner (animateTransform), not an icon. -->
         <svg id="artifactsSpinner" class="title-spinner bs-spinner" width="12" height="12" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" opacity="0.25"/><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" stroke-dasharray="20 15" stroke-linecap="round"><animateTransform attributeName="transform" type="rotate" from="0 7 7" to="360 7 7" dur="0.7s" repeatCount="indefinite"/></circle></svg>
         <span id="generateProgress" class="generate-progress hidden cg-mono" aria-live="polite"></span>
@@ -202,6 +203,7 @@
   <section id="reelArea">
     <div class="bs-toolbar" id="reelToolbar">
       <span class="bs-label">Reel</span>
+      <!-- Empty-state text only; renderQueueImpl rewrites data-tooltip with the live clip/cell tally. -->
       <span id="reelCount" class="bs-count cg-mono" data-tooltip="Clips queued for the reel">(0)</span>
       <span id="reelDuration" class="bs-count cg-mono" data-tooltip="Estimated total length of the reel"></span>
       <!-- Intentional inline SVG (icon convention exception): animated loading spinner (animateTransform), not an icon. -->

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -1424,9 +1424,10 @@
           ? Math.min(gen.started_at, intake.started_at)
           : gen.started_at || intake.started_at;
       _generateEtaTracker.start(genStartedAt ? genStartedAt * 1000 : undefined);
-      // The "N / M cells" readout counts sheet cells only (intake spans aren't
-      // cells); an intake-only run has no sheet count and shows elapsed alone.
-      updateGenerateProgress(gen.done || 0, gen.total || 0);
+      // Both sides count artifacts now (the sheet job in timestamp segments,
+      // the intake job one per span), so the two totals sum cleanly and an
+      // intake-only run keeps its readout instead of falling back to elapsed.
+      updateGenerateProgress(combinedDone, combinedTotal);
       _studioEtaTicker.ensure();
     } else if (state._jobStatusGenerateWasInProgress) {
       setArtifactGenerating(false);
@@ -3058,6 +3059,8 @@
     isReel: false,
     attachDragstart: true,
     durationSel: null,
+    countNoun: "artifact",
+    countNounPlural: "artifacts",
   };
   var REEL_QUEUE = {
     listSel: "#reelList",
@@ -3069,6 +3072,8 @@
     isReel: true,
     attachDragstart: false,
     durationSel: "#reelDuration",
+    countNoun: "clip",
+    countNounPlural: "clips",
   };
 
   // Composer-trim key for a queue item, or null. Sheet items key on
@@ -3168,12 +3173,36 @@
     });
   }
 
+  // Badge tooltip. The number is card count, but a card is one timestamp
+  // segment, so a handful of cells can stand behind many more cards — spell the
+  // relationship out rather than letting the badge look like it disagrees with
+  // the "N / M artifacts" readout beside it.
+  function queueCountTooltip(q, noun, nounPlural) {
+    var cellsSeen = {};
+    var cellCount = 0;
+    for (var i = 0; i < q.length; i++) {
+      if (isIntakeSource(q[i].source)) continue;
+      var key = q[i].participant + "." + q[i].row;
+      if (!cellsSeen[key]) { cellsSeen[key] = true; cellCount++; }
+    }
+    var phrase = clipgenPluralUnit(q.length, noun, nounPlural);
+    if (cellCount > 0 && cellCount !== q.length) {
+      return phrase + " from " + clipgenPluralUnit(cellCount, "cell", "cells");
+    }
+    return phrase + " queued";
+  }
+
   function renderQueueImpl(cfg) {
     clearGridHighlights();
     var list = qs(cfg.listSel);
     var q = state[cfg.queueKey];
     var n = q.length;
-    qs(cfg.countSel).textContent = "(" + n + ")";
+    var countEl = qs(cfg.countSel);
+    countEl.textContent = "(" + n + ")";
+    countEl.setAttribute(
+      "data-tooltip",
+      queueCountTooltip(q, cfg.countNoun, cfg.countNounPlural)
+    );
     list.innerHTML = "";
     saveQueues();
     refreshIntakeCardStates();
@@ -3642,8 +3671,8 @@
     var el = qs("#generateProgress");
     if (!el) return;
     var hasCount = _genLastTotal > 0;
-    // Intake-only jobs never populate the cell counter, so fall back to an
-    // elapsed-only readout while generating. Hide entirely once idle.
+    // A run with no countable work falls back to an elapsed-only readout while
+    // generating. Hide entirely once idle.
     if (!state.artifactGenerating && !hasCount) {
       el.classList.add("hidden");
       el.textContent = "";
@@ -3654,7 +3683,13 @@
     // so the user can read the final tally, and a resting tally shouldn't move.
     el.classList.toggle("cg-shimmer", state.artifactGenerating);
     var parts = [];
-    if (hasCount) parts.push(_genLastDone + " / " + _genLastTotal + " cells");
+    // Artifacts, not cells: this has to agree with the panel's card count badge
+    // sitting right next to it (a multi-timestamp cell is several artifacts).
+    if (hasCount) {
+      parts.push(
+        _genLastDone + " / " + clipgenPluralUnit(_genLastTotal, "artifact", "artifacts")
+      );
+    }
     if (state.artifactGenerating) {
       parts.push(formatDuration(_generateEtaTracker.update().elapsedSec));
     }

--- a/source/files.py
+++ b/source/files.py
@@ -448,12 +448,14 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
                 f"No valid timestamps found in cell {cell_ref}",
                 [
                     f"Cell contents: '{clip['cell'].value}'",
-                    f"Participant: {clip['participant']}, Description: {clip['desc'][:50]}...",
+                    f"Participant: {clip['participant']}, Description: {(clip.get('desc') or '')[:50]}...",
                 ],
             )
 
-    # Clean description: remove bracketed prefix and sanitize for use in filename
-    raw_desc = clip["desc"]
+    # Clean description: remove bracketed prefix and sanitize for use in filename.
+    # `.get` mirrors the fast path above: a record built without desc/category is
+    # legal (synthetic clips, sheet rows with empty columns) and must not KeyError.
+    raw_desc = clip.get("desc") or ""
     bracket_pos = raw_desc.rfind("]")
     cleaned_desc = (
         raw_desc[bracket_pos + 1 :].strip() if bracket_pos >= 0 else raw_desc.strip()
@@ -462,8 +464,8 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
     if config.DEBUGGING:
         config.debug_ic(clip["desc"])
 
-    # Sanitize category (handle None/empty)
-    if clip["category"]:
+    # Sanitize category (handle missing/None/empty)
+    if clip.get("category"):
         clip["category"] = utils.sanitize_filename(clip["category"])
     else:
         clip["category"] = "uncategorized"

--- a/source/server.py
+++ b/source/server.py
@@ -416,7 +416,11 @@ def _record_reel_event(event: dict[str, Any]) -> None:
 
 
 def _reset_generate_job_state(total: int) -> None:
-    """Initialize the generate progress snapshot when /api/generate starts."""
+    """Initialize the generate progress snapshot when /api/generate starts.
+
+    *total* counts artifacts (one per timestamp segment), matching the Studio
+    queue's card count — not cells, and not yielded NDJSON lines.
+    """
     with _job_state_lock:
         _generate_job_state["total"] = max(0, int(total))
         _generate_job_state["done"] = 0
@@ -424,7 +428,11 @@ def _reset_generate_job_state(total: int) -> None:
 
 
 def _increment_generate_done(n: int = 1) -> None:
-    """Advance the generate-job 'done' counter by n (one per yielded line)."""
+    """Advance the generate-job 'done' counter by n artifacts.
+
+    One yielded line covers a whole cell, so callers pass that cell's segment
+    count rather than 1.
+    """
     with _job_state_lock:
         _generate_job_state["done"] += n
 
@@ -1411,6 +1419,10 @@ def _apply_time_overrides(clips: list[Any], overrides: dict[str, Any]) -> None:
     points on the duration badge). Setting ``clip["times"]`` here makes
     ``files.prepare_clip()`` take its pre-parsed fast path and skip the cell
     re-parse, so the edited durations win over the spreadsheet values.
+
+    Must run *before* the caller prepares the clips (``/api/generate`` and
+    ``/api/reel`` both prepare in the route so they can count segments), or the
+    sheet parse would land first and the overrides would be ignored.
     """
     if not overrides:
         return
@@ -1482,9 +1494,25 @@ def api_generate() -> FlaskResponse:
         _release_busy("generate")
         return err(str(e), 500)
 
+    # Parse timestamps up front so progress is counted in artifacts (one per
+    # segment) rather than cells — a cell holding "1:20-1:35 4:02-4:20" produces
+    # two files and two queue cards, and the readout must agree with both.
+    # prepare_clip is pure string work (~3 ms for 500 cells) and its pre-parsed
+    # fast path makes the pipeline's later call a no-op; /api/reel does the same.
+    # Per-clip guard keeps a malformed cell failing on its own line inside
+    # _generate_and_persist instead of 500-ing the whole request.
+    for clip in clips:
+        try:
+            files.prepare_clip(clip)
+        except Exception as exc:
+            utils.debug_print(f"prepare_clip failed during progress count: {exc}")
+    total_artifacts = sum(len(clip.get("times") or []) for clip in clips)
+
     def stream() -> Any:
         _generate_cancel_event.clear()
-        _reset_generate_job_state(len(cell_strings))
+        # Fall back to the cell count if nothing parsed, so the readout still
+        # shows a denominator instead of hiding itself.
+        _reset_generate_job_state(total_artifacts or len(cell_strings))
         cancel_flag = _generate_cancel_event.is_set
         clip_cells: set[str] = set()
         req_cards, req_dur = pipeline._resolve_titlecard_options(
@@ -1531,7 +1559,10 @@ def api_generate() -> FlaskResponse:
                 (fresh if matches else stale).append(a)
 
             if fresh:
-                _increment_generate_done()
+                # Advance by the cell's segment count, not len(fresh): a
+                # 3-segment cell with 2 cached artifacts still retires 3 queue
+                # cards on the client, and the two counters must stay in step.
+                _increment_generate_done(len(clip.get("times") or []))
                 yield (
                     json.dumps(
                         {
@@ -1616,7 +1647,7 @@ def api_generate() -> FlaskResponse:
                                 f.cancel()
                             break
                         clip, cell_str = future_to_cell[future]
-                        _increment_generate_done()
+                        _increment_generate_done(len(clip.get("times") or []))
                         try:
                             generated, artifacts = future.result()
                             yield (
@@ -1641,7 +1672,7 @@ def api_generate() -> FlaskResponse:
                 for clip, cell_str in to_generate:
                     if cancel_flag():
                         break
-                    _increment_generate_done()
+                    _increment_generate_done(len(clip.get("times") or []))
                     try:
                         generated, artifacts = _generate_and_persist(clip)
                         yield (
@@ -1663,7 +1694,8 @@ def api_generate() -> FlaskResponse:
 
         for cs in cell_strings:
             if cs not in clip_cells:
-                _increment_generate_done()
+                # No clip means no segments, so this ref contributed nothing to
+                # total_artifacts — advancing here would overshoot the total.
                 yield (
                     json.dumps({"cell": cs, "ok": False, "error": "No clip found"})
                     + "\n"

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -3994,6 +3994,94 @@ def test_api_job_status_reflects_generate_progress(client, monkeypatch, tmp_path
     assert _poll_until(lambda: server._busy_slots["generate"] is False)
 
 
+def _setup_single_cell_generate(monkeypatch, tmp_path, cell_value, *, generated=1):
+    """Wire /api/generate down to one P01.5 cell holding *cell_value*."""
+    import types
+
+    monkeypatch.setattr(server, "_worksheet", object())
+    monkeypatch.setattr("config.OUTPUT_DIR", str(tmp_path))
+    _set_artifacts(monkeypatch, [])
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+
+    cell = types.SimpleNamespace(row=5, col=2, value=cell_value)
+    monkeypatch.setattr("spreadsheet.parse_cell_specifications", lambda t: [("P01", 5)])
+    monkeypatch.setattr(
+        "spreadsheet.generate_list",
+        lambda ws, mode, *, ctx=None, cell_specs, skip_prompts: [
+            {"participant": "P01", "cell": cell, "desc": "obs", "category": "nav"}
+        ],
+    )
+    monkeypatch.setattr("pipeline.process_clips", lambda *a, **kw: (generated, []))
+
+
+def test_api_generate_progress_counts_artifacts_not_cells(
+    client, monkeypatch, tmp_path
+):
+    """A multi-timestamp cell is one NDJSON line but several artifacts.
+
+    Studio's Artifacts badge counts queue cards — one per timestamp segment — so
+    the job-state total has to count segments too. Counting cells is what made
+    the panel read "(58)" next to "51 / 52 cells" for one Generate click.
+    """
+    _setup_single_cell_generate(
+        monkeypatch, tmp_path, "1:00-1:30 2:00-2:30", generated=2
+    )
+
+    resp = client.post(
+        "/studio/api/generate", json={"cells": ["P01.5"], "format": "clip"}
+    )
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+
+    assert len(lines) == 1, "one cell still yields one line"
+    assert lines[0]["ok"] is True
+    # ...but the progress snapshot advances by both segments, in one step.
+    assert server._generate_job_state["total"] == 2
+    assert server._generate_job_state["done"] == 2
+
+
+def test_api_generate_progress_counts_trimmed_override_segments(
+    client, monkeypatch, tmp_path
+):
+    """Trimming in the queue replaces the cell's segments, and the count follows.
+
+    The frontend posts the complete remaining segment list whenever a cell was
+    edited or had cards removed, so the override — not the sheet value — decides
+    how many artifacts that cell contributes.
+    """
+    _setup_single_cell_generate(monkeypatch, tmp_path, "1:00", generated=2)
+
+    resp = client.post(
+        "/studio/api/generate",
+        json={
+            "cells": ["P01.5"],
+            "format": "clip",
+            "overrides": {"P01.5": [[10, 40], [60, 90]]},
+        },
+    )
+    assert resp.status_code == 200
+    assert server._generate_job_state["total"] == 2
+    assert server._generate_job_state["done"] == 2
+
+
+def test_api_generate_progress_skips_unmatched_refs(client, monkeypatch, tmp_path):
+    """A ref that resolves to no clip contributes 0 segments to both counters.
+
+    It still gets its own "No clip found" line, but advancing on that line would
+    push done past total and overfill the Generate button.
+    """
+    _setup_single_cell_generate(monkeypatch, tmp_path, "1:00", generated=1)
+
+    resp = client.post(
+        "/studio/api/generate", json={"cells": ["P01.5", "P09.99"], "format": "clip"}
+    )
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+
+    assert [line["cell"] for line in lines] == ["P01.5", "P09.99"]
+    assert lines[1]["error"] == "No clip found"
+    assert server._generate_job_state["total"] == 1
+    assert server._generate_job_state["done"] == 1
+
+
 def test_api_job_status_cancelling_flag(client, monkeypatch, tmp_path):
     """When cancel has been signaled but the worker hasn't yet exited, the
     status reflects in_progress=True + cancelling=True so the UI can show

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -54,6 +54,25 @@ def test_studio_css_does_not_freeze_drop_targets_during_generation():
     assert "studio-generating" not in css
 
 
+def test_artifacts_toolbar_makes_room_for_the_progress_readout():
+    """The mid-run readout must not push Generate/Stash/Clear off the toolbar.
+
+    `.bs-toolbar` is a fixed-height flex row with no wrap, and the row only just
+    fits at rest — measured 868px of content in an 799px column once the
+    "N / M artifacts · elapsed" readout and its spinner appear.
+    """
+    css = STUDIO_CSS.read_text(encoding="utf-8")
+    assert "@container artifacts-toolbar (max-width: 920px)" in css
+    assert (
+        "#artifactsToolbar:has(#generateProgress:not(.hidden)) #artifactFormat" in css
+    )
+    assert (
+        "#artifactsToolbar:has(#generateProgress:not(.hidden)) #titlecardGroup" in css
+    )
+    # The rule keys off .hidden, which is what _paintGenerateProgress toggles.
+    assert 'el.classList.add("hidden")' in _studio_js()
+
+
 def test_studio_generate_uses_abort_controllers_for_both_branches():
     """Generate sheet + intake fetches must be cancellable via AbortController
     so the network connections are torn down promptly on cancel."""
@@ -134,6 +153,41 @@ def test_finish_branch_handles_zero_zero_case():
     should surface an error, not silently report '0 artifacts'."""
     src = _studio_js()
     assert "No artifacts were generated" in src
+
+
+def test_generate_progress_counts_artifacts_not_cells():
+    """The readout beside the Artifacts badge must count the same things it does.
+
+    The badge is queue-card count (one card per timestamp segment) while the
+    POST body is deduped cell refs, so a per-line ``++`` made the panel show two
+    totals for one Generate — "(58)" next to "51 / 52 cells".
+    """
+    src = _studio_js()
+    # Total is cards, not the deduped ref list, and the intake branch shares the
+    # unit so a mixed or intake-only run keeps one honest denominator.
+    assert "var sheetArtifactTotal = sheetItems.length;" in src
+    assert "updateGenerateProgress(0, sheetArtifactTotal + intakeTotal);" in src
+    assert "sheetCellTotal" not in src
+    assert "sheetCellsDone" not in src
+    # A line covering a multi-segment cell advances by that cell's card count.
+    assert "sheetArtifactsDone += cardsPerCell[data.cell] || 1;" in src
+    # Guard against the double-advance when a ref draws both a result line and
+    # a trailing "No clip found".
+    assert "if (!cellCounted[data.cell]) {" in src
+    # Readout noun matches the panel, and works for screenshots/GIFs too.
+    assert '_genLastTotal + " cells"' not in src
+    assert 'clipgenPluralUnit(_genLastTotal, "artifact", "artifacts")' in src
+
+
+def test_queue_count_badges_explain_the_cell_relationship():
+    """Both badge tooltips are rebuilt per render, from the live queue."""
+    src = _studio_js()
+    assert "function queueCountTooltip(q, noun, nounPlural)" in src
+    assert "queueCountTooltip(q, cfg.countNoun, cfg.countNounPlural)" in src
+    assert 'countNoun: "artifact"' in src
+    assert 'countNoun: "clip"' in src
+    # The stale static wording called artifact cards "Cells".
+    assert "Cells queued for generation" not in STUDIO_HTML.read_text(encoding="utf-8")
 
 
 def test_clear_card_status_selects_card_gen_badge():


### PR DESCRIPTION
## Summary

The Artifacts badge counts queue cards — one per timestamp segment — while the progress readout counted unique sheet cells, so one Generate click showed two totals side by side (`ARTIFACTS (58)` next to `51 / 52 cells`).

- `/studio/api/generate` now calls `files.prepare_clip` up front (as `/api/reel` already did) and counts segments, so its job-state total and per-line increments are in artifacts; the client tallies cards per cell and advances by that count, at most once per cell.
- Sheet and intake branches share the unit, so a mixed or intake-only run gets one denominator live and the same one after a mid-run reload; both count badges gained a live tooltip spelling out the relationship (`58 artifacts from 52 cells`).
- The readout adds ~215px to a toolbar that only just fit, pushing Generate/Stash/Clear off the end (already true at the old wording), so the existing `@container artifacts-toolbar` collapse rule gained a wider threshold gated on the readout being visible.
- Reel is unchanged: its progress is a bar with no visible number, and making it segment-accurate means touching the shared `_run_clip_pipeline` contract the CLI progress bars use.

## Test plan

- [x] `/check` — ruff format + lint, ty, full suite green
- [x] New coverage: multi-segment cell, trimmed-override cell, and unmatched-ref counting in `tests/test_studio_api.py`; readout/tooltip/toolbar-fit source assertions in `tests/test_studio_frontend_source.py`
- [x] `/ui-check` — six pages and five journeys clean, screenshots reviewed
- [x] Probed the live page at the reported numbers: badge `(58)`, tooltip `58 artifacts from 52 cells`, readout `51 / 58 artifacts`, zero toolbar overflow with Generate/Stash/Clear all visible
- [x] Verified against a real Google Sheet