### PR TITLE
fix(composer): harden playback, exports, annotations, and timeline

### DIFF
--- a/assets/web/card-scrubber.js
+++ b/assets/web/card-scrubber.js
@@ -9,8 +9,20 @@
 
   var _spriteRaf = 0;
   var _audioCtx = null;
+  // Decoded-audio cache. Key: the consumer's audio key (filename or span key —
+  // a span edit changes the key, so the same bar re-caches under a new entry).
+  // Invalidation: LRU by _audioTicks once _audioTotalSeconds exceeds the cap,
+  // plus purgeAudio() for consumers that switch source video wholesale.
+  // Bound: total buffered seconds — entries range from a 2 s clip snippet to a
+  // 180 s Composer bar (~35 MB decoded), so an entry count would not bound
+  // memory. 600 s ≈ ~115 MB float32 at a 48 kHz context rate.
+  var _AUDIO_CACHE_MAX_SECONDS = 600;
   var _audioBuffers = {};
   var _audioLoading = {};
+  var _audioTicks = {}; // key → LRU tick (parallel map keeps the buffer shape)
+  var _audioTick = 0;
+  var _audioTotalSeconds = 0;
+  var _audioGen = 0; // bumped by purgeAudio(); in-flight decodes then discard
   var _audioSource = null;
   var _audioGain = null;
   var _audioLastTime = -1;
@@ -35,16 +47,49 @@
     return _audioCtx;
   }
 
+  function _touchAudio(key) {
+    _audioTicks[key] = ++_audioTick;
+  }
+
+  function _evictAudio() {
+    while (_audioTotalSeconds > _AUDIO_CACHE_MAX_SECONDS) {
+      var oldest = null;
+      var oldestTick = Infinity;
+      for (var key in _audioBuffers) {
+        if (_audioTicks[key] < oldestTick) {
+          oldestTick = _audioTicks[key];
+          oldest = key;
+        }
+      }
+      if (oldest === null) return;
+      _audioTotalSeconds -= _audioBuffers[oldest].duration;
+      delete _audioBuffers[oldest];
+      delete _audioTicks[oldest];
+      delete _waveformCache[oldest];
+    }
+  }
+
   function loadAudioBuffer(url, key) {
-    if (_audioBuffers[key]) return Promise.resolve(_audioBuffers[key]);
+    if (_audioBuffers[key]) {
+      _touchAudio(key);
+      return Promise.resolve(_audioBuffers[key]);
+    }
     if (_audioLoading[key]) return _audioLoading[key];
+    var gen = _audioGen;
     // arrayBuffer (audio) — apiGet only handles JSON, so use fetch directly.
     _audioLoading[key] = fetch(url)
       .then(function (r) { return r.arrayBuffer(); })
       .then(function (buf) { return getAudioContext().decodeAudioData(buf); })
       .then(function (decoded) {
-        _audioBuffers[key] = decoded;
         delete _audioLoading[key];
+        // A purge mid-decode means this buffer belongs to a dropped source;
+        // hand it to the caller but keep it out of the cache.
+        if (gen === _audioGen) {
+          _audioBuffers[key] = decoded;
+          _touchAudio(key);
+          _audioTotalSeconds += decoded.duration;
+          _evictAudio();
+        }
         return decoded;
       })
       .catch(function () {
@@ -52,6 +97,17 @@
         return null;
       });
     return _audioLoading[key];
+  }
+
+  // Drop every cached buffer + waveform (e.g. on a source-video switch). Live
+  // playback stops; in-flight decodes resolve but skip the cache.
+  function purgeAudio() {
+    _audioGen++;
+    audioScrubStop();
+    _audioBuffers = {};
+    _audioTicks = {};
+    _waveformCache = {};
+    _audioTotalSeconds = 0;
   }
 
   function audioScrubAt(audioKey, audioUrl, timeSec) {
@@ -63,6 +119,7 @@
       loadAudioBuffer(audioUrl, audioKey);
       return;
     }
+    _touchAudio(audioKey);
     if (timeSec < 0 || timeSec >= buf.duration) return;
 
     var ctx = getAudioContext();
@@ -369,6 +426,7 @@
     detachAll: detachAll,
     detachStale: detachStale,
     stopAll: stopAll,
+    purgeAudio: purgeAudio,
     // Primitives — let a consumer with its own hover handler (e.g. the viewer's
     // <video>-seek scrub) drive audio + waveform without a second attach().
     loadAudioBuffer: loadAudioBuffer,

--- a/assets/web/composer-annotate.js
+++ b/assets/web/composer-annotate.js
@@ -102,6 +102,11 @@
   // strict comparison made a just-created annotation vanish on mouse-up about
   // half the time. The tolerance also absorbs the <video> settling a frame
   // shy of a requested seek when a span was snapped to a cut edge.
+  // KNOWN DIVERGENCE: the server's screenshot window is strict
+  // (span.start < t and span.end > t, composer_server._annotations_in_span),
+  // so within these ±5 ms the preview can draw an annotation the exported
+  // frame omits. Accepted — the eps exists for preview stability, and
+  // widening the server window would burn annotations at t == span.end.
   var SPAN_EPS = 0.005;
 
   function spanContainsPlayhead(a) {
@@ -215,6 +220,10 @@
       };
     }
     // text — mirrors the server's PIL render: dark backing box + colored text.
+    // KNOWN DIVERGENCE: this draws in the UI font (Inter); the burn renders
+    // whatever system font _ANNOTATION_FONT_PATHS finds (Helvetica/Arial/
+    // DejaVu — PIL cannot load the bundled .woff2). Advance widths differ, so
+    // the backing-box width in the export won't match this preview exactly.
     var text = ann.geometry.text || "";
     if (!text) return null;
     var size = Math.max(8,
@@ -543,6 +552,10 @@
   function showTextInput(pos) {
     var input = qs("#coAnnotateText");
     var canvas = canvasEl();
+    // The text tool's pointerdown preventDefault()s (see below), so clicking a
+    // new spot never blurs an open input — commit any typed text instead of
+    // silently discarding it with the reposition below.
+    flushTextInput();
     _pendingText = pos;
     input.style.left = (canvas.offsetLeft + pos.x * canvas.width) + "px";
     input.style.top = (canvas.offsetTop + pos.y * canvas.height) + "px";
@@ -559,12 +572,13 @@
     _pendingText = null;
   }
 
-  function commitTextInput() {
+  // Create the label for the open text input; true when one was created.
+  function flushTextInput() {
     var input = qs("#coAnnotateText");
     var text = input.value.trim();
     var pos = _pendingText;
-    hideTextInput();
-    if (!text || !pos) return;
+    if (!text || !pos) return false;
+    input.value = "";
     CO.createAnnotation({
       participant: state.participant,
       type: "text",
@@ -572,7 +586,13 @@
       geometry: { x: pos.x, y: pos.y, text: text },
       style: { color: state.annColor, fontSize: state.annFontSize },
     });
-    setAnnotateTool("select");
+    return true;
+  }
+
+  function commitTextInput() {
+    var created = flushTextInput();
+    hideTextInput();
+    if (created) setAnnotateTool("select");
   }
 
   // ---- Style chip controls (stroke width / stroke style / text size) ----
@@ -669,6 +689,12 @@
     function onKey(ev) {
       if (ev.key === "Escape") { ev.stopPropagation(); closePaletteMenu(); }
     }
+    // The menu is fixed-positioned from the anchor's rect at open time; a
+    // palette-rail scroll or window resize would leave it floating detached
+    // from its chip (the shared tooltip singleton closes on the same events).
+    function onReposition() {
+      closePaletteMenu();
+    }
     // Defer the outside-click listener so the opening click doesn't close it.
     // Track the timer so a close before it fires (fast reopen / immediate
     // Escape) can cancel it — otherwise the listener orphans on document.
@@ -676,10 +702,14 @@
       document.addEventListener("pointerdown", onDocDown, true);
     }, 0);
     document.addEventListener("keydown", onKey, true);
+    window.addEventListener("scroll", onReposition, true);
+    window.addEventListener("resize", onReposition);
     _paletteMenuCleanup = function () {
       clearTimeout(openTimer);
       document.removeEventListener("pointerdown", onDocDown, true);
       document.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("scroll", onReposition, true);
+      window.removeEventListener("resize", onReposition);
       if (menu.parentNode) menu.parentNode.removeChild(menu);
       anchor.setAttribute("aria-expanded", "false");
       _paletteMenuCleanup = null;
@@ -958,7 +988,22 @@
       }
     });
 
+    // Coalesce pointermove work to one update per frame: pointer events can
+    // arrive at 120–240 Hz and every branch below ends in a canvas render
+    // (the hub's timeupdate handler is the same pattern). A move that lands
+    // after pointerup no-ops — endGesture nulls every gesture flag.
+    var _moveRaf = 0;
+    var _lastMove = null;
     canvas.addEventListener("pointermove", function (e) {
+      _lastMove = e;
+      if (_moveRaf) return;
+      _moveRaf = requestAnimationFrame(function () {
+        _moveRaf = 0;
+        handlePointerMove(_lastMove);
+      });
+    });
+
+    function handlePointerMove(e) {
       var pos = eventToNormalized(e);
       if (!pos) return;
       if (_shaping) {
@@ -1004,14 +1049,26 @@
             geometry.x = clamp(orig.x + dx, 0, 1);
             geometry.y = clamp(orig.y + dy, 0, 1);
           } else {
+            // Clamp the DELTA against the stroke's bounding box, not each
+            // point — per-point clamping flattens edge-side points onto the
+            // border and permanently deforms the stroke.
+            var minX = 1, minY = 1, maxX = 0, maxY = 0;
+            orig.points.forEach(function (p) {
+              if (p[0] < minX) minX = p[0];
+              if (p[0] > maxX) maxX = p[0];
+              if (p[1] < minY) minY = p[1];
+              if (p[1] > maxY) maxY = p[1];
+            });
+            var cdx = clamp(dx, -minX, 1 - maxX);
+            var cdy = clamp(dy, -minY, 1 - maxY);
             geometry.points = orig.points.map(function (p) {
-              return [clamp(p[0] + dx, 0, 1), clamp(p[1] + dy, 0, 1)];
+              return [p[0] + cdx, p[1] + cdy];
             });
           }
         });
         renderAnnotations();
       }
-    });
+    }
 
     function endGesture(e) {
       if (canvas.hasPointerCapture && canvas.hasPointerCapture(e.pointerId)) {
@@ -1033,10 +1090,13 @@
           return hb.ann.id;
         });
         if (m.additive) {
-          // Union with the existing selection.
+          // Union with the existing selection in ONE selection write — a
+          // per-id toggle re-renders the full timeline for every hit.
+          var union = state.selectedAnnotationIds.slice();
           hitIds.forEach(function (id) {
-            if (!CO.isAnnotationSelected(id)) CO.toggleAnnotationSelection(id);
+            if (union.indexOf(id) === -1) union.push(id);
           });
+          CO.setAnnotationSelection(union);
         } else {
           // A near-zero drag is a click on empty space (selection already
           // cleared on pointerdown); a real drag replaces the selection.
@@ -1111,5 +1171,4 @@
   CO.initAnnotate = initAnnotate;
   CO.renderAnnotations = renderAnnotations;
   CO.setAnnotateTool = setAnnotateTool;
-  CO.syncAnnotateCanvas = syncCanvasToVideo;
 })();

--- a/assets/web/composer-markers.js
+++ b/assets/web/composer-markers.js
@@ -79,6 +79,12 @@
         return;
       }
       var baselineOffset = baselines[pid] || 0;
+      // NOTE: `off` (the Convergence sheet-lane offset) is applied here but
+      // NOT by Studio's own sheet grid — with a non-zero offset the same
+      // observation queues at different spans from there vs. from a Composer
+      // trim card. Deliberate: these lanes must line up with the video the
+      // way the Convergence Browser does, and any trim saved here bakes the
+      // offset in (trims are video-global seconds).
       var markers = [];
       sheet.rows.forEach(function (row) {
         var cell = row.cells && row.cells[pid];
@@ -126,7 +132,13 @@
           var type = cl.event_type || cl.detector || "";
           return {
             // Keyed on the cluster's earliest event so trims survive reloads
-            // while the event set is stable (clusterIntakeEvents sorts by time).
+            // while the event set is stable (clusterIntakeEvents sorts by
+            // time). KNOWN TRADEOFF: a re-scan or un-exclude that adds an
+            // earlier event to the burst changes events[0] and orphans the
+            // trim — it stays in the manifest (and as a card in Studio's
+            // Composer Intake) but no longer applies here. There is no stable
+            // cluster identity to key on instead; deleting the orphan via
+            // Studio's card is the recovery path.
             key: "screenspace:" + cl.events[0].id,
             source: "screenspace",
             start: cl.start + off,
@@ -157,6 +169,9 @@
           if (!marks.length) return;
           marks.forEach(function (mark) {
             markers.push({
+              // The pid:seg fallback is defensive only — every mark the
+              // transcripts server writes has an id, and Studio's intake
+              // badge lookup (trimBadgeKey) only matches id-based keys.
               key: "transcript-mark:" + (mark.id || pid + ":" + seg.id),
               source: "transcript",
               start: seg.start + off,

--- a/assets/web/composer-scrub.js
+++ b/assets/web/composer-scrub.js
@@ -50,6 +50,21 @@
     return keyStem + "|" + start.toFixed(2) + "|" + end.toFixed(2);
   }
 
+  // The server samples a span from the part that owns its START, clamped to
+  // that part's tail (_resolve_scrub_source) — mirror the clamp here so the
+  // client never maps frames or audio onto footage the server didn't render.
+  function partTailFor(start, fallbackEnd) {
+    var parts = state.parts || [];
+    for (var i = 0; i < parts.length; i++) {
+      var off = parts[i].offset || 0;
+      if (typeof parts[i].duration === "number" &&
+          start >= off && start < off + parts[i].duration) {
+        return off + parts[i].duration;
+      }
+    }
+    return fallbackEnd;
+  }
+
   function mediaUrl(kind, start, end) {
     return "api/" + kind + "/" + encodeURIComponent(state.participant) +
       "?start=" + start + "&end=" + end;
@@ -221,9 +236,14 @@
     ctx.beginPath();
     ctx.rect(x, y, w, h);
     ctx.clip();
+    // Cap each tile at the owning part's tail: the server truncates the
+    // sprite's content there, so an uncapped tile span would spread the
+    // truncated frames across the full tile and drift every frame after the
+    // part boundary. The stretch past the boundary stays a flat bar.
+    var spanCap = partTailFor(start, end);
     for (var n = n0; n <= n1; n++) {
       var tileStart = start + n * tileSpan;
-      var tileEnd = Math.min(tileStart + tileSpan, end);
+      var tileEnd = Math.min(tileStart + tileSpan, end, spanCap);
       if (tileEnd <= tileStart) continue;
       var key = barKey + n;
       var entry = _sprites[key];
@@ -260,6 +280,13 @@
     if (end - start > CLIPGEN_CONFIG.composerScrubMaxAudioSeconds) {
       // The server caps the WAV at this length; scrubbing a longer span would
       // misalign hover fraction ↔ audio time, so skip it entirely.
+      scrubHoverEnd();
+      return;
+    }
+    if (partTailFor(start, end) < end - 0.05) {
+      // Boundary-straddling span: the server samples only the owning part's
+      // tail, so audio past the boundary doesn't exist — and a full-width
+      // waveform would claim it does. Thumbnails clamp instead (drawTile).
       scrubHoverEnd();
       return;
     }
@@ -318,6 +345,10 @@
       _fetchTimer = 0;
     }
     scrubHoverEnd();
+    // The decoded-audio + waveform caches live in card-scrubber and are keyed
+    // by span, not participant — purge them or the old video's audio survives
+    // the switch until LRU pressure evicts it.
+    if (window.clipgenCardScrubber) window.clipgenCardScrubber.purgeAudio();
     if (_waveHost) _waveHost.innerHTML = ""; // drop the size-cached canvas
   }
 
@@ -369,6 +400,13 @@
     }
     syncScrubToggles();
   }
+
+  window.addEventListener("pagehide", function () {
+    if (_fetchTimer) {
+      clearTimeout(_fetchTimer);
+      _fetchTimer = 0;
+    }
+  });
 
   CO.initMarkerScrub = initMarkerScrub;
   CO.syncScrubToggles = syncScrubToggles;

--- a/assets/web/composer-timeline.js
+++ b/assets/web/composer-timeline.js
@@ -76,8 +76,11 @@
 
   function laneRows(source) {
     if (!state.sourceToggles[source]) return 0; // hidden lane occupies no space
+    // An empty lane occupies none either: a band with nothing to draw would
+    // still cost a full row of strip height and grow a no-op fold button.
+    if (!(state.markers[source] || []).length) return 0;
     if (state.laneFolds[source]) return 1;
-    return neededRows(state.markers[source] || []);
+    return neededRows(state.markers[source]);
   }
 
   // Marker sub-rows and the cuts track always use their large (thumb-sized)
@@ -129,15 +132,20 @@
   // Grow/shrink the whole timeline strip to fit the current fold state by
   // writing the shared --co-timeline-height var (both the shell and the strip
   // are sized from it); the wrapper's ResizeObserver then re-renders.
-  var _sectionExtra = null;
-
   function updateTimelineHeight() {
     var section = qs("#coTimelineSection");
     var wrapper = qs("#coTimelineWrapper");
-    if (_sectionExtra === null) {
-      _sectionExtra = Math.max(section.offsetHeight - wrapper.offsetHeight, 24);
-    }
-    var target = layout().canvasH + _sectionExtra;
+    // Chrome around the wrapper, re-measured every call: the media banner is
+    // inserted into this flex column asynchronously (after the remux status
+    // probe), so a one-shot measure goes stale by the banner's height.
+    var sectionExtra = Math.max(section.offsetHeight - wrapper.offsetHeight, 24);
+    // Cap the strip: #coShell is sized 100vh minus this var, and an uncapped
+    // value (three unfolded dense lanes ≈ 1100px) drives that calc() negative
+    // and swallows the video stage.
+    var target = Math.min(
+      layout().canvasH + sectionExtra,
+      Math.round(window.innerHeight * 0.6)
+    );
     var current = parseFloat(
       getComputedStyle(document.documentElement)
         .getPropertyValue("--co-timeline-height")
@@ -199,6 +207,10 @@
   function sizeCanvases() {
     var canvas = canvasEl();
     _cachedRect = null;
+    // Re-fit the strip first: the wrapper resize that landed us here may be
+    // the media banner appearing/disappearing inside the same flex column.
+    // updateTimelineHeight no-ops within 1px, so this settles, never loops.
+    updateTimelineHeight();
     var rect = canvas.getBoundingClientRect();
     canvas.width = Math.floor(rect.width);
     canvas.height = Math.floor(rect.height);
@@ -434,11 +446,27 @@
     renderPlayhead();
   }
 
-  // Per-lane fold buttons in the DOM rail (rebuilt on every render, like
-  // screenspace's boundary flags). Hidden/empty lanes get no button.
+  // Per-lane fold buttons in the DOM rail. Hidden/empty lanes get no button.
+  // The signature skips the rebuild while the lane geometry is unchanged —
+  // renderTimeline runs per pan/zoom frame and an innerHTML rebuild per frame
+  // both wastes work and destroys a hovered tooltip anchor.
+  var _railSig = null;
+
   function renderLaneRail(L) {
     var rail = qs("#coLaneRail");
     if (!rail) return;
+    var sig = !state.duration ? "" : SOURCES.map(function (s) {
+      return s + ":" + L.lanes[s].rows + ":" + L.lanes[s].y +
+        ":" + (state.laneFolds[s] ? 1 : 0);
+    }).join("|") + "|annotations:" + L.annotationsLane.rows +
+      ":" + L.annotationsLane.y + ":" + (state.laneFolds.annotations ? 1 : 0);
+    if (sig === _railSig) return;
+    _railSig = sig;
+    // The rebuild destroys a focused fold button (keyboard: Enter on one
+    // triggers this render) — remember which and re-focus its replacement.
+    var focused = document.activeElement;
+    var focusSource = focused && rail.contains(focused)
+      ? focused.getAttribute("data-source") : null;
     rail.innerHTML = "";
     if (!state.duration) return;
     var frag = document.createDocumentFragment();
@@ -475,6 +503,10 @@
         foldButton("annotations", L.annotationsLane.y, L.annotationsLane.h));
     }
     rail.appendChild(frag);
+    if (focusSource) {
+      var again = rail.querySelector('[data-source="' + focusSource + '"]');
+      if (again) again.focus();
+    }
   }
 
   function renderPlayhead() {
@@ -655,14 +687,29 @@
     qs("#coZoomOutBtn").appendChild(el("span", "co-btn-icon co-icon-zoom-out"));
 
     sizeCanvases();
+    // The RO fires on the wrapper's SIZE only; the strip is fixed to the
+    // viewport bottom, so a viewport-height change moves the canvas without
+    // resizing it. The window resize listener drops the cached rect (stale
+    // top = hit-tests land on the wrong lane) and re-clamps the strip height
+    // against the new viewport.
+    var onWindowResize = function () {
+      _cachedRect = null;
+      updateTimelineHeight();
+    };
+    var onScroll = function () { _cachedRect = null; };
     if (typeof ResizeObserver === "function") {
       var obs = new ResizeObserver(function () { sizeCanvases(); });
       obs.observe(qs("#coTimelineWrapper"));
-      window.addEventListener("pagehide", function () { obs.disconnect(); });
+      window.addEventListener("resize", onWindowResize);
+      window.addEventListener("pagehide", function () {
+        obs.disconnect();
+        window.removeEventListener("resize", onWindowResize);
+        window.removeEventListener("scroll", onScroll, true);
+      });
     } else {
       window.addEventListener("resize", sizeCanvases);
     }
-    window.addEventListener("scroll", function () { _cachedRect = null; }, true);
+    window.addEventListener("scroll", onScroll, true);
 
     canvas.addEventListener("wheel", function (e) {
       e.preventDefault();
@@ -677,7 +724,9 @@
         state.offset = clamp(mouseTs - frac * visLen, 0, state.duration - visLen);
       }
       if (state.zoom <= 1) state.offset = 0;
-      renderTimeline();
+      // rAF-coalesced: a trackpad delivers 100+ wheel events/s and a full
+      // render (canvas + DOM rail rebuild) per event is wasted between paints.
+      scheduleRender();
     }, { passive: false });
 
     // One pointer gesture at a time: edge drag > body drag > pan (zoomed) > scrub.
@@ -693,6 +742,11 @@
     }
 
     canvas.addEventListener("pointerdown", function (e) {
+      // Primary button only: a right-click is the trim-reset gesture (and the
+      // context menu), a middle-click is autoscroll — neither may start a
+      // drag/seek, and a right-click drag racing the trim DELETE could write
+      // the just-deleted span back onto the marker.
+      if (e.button !== 0) return;
       if (!state.duration) return;
       // Set early so the scrub branch's immediate seek sees an active drag and
       // revealTime() no-ops (the clicked time is on-screen anyway).
@@ -787,7 +841,23 @@
       canvas.setPointerCapture(e.pointerId);
     });
 
+    // Coalesce pointer tracking to one pass per frame: the hover branch alone
+    // runs two full-layout hit-tests plus tooltip DOM writes per event, and
+    // the scrub drag seeks the video — none of it useful between paints. A
+    // move that lands after pointerup falls into the hover branch (drag is
+    // null by then), which is the same treatment a fresh hover would get.
+    var _moveRaf = 0;
+    var _lastMove = null;
     canvas.addEventListener("pointermove", function (e) {
+      _lastMove = e;
+      if (_moveRaf) return;
+      _moveRaf = requestAnimationFrame(function () {
+        _moveRaf = 0;
+        handlePointerMove(_lastMove);
+      });
+    });
+
+    function handlePointerMove(e) {
       if (!drag) {
         // Hover: edge cursor affordance + tooltip + opt-in audio scrub.
         if (!state.duration) return;
@@ -884,7 +954,7 @@
         ts = xToTime(e.clientX);
         if (ts !== null) CO.seekVideo(ts);
       }
-    });
+    }
 
     function endDrag(e) {
       if (!drag) return;

--- a/assets/web/composer.css
+++ b/assets/web/composer.css
@@ -370,6 +370,10 @@ body[data-frontend="composer"] {
    color; the secondary is the slot X swaps it with. */
 .co-swatch-pair {
   position: relative;
+  /* New stacking context: the swatches' z-index 1/2 layer the two squares
+     against each other only, not against the page (the pair's parents create
+     no context of their own, so without this the values are root-level). */
+  isolation: isolate;
   width: 44px;
   height: 44px;
   flex: 0 0 auto;
@@ -467,7 +471,7 @@ body[data-frontend="composer"] {
   width: 6px;
   height: 6px;
   border: 1px solid currentColor;
-  border-radius: 1px;
+  border-radius: var(--radius-xs);
 }
 
 .co-swatch-reset-glyph::before {
@@ -509,7 +513,12 @@ body[data-frontend="composer"] {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  /* Shrink-to-fit against the narrow rail anchor would pin the menu at
+     min-width and wrap any longer preset label; size to the longest label,
+     capped so a future label can't run off-screen (.topnav-qa-panel pattern). */
+  width: max-content;
   min-width: 120px;
+  max-width: 280px;
   padding: var(--space-1);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
@@ -589,6 +598,10 @@ body[data-frontend="composer"] {
 
 #coVideoFrame {
   position: relative;
+  /* New stacking context: keeps the annotate canvas / text input z-indexes
+     (1/2) layered against the video only — without this they participate in
+     the ROOT context, above anything z-index:auto elsewhere on the page. */
+  isolation: isolate;
   flex: 1;
   min-width: 0;
   height: 100%;

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -89,7 +89,8 @@
   function videoGlobalTime() {
     var video = qs("#coVideo");
     var part = state.parts[state.activePart];
-    return (video ? video.currentTime : 0) + (part ? part.offset : 0);
+    // `|| 0`: fallback parts (server couldn't probe) may lack a numeric offset.
+    return (video ? video.currentTime : 0) + ((part && part.offset) || 0);
   }
   CO.videoGlobalTime = videoGlobalTime;
 
@@ -109,7 +110,7 @@
     if (!state.parts.length) return;
     var g = clamp(time, 0, Math.max(0, state.duration - 0.001));
     var i = partForGlobal(g);
-    var local = g - state.parts[i].offset;
+    var local = g - (state.parts[i].offset || 0);
     state.playhead = g;
     if (i !== state.activePart) {
       switchToPart(i, local, state.playing);
@@ -127,21 +128,38 @@
     _seek.seek(time);
   }
 
+  // The one-shot loadedmetadata seek of the part switch in flight, if any.
+  // Tracked so a second switch (or a participant change) before the metadata
+  // arrives can drop it — otherwise the stale handler fires on the NEW
+  // source's loadedmetadata, seeking to the old part's local time and
+  // auto-playing with the old call's resume flag.
+  var _pendingPartMeta = null;
+
+  function cancelPendingPartMeta() {
+    if (!_pendingPartMeta) return;
+    var video = qs("#coVideo");
+    if (video) video.removeEventListener("loadedmetadata", _pendingPartMeta);
+    _pendingPartMeta = null;
+  }
+
   function switchToPart(i, localTime, resume) {
     var video = qs("#coVideo");
     if (!video) return;
     // A same-part seek may still be deferred on loadedmetadata; drop it so it
     // can't fire after this part loads and clobber this cross-part seek.
     cancelPendingSeek();
+    cancelPendingPartMeta();
     state.activePart = i;
     video.src = "media/" + encodeURIComponent(state.parts[i].name);
     video.load();
     var onMeta = function () {
       video.removeEventListener("loadedmetadata", onMeta);
+      if (_pendingPartMeta === onMeta) _pendingPartMeta = null;
       video.currentTime = localTime;
       applyPlaybackRate(); // load() reset the element to its default rate
       if (resume) window.ClipgenVideoControls.safePlay(video);
     };
+    _pendingPartMeta = onMeta;
     video.addEventListener("loadedmetadata", onMeta);
   }
 
@@ -256,6 +274,7 @@
       if (!state.duration && state.parts.length === 1 && isFinite(video.duration)) {
         state.duration = video.duration;
         state.parts[0].duration = video.duration;
+        state.parts[0].offset = 0; // fallback parts ship without probed offsets
         updateTimeLabel();
         updateVideoInfo();
         renderTimeline();
@@ -313,6 +332,7 @@
       window.clipgenMediaBanner.show(qs("#coTimelineSection"), p);
     }
     cancelPendingSeek();
+    cancelPendingPartMeta();
     state.participant = pid;
     setStoredUIStateField("composer", "participant", pid);
     state.parts = p.parts || [];
@@ -806,10 +826,12 @@
 
   // Batch commit of *field* ("style" or "geometry") across many annotations, each
   // already mutated, with *before* the pre-edit value. One undo step, so a group
-  // style change or move undoes atomically; every edit rolls back if any patch is
-  // rejected. Each op's *after* comes from the PATCH response (server-sanitized),
-  // as in the single-annotation path — a partial local object can't reset
-  // backfilled defaults.
+  // style change or move undoes atomically. Each op's *after* comes from the
+  // PATCH response (server-sanitized), as in the single-annotation path — a
+  // partial local object can't reset backfilled defaults. On partial failure
+  // only the *rejected* edits roll back locally: the accepted ones are already
+  // in the manifest, and reverting them in the view would make it disagree
+  // with the server until reload.
   function commitAnnotationFieldGroup(field, edits) {
     if (!edits.length) return Promise.resolve();
     var patches = edits.map(function (e) {
@@ -817,41 +839,64 @@
       payload[field] = e.ann[field];
       return applyAnnPatch(e.ann.id, payload).then(function (saved) {
         return {
-          type: "ann-edit",
-          id: e.ann.id,
-          field: field,
-          before: e.before,
-          after: JSON.parse(JSON.stringify(saved[field])),
+          op: {
+            type: "ann-edit",
+            id: e.ann.id,
+            field: field,
+            before: e.before,
+            after: JSON.parse(JSON.stringify(saved[field])),
+          },
         };
+      }, function (error) {
+        return { edit: e, error: error };
       });
     });
-    return Promise.all(patches).then(function (ops) {
-      recordOp(ops.length === 1 ? ops[0] : { type: "ann-group", ops: ops });
-    }, function (error) {
-      edits.forEach(function (e) {
-        var ann = findAnnotation(e.ann.id);
-        if (ann) ann[field] = JSON.parse(JSON.stringify(e.before));
+    return Promise.all(patches).then(function (results) {
+      var ops = [];
+      var firstError = null;
+      results.forEach(function (r) {
+        if (r.op) { ops.push(r.op); return; }
+        var ann = findAnnotation(r.edit.ann.id);
+        if (ann) ann[field] = JSON.parse(JSON.stringify(r.edit.before));
+        if (!firstError) firstError = r.error;
       });
-      refreshAnnotationViews();
-      opFailed(error);
+      if (ops.length) {
+        recordOp(ops.length === 1 ? ops[0] : { type: "ann-group", ops: ops });
+      }
+      if (firstError) {
+        refreshAnnotationViews();
+        opFailed(firstError);
+      }
     });
   }
   CO.commitAnnotationFieldGroup = commitAnnotationFieldGroup;
 
-  // Delete every selected annotation as a single undo step.
+  // Delete every selected annotation as a single undo step. Deletes that land
+  // still get an undo op when a sibling delete fails — without that, a partial
+  // failure left the succeeded deletes unrecoverable.
   function deleteSelectedAnnotations() {
     var snapshots = selectedAnnotations().map(function (ann) {
       return JSON.parse(JSON.stringify(ann));
     });
     if (!snapshots.length) return;
     Promise.all(snapshots.map(function (snap) {
-      return applyAnnDelete(snap.id);
-    })).then(function () {
-      var ops = snapshots.map(function (snap) {
-        return { type: "ann-delete", annotation: snap };
+      return applyAnnDelete(snap.id).then(function () {
+        return { op: { type: "ann-delete", annotation: snap } };
+      }, function (error) {
+        return { error: error };
       });
-      recordOp(ops.length === 1 ? ops[0] : { type: "ann-group", ops: ops });
-    }).catch(opFailed);
+    })).then(function (results) {
+      var ops = [];
+      var firstError = null;
+      results.forEach(function (r) {
+        if (r.op) ops.push(r.op);
+        else if (!firstError) firstError = r.error;
+      });
+      if (ops.length) {
+        recordOp(ops.length === 1 ? ops[0] : { type: "ann-group", ops: ops });
+      }
+      if (firstError) opFailed(firstError);
+    });
   }
   CO.deleteSelectedAnnotations = deleteSelectedAnnotations;
 
@@ -933,6 +978,13 @@
 
   var _exporting = false;
 
+  // Ask the server to abort the in-flight burn/GIF encode. Harmless when
+  // nothing is running: the event is cleared at the start of the next export.
+  function onCancelExport() {
+    apiPost("api/export/cancel", {}).catch(function () {});
+    showToast("Cancelling export…");
+  }
+
   function exportSpan() {
     // Burn/GIF need a span: the selected cut wins, else the selected
     // annotation's own visibility span.
@@ -943,17 +995,33 @@
     return null;
   }
 
-  function runExport(path, body, busyLabel) {
+  // *btn*: the toolbar button that launched a cancellable (burn/GIF) export.
+  // While the encode runs it reads "Cancel" and a re-click posts the cancel
+  // (see exportBurn); screenshot exports are near-instant and pass no button.
+  function runExport(path, body, busyLabel, btn) {
     if (_exporting) { showToast("An export is already running"); return; }
     _exporting = true;
+    var restoreLabel = btn ? btn.textContent : "";
+    var restoreTip = btn ? btn.getAttribute("data-tooltip") : "";
+    if (btn) {
+      btn.textContent = "Cancel";
+      btn.setAttribute("data-tooltip", "Cancel this export");
+    }
+    function done() {
+      _exporting = false;
+      if (btn) {
+        btn.textContent = restoreLabel;
+        btn.setAttribute("data-tooltip", restoreTip);
+      }
+    }
     showToast(busyLabel + "…");
     apiPost(path, body).then(function (data) {
-      _exporting = false;
+      done();
       if (!data.ok) { showToast(data.error || "Export failed"); return; }
       logArtifactResult({ ok: true, artifact: data.artifact }, null);
       showToast("Exported " + (data.artifact.file || ""));
     }).catch(function (err) {
-      _exporting = false;
+      done();
       // A 4xx envelope now rejects; err.message carries the server's text
       // ("An export is already running", "The span is outside the recording").
       showToast(err && err.message ? err.message : "Export failed");
@@ -970,6 +1038,8 @@
 
   function exportBurn(gif) {
     if (!state.participant) return;
+    // Re-click while an export runs = cancel it (the button reads "Cancel").
+    if (_exporting) { onCancelExport(); return; }
     var span = exportSpan();
     if (!span) {
       showToast("Select a cut (or an annotation) to define the export span");
@@ -979,7 +1049,8 @@
       participant: state.participant,
       start: span.start,
       end: span.end,
-    }, gif ? "Exporting GIF" : "Burning clip");
+    }, gif ? "Exporting GIF" : "Burning clip",
+    qs(gif ? "#coExportGifBtn" : "#coExportBurnBtn"));
   }
 
   // ---- Marker trims (user actions; non-destructive span overrides) ----

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -1226,7 +1226,8 @@
 
   // Composer intake poll: the cuts/trims lists are tiny, so fetch the whole
   // composer manifest and fingerprint the spans — re-render only on change.
-  // Trims also repaint the SS/TR panels (their asterisk badges read coTrims).
+  // Trims also repaint the SS/TR panels (their asterisk badges read
+  // coTrimCardKeys).
   function pollComposerIntake() {
     return apiGet("../composer/api/manifest")
       .then(function (data) {
@@ -1273,7 +1274,6 @@
         if (fp === state._coIntakeFp) return false;
         state._coIntakeFp = fp;
         state.coIntakeItems = items;
-        state.coTrims = trims;
         state.coTrimCardKeys = cardKeys;
         renderComposerIntake();
         renderIntake(false);

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -89,7 +89,6 @@
     trIntakeHoveredIdx: -1,
     trIntakeTooltipsEnabled: true,
     coIntakeItems: [],
-    coTrims: {},
     coTrimCardKeys: {},
     coIntakeFilterParticipants: [],
     coIntakeFilterTypes: [],

--- a/source/composer_server.py
+++ b/source/composer_server.py
@@ -201,7 +201,11 @@ def api_participants() -> Any:
                 "has_video": True,
                 "in_sheet": p.get("in_sheet", False),
                 "browser_seekable": p.get("browser_seekable"),
-                "parts": parts or [{"name": Path(vp).name} for vp in p["video_paths"]],
+                # Fallback parts (unprobeable durations) still carry offset: the
+                # client computes global time as currentTime + part.offset on
+                # every timeupdate, and an absent field turns the playhead NaN.
+                "parts": parts
+                or [{"name": Path(vp).name, "offset": 0} for vp in p["video_paths"]],
                 "total_duration": (
                     sum(part["duration"] for part in parts) if parts else None
                 ),
@@ -272,22 +276,33 @@ def api_cut_create() -> Any:
 @composer_bp.route("/api/cuts/<cut_id>", methods=["PATCH"])
 def api_cut_update(cut_id: str) -> Any:
     data = request.get_json(silent=True) or {}
+    # Read the current values under the lock, then clamp OUTSIDE it —
+    # _clamp_span walks the input dir and may ffprobe on a cold cache, and
+    # holding _manifest_lock across that blocks every other composer route
+    # (api_cut_create clamps before locking for the same reason).
     with _manifest_lock:
         cut = find_by_id(_manifest.get("cuts", []), cut_id)
         if cut is None:
             return err(f"No cut {cut_id}", 404)
         start = cut["start"]
         end = cut["end"]
-        try:
-            if data.get("start") is not None:
-                start = float(data["start"])
-            if data.get("end") is not None:
-                end = float(data["end"])
-        except (TypeError, ValueError):
-            return err("start/end must be numbers")
-        if end <= start:
-            return err("end must be after start")
-        cut["start"], cut["end"] = _clamp_span(cut["participant"], start, end)
+        participant = cut["participant"]
+    try:
+        if data.get("start") is not None:
+            start = float(data["start"])
+        if data.get("end") is not None:
+            end = float(data["end"])
+    except (TypeError, ValueError):
+        return err("start/end must be numbers")
+    if end <= start:
+        return err("end must be after start")
+    start, end = _clamp_span(participant, start, end)
+    with _manifest_lock:
+        # Re-find: the cut may have been deleted while the lock was released.
+        cut = find_by_id(_manifest.get("cuts", []), cut_id)
+        if cut is None:
+            return err(f"No cut {cut_id}", 404)
+        cut["start"], cut["end"] = start, end
         if data.get("label") is not None:
             cut["label"] = str(data["label"])
         _persist_locked()
@@ -560,7 +575,10 @@ def api_annotation_delete(ann_id: str) -> Any:
 # ---- Annotation rendering (PIL; no ffmpeg drawtext) ----
 
 # Common system font locations, probed in order. load_default() is the
-# fixed-size last resort (visibly cruder, but never fails).
+# fixed-size last resort (visibly cruder, but never fails). KNOWN DIVERGENCE:
+# the browser preview draws annotation text in the UI font (Inter, a .woff2
+# PIL cannot load), so exported text is metrically close but not identical to
+# the preview — see the matching note in composer-annotate.js.
 _ANNOTATION_FONT_PATHS = (
     "/System/Library/Fonts/Helvetica.ttc",
     "/Library/Fonts/Arial.ttf",
@@ -1208,13 +1226,14 @@ def _run_overlay_export(data: dict[str, Any], *, gif: bool) -> Any:
     # Studio's intake uses, so the overlay filter sees one continuous input.
     video_paths = [p["path"] for p in parts]
     timeline = video.timeline_or_none(video_paths)
-    pieces = (
-        utils.map_global_range_to_segments(timeline, start, end)
-        if timeline is not None
-        else None
-    )
-    if pieces is not None and not pieces:
-        return err("The span is outside the recording", 400)
+    pieces = None
+    if timeline is not None:
+        pieces = utils.map_global_range_to_segments(timeline, start, end)
+        # map_global_range_to_segments signals an out-of-range start (or an
+        # empty range) with None, never [] — for a multi-part participant that
+        # means "span outside the recording", not "take the single-part path".
+        if not pieces:
+            return err("The span is outside the recording", 400)
 
     stitch_tmp: str | None = None
     if pieces is not None and len(pieces) > 1:

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -91,6 +91,19 @@ def test_participants_reports_parts_and_total(co_client):
     assert body["has_sheet"] is False
 
 
+def test_participants_fallback_parts_carry_offset(co_client, monkeypatch):
+    """Unprobeable videos still serve offset-complete part entries.
+
+    The client computes global time as ``currentTime + part.offset`` on every
+    timeupdate; a fallback entry without the field turned the playhead NaN.
+    """
+    monkeypatch.setattr(video, "get_file_duration", lambda path: None)
+    body = co_client.get("/composer/api/participants").get_json()
+    (p,) = body["participants"]
+    assert p["total_duration"] is None
+    assert [part["offset"] for part in p["parts"]] == [0, 0]
+
+
 def test_participants_prewarms_probes_before_the_loop(co_client, monkeypatch):
     """Every part is probed in one batch, not one ffprobe per participant.
 
@@ -212,6 +225,22 @@ def test_cut_patch_clamps_to_duration(co_client):
         f"/composer/api/cuts/{cut['id']}", json={"end": 999.0}
     ).get_json()
     assert patched["cut"]["end"] == 20  # stitched duration caps the out point
+
+
+def test_cut_patch_start_zero_survives(co_client):
+    """``start: 0`` must read as a value, not a missing field.
+
+    The guard is ``data.get("start") is not None`` — an ``if data.get("start")``
+    regression would silently keep the old start on a snap-to-zero PATCH.
+    """
+    cut = co_client.post(
+        "/composer/api/cuts", json={"participant": "P01", "start": 2.0, "end": 5.0}
+    ).get_json()["cut"]
+    patched = co_client.patch(
+        f"/composer/api/cuts/{cut['id']}", json={"start": 0}
+    ).get_json()
+    assert patched["cut"]["start"] == 0.0
+    assert patched["cut"]["end"] == 5.0
 
 
 def test_cut_patch_unknown_id_404(co_client):
@@ -879,6 +908,28 @@ def test_annotated_burn_rejects_a_span_that_only_grazes_an_annotation(
 
     assert resp["ok"] is False
     assert "visible for long enough" in resp["error"]
+
+
+def test_annotated_export_rejects_out_of_range_span(co_client, monkeypatch):
+    """A multi-part span past the recording errs cleanly, never encodes.
+
+    ``map_global_range_to_segments`` signals an out-of-range start with None
+    (never ``[]``); conflating that with the single-part fast path sent the
+    span down the parts-based branch and into a doomed ffmpeg run.
+    """
+    _make_annotation(co_client, span={"start": 24.0, "end": 30.0})
+
+    def _no_ffmpeg(*_a, **_kw):
+        raise AssertionError("ffmpeg must not run for an out-of-range span")
+
+    monkeypatch.setattr(composer_server.video, "run_ffmpeg_process", _no_ffmpeg)
+
+    resp = co_client.post(
+        "/composer/api/export/burn",
+        json={"participant": "P01", "start": 25.0, "end": 30.0},
+    )
+    assert resp.status_code == 400
+    assert "outside the recording" in resp.get_json()["error"]
 
 
 def test_ffmpeg_exports_rejected_while_another_export_runs(co_client):

--- a/tests/test_composer_server.py
+++ b/tests/test_composer_server.py
@@ -950,6 +950,40 @@ def test_ffmpeg_exports_rejected_while_another_export_runs(co_client):
         composer_server._export_busy.release()
 
 
+def test_export_cancel_sets_the_shared_event(co_client):
+    composer_server._export_cancel.clear()
+    resp = co_client.post("/composer/api/export/cancel").get_json()
+    assert resp["ok"] is True
+    assert composer_server._export_cancel.is_set()
+    composer_server._export_cancel.clear()
+
+
+def test_remux_routes_registered_on_composer(co_app):
+    """The shared remux routes ride on the composer blueprint itself.
+
+    tests/test_container_seekability.py exercises the route bodies against a
+    throwaway blueprint; this pins the composer registration.
+    """
+    rules = {r.rule for r in co_app.url_map.iter_rules()}
+    assert "/composer/api/remux/status" in rules
+    assert "/composer/api/remux/<pid>" in rules
+
+
+def test_repin_sheet_state_repoints_context(monkeypatch):
+    """Worksheet swaps go through repin_sheet_state, not a re-init.
+
+    The remux registration hands the blueprint ``lambda: _sheet_context``, so
+    this repoint is what keeps remux (and participant resolution) on the newly
+    opened sheet.
+    """
+    monkeypatch.setattr(composer_server, "_sheet_context", None)
+    sentinel = object()
+    composer_server.repin_sheet_state(sentinel)
+    assert composer_server._sheet_context is sentinel
+    composer_server.repin_sheet_state(None)
+    assert composer_server._sheet_context is None
+
+
 def test_combined_app_registers_composer(tmp_path, monkeypatch):
     import server
     import start_settings


### PR DESCRIPTION
## Summary

Fixes from a full code review of the Composer feature (backend, frontend, and integration surface):

- Bound + purge the decoded audio-scrub cache (LRU in `card-scrubber.js`, purged on participant switch), and serve/backfill part `offset` for unprobeable videos so the playhead can't go NaN
- Make burn/GIF exports cancellable (the launching button flips to Cancel; `POST api/export/cancel` previously had no caller), and return "span outside the recording" for out-of-range multi-part exports instead of a raw ffmpeg failure
- Timeline: ignore non-primary buttons on pointerdown, invalidate the cached canvas rect on window resize, cap `--co-timeline-height` at 60% viewport with per-call chrome re-measure (media banner no longer clips the bottom lane), skip empty lanes, rAF-coalesce pointermove/wheel, focus-preserving lane rail
- Annotations: commit in-progress text on text-tool re-click instead of discarding it, clamp freehand drags by bounding box, roll back only rejected edits in grouped commits, palette-menu sizing + scroll-close
- Hygiene: move `api_cut_update`'s ffprobe clamp outside `_manifest_lock`, clamp scrub media at part boundaries, drop dead surface (`CO.syncAnnotateCanvas`, `state.coTrims`), document known divergences (burn font, span eps, cluster trim keys, convergence offsets)

## Test plan

- [x] `ruff format --check` + `ruff check` + `ty check` clean
- [x] Full pytest suite green, incl. 6 new composer tests (cut PATCH at start 0, fallback-parts offset shape, out-of-range export span, export-cancel, remux registration, `repin_sheet_state`)
- [x] /ui-check (all six pages loaded clean; composer screenshot reviewed — empty-lane suppression and lane rail verified)
- [ ] Manual in Safari/WKWebView: rapid seeks across part boundaries, hover hit-testing after a window resize, fragmented-MP4 banner + lane fit, audio-scrub memory over a long session