### PR TITLE
fix(transcripts): acknowledge a transcription cancel immediately

### DIFF
--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -11,9 +11,11 @@
  * loadFriction lives in the agents satellite, which loads AFTER this one, so the
  * friction run/stop rows reach it late-bound via TS.loadFriction rather than a
  * captured local. _confirmUncachedWhisperModels stays in the hub (model-install
- * state). Plain utils.js globals (qs/el/escapeHtml/apiPost/apiDelete/
- * clipgenPluralUnit/applyMaskIcon/attachHoverTooltip/positionPopoverAnchored)
- * are reached via the scope chain.
+ * state). updateTranscribeFill comes from the video satellite, which loads
+ * before this one, so it can be destructured like the hub's own exports. Plain
+ * utils.js globals (qs/el/escapeHtml/apiPost/apiDelete/clipgenPluralUnit/
+ * applyMaskIcon/attachHoverTooltip/positionPopoverAnchored) are reached via the
+ * scope chain.
  */
 (function () {
   "use strict";
@@ -25,6 +27,8 @@
     maybeWarmOnPillHover = TS.maybeWarmOnPillHover,
     tryPostTranscriptionWarmup = TS.tryPostTranscriptionWarmup,
     pollTaskStatus = TS.pollTaskStatus,
+    refreshTranscribeWording = TS.refreshTranscribeWording,
+    updateTranscribeFill = TS.updateTranscribeFill, // video satellite (loads before this one)
     startPolling = TS.startPolling,
     _refreshAgentStateNow = TS._refreshAgentStateNow,
     _trFetchModels = TS._trFetchModels,
@@ -38,6 +42,11 @@
     failed: { rest: "icons/exclamation-triangle.svg", hover: "icons/microphone.svg", label: "Retry transcription", action: "transcribe" },
     queued: { rest: "icons/clock.svg", hover: "icons/stop-circle.svg", label: "Cancel", action: "cancel" },
     running: { rest: "icons/arrow-path.svg", hover: "icons/stop-circle.svg", label: "Cancel transcription", action: "cancel" },
+    // Cancel acknowledged, worker not stopped yet. Same glyph on both faces:
+    // there is nothing left to click, so a hover swap would promise an action
+    // that is not there. action:"none" is the re-click guard at the config level
+    // — the click handler can no longer reach the cancel branch at all.
+    cancelling: { rest: "icons/stop-circle.svg", hover: "icons/stop-circle.svg", label: "Cancelling…", action: "none" },
     completed: { rest: "icons/check-circle.svg", hover: "icons/arrow-path.svg", label: "Re-transcribe", action: "retranscribe" }
   };
 
@@ -75,9 +84,19 @@
     var taskId = null;
 
     if (task && (task.status === "running" || task.status === "queued")) {
-      status = task.status;
       taskId = task.id;
-      if (task.status === "running") progress = Math.round((task.progress || 0) * 100);
+      var pending = state.cancellingTasks[task.id];
+      if (pending) {
+        status = "cancelling";
+        // Frozen at the click, not re-read from the task: the worker keeps
+        // emitting segments until its next checkpoint, and renderPills' patch
+        // path still writes this width on every tick — so an unfrozen fill would
+        // keep creeping under "Cancelling…", the same lie the dotted band told.
+        progress = pending.progress;
+      } else {
+        status = task.status;
+        if (task.status === "running") progress = Math.round((task.progress || 0) * 100);
+      }
     } else if (task && task.status === "failed") {
       status = "failed";
       taskId = task.id;
@@ -264,7 +283,11 @@
       var lines = [];
       for (var k = 0; k < keys.length; k++) {
         var label = _dotStateLabel(ag[keys[k]]);
-        if (keys[k] === "transcription" && ag[keys[k]] === "running" &&
+        // The dot itself stays --running (something really is winding down), but
+        // the wording has to agree with the trigger beside it.
+        if (keys[k] === "transcription" && s.status === "cancelling") {
+          label = "stopping…";
+        } else if (keys[k] === "transcription" && ag[keys[k]] === "running" &&
             s.phase === "loading_model") {
           label = "loading model…";
         }
@@ -351,6 +374,11 @@
     btn.className = "pill-trigger pill-trigger--" + s.status;
     btn.setAttribute("aria-label", cfg.label);
     btn.setAttribute("data-tooltip", cfg.label);
+    // Inert while the cancel is in flight — nothing to press, and a second
+    // DELETE against the same task is a no-op the server would reject. The
+    // shared button[data-tooltip]:disabled rule in tokens.css keeps the tooltip
+    // reachable (pointer-events: auto).
+    if (s.status === "cancelling") btn.setAttribute("disabled", "disabled");
 
     // Two stacked icons; CSS hides one and shows the other on hover/focus.
     var rest = document.createElement("span");
@@ -366,12 +394,13 @@
     btn.addEventListener("click", function (e) {
       e.stopPropagation();
       if (cfg.action === "cancel") {
-        if (s.taskId) {
-          apiDelete("api/transcribe/" + s.taskId).then(function () { pollTaskStatus(); });
-        }
+        cancelTranscribeTask(s.taskId, s.progress);
       } else if (cfg.action === "retranscribe") {
         startTranscribe(p.id, true);
-      } else {
+      } else if (cfg.action === "transcribe") {
+        // Explicit, not a bare else: the cancelling row's action is "none", and
+        // falling through here would turn a click on an in-flight cancel into a
+        // second *start*.
         startTranscribe(p.id, false);
       }
     });
@@ -537,14 +566,15 @@
       agent: "transcription",
       depMet: true,
       agentState: s.agents.transcription,
+      // Reads the same flag the pill trigger writes, so this row's optimistic
+      // "Stopping…" survives _refreshPillOptionsContent instead of reverting to
+      // "Stop" on the next poll — and so a cancel started from the trigger shows
+      // up here too.
+      cancelPending: s.status === "cancelling",
       hasResult: !!p.has_transcript,
       cascadeWarning: !!(p.agents && (p.agents.summary === "done" || p.agents.citations === "done")),
       onStart: function () { startTranscribe(p.id, !!p.has_transcript); },
-      onStop: function () {
-        if (s.taskId) {
-          apiDelete("api/transcribe/" + s.taskId).then(function () { pollTaskStatus(); });
-        }
-      },
+      onStop: function () { cancelTranscribeTask(s.taskId, s.progress); },
     }));
 
     // 2. Summary
@@ -681,7 +711,14 @@
     var mode = "start"; // start | stop | disabled
     var title = "";
 
-    if (running) {
+    if (opts.cancelPending) {
+      // Disabled rather than "stop": the DELETE is already out, and this pane is
+      // rebuilt from pillState on every poll, so the label has to come from the
+      // shared flag or it reverts to "Stop" within one tick.
+      btnLabel.textContent = "Stopping…";
+      btn.classList.add("pill-agent-btn--stop");
+      mode = "disabled";
+    } else if (running) {
       btnLabel.textContent = "Stop";
       btn.classList.add("pill-agent-btn--stop");
       mode = "stop";
@@ -836,6 +873,37 @@
 
   function startTranscribe(pid, force) {
     transcribeParticipants([pid], force);
+  }
+
+  // The single cancel path — the pill trigger and the dropdown's Transcription
+  // row both land here, so the optimistic flag, the revert and the toast exist
+  // once. The flag goes down *before* the request so the pill, the timeline
+  // band, the status dot, the empty pane and the streaming footer all stop
+  // claiming work is in progress in the same frame as the click, instead of up
+  // to a poll interval (and, on the loading_model path, a whole model load)
+  // later. renderPills() replaces the clicked button mid-dispatch, which is
+  // safe: :active ends at mouseup, before click fires, so the press squish has
+  // already played.
+  function cancelTranscribeTask(taskId, progress) {
+    if (!taskId || state.cancellingTasks[taskId]) return;
+    state.cancellingTasks[taskId] = { at: Date.now(), progress: progress || 0 };
+    renderPills();
+    updateTranscribeFill();
+    refreshTranscribeWording();
+    apiDelete("api/transcribe/" + taskId).then(function () {
+      pollTaskStatus();
+    }).catch(function () {
+      // The common failure is "Task not found or already finished" from a task
+      // that crossed the line while the request was in flight. If the poll has
+      // already swept the flag the pill is correct and a toast is just noise —
+      // only speak up if we are the ones putting the state back.
+      if (!state.cancellingTasks[taskId]) return;
+      delete state.cancellingTasks[taskId];
+      renderPills();
+      updateTranscribeFill();
+      refreshTranscribeWording();
+      showToast("Failed to cancel transcription");
+    });
   }
 
   // Participants with an un-acked transcribe POST. The server has no in-flight

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -207,20 +207,35 @@
     }
   }
 
-  // The selected participant's running-transcription progress (0..1), or null
-  // when it has no running task. Progress is media-time processed / duration,
-  // so it maps directly onto the timeline's x-axis.
-  function _selectedTranscribeProgress() {
+  // The selected participant's running transcription task (the last match, so
+  // duplicates resolve the same way they always have), or null.
+  function _selectedRunningTask() {
     var pid = state.selectedParticipant;
     if (!pid || !state.tasks) return null;
-    var prog = null;
+    var found = null;
     for (var i = 0; i < state.tasks.length; i++) {
       var t = state.tasks[i];
-      if (t.participant === pid && t.status === "running") {
-        prog = Math.max(0, Math.min(1, t.progress || 0));
-      }
+      if (t.participant === pid && t.status === "running") found = t;
     }
-    return prog;
+    return found;
+  }
+
+  // The selected participant's running-transcription progress (0..1), or null
+  // when it has no running task — or when its cancel is already in flight.
+  // Progress is media-time processed / duration, so it maps directly onto the
+  // timeline's x-axis. The cancel case is the whole point: the server reports
+  // "running" until the worker checkpoints, and a dotted band that outlives the
+  // click by a model load is the timeline telling the user their cancel did not
+  // take.
+  function _selectedTranscribeProgress() {
+    var t = _selectedRunningTask();
+    if (!t || state.cancellingTasks[t.id]) return null;
+    return Math.max(0, Math.min(1, t.progress || 0));
+  }
+
+  function _selectedCancelPending() {
+    var t = _selectedRunningTask();
+    return !!(t && state.cancellingTasks[t.id]);
   }
 
   function _prefersReducedMotion() {
@@ -343,11 +358,15 @@
       ctx.fillStyle = theme.textDim;
       ctx.font = "11px -apple-system, sans-serif";
       ctx.textAlign = "center";
+      // "Loading…" is about the *video*, so falling back to it the instant a
+      // cancel wipes the band would read as "something else is still starting up".
       var placeholder = _txFillActive
         ? "Transcribing… " + Math.round(_txFillDisplay * 100) + "%"
-        : state.selectedParticipant
-          ? "Loading…"
-          : "No video";
+        : _selectedCancelPending()
+          ? "Cancelling…"
+          : state.selectedParticipant
+            ? "Loading…"
+            : "No video";
       ctx.fillText(placeholder, cssW / 2, cssH / 2 + 4);
       ctx.textAlign = "start";
       renderPlayhead();

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -1855,7 +1855,6 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pill-trigger--running .pill-trigger-icon--rest { animation: none; }
   .pill-progress { transition: none; }
 }
 
@@ -1874,7 +1873,29 @@ body {
   flex-shrink: 0;
   position: relative;
   color: var(--color-text-dim);
-  transition: color var(--duration-fast);
+  /* transform rides the transition so the press springs back on release rather
+     than snapping. --duration-instant, not --duration-fast: a quick click is
+     often shorter than 150ms and would never reach full depth. */
+  transition: color var(--duration-fast), transform var(--duration-instant);
+}
+
+/* Press feedback for both faces of the trigger: the microphone that starts a run
+   and the stop-circle that cancels one.
+ *
+ * 0.86, not the repo's usual 0.96 (gallery/topnav/viewer/studio) — those squish a
+ * ~30px chrome button, this is an 18px icon, where 4% is a sub-pixel change.
+ *
+ * On the button, NOT on .pill-trigger-icon. The running glyph's `spin` sets
+ * `transform` from a CSS animation, and an animation outranks a normal
+ * declaration in the cascade — an icon-level squish would be silently dropped on
+ * exactly the running pill a Cancel click lands on. A transform here composes
+ * with the child's rotation, leaves the opacity crossfade alone, and cannot
+ * reflow (fixed 18px flex item) or clip (it scales down inside .pill's
+ * overflow: hidden). Ungated by prefers-reduced-motion, like every other press
+ * affordance in the repo: a 120ms scale bound to the pointer is direct
+ * manipulation, not ambient motion. */
+.pill-trigger:active:not(:disabled) {
+  transform: scale(0.86);
 }
 
 .pill-trigger-icon {
@@ -1913,6 +1934,17 @@ body {
 .pill-trigger--failed { color: var(--sev-critical); }
 .pill-trigger--idle { color: var(--color-text-dim); }
 
+/* Cancel acknowledged, worker not stopped yet. The glyph is the stop-circle the
+   user just pressed, held in the same critical red the hover showed, breathing
+   rather than spinning: spin means "work is progressing", which is precisely the
+   claim being retracted. On the button, so both stacked icons breathe together
+   and the --running spin selector is never in play. cg-pulse animates only
+   opacity, so it never fights the :active transform above. */
+.pill-trigger--cancelling {
+  color: var(--sev-critical);
+  animation: cg-pulse 1s ease-in-out infinite;
+}
+
 .pill-trigger--running .pill-trigger-icon--rest {
   animation: spin 1.2s linear infinite;
 }
@@ -1931,6 +1963,15 @@ body {
 .pill-trigger--failed:hover,
 .pill-trigger--failed:focus-visible {
   color: var(--color-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Must sit AFTER the .pill-trigger--running spin rule above: same selector,
+     same specificity, so source order decides. Placed before it (where this
+     block used to live) the opt-out lost to the animation and the icon kept
+     spinning for every reduced-motion user. */
+  .pill-trigger--running .pill-trigger-icon--rest { animation: none; }
+  .pill-trigger--cancelling { animation: none; opacity: 0.75; }
 }
 
 .pill-chevron {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -21,6 +21,18 @@
     segments: [],
     corrections: [],
     tasks: [],
+    // Task ids with a cancel DELETE in flight → { at, progress }. The server
+    // keeps reporting a cancelled-but-still-running task as "running" until the
+    // worker reaches its next checkpoint — up to a whole cold model load away —
+    // so every surface that reads task.status has to ask this too, or it goes on
+    // saying "transcribing" for ten seconds after the click.
+    //
+    // Keyed by task id, never by participant: a re-transcribe issued right after
+    // a cancel is a *new* task, and a pid key that had not yet been swept would
+    // paint the fresh run as "Cancelling…" and disable its own stop button.
+    // Written by the pills satellite, read by pills + video — hence state, not a
+    // module var (see agents/skills/carve-satellite/SKILL.md).
+    cancellingTasks: {},
     searchQuery: "",
     searchResults: null,
     activeSegmentIndex: -1,
@@ -386,6 +398,13 @@
     return latest;
   }
 
+  // A cancel DELETE is in flight for this task. Every surface that words a
+  // task's progress asks this; without a shared predicate each one re-derives
+  // "running means working" and they drift apart.
+  function _cancelPending(task) {
+    return !!(task && state.cancellingTasks[task.id]);
+  }
+
   function _selectedParticipantRow() {
     var pid = state.selectedParticipant;
     if (!pid) return null;
@@ -424,6 +443,12 @@
 
     if (!pid) {
       taskLine = "No participant selected";
+    } else if (_cancelPending(task)) {
+      // Stays --working, not --ready: the worker really is still winding down,
+      // and a ready dot beside a pill that says "Cancelling…" is a second
+      // contradiction on top of the one this whole change removes.
+      cls = "status-indicator--working";
+      taskLine = pid + ": cancelling…";
     } else if (task && task.status === "running" && task.phase === "loading_model") {
       cls = "status-indicator--working";
       taskLine = pid + ": loading transcription model\u2026";
@@ -489,6 +514,19 @@
       return computeIndicatorState().lines.join("\n");
     }, { multiline: true, align: "center" });
     updateStatusIndicator();
+  }
+
+  // Repaint the three hub-owned surfaces that word a task's progress — the
+  // status dot, the empty-pane copy and the streaming footer — without waiting
+  // for the next poll. Only the pills satellite needs this: it is the one place
+  // that changes task wording outside the poll loop. Deliberately NOT folded
+  // into _txEtaTicker's tick body, which is a per-second hot path.
+  function refreshTranscribeWording() {
+    updateStatusIndicator();
+    var task = _taskForSelectedParticipant();
+    _setTranscriptEmptyText(task);
+    var txt = document.querySelector("#segmentList .streaming-text");
+    if (txt && task) txt.textContent = _streamingTextStr(task.progress || 0);
   }
 
   function refreshTranscriptionModelHintOnce() {
@@ -892,7 +930,12 @@
     // state, not an in-flight one, so it stays flat.
     var waiting = !!(task && (task.status === "running" || task.status === "queued"));
     main.classList.toggle("cg-shimmer", waiting);
-    if (task && task.status === "running" && task.phase === "loading_model") {
+    if (_cancelPending(task)) {
+      main.textContent = "Cancelling…";
+      // Deliberately not "finishing the current segment": a cancel during
+      // loading_model is waiting on the model load, not on a segment.
+      hint.textContent = "Waiting for the transcription worker to stop";
+    } else if (task && task.status === "running" && task.phase === "loading_model") {
       main.textContent = "Loading transcription model…";
       hint.textContent = "The first transcription after a restart takes a few extra seconds";
     } else if (task && task.status === "running") {
@@ -1204,6 +1247,10 @@
   function _streamingTextStr(progress) {
     var pid = state.streamingParticipant || state.selectedParticipant;
     var task = _taskForSelectedParticipant();
+    // Single choke point for the footer \u2014 the append path, the coalesced RAF
+    // update and the per-second ETA ticker all render through here, so one
+    // branch keeps all three honest while a cancel is in flight.
+    if (_cancelPending(task)) return "Cancelling\u2026";
     return "Transcribing\u2026 " + Math.round(progress * 100) + "%" + _txEtaSuffix(pid, task);
   }
 
@@ -2175,6 +2222,31 @@
   var _postCompletionGrace = 0;
   var POST_COMPLETION_GRACE_CYCLES = 4; // ~12s at POLL_INTERVAL=3000ms
 
+  // Ceiling on how long a pill may sit in "Cancelling…". Nothing normal comes
+  // close — the worst real case is a cold model load (~10s, uninterruptible)
+  // plus one poll. This exists only so a wedged worker thread, whose task stays
+  // "running" forever, hands the stop button back instead of leaving a dead pill.
+  var CANCEL_PENDING_MAX_MS = 30000;
+
+  // Drop the pending-cancel flag for every task the server no longer reports as
+  // active. One predicate covers all four exits: the status flipped to cancelled
+  // (the happy path), it flipped to completed or failed (the cancel raced the
+  // finish line), or the task vanished from the list entirely (dismissed, worker
+  // restart).
+  function _sweepCancellingTasks() {
+    var active = {};
+    for (var i = 0; i < state.tasks.length; i++) {
+      var t = state.tasks[i];
+      if (t.status === "running" || t.status === "queued") active[t.id] = true;
+    }
+    var now = Date.now();
+    for (var id in state.cancellingTasks) {
+      if (!active[id] || now - state.cancellingTasks[id].at > CANCEL_PENDING_MAX_MS) {
+        delete state.cancellingTasks[id];
+      }
+    }
+  }
+
   function _anyAgentActive() {
     for (var i = 0; i < state.participants.length; i++) {
       var ag = state.participants[i].agents;
@@ -2241,6 +2313,15 @@
     // the poll loop can wind down (matches the prior behaviour here).
     if (!completed) {
       state.streamingParticipant = null;
+      // The partial rows stay — they are real transcript the user may still want
+      // to read — but the footer under them has to go, or a cancelled run leaves
+      // a frozen "Cancelling…" line forever: nothing calls renderSegments() on
+      // this path, and renderSegmentsImpl is the only other place the indicator
+      // is removed. Cancel the queued insert first, or a RAF scheduled while the
+      // tab was hidden re-inserts the footer right after we remove it.
+      _cancelStreamingIndicator();
+      var ind = document.querySelector("#segmentList .streaming-indicator");
+      if (ind) ind.parentNode.removeChild(ind);
       return;
     }
     var ver = state.participantReqVer;
@@ -2265,6 +2346,10 @@
     apiGet("api/transcribe/status").then(function (data) {
       if (!data.ok) return;
       state.tasks = data.tasks;
+      // Before updateTranscribeFill / updateStatusIndicator / renderPills below
+      // — all three read the flag, and a stale one would keep the band off and
+      // the pill inert for a full extra tick.
+      _sweepCancellingTasks();
       if (_anyTxEtaActive()) _txEtaTicker.ensure();
 
       // Fill the timeline in sync with the selected participant's transcription
@@ -3781,6 +3866,7 @@
   TS.maybeWarmOnPillHover = maybeWarmOnPillHover; // pills
   TS.tryPostTranscriptionWarmup = tryPostTranscriptionWarmup; // pills
   TS.pollTaskStatus = pollTaskStatus; // pills
+  TS.refreshTranscribeWording = refreshTranscribeWording; // pills (cancel repaints before the next poll)
   TS.startPolling = startPolling; // pills
   TS._refreshAgentStateNow = _refreshAgentStateNow; // pills
   TS._trFetchModels = _trFetchModels; // pills

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -882,3 +882,175 @@ def test_transcribe_enqueue_adopts_the_returned_tasks_immediately():
     assert body.index("state.tasks.concat") < body.index("renderPills()"), (
         "adopt before repainting, or the pills render the pre-enqueue state"
     )
+
+
+# ---- Cancelling a transcription ----
+#
+# The server keeps reporting a cancelled-but-still-running task as "running"
+# until the worker reaches its next checkpoint — up to a whole uninterruptible
+# cold model load away. Every assertion below defends some part of the
+# client-side optimistic state that closes that gap.
+
+
+def test_the_cancel_trigger_reports_before_the_server_does():
+    """A flag written in the DELETE's callback is no better than the poll: the
+    round trip is the short part of the wait. Cancelling during loading_model
+    means ~10s of a spinning icon, a creeping fill and a dotted timeline band all
+    insisting the transcription is still running."""
+    start = _JS.index("function cancelTranscribeTask(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    flag = body.index("state.cancellingTasks[taskId] = {")
+    request = body.index("apiDelete(")
+    assert flag < request, "the optimistic flag must go down before the request"
+    for repaint in (
+        "renderPills()",
+        "updateTranscribeFill()",
+        "refreshTranscribeWording()",
+    ):
+        assert body.index(repaint) < request, (
+            f"{repaint} must run before the request, not in its callback"
+        )
+
+
+def test_the_cancelling_flag_is_keyed_by_task_not_participant():
+    """A re-transcribe issued right after a cancel is a *new* task. Keyed by
+    participant, a flag the poll had not yet swept would paint the fresh run as
+    "Cancelling…" and disable its own stop button, stranding the pill until the
+    stale-flag timeout."""
+    for wrong in (
+        "cancellingTasks[p.id]",
+        "cancellingTasks[pid]",
+        "cancellingTasks[p.participant]",
+    ):
+        assert wrong not in _JS, f"{wrong} keys the flag by participant"
+    start = _JS.index("function cancelTranscribeTask(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    assert "state.cancellingTasks[taskId] = {" in body
+
+
+def test_a_pending_cancel_stops_the_timeline_band_immediately():
+    """The dotted band is the loudest "still working" signal on the page. It is
+    driven purely off task.status === "running", which stays true across the
+    whole cancel — so the band has to ask the flag too, or it outlives the click
+    by a model load."""
+    start = _JS.index("function _selectedTranscribeProgress()")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    assert "state.cancellingTasks[t.id]" in body and "return null" in body
+
+
+def test_a_pending_cancel_is_swept_off_every_exit():
+    """Four ways a cancelling task stops being active: it flips to cancelled (the
+    happy path), to completed or failed (the cancel raced the finish line), or it
+    vanishes from the list (dismissed, worker restart). A flag that survives any
+    of them leaves the pill permanently inert."""
+    start = _JS.index("function _sweepCancellingTasks()")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    assert '"running"' in body and '"queued"' in body, (
+        "the live set is both active statuses"
+    )
+    assert "!active[id]" in body, "a task that vanished entirely must clear too"
+    assert "CANCEL_PENDING_MAX_MS" in body, "a wedged worker needs an age backstop"
+
+    poll_start = _JS.index("function pollTaskStatus()")
+    poll = _JS[poll_start : _JS.index("\n  // ---- ", poll_start)]
+    assert (
+        poll.index("state.tasks = data.tasks")
+        < poll.index("_sweepCancellingTasks()")
+        < poll.index("updateTranscribeFill()")
+    ), "sweep after adopting the tasks, before anything reads the flag"
+
+
+def test_a_failed_cancel_reverts_the_optimistic_state():
+    """The usual rejection is "already finished" from a task that crossed the line
+    mid-request. The early return is the load-bearing half: if the poll already
+    swept the flag the pill is correct, and a toast would contradict it."""
+    start = _JS.index("function cancelTranscribeTask(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    catch = body[body.index(".catch(function ()") :]
+    assert catch.index("if (!state.cancellingTasks[taskId]) return;") < catch.index(
+        "delete state.cancellingTasks[taskId]"
+    ), "bail out before reverting when the poll already resolved the race"
+    assert catch.index("delete state.cancellingTasks[taskId]") < catch.index(
+        "showToast("
+    )
+
+
+def test_every_transcribing_surface_asks_the_same_cancel_question():
+    """Five surfaces word a task's progress. Any one of them re-deriving "running
+    means working" from task.status alone goes on claiming the transcription is
+    live for the whole cancel — which is the original bug, just relocated."""
+    for fn in (
+        "function computeIndicatorState()",
+        "function _setTranscriptEmptyText(",
+        "function _streamingTextStr(",
+    ):
+        start = _JS.index(fn)
+        body = _JS[start : _JS.index("\n  function ", start + 1)]
+        assert "_cancelPending(" in body, f"{fn} must consult the shared predicate"
+    start = _JS.index("function buildAgentRow(")
+    assert "opts.cancelPending" in _JS[start : _JS.index("\n  function ", start + 1)]
+
+
+def test_the_press_squish_survives_the_running_spin():
+    """The press feedback has to work on the stop-circle of a *running* pill —
+    the one case where the icon already carries a transform from an animation.
+    Animations outrank normal declarations in the cascade, so an icon-level
+    :active rule is silently dropped exactly where it is needed."""
+    assert ".pill-trigger:active" in _CSS, "the trigger needs a press affordance"
+    # Comments stripped: the rule below carries this reasoning in prose, and the
+    # prose names both halves of what it forbids.
+    declarations = re.sub(r"/\*.*?\*/", "", _CSS, flags=re.DOTALL)
+    assert not re.search(r"\.pill-trigger-icon[^{;]*:active", declarations), (
+        "the squish belongs on the button; on the icon the spin animation wins"
+    )
+    start = _CSS.index(".pill-trigger {")
+    assert "transform" in _CSS[start : _CSS.index("}", start)], (
+        "transform must be in the transition list or the press snaps"
+    )
+
+
+def test_reduced_motion_opt_outs_come_after_the_animations_they_cancel():
+    """Regression test for a bug that already shipped: the spin opt-out sat above
+    the spin rule with an identical selector and identical specificity, so source
+    order handed the win to the animation and the icon spun anyway."""
+    for selector, animation in (
+        (".pill-trigger--running .pill-trigger-icon--rest", "animation: spin"),
+        (".pill-trigger--cancelling", "animation: cg-pulse"),
+    ):
+        anim_at = _CSS.index(animation)
+        opt_out = _CSS.index(selector + " { animation: none")
+        assert opt_out > anim_at, (
+            f"{selector}'s reduced-motion opt-out must follow its animation"
+        )
+
+
+def test_the_cancelling_trigger_cannot_fire_a_second_delete():
+    """Two ways a click on an in-flight cancel goes wrong: a repeat DELETE the
+    server rejects, or — worse — falling through the action table's trailing
+    else and enqueueing a whole second transcription."""
+    start = _JS.index("var PILL_TRIGGER = {")
+    table = _JS[start : _JS.index("};", start)]
+    cancelling = table[table.index("cancelling:") :]
+    assert 'action: "none"' in cancelling[: cancelling.index("\n")]
+
+    start = _JS.index("function buildPillTrigger(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    assert 'else if (cfg.action === "transcribe")' in body, (
+        "a bare trailing else turns a cancelling click into a start"
+    )
+    assert 's.status === "cancelling"' in body and 'setAttribute("disabled"' in body
+
+
+def test_a_cancelled_stream_does_not_leave_its_footer_behind():
+    """Nothing calls renderSegments() on the non-completed path, and
+    renderSegmentsImpl is the only other place the indicator is removed — so a
+    cancelled run used to leave its progress footer frozen under the partial rows
+    until the participant was reselected."""
+    start = _JS.index("function _finalizeStreamingIfComplete(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    branch = body[body.index("if (!completed) {") :]
+    branch = branch[: branch.index("\n    }")]
+    assert "_cancelStreamingIndicator()" in branch, (
+        "cancel the queued insert first, or a backgrounded RAF re-adds the footer"
+    )
+    assert ".streaming-indicator" in branch and "removeChild" in branch


### PR DESCRIPTION
## Summary

Cancelling a transcription gave almost no feedback: the stop-circle had no press state, the click set no local state, and every surface kept rendering the pre-click world until the server changed its mind — which for a cancel during `loading_model` means a whole uninterruptible cold model load (~10s).

- **Press squish** on `.pill-trigger` (`:active { transform: scale(0.86) }`) so both the microphone and the stop-circle visibly take the click. On the button, not the icon: the running glyph's `spin` sets `transform` from an animation, which would outrank an icon-level rule on exactly the pill Cancel lands on.
- **An optimistic `cancelling` pill state** (`state.cancellingTasks`, keyed by task id so a re-transcribe issued right after a cancel is never painted as the cancelled one) — inert pulsing red stop-circle, progress fill frozen at its click-time value, and the timeline's dotted band cleared in the same frame rather than a poll later.
- **One cancel path** (`cancelTranscribeTask`) behind the pill trigger and the dropdown's Transcription row, with the revert + toast the old handler lacked; the status dot, empty-pane copy, streaming footer and that dropdown row all read one shared `_cancelPending` predicate instead of re-deriving "running means working".
- Two adjacent defects fixed in passing: the **reduced-motion opt-out for the pill spinner was dead code** (identical selector and specificity *above* the spin rule, so the animation won on source order and the icon spun anyway), and a **cancelled run orphaned its "Transcribing… N%" footer forever**.

No server change — flipping a `loading_model` task straight to `CANCELLED` looks tempting but races `_run`, which writes `phase` and then `status` again after the load returns.

## Test plan

- [x] `/check` — ruff format + lint, ty, full suite green
- [x] `/ui-check` — all six pages boot clean, screenshot reviewed
- [x] 10 new assertions in `tests/test_transcripts_dom_wiring.py`, including a regression test for the reduced-motion ordering bug
- [x] `shot.py --eval` probes: cancelling trigger disabled + `--sev-critical`, fill frozen at 42%, status reads "P01: cancelling…", dropdown row shows a disabled "Stopping…", a re-click enqueues nothing, and timeline canvas ink drops on the cancel call itself (band cleared synchronously, no poll)
- [ ] Manual: cancel during a real cold model load — confirm nothing flips back to "transcribing" when `_run` sets that phase after the load returns; and check the reduced-motion spinner now actually stops