### PR TITLE
fix(startup): harden application startup and loading paths

### DIFF
--- a/assets/web/_head.html
+++ b/assets/web/_head.html
@@ -9,3 +9,17 @@
        fonts.googleapis.com: the desktop shell and any offline run would block on
        the CDN and fall back to system fonts. See assets/web/fonts.css. -->
   <link rel="stylesheet" href="fonts.css">
+  <script>
+    // Pre-paint theme bootstrap, mirroring boot.html: tokens.css defaults to
+    // dark and utils.js only applies the stored preference at DOMContentLoaded
+    // (initThemeToggle), so without this a light-theme user gets a dark flash
+    // on every navigation. utils.js applyStoredThemePreference re-applies the
+    // same value later and syncs the toggle button.
+    (function () {
+      var stored = null;
+      try { stored = window.localStorage.getItem("clipgen-theme"); } catch (e) {}
+      if (stored === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+      }
+    })();
+  </script>

--- a/assets/web/composer-annotate.js
+++ b/assets/web/composer-annotate.js
@@ -899,6 +899,25 @@
     updateChipPreviews();
     syncPaletteChips();
 
+    // The hub seeds state.ann* and this toolbar paints before the
+    // api/participants config fetch lands, so both run on the JS defaults.
+    // The hub calls this after clipgenApplyConfig to re-seed from the real
+    // server config and repaint everything that shows a default.
+    CO.syncAnnotationDefaults = function () {
+      state.annColor = CLIPGEN_CONFIG.composerAnnotationColor;
+      state.annColorSecondary = CLIPGEN_CONFIG.composerAnnotationColorSecondary;
+      state.annStrokeWidth = CLIPGEN_CONFIG.composerAnnotationStrokeWidth;
+      state.annStrokeStyle = CLIPGEN_CONFIG.composerAnnotationStrokeStyle;
+      state.annFontSize = CLIPGEN_CONFIG.composerAnnotationFontSize;
+      resetGlyph.style.setProperty(
+        "--co-swatch-default", CLIPGEN_CONFIG.composerAnnotationColor);
+      resetGlyph.style.setProperty(
+        "--co-swatch-default-secondary",
+        CLIPGEN_CONFIG.composerAnnotationColorSecondary);
+      paintSwatches();
+      updateChipPreviews();
+    };
+
     // Tool buttons ([data-tool] excludes the independent #coToolHide toggle).
     qsa(".co-tool-btn[data-tool]").forEach(function (btn) {
       btn.addEventListener("click", function () {

--- a/assets/web/composer.js
+++ b/assets/web/composer.js
@@ -1848,7 +1848,12 @@
 
     apiGet("api/participants").then(function (data) {
       if (!data.ok) return;
-      if (data.config) clipgenApplyConfig(data.config);
+      if (data.config) {
+        clipgenApplyConfig(data.config);
+        // boot() seeded state.ann* (and the annotate toolbar painted) from the
+        // JS defaults before this fetch landed; re-seed from the real config.
+        if (CO.syncAnnotationDefaults) CO.syncAnnotationDefaults();
+      }
       updateTimelineHint(); // the double-click hint follows the fetched config
       state.hasSheet = !!data.has_sheet;
       state.participants = data.participants || [];

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -1190,16 +1190,23 @@
       // visible when this lands, the panel would otherwise stay on v0.0.0.
       if (state.startTab === "about") renderAbout();
       return s;
+    }).catch(function (err) {
+      // Same contract as loadGoogleSheets: log and keep refresh()'s boot
+      // chain going — one failed link must not strand every later panel
+      // on its static "Scanning…" shimmer.
+      console.error("Status load failed", err);
     });
   }
 
   function loadDirs() {
     return apiGet("/api/dirs").then(function (d) {
       if (!d || !d.ok) return;
-      els.inputDir.value = d.input || "";
-      els.outputDir.value = d.output || "";
+      if (els.inputDir) els.inputDir.value = d.input || "";
+      if (els.outputDir) els.outputDir.value = d.output || "";
       renderFolderRecents(els.inputRecentsList, d.recent_inputs || [], els.inputDir, "input");
       renderFolderRecents(els.outputRecentsList, d.recent_outputs || [], els.outputDir, "output");
+    }).catch(function (err) {
+      console.error("Directory load failed", err);
     });
   }
 
@@ -1473,6 +1480,11 @@
       if (els.rememberWindowRow) els.rememberWindowRow.hidden = !r.desktop;
       state.recentProjects = r.settings.recent_projects || [];
       renderRailRecents(state.recentProjects);
+    }).catch(function (err) {
+      // Log-and-continue like the loaders below — and still render the
+      // recents rail so it shows its empty state instead of staying blank.
+      console.error("Start settings load failed", err);
+      renderRailRecents(state.recentProjects || []);
     });
   }
 
@@ -2270,7 +2282,10 @@
   function open(tab) {
     if (!state.mounted) {
       // Not mount().then(open): then() would pass mount's resolved value as tab.
-      mount().then(function () { open(tab); });
+      // Re-enter only if the mount actually succeeded — mount() resolves (never
+      // rejects) on a missing slot or a failed template fetch, and recursing on
+      // that would spin forever re-fetching start-overlay.html.
+      mount().then(function () { if (state.mounted) open(tab); });
       return;
     }
     if (state.open) return;
@@ -2499,6 +2514,14 @@
       apiGet("/api/status").then(function (s) {
         state.statusData = s;
         state.sheetLoaded = !!s.sheet_loaded;
+        // Every hub page runs this fetch, so it doubles as the topnav version
+        // chip's data source — setVersion reads CLIPGEN_CONFIG.version, which
+        // nothing else populates (/api/status ships version as a sibling of
+        // config, so clipgenApplyConfig never sees it).
+        if (typeof s.version === "string" && s.version) {
+          CLIPGEN_CONFIG.version = s.version;
+          if (window.ClipgenTopNav) window.ClipgenTopNav.refreshVersion();
+        }
         if (shouldAutoOpen(s)) open();
       }).catch(function () { /* offline / dev */ });
     });

--- a/assets/web/start-overlay.js
+++ b/assets/web/start-overlay.js
@@ -2514,14 +2514,6 @@
       apiGet("/api/status").then(function (s) {
         state.statusData = s;
         state.sheetLoaded = !!s.sheet_loaded;
-        // Every hub page runs this fetch, so it doubles as the topnav version
-        // chip's data source — setVersion reads CLIPGEN_CONFIG.version, which
-        // nothing else populates (/api/status ships version as a sibling of
-        // config, so clipgenApplyConfig never sees it).
-        if (typeof s.version === "string" && s.version) {
-          CLIPGEN_CONFIG.version = s.version;
-          if (window.ClipgenTopNav) window.ClipgenTopNav.refreshVersion();
-        }
         if (shouldAutoOpen(s)) open();
       }).catch(function () { /* offline / dev */ });
     });

--- a/assets/web/topnav.css
+++ b/assets/web/topnav.css
@@ -306,17 +306,6 @@ html[data-desktop-chrome="macos"][data-desktop-fullscreen] .topnav-left {
   transform: translateX(0) scale(1);
 }
 
-/* Version pill — small mono text */
-.topnav-version {
-  margin-left: 6px;
-  padding: 2px 6px;
-  font-family: var(--font-mono);
-  font-feature-settings: "tnum";
-  font-size: 11px;
-  color: var(--fg-faint);
-  border-radius: 4px;
-}
-
 /* ---- Quick Actions menu ---- */
 
 .topnav-qa {

--- a/assets/web/topnav.js
+++ b/assets/web/topnav.js
@@ -85,11 +85,9 @@
     els.qaWrap = nav.querySelector(".topnav-qa");
     els.qaTrigger = nav.querySelector(".topnav-qa-trigger");
     els.qaPanel = nav.querySelector(".topnav-qa-panel");
-    els.version = nav.querySelector(".topnav-version");
 
     bindEvents();
     setQuickActions(window.CLIPGEN_QUICK_ACTIONS || []);
-    setVersion();
 
     isReady = true;
     for (var i = 0; i < readyCallbacks.length; i++) {
@@ -220,12 +218,6 @@
     themeBtn.innerHTML = '<span class="theme-toggle-icon theme-icon-sun"></span><span class="theme-toggle-icon theme-icon-moon"></span>';
     right.appendChild(themeBtn);
 
-    // Version pill
-    var version = document.createElement("span");
-    version.className = "topnav-version";
-    version.setAttribute("aria-label", "clipgen version");
-    right.appendChild(version);
-
     return right;
   }
 
@@ -344,22 +336,6 @@
     return btn;
   }
 
-  function setVersion() {
-    if (!els.version) return;
-    var v = "";
-    try {
-      if (window.CLIPGEN_CONFIG && typeof window.CLIPGEN_CONFIG.version === "string") {
-        v = window.CLIPGEN_CONFIG.version;
-      }
-    } catch (_) {}
-    if (!v) {
-      els.version.style.display = "none";
-      return;
-    }
-    els.version.style.display = "";
-    els.version.textContent = "v" + v;
-  }
-
   function onReady(cb) {
     if (typeof cb !== "function") return;
     if (isReady) {
@@ -377,7 +353,6 @@
   window.ClipgenTopNav = {
     setQuickActions: setQuickActions,
     getQuickActions: getQuickActions,
-    refreshVersion: setVersion,
     onReady: onReady,
     onBeforeOpen: onBeforeOpen,
   };

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -209,9 +209,9 @@
   // With no spreadsheet open, /studio/api/sheet answers {ok, sheet_loaded: false}
   // with no rows — nothing this page can index — so stop asking after the first
   // such answer. Cleared on tab focus (see startXrefPolling's resume): a sheet
-  // opened from another tab reloads only that document, not this one. The first
-  // tick always runs, which matters because this handler is the page's only
-  // caller of clipgenApplyConfig.
+  // opened from another tab reloads only that document, not this one. The
+  // clipgenApplyConfig call below is a refresh only; loadParticipants applies
+  // the same config from this page's own api/participants at boot.
   var _sheetXrefIdle = false;
 
   function loadCrossRefData() {
@@ -714,6 +714,10 @@
         _clearBootPlaceholders();
         return;
       }
+      // Primary config channel for this page: the only other caller of
+      // clipgenApplyConfig here is the xref poller's /studio/api/sheet leg,
+      // which is status-gated and lands (if ever) after first render.
+      if (data.config) clipgenApplyConfig(data.config);
       state.participants = data.participants;
       state.hasSheet = !!data.has_sheet;
       state.transcribePrewarm = data.transcribe_prewarm || "queue_open";

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -136,6 +136,24 @@ var clipgenApplyConfig = function (payload) {
   if (typeof payload.gifFormat === "string") {
     CLIPGEN_CONFIG.gifFormat = payload.gifFormat;
   }
+  if (typeof payload.composerAnnotationColor === "string") {
+    CLIPGEN_CONFIG.composerAnnotationColor = payload.composerAnnotationColor;
+  }
+  if (typeof payload.composerAnnotationColorSecondary === "string") {
+    CLIPGEN_CONFIG.composerAnnotationColorSecondary = payload.composerAnnotationColorSecondary;
+  }
+  if (typeof payload.composerAnnotationStrokeWidth === "number") {
+    CLIPGEN_CONFIG.composerAnnotationStrokeWidth = payload.composerAnnotationStrokeWidth;
+  }
+  if (typeof payload.composerAnnotationStrokeStyle === "string") {
+    CLIPGEN_CONFIG.composerAnnotationStrokeStyle = payload.composerAnnotationStrokeStyle;
+  }
+  if (typeof payload.composerAnnotationFontSize === "number") {
+    CLIPGEN_CONFIG.composerAnnotationFontSize = payload.composerAnnotationFontSize;
+  }
+  if (typeof payload.composerAnnotationSpanSeconds === "number") {
+    CLIPGEN_CONFIG.composerAnnotationSpanSeconds = payload.composerAnnotationSpanSeconds;
+  }
   if (typeof payload.composerScrubMaxAudioSeconds === "number") {
     CLIPGEN_CONFIG.composerScrubMaxAudioSeconds = payload.composerScrubMaxAudioSeconds;
   }
@@ -2145,7 +2163,10 @@ var initFrontendSwitcher = function () {
   });
 
   fetch("/api/status")
-    .then(function (r) { return r.json(); })
+    .then(function (r) {
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.json();
+    })
     .then(function (status) {
       var items = panel.querySelectorAll(".frontend-switcher-item");
       items.forEach(function (item) {

--- a/clipgen.py
+++ b/clipgen.py
@@ -41,3 +41,16 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         utils.info_print("Interrupted by user")
         sys.exit(0)
+    except Exception:
+        # Last resort for a windowed launch (Finder double-click of the frozen
+        # bundle): with no attached console an unexpected crash is a bouncing
+        # dock icon and silence. fatal_startup_error prints on console runs too,
+        # but the re-raise keeps the full traceback as the final word there.
+        if utils.GUI_LAUNCH:
+            import traceback
+
+            utils.fatal_startup_error(
+                "clipgen hit an unexpected error and has to close.",
+                traceback.format_exc().strip().splitlines()[-8:],
+            )
+        raise

--- a/source/cli.py
+++ b/source/cli.py
@@ -3901,7 +3901,7 @@ def main() -> None:
         if value.lower() == ".webp"
     ]
     if webp_formats and not video.check_webp_support():
-        utils.error_print(
+        utils.fatal_startup_error(
             "WebP output is configured but ffmpeg lacks libwebp support.",
             [
                 f"Affected config: {', '.join(webp_formats)}",
@@ -3911,7 +3911,7 @@ def main() -> None:
         sys.exit(1)
 
     if config.GIF_FORMAT.lower() == ".webm" and not video.check_vp9_support():
-        utils.error_print(
+        utils.fatal_startup_error(
             "WebM output is configured but ffmpeg lacks libvpx-vp9 support.",
             [
                 "Affected config: GIF_FORMAT",
@@ -3955,7 +3955,7 @@ def main() -> None:
                     # without touching the (absent) gspread client.
                     args.spreadsheet = fallback
                 else:
-                    utils.error_print(
+                    utils.fatal_startup_error(
                         "Google authentication failed.",
                         [
                             "Use -s path/to/file.xlsx to work with a local Excel file instead.",
@@ -3977,6 +3977,18 @@ def main() -> None:
                 utils.standard_print("Using local Excel file.")
             else:
                 worksheet = select_worksheet(gspread_client, args, cli_mode)
+
+            # The Start overlay's per-source filename overrides are functional
+            # config — they decide which file a participant's clips are cut
+            # from. Web launches seed them in server._seed_filename_overrides;
+            # seed here so headless CLI and interactive runs honor them too.
+            meta = files.derive_sheet_meta(worksheet)
+            if meta is not None:
+                import start_settings
+
+                config.FILENAME_OVERRIDES = start_settings.filename_overrides(
+                    meta["type"], meta["id_or_path"], meta.get("worksheet", "")
+                )
 
             web_mode = _resolve_web_mode(args)
             if web_mode is not None:

--- a/source/files.py
+++ b/source/files.py
@@ -354,6 +354,45 @@ def resolve_participant_videos(sheet_context: Any = None) -> list[dict[str, Any]
     return entries
 
 
+def derive_sheet_meta(worksheet: Any) -> dict[str, str] | None:
+    """Return ``{type, id_or_path, label, worksheet}`` identifying *worksheet*.
+
+    This triple keys the per-source filename overrides in ``start.json`` and
+    the Start overlay's recent-projects entries. Shared by the server (picker
+    display, override seeding) and the CLI launch path, so both derive the
+    same identity for the same worksheet.
+    """
+    if worksheet is None:
+        return None
+    try:
+        import excel_io
+
+        if isinstance(worksheet, excel_io.ExcelSheetAdapter):
+            path = getattr(worksheet, "_workbook_path", "") or ""
+            if not path:
+                return None
+            return {
+                "type": "excel",
+                "id_or_path": path,
+                "label": Path(path).name,
+                "worksheet": getattr(worksheet, "title", ""),
+            }
+    except ImportError:
+        pass  # no excel_io in this build; fall through to the gspread branch
+    # gspread Worksheet (or anything quacking like one): use the parent
+    # spreadsheet title as both the identifier and the label.
+    parent = getattr(worksheet, "spreadsheet", None)
+    title = getattr(parent, "title", "") if parent is not None else ""
+    if not title:
+        return None
+    return {
+        "type": "google",
+        "id_or_path": title,
+        "label": title,
+        "worksheet": getattr(worksheet, "title", ""),
+    }
+
+
 def find_participant_record(
     sheet_context: Any, participant_id: str
 ) -> dict[str, Any] | None:

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -2843,6 +2843,15 @@ def _init_screenspace_state(sheet_context: Any = None) -> None:
 
     global _manifest, _worker, _participant_source
 
+    # A sheet swap re-runs this init: detach and stop the old worker daemon
+    # before any state is replaced — a task finishing while the lines below
+    # run would otherwise fire on_task_complete and write the old worker's
+    # tasks/events into the replacement manifest.
+    if _worker is not None:
+        _worker.on_task_complete = None
+        _worker.on_progress_update = None
+        _worker.stop()
+
     _manifest = screenspace.load_screenspace_manifest()
     _backfill_missing_events(_manifest)
 

--- a/source/server.py
+++ b/source/server.py
@@ -1277,6 +1277,42 @@ def _load_studio_settings() -> dict[str, Any]:
     return applied
 
 
+def _revert_unsupported_formats() -> None:
+    """Re-run the ffmpeg capability guards against the loaded studio settings.
+
+    ``cli.main`` validates webp/vp9/drawtext support before this module applies
+    ``studio_settings.json``, so a persisted format can name an encoder this
+    ffmpeg build lacks — or re-enable titlecards the CLI guard just disabled
+    for missing drawtext. By now the server is booting, so warn and revert to
+    the defaults instead of exiting. The ``video.check_*`` probes are cached,
+    so the repeat costs nothing when the CLI already ran them.
+    """
+    webp_names = [
+        name
+        for name in ("SCREENSHOT_FORMAT", "GIF_FORMAT")
+        if str(getattr(config, name)).lower() == ".webp"
+    ]
+    if webp_names and not video.check_webp_support():
+        for name in webp_names:
+            setattr(config, name, _settings_defaults[name])
+        utils.warning_print(
+            f"{', '.join(webp_names)} set to .webp but ffmpeg lacks libwebp; "
+            f"reverting to the default format."
+        )
+    if config.GIF_FORMAT.lower() == ".webm" and not video.check_vp9_support():
+        config.GIF_FORMAT = _settings_defaults["GIF_FORMAT"]
+        utils.warning_print(
+            "GIF_FORMAT set to .webm but ffmpeg lacks libvpx-vp9; "
+            "reverting to the default format."
+        )
+    if config.TITLECARDS_ENABLED and not video.check_drawtext_support():
+        config.TITLECARDS_ENABLED = False
+        utils.warning_print(
+            "Titlecards are enabled but ffmpeg lacks the drawtext filter; "
+            "disabling titlecards for this run."
+        )
+
+
 def _save_studio_settings(overrides: dict[str, Any]) -> Path | None:
     """Write only non-default settings to studio_settings.json."""
     to_save = {}
@@ -3115,6 +3151,7 @@ def _init_studio_state(worksheet: Any) -> None:
     global _worksheet, _generated_artifacts, _generated_reels
 
     _load_studio_settings()
+    _revert_unsupported_formats()
     _worksheet = worksheet
     new_context = None
     if worksheet is not None:
@@ -3143,35 +3180,7 @@ def _derive_sheet_meta(worksheet: Any) -> dict[str, str] | None:
     loaded sheet when the overlay is opened on a session that was launched
     from the CLI (not via the runtime ``/api/spreadsheets/open`` endpoint).
     """
-    if worksheet is None:
-        return None
-    try:
-        import excel_io
-
-        if isinstance(worksheet, excel_io.ExcelSheetAdapter):
-            path = getattr(worksheet, "_workbook_path", "") or ""
-            if not path:
-                return None
-            return {
-                "type": "excel",
-                "id_or_path": path,
-                "label": Path(path).name,
-                "worksheet": getattr(worksheet, "title", ""),
-            }
-    except ImportError:
-        pass  # no excel_io in this build; fall through to the gspread branch
-    # gspread Worksheet (or anything quacking like one): use the parent
-    # spreadsheet title as both the identifier and the label.
-    parent = getattr(worksheet, "spreadsheet", None)
-    title = getattr(parent, "title", "") if parent is not None else ""
-    if not title:
-        return None
-    return {
-        "type": "google",
-        "id_or_path": title,
-        "label": title,
-        "worksheet": getattr(worksheet, "title", ""),
-    }
+    return files.derive_sheet_meta(worksheet)
 
 
 def _spreadsheet_label() -> str:
@@ -3623,6 +3632,11 @@ def _init_combined_state(
         observation_rows_getter=_sheet_observation_rows,
         participant_marks_getter=transcripts_server.marks_for_participant,
     )
+
+    # Last, so an armed trigger firing on the daemon's immediate first poll
+    # can't start a workflow run against half-initialized sibling state (or a
+    # report agent with the getters above still unset).
+    workflows_server._start_watch_thread()
 
 
 def build_combined_app(
@@ -4635,6 +4649,11 @@ def _port_available(port: int) -> bool:
     ``sys.exit(1)``) off the console in the ordinary second-instance case.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        # Match werkzeug's bind semantics (HTTPServer sets allow_reuse_address):
+        # without SO_REUSEADDR the probe reports a port still draining TIME_WAIT
+        # connections as taken, and a quick restart silently relocates off 8089
+        # even though the real bind would have succeeded.
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             probe.bind(("127.0.0.1", port))
         except OSError:

--- a/source/start_settings.py
+++ b/source/start_settings.py
@@ -96,9 +96,13 @@ def load_start_settings() -> dict[str, Any]:
         return _defaults()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        # Not silent: this file also carries filename_overrides, which change
+        # which source video a participant's clips are cut from.
+        utils.warning_print(f"Could not read start settings ({exc}); using defaults.")
         return _defaults()
     if not isinstance(data, dict):
+        utils.warning_print("Start settings file is not a JSON object; using defaults.")
         return _defaults()
     merged = _defaults()
     merged.update(data)
@@ -127,8 +131,10 @@ def _prepend_dedup(items: list[Any], new_item: Any, key: Any = None) -> list[Any
     if key is None:
         deduped = [x for x in items if x != new_item]
     else:
+        # Keyed entries are dicts and every key fn calls .get(); drop anything
+        # else so a malformed list off disk can't crash the boot-build thread.
         new_key = key(new_item)
-        deduped = [x for x in items if key(x) != new_key]
+        deduped = [x for x in items if isinstance(x, dict) and key(x) != new_key]
     return [new_item] + deduped[: RECENTS_CAP - 1]
 
 

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -363,10 +363,14 @@ def api_participants() -> FlaskResponse:
 
     # ``has_sheet`` gates the off-sheet badge: with no sheet every entry is
     # ``in_sheet: False``, and marking them all would be noise.
+    # Bootstrap channel for shared frontend config (hotkey overrides etc.),
+    # mirroring screenspace/workflows: the page's only other config path is the
+    # cross-frontend /studio/api/sheet poll, which is status-gated and late.
     return ok(
         participants=result,
         has_sheet=bool(_participant_source and _participant_source["sheet_context"]),
         transcribe_prewarm=_transcribe_prewarm_setting(),
+        config=utils.get_frontend_config(),
     )
 
 
@@ -2576,6 +2580,15 @@ def _init_transcripts_state(sheet_context: Any = None) -> None:
     the stored reference is replaced rather than going stale.
     """
     global _manifest, _worker, _participant_source
+
+    # A sheet swap re-runs this init: detach and stop the old worker daemon
+    # before any state is replaced — a transcription finishing while the lines
+    # below run would otherwise fire on_task_complete, re-merge its result
+    # into the replacement manifest past the cleared _merged_task_ids, and
+    # start thinking-agent chains against the new sheet.
+    if _worker is not None:
+        _worker.on_task_complete = None
+        _worker.stop()
 
     _manifest = transcripts.load_transcripts_manifest()
     _merged_task_ids.clear()

--- a/source/workflows_server.py
+++ b/source/workflows_server.py
@@ -1325,8 +1325,13 @@ def _init_workflows_state(
 
     Loads the workflows manifest and records the active sheet context +
     worksheet (the latter feeds the ``sheet_selection`` executor), then seeds
-    the watch-dir baseline and starts the trigger daemon. Per-participant
-    video paths and the input dir are resolved on demand.
+    the watch-dir baseline. Per-participant video paths and the input dir are
+    resolved on demand.
+
+    Deliberately does *not* start the trigger daemon: an armed trigger firing
+    here could launch a workflow run before the sibling blueprints (and
+    ``thinking_agents.configure``) are initialized. ``server._init_combined_state``
+    calls :func:`_start_watch_thread` as its last step instead.
 
     Called once, from ``build_combined_app``. A worksheet swap goes through
     :func:`repin_sheet_state` instead — re-running this would reload the
@@ -1344,7 +1349,6 @@ def _init_workflows_state(
     with _manifest_lock:
         _persist_locked()
     _seed_watch_seen()
-    _start_watch_thread()
 
 
 def repin_sheet_state(sheet_context: Any = None, worksheet: Any = None) -> None:

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -159,6 +159,29 @@ def test_clipgen_config_defaults_match_python():
     assert py_config["profiling"] == config.PROFILING
 
 
+def test_clipgen_apply_config_covers_frontend_config():
+    """clipgenApplyConfig must have a branch for every get_frontend_config key.
+
+    test_clipgen_config_defaults_match_python compares default *values*, so a
+    key the server ships but the applier silently drops stays green while the
+    live frontend runs the JS defaults forever (the six composerAnnotation*
+    keys shipped un-applied this way). Coverage is asserted as payload.<key>
+    access inside the function body.
+    """
+    match = re.search(
+        r"var\s+clipgenApplyConfig\s*=\s*function\s*\(payload\)\s*\{(.*?)\n\};",
+        _js_source(),
+        re.DOTALL,
+    )
+    assert match, "clipgenApplyConfig not found in utils.js"
+    handled = set(re.findall(r"payload\.(\w+)", match.group(1)))
+    missing = set(utils.get_frontend_config().keys()) - handled
+    assert not missing, (
+        f"clipgenApplyConfig drops config keys the server ships: "
+        f"{sorted(missing)}. Add a type-guarded branch for each in utils.js."
+    )
+
+
 def test_get_frontend_config_shape():
     """Contract: every consumer of get_frontend_config relies on these keys."""
     cfg = utils.get_frontend_config()


### PR DESCRIPTION
## Summary

Fixes from a code review of the startup/loading paths — frontend boot, config contract, and server init ordering:

- **Start overlay**: `open()` no longer recurses forever when `mount()` fails (hung tab / fetch loop); the first three `refresh()` loaders catch-and-continue like their siblings so one failure can't strand every panel on its shimmer.
- **Config contract**: `clipgenApplyConfig` applies the six `composerAnnotation*` keys it silently dropped (Composer re-seeds its annotate toolbar once config lands); `/transcripts/api/participants` now ships `config` so the page no longer depends on the status-gated xref poll; new keyset-coverage test in `tests/test_shared_constants.py`. The topnav version chip — found permanently hidden because nothing populated `CLIPGEN_CONFIG.version` — is removed outright along with its plumbing (the About tab still shows the version).
- **Server init**: ffmpeg capability guards re-run after `studio_settings.json` applies (warn + revert instead of bypassing the CLI checks); a sheet swap detaches and stops the previous screenspace/transcripts worker *before* replacing state, instead of leaking a daemon with a live manifest-writing callback; the workflows watch daemon starts last, after `thinking_agents.configure`; the port probe sets `SO_REUSEADDR` so a quick restart stays on :8089 through TIME_WAIT.
- **CLI / launcher**: webp/vp9/auth hard exits route through `fatal_startup_error`, plus a last-resort native alert for unexpected crashes on GUI launches; CLI runs now seed `config.FILENAME_OVERRIDES` via the new shared `files.derive_sheet_meta` (previously Start-overlay overrides were silently ignored headless).
- **`start_settings`**: corrupt `start.json` warns instead of silently dropping filename overrides; non-dict recents entries no longer crash `record_project_session` on the boot-build thread.
- **`_head.html`**: pre-paint theme bootstrap, ending the dark flash for light-theme users on every navigation.

## Test plan

- [x] `/check`: ruff format + lint, ty, full test suite (3523 passed)
- [x] `/ui-check`: six-page smoke + five journeys green; screenshots reviewed (Transcripts, Composer, Studio light theme)
- [x] Pre-paint theme and chip removal verified live via `shot.py --eval` + screenshot
- [ ] Manual: sheet swap under an in-flight scan/transcription (worker stop ordering), desktop-launch crash alert, TIME_WAIT restart on :8089