### PR TITLE
fix: shorten end-of-recording clips, plus four smaller audit fixes

### DIFF
--- a/assets/web/studio-generate.js
+++ b/assets/web/studio-generate.js
@@ -43,6 +43,16 @@
     _generateEtaTracker = STUDIO._generateEtaTracker,
     _studioEtaTicker = STUDIO._studioEtaTicker;
 
+  // Canonical key for a "participant.row" cell ref. The POST carries the
+  // client's own string, but a result line echoes the *sheet header* the server
+  // resolved it to (spreadsheet.generate_cell_timestamps), and the two match
+  // case-insensitively rather than exactly — so every map keyed on a cell ref
+  // must fold, or a case difference splits one cell across two keys and the
+  // trailing "No clip found" line paints cards that already succeeded.
+  function generateCellKey(ref) {
+    return String(ref).toLowerCase();
+  }
+
   function buildGenerateCardIndex(listEl) {
     var map = {};
     var cards = listEl.querySelectorAll(".queue-card");
@@ -51,7 +61,7 @@
       var participant = card.getAttribute("data-participant");
       var row = card.getAttribute("data-row");
       if (!participant || row == null) continue;
-      var key = participant + "." + row;
+      var key = generateCellKey(participant + "." + row);
       if (!map[key]) map[key] = [];
       map[key].push(card);
     }
@@ -194,8 +204,11 @@
       var cells = [];
       var cardsPerCell = {};
       for (var si = 0; si < sheetItems.length; si++) {
-        var ck = sheetItems[si].participant + "." + sheetItems[si].row;
-        if (!cellsSeen[ck]) { cellsSeen[ck] = true; cells.push(ck); }
+        // The POST carries the ref as written; the tallies key on the folded
+        // form so a returning line finds them whatever casing it comes back in.
+        var ref = sheetItems[si].participant + "." + sheetItems[si].row;
+        var ck = generateCellKey(ref);
+        if (!cellsSeen[ck]) { cellsSeen[ck] = true; cells.push(ref); }
         cardsPerCell[ck] = (cardsPerCell[ck] || 0) + 1;
       }
       var cellCounted = {};
@@ -217,12 +230,14 @@
         // At most one advance per cell: the server can emit both a result line
         // and a trailing "No clip found" for the same ref when its casing
         // differs from the sheet header, which would push done past total.
-        if (!cellCounted[data.cell]) {
-          cellCounted[data.cell] = true;
-          sheetArtifactsDone += cardsPerCell[data.cell] || 1;
+        // Folded, so those two spellings are one key (see generateCellKey).
+        var cellKey = generateCellKey(data.cell);
+        if (!cellCounted[cellKey]) {
+          cellCounted[cellKey] = true;
+          sheetArtifactsDone += cardsPerCell[cellKey] || 1;
           updateGenerateButtonProgress();
         }
-        var cards = generateCardIndex[data.cell] || [];
+        var cards = generateCardIndex[cellKey] || [];
         if (data.ok) {
           for (var ci = 0; ci < cards.length; ci++) setCardResult(cards[ci], true);
           totalSuccess += (data.generated || 1);

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -1182,6 +1182,15 @@ def _run_overlay_export(data: dict[str, Any], *, gif: bool) -> Any:
     if not annotations:
         return err("No annotations in this span — use Generate for plain clips.")
     windows = _annotation_windows(annotations, start, end)
+    # An annotation can overlap the span by less than the 0.01 s a window needs
+    # to survive, which clears the "no annotations" check above and still leaves
+    # nothing to burn. Without this the filter graph would come out empty and
+    # ffmpeg would fail on a `[0:v]` label the graph never defines.
+    if not windows:
+        return err(
+            "No annotation is visible for long enough in this span — widen the "
+            "span or the annotation's visibility."
+        )
     if len(windows) > MAX_OVERLAY_WINDOWS:
         return err(
             f"Too many distinct annotation windows ({len(windows)}); "
@@ -1291,6 +1300,12 @@ def _run_overlay_export(data: dict[str, Any], *, gif: bool) -> Any:
             os_error_message="Annotated export failed.",
             cancel_flag=_export_cancel.is_set,
         )
+    except Exception:
+        # A failed mkstemp / overlay.save would otherwise leave the placeholder
+        # get_unique_filename reserved above sitting on disk; the two explicit
+        # ffmpeg failure paths below release it themselves.
+        files.release_reservation(out_path)
+        raise
     finally:
         for png_path, _, _ in overlay_specs:
             _unlink_quiet(png_path)

--- a/source/pipeline.py
+++ b/source/pipeline.py
@@ -551,8 +551,9 @@ def _process_single_clip_segments(
 
     # Padding / max-duration (Workflows artifact nodes); the default path is a
     # no-op and never probes. The EOF limit is only needed when *extending* the
-    # end, since run_ffmpeg silently skips a clip running past EOF — trimming or
-    # capping can never push the end out.
+    # end — trimming or capping can never push the end out. run_ffmpeg now
+    # clamps an over-running span itself, so this is about keeping the padded
+    # end *honest* in the artifact record rather than about salvaging the cut.
     padding_active = pad_pre != 0.0 or pad_post != 0.0 or max_duration > 0.0
     span_limit: float | None = None
     if pad_post > 0.0:

--- a/source/server.py
+++ b/source/server.py
@@ -1426,9 +1426,14 @@ def _apply_time_overrides(clips: list[Any], overrides: dict[str, Any]) -> None:
     """
     if not overrides:
         return
+    # Folded lookup: the client keys these on the ref it posted, while the clip
+    # carries the sheet header the server resolved it to, and the two only match
+    # case-insensitively (spreadsheet.find_participant_column). An exact-match
+    # lookup would silently drop the user's edited in/out points.
+    by_key = {str(k).lower(): v for k, v in overrides.items()}
     for clip in clips:
-        key = clip["participant"] + "." + str(clip["cell"].row)
-        seg_times = overrides.get(key)
+        key = (clip["participant"] + "." + str(clip["cell"].row)).lower()
+        seg_times = by_key.get(key)
         if not seg_times:
             continue
         new_times: list[tuple[str, str]] = []
@@ -1464,6 +1469,9 @@ def api_generate() -> FlaskResponse:
     cell_strings = data.get("cells", [])
     output_format = data.get("format", "clip")
     overrides: dict[str, Any] = data.get("overrides") or {}
+    # Folded for the same reason _apply_time_overrides folds its lookup: the
+    # client keys on the ref it posted, the clip carries the sheet header.
+    override_keys = {str(k).lower() for k in overrides}
     titlecards_enabled, titlecard_duration_seconds = _parse_titlecard_request(data)
 
     if not cell_strings:
@@ -1525,7 +1533,10 @@ def api_generate() -> FlaskResponse:
         existence_cache: dict[str, bool] = {}
         for clip in clips:
             cell_str = clip["participant"] + "." + str(clip["cell"].row)
-            clip_cells.add(cell_str)
+            # Folded: cell_str is the *sheet header* the ref resolved to, and the
+            # match is case-insensitive, so the trailing "No clip found" sweep
+            # below must not treat a differently-spelled ref as unresolved.
+            clip_cells.add(cell_str.lower())
 
             existing = _find_existing_artifacts(
                 clip["cell"].row,
@@ -1538,7 +1549,7 @@ def api_generate() -> FlaskResponse:
             # effect on the next Generate. An overridden cell is always stale:
             # artifacts are keyed by cell row/col/format only, so an edited in/out
             # point would otherwise be reused at the old duration.
-            cell_overridden = cell_str in overrides
+            cell_overridden = cell_str.lower() in override_keys
             fresh: list[dict[str, Any]] = []
             stale: list[dict[str, Any]] = []
             for a in existing:
@@ -1693,7 +1704,7 @@ def api_generate() -> FlaskResponse:
                         )
 
         for cs in cell_strings:
-            if cs not in clip_cells:
+            if str(cs).lower() not in clip_cells:
                 # No clip means no segments, so this ref contributed nothing to
                 # total_artifacts — advancing here would overshoot the total.
                 yield (

--- a/source/video.py
+++ b/source/video.py
@@ -1029,13 +1029,6 @@ def run_ffmpeg(
             [f"Video file: '{input_file}'"],
         )
         return False
-    if start_seconds is not None and start_seconds + duration > duration_seconds:
-        utils.error_print(
-            f"Clip range ({start_pos} to {end_pos}) extends beyond video duration ({duration_seconds}s). Skipping.",
-            [f"Video file: '{input_file}'"],
-        )
-        return False
-
     if duration < 0:
         utils.error_print(
             "Negative duration calculated for video clip. Skipping.",
@@ -1045,6 +1038,28 @@ def run_ffmpeg(
             ],
         )
         return False
+    # A span running past the end of the recording is shortened, not dropped.
+    # The common case is a bare single timestamp near the end of a session: its
+    # end is start + DEFAULT_DURATION_SECONDS, so it overshoots by construction,
+    # and rejecting it meant the last observation of a study produced nothing.
+    # ffmpeg stops at EOF on its own, which is exactly what the other two clip
+    # paths already rely on — utils.map_global_range_to_segments clamps the end
+    # for multi-video participants, and transcript intake clamps only the start.
+    if start_seconds is not None and start_seconds + duration > duration_seconds:
+        clamped = int(duration_seconds - start_seconds)
+        if clamped <= 0:
+            utils.error_print(
+                f"Clip range ({start_pos} to {end_pos}) leaves under a second before "
+                f"the end of the video ({duration_seconds}s). Skipping.",
+                [f"Video file: '{input_file}'"],
+            )
+            return False
+        utils.warning_print(
+            f"Clip range ({start_pos} to {end_pos}) extends beyond video duration "
+            f"({duration_seconds}s); shortening the clip to {clamped}s.",
+            [f"Video file: '{input_file}'"],
+        )
+        duration = clamped
     if duration > duration_seconds:
         utils.error_print(
             f"Timestamp duration ({duration}s) exceeds video file length ({duration_seconds}s). Skipping.",
@@ -1481,15 +1496,27 @@ def extract_gif(
                 [f"Video file: '{input_file}'"],
             )
             return False
+        # Shortened rather than skipped, for the same reason as run_ffmpeg's
+        # clamp above: a GIF from a bare end-of-session timestamp overshoots by
+        # construction and used to produce nothing at all.
         if (
             start_seconds is not None
             and start_seconds + duration_seconds > file_duration
         ):
-            utils.error_print(
-                f"GIF range ({timestamp} + {duration_seconds}s) extends beyond video duration ({file_duration}s). Skipping.",
+            clamped = int(file_duration - start_seconds)
+            if clamped <= 0:
+                utils.error_print(
+                    f"GIF range ({timestamp} + {duration_seconds}s) leaves under a "
+                    f"second before the end of the video ({file_duration}s). Skipping.",
+                    [f"Video file: '{input_file}'"],
+                )
+                return False
+            utils.warning_print(
+                f"GIF range ({timestamp} + {duration_seconds}s) extends beyond video "
+                f"duration ({file_duration}s); shortening the GIF to {clamped}s.",
                 [f"Video file: '{input_file}'"],
             )
-            return False
+            duration_seconds = clamped
 
     utils.verbose_print(
         f"Extracting GIF from {input_file} at {timestamp} ({duration_seconds}s)."

--- a/source/workflows_server.py
+++ b/source/workflows_server.py
@@ -268,9 +268,11 @@ def api_blueprint_trigger(bp_id: str) -> Any:
         result = copy.deepcopy(target)
     # Re-baseline on arm so the current backlog (present videos, already-finished
     # transcripts/scans) never retro-fires. The poll maintains no baselines while
-    # nothing is armed, so this re-seed is what upholds that promise.
+    # nothing is armed, so this re-seed is what upholds that promise. Scoped to
+    # the type being armed: the other two may already be armed and live, and a
+    # blanket re-seed would drop their pending arrivals/completions.
     if enabled:
-        _seed_watch_seen()
+        _seed_watch_seen(trigger_type)
     return ok(blueprint=result)
 
 
@@ -1108,27 +1110,36 @@ def _scan_markers() -> dict[str, str]:
     return markers
 
 
-def _seed_watch_seen() -> None:
-    """Baseline every trigger source so the existing backlog never auto-fires.
+def _seed_watch_seen(trigger_type: str | None = None) -> None:
+    """Baseline a trigger source so its existing backlog never auto-fires.
 
     Present videos, already-transcribed participants, and already-completed
-    scans are all recorded; the watcher fires only for arrivals/completions
-    that happen *after* this call.
+    scans are recorded; the watcher fires only for arrivals/completions that
+    happen *after* this call.
+
+    *trigger_type* scopes the reset to one source. ``None`` seeds all three and
+    belongs to startup only: re-seeding a type that is already armed throws away
+    its live state — a video mid-partial-copy sitting in ``_watch_pending`` would
+    be marked seen and never fire, and any completion since the last poll tick
+    would be swallowed. Arming passes the type it is arming.
     """
     global _watch_transcript_cache, _watch_scan_cache
     with _watch_lock:
-        _watch_seen.clear()
-        _watch_pending.clear()
-        for entry in utils.discover_participant_videos():
-            if entry.get("has_video"):
-                _watch_seen.add(str(entry["id"]))
-        # Force a fresh parse (the cached mtime may predate this call).
-        _watch_transcript_cache = (-1.0, {})
-        _watch_scan_cache = (-1.0, {})
-        _watch_transcript_baseline.clear()
-        _watch_transcript_baseline.update(_transcript_markers())
-        _watch_scan_seen.clear()
-        _watch_scan_seen.update(_scan_markers())
+        if trigger_type in (None, "new_video"):
+            _watch_seen.clear()
+            _watch_pending.clear()
+            for entry in utils.discover_participant_videos():
+                if entry.get("has_video"):
+                    _watch_seen.add(str(entry["id"]))
+        if trigger_type in (None, "transcript_complete"):
+            # Force a fresh parse (the cached mtime may predate this call).
+            _watch_transcript_cache = (-1.0, {})
+            _watch_transcript_baseline.clear()
+            _watch_transcript_baseline.update(_transcript_markers())
+        if trigger_type in (None, "scan_event"):
+            _watch_scan_cache = (-1.0, {})
+            _watch_scan_seen.clear()
+            _watch_scan_seen.update(_scan_markers())
 
 
 def _stat_first_video(video_paths: list[str]) -> tuple[int, float] | None:

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -855,6 +855,32 @@ def test_annotated_burn_within_part_keeps_single_pass_fast_path(
     assert resp["artifact"]["sourceVideo"] == "study_P01-1.mp4"
 
 
+def test_annotated_burn_rejects_a_span_that_only_grazes_an_annotation(
+    co_client, monkeypatch
+):
+    """Overlap under the 0.01 s window floor leaves nothing to burn.
+
+    The annotation is "in the span" as far as _annotations_in_span is concerned,
+    so the no-annotations check passes, but _annotation_windows drops the window
+    — which used to hand ffmpeg an empty filter graph and a `[0:v]` label it
+    never defined.
+    """
+    _make_annotation(co_client, span={"start": 10.0, "end": 20.0})
+
+    def _no_ffmpeg(*_a, **_kw):
+        raise AssertionError("ffmpeg must not run with nothing to overlay")
+
+    monkeypatch.setattr(composer_server.video, "run_ffmpeg_process", _no_ffmpeg)
+
+    resp = co_client.post(
+        "/composer/api/export/burn",
+        json={"participant": "P01", "start": 19.995, "end": 25.0},
+    ).get_json()
+
+    assert resp["ok"] is False
+    assert "visible for long enough" in resp["error"]
+
+
 def test_ffmpeg_exports_rejected_while_another_export_runs(co_client):
     # _export_cancel is a single shared Event; the busy lock enforces the
     # one-export-at-a-time assumption it relies on. Without it a second

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1187,6 +1187,20 @@ def test_apply_time_overrides_single_and_multi_segment():
     assert "times" not in clips[2]
 
 
+def test_apply_time_overrides_matches_a_ref_case_insensitively():
+    """The posted ref and the sheet header only ever match case-insensitively.
+
+    find_participant_column resolves a ref against the header with .lower(), so
+    an exact-match lookup here would silently drop the user's trimmed in/out
+    points for any ref not spelled exactly like its column.
+    """
+    import types
+
+    clips = [{"participant": "P01", "cell": types.SimpleNamespace(row=5)}]
+    server._apply_time_overrides(clips, {"p01.5": [[10, 70]]})
+    assert clips[0]["times"] == [("0:10", "1:10")]
+
+
 def test_apply_time_overrides_forces_hours_across_hour_boundary():
     """When either endpoint crosses an hour, both render H:MM:SS (no mixed pair)."""
     import types
@@ -4079,6 +4093,28 @@ def test_api_generate_progress_skips_unmatched_refs(client, monkeypatch, tmp_pat
     assert [line["cell"] for line in lines] == ["P01.5", "P09.99"]
     assert lines[1]["error"] == "No clip found"
     assert server._generate_job_state["total"] == 1
+    assert server._generate_job_state["done"] == 1
+
+
+def test_api_generate_ref_spelled_unlike_its_header_gets_one_line(
+    client, monkeypatch, tmp_path
+):
+    """A resolved ref must not also draw a trailing "No clip found".
+
+    The result line echoes the sheet header the ref resolved to, while the
+    unmatched-ref sweep compares against the ref as posted — and the two only
+    match case-insensitively. Exact-match comparison emitted both lines for one
+    cell, which double-advanced the readout and painted succeeded cards failed.
+    """
+    _setup_single_cell_generate(monkeypatch, tmp_path, "1:00", generated=1)
+
+    resp = client.post(
+        "/studio/api/generate", json={"cells": ["p01.5"], "format": "clip"}
+    )
+    lines = [json.loads(line) for line in resp.data.decode().strip().split("\n")]
+
+    assert [line["cell"] for line in lines] == ["P01.5"]
+    assert lines[0]["ok"] is True
     assert server._generate_job_state["done"] == 1
 
 

--- a/tests/test_studio_frontend_source.py
+++ b/tests/test_studio_frontend_source.py
@@ -170,10 +170,15 @@ def test_generate_progress_counts_artifacts_not_cells():
     assert "sheetCellTotal" not in src
     assert "sheetCellsDone" not in src
     # A line covering a multi-segment cell advances by that cell's card count.
-    assert "sheetArtifactsDone += cardsPerCell[data.cell] || 1;" in src
+    assert "sheetArtifactsDone += cardsPerCell[cellKey] || 1;" in src
     # Guard against the double-advance when a ref draws both a result line and
     # a trailing "No clip found".
-    assert "if (!cellCounted[data.cell]) {" in src
+    assert "if (!cellCounted[cellKey]) {" in src
+    # Every cell-ref map folds case, so a ref spelled unlike its sheet header
+    # can't split one cell across two keys (the server folds the same way).
+    assert "function generateCellKey(ref)" in src
+    assert "var cellKey = generateCellKey(data.cell);" in src
+    assert "generateCardIndex[cellKey]" in src
     # Readout noun matches the panel, and works for screenshots/GIFs too.
     assert '_genLastTotal + " cells"' not in src
     assert 'clipgenPluralUnit(_genLastTotal, "artifact", "artifacts")' in src

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1606,6 +1606,89 @@ def test_run_ffmpeg_forwards_cancel_flag(monkeypatch):
     assert captured == [sentinel]
 
 
+# -- end-of-recording spans are shortened, not dropped --
+
+
+def _run_ffmpeg_harness(monkeypatch, captured, *, file_duration):
+    """Stub out the filesystem + ffmpeg around run_ffmpeg / extract_gif."""
+    monkeypatch.setattr(video.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(
+        video.Path, "stat", lambda self: type("_S", (), {"st_size": 1})()
+    )
+    monkeypatch.setattr(video, "get_file_duration", lambda *_a: file_duration)
+    monkeypatch.setattr(video, "verify_output_file", lambda *_a, **_kw: True)
+    monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 0)
+
+    def _fake(cmd, **_kwargs):
+        captured.append(list(cmd))
+        return subprocess.CompletedProcess(args=["ffmpeg"], returncode=0, stderr="")
+
+    monkeypatch.setattr(video, "run_ffmpeg_process", _fake)
+
+
+def test_run_ffmpeg_shortens_a_clip_running_past_the_end(monkeypatch):
+    """A bare end-of-session timestamp overshoots by DEFAULT_DURATION_SECONDS.
+
+    ffmpeg stops at EOF anyway, and the multi-video path already clamps, so the
+    clip is cut short rather than dropped.
+    """
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=100)
+
+    ok = video.run_ffmpeg("in.mp4", "out.mp4", "01:20", "02:20", reencode=False)
+
+    assert ok is True
+    cmd = captured[0]
+    assert cmd[cmd.index("-t") + 1] == "20"  # 100 - 80, not the requested 60
+
+
+def test_run_ffmpeg_leaves_an_in_bounds_clip_alone(monkeypatch):
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=100)
+
+    assert video.run_ffmpeg("in.mp4", "out.mp4", "00:10", "00:40", reencode=False)
+    cmd = captured[0]
+    assert cmd[cmd.index("-t") + 1] == "30"
+
+
+def test_run_ffmpeg_still_skips_a_start_past_the_end(monkeypatch):
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=100)
+
+    assert (
+        video.run_ffmpeg("in.mp4", "out.mp4", "02:00", "03:00", reencode=False) is False
+    )
+    assert captured == []
+
+
+def test_run_ffmpeg_skips_when_clamping_leaves_nothing(monkeypatch):
+    """Defensive floor: a sub-second tail truncates to 0 and must not be cut."""
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=80.5)
+
+    assert (
+        video.run_ffmpeg("in.mp4", "out.mp4", "01:20", "02:20", reencode=False) is False
+    )
+    assert captured == []
+
+
+def test_extract_gif_shortens_a_range_running_past_the_end(monkeypatch):
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=100)
+
+    assert video.extract_gif("in.mp4", "out.gif", "01:30", 60) is True
+    cmd = captured[0]
+    assert cmd[cmd.index("-t") + 1] == "10"  # 100 - 90
+
+
+def test_extract_gif_still_skips_a_start_past_the_end(monkeypatch):
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=100)
+
+    assert video.extract_gif("in.mp4", "out.gif", "02:00", 5) is False
+    assert captured == []
+
+
 def test_enforce_filesize_limit_noop_when_disabled(monkeypatch):
     monkeypatch.setattr(video.config, "MAX_FILESIZE_MB", 0)
 

--- a/tests/test_workflows_api.py
+++ b/tests/test_workflows_api.py
@@ -1267,6 +1267,34 @@ def test_arming_reseeds_so_backlog_never_fires(wf_client, monkeypatch):
     assert calls == []
 
 
+def test_arming_one_type_leaves_another_types_pending_arrival_alone(
+    wf_client, monkeypatch
+):
+    # Arming re-baselines only the type being armed. A blanket re-seed marked a
+    # video that was mid-partial-copy (pending its second stable stat for the
+    # already-armed new_video trigger) as seen, so it never fired.
+    calls = _record_launches(monkeypatch)
+    watcher = _video_source_blueprint(wf_client)
+    chained = _video_source_blueprint(wf_client)
+    _mock_discovery(monkeypatch, [_entry("P01")], {"P01": (100, 1.0)})
+
+    wf_client.put(
+        f"/workflows/api/blueprints/{watcher}/trigger",
+        json={"enabled": True, "type": "new_video"},
+    )
+    _mock_discovery(monkeypatch, [_entry("P02")], {"P02": (100, 1.0)})
+    workflows_server._watch_poll_once()  # P02 recorded as pending, not yet fired
+    assert calls == []
+
+    wf_client.put(
+        f"/workflows/api/blueprints/{chained}/trigger",
+        json={"enabled": True, "type": "transcript_complete"},
+    )
+
+    workflows_server._watch_poll_once()  # P02 still pending -> now stable -> fires
+    assert [c[1] for c in calls] == ["P02"]
+
+
 def test_watch_two_armed_is_ambiguous_and_skips(wf_client, monkeypatch):
     calls = _record_launches(monkeypatch)
     a = _video_source_blueprint(wf_client)


### PR DESCRIPTION
## Summary

A bug-hunt pass over the newest merged work and the recurring failure-path / concurrency classes in `agents/CODE-REVIEW.md`, fixing the five defects it turned up.

- **`video.py` — clips at the end of a recording.** A bare single timestamp gets `end = start + DEFAULT_DURATION_SECONDS`, so any observation in the last minute of a session overshot the file and `run_ffmpeg` / `extract_gif` dropped it whole; Studio showed "No artifact produced" with the reason only on the console. Both now shorten and warn, matching `map_global_range_to_segments` (which already clamps, so a multi-part participant got a clip for input a single-file one lost) and the transcript-intake path.
- **`composer_server.py` — annotated exports.** A span overlapping an annotation by under 10 ms cleared the "no annotations" check but left zero windows, handing ffmpeg an empty `-filter_complex` plus a `[0:v]` label the graph never defines. Now a clear message; also releases the reserved output filename when the overlay render raises.
- **`workflows_server.py` — auto-run triggers.** Arming any trigger re-baselined all three sources, so arming a second type marked a mid-copy video (pending its stability check for an armed `new_video` trigger) as seen and it never fired. Seeding is scoped to the type being armed.
- **`server.py` + `studio-generate.js` — generate cell refs.** A ref resolves against its sheet header case-insensitively but was compared exactly everywhere after, which double-advanced the readout, painted succeeded cards failed, silently discarded trimmed in/out points, and reused stale cached artifacts. Folded on both sides.

## Test plan

- [x] `/check` — ruff format, ruff, ty, full suite green
- [x] `/ui-check` — six pages, zero page errors; Studio generate journey screenshot reviewed ("Generated 1 artifact")
- [x] 10 new tests; neither `video.py` EOF guard had any coverage before
- [ ] Not verified in WebKit (`/ui-check` drives Chromium only) — the frontend change is a key-folding helper in `studio-generate.js`, so engine-specific risk is low
- [ ] Real-media spot check of a clip whose timestamp sits inside the last minute of a recording
