### PR TITLE
fix(workflows): let the participant dropdown escape the canvas and scroll

### DIFF
--- a/assets/web/workflows-canvas.js
+++ b/assets/web/workflows-canvas.js
@@ -87,6 +87,11 @@
     // The wire-delete button is screen-positioned, so reposition it when the
     // viewport changes (wires themselves move with the SVG transform).
     if (WF.refreshWireDelete) WF.refreshWireDelete();
+    // An open participant menu is mounted on <body>, so it does NOT move with
+    // the world transform — the card slides out from under it. Same chokepoint
+    // argument as the zoom readout below: close it here and no pan/zoom/drag
+    // path can leave it stranded mid-air.
+    if (WF.closeParticipantMenu) WF.closeParticipantMenu();
     // Zoom % readout beside the minimap buttons. writeViewport is the single
     // chokepoint every pan/zoom path funnels through, so it can't go stale.
     var zoomLevel = qs("#wfZoomLevel");

--- a/assets/web/workflows-nodes.js
+++ b/assets/web/workflows-nodes.js
@@ -12,6 +12,16 @@
   var WF = window.ClipgenWorkflows;
   var state = WF.state;
 
+  // The one participant menu currently portaled onto <body>, as {menu, close}.
+  // Anything that invalidates its anchor — a card rebuild, a canvas pan/zoom,
+  // leaving the page — closes it through closeParticipantMenu() below, which
+  // also un-portals it and drops bindMenuToggle's document-level listeners.
+  var _openParticipantMenu = null;
+
+  function closeParticipantMenu() {
+    if (_openParticipantMenu) _openParticipantMenu.close();
+  }
+
   // One column of port rows (inputs left, outputs right — the outputs column is
   // CSS-flipped so its dot sits on the card edge). Ports already wired per
   // `state.edges` get `.wf-port-connected`, which fills the dot rather than
@@ -224,7 +234,7 @@
     btn.type = "button";
     btn.setAttribute("aria-haspopup", "menu");
     btn.setAttribute("aria-expanded", "false");
-    var menu = el("div", "wf-participant-menu hidden");
+    var menu = el("div", "wf-participant-menu cg-menu hidden");
     menu.setAttribute("role", "menu");
     wrap.appendChild(btn);
     wrap.appendChild(menu);
@@ -299,7 +309,34 @@
       });
     });
 
-    if (WF.bindMenuToggle) WF.bindMenuToggle(btn, menu);
+    // The menu is portaled onto <body> while open. It cannot stay in the card:
+    // .wf-canvas clips with overflow:hidden and #wfWorld's transform is both a
+    // stacking context and a containing block, so neither z-index nor
+    // position:fixed can lift it out — and in-place it would also inherit the
+    // canvas zoom scale. Same reason (and same shape) as the Transcripts pill
+    // popover in transcripts-pills.js.
+    if (WF.bindMenuToggle) {
+      // `toggle` is assigned before any click can fire, so onOpen can close over it.
+      var toggle = WF.bindMenuToggle(btn, menu, {
+        onOpen: function () {
+          closeParticipantMenu(); // only one open at a time
+          document.body.appendChild(menu);
+          positionPopoverAnchored(menu, btn.getBoundingClientRect());
+          _openParticipantMenu = { menu: menu, close: toggle.close };
+        },
+        onClose: function () {
+          // Back into the card so it dies with it on the next rebuild. If the
+          // card is already gone (renderAllNodes, or one of the in-place
+          // container rebuilds in this file), drop the menu instead of
+          // stranding it on <body>.
+          if (wrap.isConnected) wrap.appendChild(menu);
+          else if (menu.parentNode) menu.parentNode.removeChild(menu);
+          if (_openParticipantMenu && _openParticipantMenu.menu === menu) {
+            _openParticipantMenu = null;
+          }
+        },
+      });
+    }
     refreshSummary();
     return wrap;
   }
@@ -556,6 +593,9 @@
   function renderAllNodesImpl() {
     var world = qs("#wfWorld");
     if (!world) return;
+    // Its anchor card is about to be discarded, and the menu itself lives on
+    // <body> — close it here or it lingers there with live listeners.
+    closeParticipantMenu();
     // Clear the cards but keep the nested wire <svg> (it lives in #wfWorld so it
     // shares the cards' stacking context — see workflows.html). renderWires()
     // below repopulates its paths.
@@ -587,6 +627,9 @@
     if (WF.renderMinimap) WF.renderMinimap();
   }
 
+  window.addEventListener("pagehide", closeParticipantMenu);
+
   WF.renderNode = renderNode;
   WF.renderAllNodes = renderAllNodes;
+  WF.closeParticipantMenu = closeParticipantMenu;
 })();

--- a/assets/web/workflows.css
+++ b/assets/web/workflows.css
@@ -1199,8 +1199,9 @@ body[data-frontend="workflows"] {
 
 /* ---- Participant multi-select (Video Source) ---- */
 
+/* No `position: relative` — the menu is portaled onto <body> and positioned in
+   viewport coordinates, so this is not its containing block. */
 .wf-participant-select {
-  position: relative;
   flex: 1;
   min-width: 0;
 }
@@ -1222,19 +1223,28 @@ body[data-frontend="workflows"] {
   text-overflow: ellipsis;
 }
 
+/* Portaled onto <body> by buildParticipantSelect and placed with
+   positionPopoverAnchored(), so it escapes .wf-canvas's overflow clip and the
+   #wfWorld transform's containing block, and is not scaled by the canvas zoom.
+   Shell (bg/border/radius/shadow/padding/z-index) comes from .cg-menu; only
+   geometry lives here, and left/top come from the positioner.
+
+   Sizing follows the "dropdowns size to their trigger, not their content" rule
+   in agents/CODE-REVIEW.md: shrink-to-fit against a viewport-sized containing
+   block would size to the longest id alone. The floor is the *unzoomed* node
+   width token rather than the trigger's measured rect — that rect is scaled by
+   the canvas zoom, so at 0.5x it would floor the menu at half the card width. */
 .wf-participant-menu {
-  position: absolute;
-  top: calc(100% + var(--space-1));
-  left: 0;
-  z-index: var(--z-dropdown);
-  min-width: 100%;
-  max-height: 12rem;
+  position: fixed;
+  width: max-content;
+  min-width: var(--wf-node-width);
+  max-width: 22rem;
+  max-height: min(24rem, 60vh);
   overflow-y: auto;
-  padding: var(--space-1);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-pop);
+  /* Zero out .cg-menu's top padding: a sticky row sticks to the *padding* box,
+     so that 4px would be a gap for rows to scroll into above the pinned "All
+     participants" header. .wf-participant-all carries it instead, below. */
+  padding-top: 0;
 }
 
 .wf-participant-opt {
@@ -1251,10 +1261,17 @@ body[data-frontend="workflows"] {
   background: var(--bg-hover);
 }
 
-/* Separate the "All participants" shortcut from the individual rows. */
+/* Separate the "All participants" shortcut from the individual rows, and keep
+   it pinned while a long cohort scrolls under it. It owns the menu's top
+   padding (see .wf-participant-menu) and needs an opaque background, since rows
+   scroll underneath. */
 .wf-participant-all {
+  position: sticky;
+  top: 0;
+  background: var(--bg-elevated);
   border-bottom: 1px solid var(--border);
   margin-bottom: var(--space-1);
+  padding-top: calc(var(--space-1) * 2);
   padding-bottom: var(--space-1-5);
 }
 

--- a/assets/web/workflows.js
+++ b/assets/web/workflows.js
@@ -971,7 +971,14 @@
   // Generic dropdown toggle: wires a trigger button to a menu element with
   // outside-click + Escape close (shared by the Run split-button and the
   // shortcuts legend). Returns {open, close} for callers that need them.
-  function bindMenuToggle(btn, menu) {
+  //
+  // Optional opts.onOpen/onClose let a caller portal the menu elsewhere in the
+  // DOM (the participant select mounts it on <body> to escape the canvas clip).
+  // onOpen fires *after* .hidden comes off so the callback can measure the menu;
+  // onClose fires after it goes back on. Wrapping the returned {open, close}
+  // would not work — the click handler below calls the internals directly.
+  function bindMenuToggle(btn, menu, opts) {
+    opts = opts || {};
     function onDocDown(e) {
       // Ignore mousedowns on the trigger itself so its click handler toggles (a
       // close-then-reopen race otherwise).
@@ -984,6 +991,7 @@
     function open() {
       menu.classList.remove("hidden");
       btn.setAttribute("aria-expanded", "true");
+      if (opts.onOpen) opts.onOpen();
       document.addEventListener("mousedown", onDocDown, true);
       document.addEventListener("keydown", onKey, true);
     }
@@ -992,6 +1000,7 @@
       btn.setAttribute("aria-expanded", "false");
       document.removeEventListener("mousedown", onDocDown, true);
       document.removeEventListener("keydown", onKey, true);
+      if (opts.onClose) opts.onClose();
     }
     btn.addEventListener("click", function () {
       if (menu.classList.contains("hidden")) open();

--- a/tests/test_workflows_frontend_source.py
+++ b/tests/test_workflows_frontend_source.py
@@ -273,6 +273,39 @@ def test_batch_via_all_participants_option():
     assert ".wf-batch-card" in css
 
 
+def test_participant_menu_portals_to_body():
+    """The picker mounts on <body> while open. In the card it was clipped by
+    .wf-canvas's overflow:hidden (and #wfWorld's transform is both a stacking
+    context and a containing block, so neither z-index nor position:fixed could
+    lift it out) — a long cohort showed ~6 rows with no way to reach the rest."""
+    nodes = (_WEB / "workflows-nodes.js").read_text(encoding="utf-8")
+    assert "document.body.appendChild(menu)" in nodes
+    assert "positionPopoverAnchored(" in nodes  # flips above + clamps, from utils.js
+
+    # Portaling makes the menu outlive its card, so every path that invalidates
+    # the anchor has to close it or it strands on <body> holding bindMenuToggle's
+    # document-level mousedown/keydown listeners.
+    assert nodes.index("closeParticipantMenu()") < nodes.index('world.innerHTML = ""')
+    assert 'window.addEventListener("pagehide", closeParticipantMenu)' in nodes
+    assert "WF.closeParticipantMenu = closeParticipantMenu" in nodes
+    # Pan/zoom slides the card out from under a screen-positioned menu.
+    canvas = (_WEB / "workflows-canvas.js").read_text(encoding="utf-8")
+    assert "WF.closeParticipantMenu()" in canvas
+
+    # The hooks are opt-in, so the Run split-button and shortcuts legend, which
+    # pass no opts, keep their plain toggle behaviour.
+    src = _workflows_js()
+    assert "opts.onOpen" in src and "opts.onClose" in src
+
+    css = WORKFLOWS_CSS.read_text(encoding="utf-8")
+    block = css[css.index(".wf-participant-menu {") :][:700]
+    assert "position: fixed" in block
+    assert "max-height: 12rem" not in block  # the old ~6-row cap
+    # A percentage min-width would resolve against the viewport once fixed.
+    assert "min-width: 100%" not in block
+    assert "min-width: var(--wf-node-width)" in block
+
+
 def test_stash_satellite_present_and_wired():
     """M5 stashes + P4 built-in recipes: the sidebar list, the "Stash selection"
     toolbar control, the satellite (loaded last), and the hub<->satellite stash


### PR DESCRIPTION
## Summary

The Video Source participant picker showed ~6 rows and looked unscrollable, because three things stacked up: it lived inside the node card so `.wf-canvas`'s `overflow: hidden` clipped it (and `#wfWorld`'s transform is both a stacking context and a containing block, so neither `z-index` nor `position: fixed` could lift it out), the canvas `onWheel` handler `preventDefault`s unconditionally so wheeling over it panned the canvas instead, and `max-height: 12rem` capped it at about six rows.

- Portal the menu onto `<body>` while open and place it with the existing `positionPopoverAnchored()` from `utils.js` — same pattern and motivation as the Transcripts pill popover. As a `<body>` child it also stops inheriting the canvas zoom scale, and its wheel events never reach the canvas listener, so `onWheel` needs no guard.
- Give `bindMenuToggle` opt-in `onOpen`/`onClose` hooks; the Run split-button and shortcuts legend pass no opts and are unchanged.
- Close it on every path that invalidates the anchor — the `renderAllNodes` card rebuild, any pan/zoom (hooked at `writeViewport`, the chokepoint the wire-delete button already uses), and `pagehide` — or it strands on `<body>` holding document-level listeners.
- Size it to the viewport rather than the 11rem node, and pin "All participants" with `position: sticky`.

## Test plan

- [x] `/check` — ruff format + lint, ty, 3485 tests passed
- [x] `/ui-check` — 16 UI tests, no `pageerror`; screenshots reviewed in dark and light themes
- [x] New `test_participant_menu_portals_to_body` locks the portal, all three close hooks, and the two CSS values that would silently regress under `position: fixed`
- [x] Headless probes with 24 participants: portaled to `<body>`, all rows present, scrolls its full range, flips above at the canvas bottom edge, zero orphans after rebuild/Escape/pan
- [ ] Manual: whether wheel-scrolling *feels* right with no canvas pan bleeding through, and a pass in Safari — `/ui-check` only drives Chromium