### PR TITLE
fix(transcripts): land the Transcripts code-review fixes

### DIFF
--- a/agents/skills/new-thinking-agent/SKILL.md
+++ b/agents/skills/new-thinking-agent/SKILL.md
@@ -14,7 +14,7 @@ Both the orchestrator **and** the HTTP routes in `transcripts_server.py` auto-pi
      - `transcript_entry` is the dict for one participant from `transcripts_manifest.json`
    - Append an `Agent(...)` entry to the `AGENTS` list
      - Respect topological order: dependencies must appear before dependents
-     - Set `depends_on` to the `manifest_field` names of agents this one needs
+     - Set `depends_on` to the agent *keys* (not `manifest_field` names) of agents this one needs
      - Set `manifest_field` to the key that will be written into the transcript entry
      - Set `on_upstream_change` to `"clear"` (drop the result when an upstream
        dependency regenerates, the default) or `"stale"` (keep it but flag for a

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -340,6 +340,12 @@
     }
   }
 
+  // The stream is closed on participant switch, cancel, completion and
+  // visibilitychange, but a bfcache-suspended page would otherwise keep the
+  // EventSource connection open — the one page-scope resource here with no
+  // pagehide teardown.
+  window.addEventListener("pagehide", _stopSummaryStream);
+
   // Stops all live summary updates — the poller AND the SSE stream — so every
   // existing teardown site (participant switch, clear, cancel, completion)
   // covers both transports without needing to know which one is active.

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -207,9 +207,25 @@
   // The summary poll (AGENT_DESCRIPTORS.summary._poller) is the fallback used
   // when EventSource is unsupported or the stream drops mid-run.
   var _summaryStream = null;
+  // Which participant's summary is currently painted in the panel. Drives the
+  // clear-on-switch in loadSummary; deliberately NOT reset by clearSummary
+  // itself (a cleared panel plus a skipped re-clear is still a cleared panel).
+  var _summaryPaintedPid = null;
 
   function loadSummary(pid) {
     var ver = state.participantReqVer;
+
+    // On a real participant switch, blank the previous summary before
+    // fetching: the catch below deliberately leaves painted panes alone on
+    // transient failures, which is only safe when what is painted belongs to
+    // *this* participant — otherwise a failed switch kept the previous
+    // participant's summary on screen under the new selection. Tracked by
+    // painted pid, not selectedParticipant, so same-participant refetches
+    // (tab refocus, mid-run re-arm) never blank a live panel.
+    if (_summaryPaintedPid !== pid) {
+      clearSummary();
+      _summaryPaintedPid = pid;
+    }
 
     // The analysis panel must be visible whenever we surface agent state for the
     // selected, transcribed participant. renderSummaryGenerating/renderSummary
@@ -884,10 +900,13 @@
     // must keep the programmatic scores on screen: they come from the
     // deterministic scorer and owe nothing to the LLM. Wiping them here is what
     // blanked the histogram, chips, tinting and timeline band for a whole run.
+    // On a real switch, clear the DOM too (clearFriction), not just the state:
+    // the fetch's catch below deliberately leaves painted panes alone on
+    // transient failures, which is only safe when what is painted belongs to
+    // *this* participant — otherwise a failed switch kept the previous
+    // participant's histogram and chips on screen.
     if (state.frictionPid !== pid) {
-      state.frictionData = null;
-      state.frictionBySegId = {};
-      state.frictionMomentIndex = -1;
+      clearFriction();
     }
     state.frictionPid = pid;
     state.frictionGenerating = false;

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -134,6 +134,7 @@
       _stopAgentPoll(desc);
       var started = Date.now();
       var ver = state.participantReqVer;
+      desc._failStreak = 0;
       desc._poller = createPoller(function () {
         if (ver !== state.participantReqVer ||
             state.selectedParticipant !== pid ||
@@ -144,6 +145,7 @@
         }
         apiGet(desc.urlBase + "/" + pid).then(function (data) {
           if (ver !== state.participantReqVer) return;
+          desc._failStreak = 0;
           if (data.ok && desc.getResult(data)) {
             _stopAgentPoll(desc);
             desc.onResult(pid, data);
@@ -153,10 +155,25 @@
             _stopAgentPoll(desc);
             desc.onEmpty(pid, data);
           }
-        }).catch(function () {
+        }).catch(function (err) {
           if (ver !== state.participantReqVer) return;
-          _stopAgentPoll(desc);
-          desc.onEmpty(pid);
+          if (err && err.status === 404) {
+            // The endpoint 404s once the run is over with nothing persisted
+            // (find_citations' failure return, Ollama down) — the genuine
+            // empty case.
+            _stopAgentPoll(desc);
+            desc.onEmpty(pid);
+            return;
+          }
+          // Transient transport blip or server hiccup mid-run: keep the poll
+          // armed and the rendered panel untouched — one failed GET must not
+          // wipe a five-minute Ollama run. Only a streak gives up, and via
+          // onStale so the painted state survives.
+          desc._failStreak = (desc._failStreak || 0) + 1;
+          if (desc._failStreak >= 3) {
+            _stopAgentPoll(desc);
+            desc.onStale(pid);
+          }
         });
       }, desc.interval, { runImmediately: false, label: "transcripts.agent." + desc.key });
       desc._poller.start();
@@ -216,10 +233,13 @@
       } else {
         renderSummaryEmpty();
       }
-    }).catch(function () {
+    }).catch(function (err) {
       if (ver !== state.participantReqVer) return;
-      // Ollama unavailable or no summary — show the empty-state CTA.
-      renderSummaryEmpty();
+      // 404 = genuinely no summary — show the empty-state CTA. Any other
+      // failure is a transport blip (e.g. a refocus reload racing a server
+      // restart): leave whatever is painted alone rather than blanking a
+      // possibly-live panel.
+      if (err && err.status === 404) renderSummaryEmpty();
     });
   }
 
@@ -882,9 +902,11 @@
       } else {
         renderFrictionEmpty();
       }
-    }).catch(function () {
+    }).catch(function (err) {
       if (ver !== state.participantReqVer) return;
-      renderFrictionEmpty();
+      // Same contract as loadSummary: only a 404 (no result exists) may blank
+      // the panel; a transient failure leaves the painted state alone.
+      if (err && err.status === 404) renderFrictionEmpty();
     });
   }
 

--- a/assets/web/transcripts-corrections.js
+++ b/assets/web/transcripts-corrections.js
@@ -100,6 +100,8 @@
         // Reload transcript to apply new correction
         if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
       }
+    }).catch(function () {
+      showToast("Failed to add correction");
     });
   }
 
@@ -111,6 +113,8 @@
         // Reload transcript to unapply correction
         if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
       }
+    }).catch(function () {
+      showToast("Failed to remove correction");
     });
   }
 

--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -339,7 +339,9 @@
       var offSheet = document.createElement("span");
       offSheet.className = "pill-offsheet-badge";
       offSheet.setAttribute("aria-label", "Not in sheet");
-      offSheet.title = "Source video found on disk; not a column in the loaded sheet";
+      // data-tooltip, matching the stale badge beside it — two badges in one
+      // pill must not mix tooltip systems (different delay and styling).
+      offSheet.setAttribute("data-tooltip", "Source video found on disk; not a column in the loaded sheet");
       pill.appendChild(offSheet);
     }
 

--- a/assets/web/transcripts-pills.js
+++ b/assets/web/transcripts-pills.js
@@ -165,7 +165,11 @@
             // Phase feeds the dot tooltip's closure — a loading_model →
             // transcribing flip must rebuild or the tooltip stays stale.
             existing[k].getAttribute("data-phase") !== (s0.phase || "") ||
-            existing[k].getAttribute("data-offsheet") !== offSheetFlag(p0)) {
+            existing[k].getAttribute("data-offsheet") !== offSheetFlag(p0) ||
+            // Regenerating artifacts in Studio flips has_stale_artifacts with
+            // identical status/agents/phase — without this the patch path
+            // short-circuits and the "stale" badge never clears.
+            existing[k].getAttribute("data-stale") !== (p0.has_stale_artifacts ? "1" : "0")) {
           canPatch = false; break;
         }
       }
@@ -176,6 +180,13 @@
           s0 = pillState(p0, taskByPid);
           var bar = wrap.querySelector(".pill-progress");
           if (bar) bar.style.width = s0.progress + "%";
+        }
+        // The open options pane tracks state the patch guard doesn't see
+        // (sessionStorage in/out markers feeding the Range row, audio-track
+        // hints) — and the steady state during a running transcription IS the
+        // patch path, so it must refresh here too, not only on rebuild.
+        if (state.pillOptionsOpen !== null) {
+          _refreshPillOptionsContent(state.pillOptionsOpen, taskByPid);
         }
         return;
       }
@@ -240,6 +251,7 @@
     wrap.setAttribute("data-agents", s.agents.transcription + "," + s.agents.summary + "," + s.agents.citations + "," + s.agents.friction);
     wrap.setAttribute("data-phase", s.phase || "");
     wrap.setAttribute("data-offsheet", offSheetFlag(p));
+    wrap.setAttribute("data-stale", p.has_stale_artifacts ? "1" : "0");
     wrap.appendChild(buildPill(p, s, isActive));
     wrap.appendChild(buildPillDots(p, s));
     if (state.pillOptionsOpen === p.id) {

--- a/assets/web/transcripts-search.js
+++ b/assets/web/transcripts-search.js
@@ -197,10 +197,21 @@
 
   function highlightQuery(text, query) {
     if (!query) return escapeHtml(text);
-    var escaped = escapeHtml(text);
-    var queryEscaped = escapeHtml(query);
-    var regex = new RegExp("(" + queryEscaped.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + ")", "gi");
-    return escaped.replace(regex, '<span class="search-highlight">$1</span>');
+    // Match on the RAW text and escape each piece separately: matching the
+    // escaped text let a query like "amp" or "lt" land inside an entity
+    // escapeHtml had just produced and split it with the span, rendering the
+    // entity literally.
+    var regex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi");
+    var out = "";
+    var last = 0;
+    var m;
+    while ((m = regex.exec(text)) !== null) {
+      out += escapeHtml(text.slice(last, m.index));
+      out += '<span class="search-highlight">' + escapeHtml(m[0]) + "</span>";
+      last = m.index + m[0].length;
+    }
+    out += escapeHtml(text.slice(last));
+    return out;
   }
 
   function hideSearchResults() {

--- a/assets/web/transcripts-search.js
+++ b/assets/web/transcripts-search.js
@@ -22,6 +22,11 @@
 
   var SEARCH_DEBOUNCE = 300;
   var _searchTimer = null;
+  // Request generation: the debounce limits how many requests fire, not their
+  // ordering. A slow response for an old query landing after a fast one for
+  // the current query must not overwrite state.searchResults — "Mark All"
+  // reads it and would persist marks for a query the user already replaced.
+  var _searchVer = 0;
 
   function markAllSearchResults() {
     if (!state.searchResults || !state.searchResults.results) return;
@@ -54,6 +59,7 @@
       clearTimeout(_searchTimer);
       var q = input.value.trim();
       if (q.length < 2) {
+        _searchVer++; // invalidate any in-flight response so it can't re-show
         hideSearchResults();
         return;
       }
@@ -88,7 +94,9 @@
 
   function doSearch(query) {
     state.searchQuery = query;
+    var reqVer = ++_searchVer;
     apiGet("api/search?q=" + encodeURIComponent(query)).then(function (data) {
+      if (reqVer !== _searchVer) return; // a newer query superseded this one
       if (!data || !data.ok) { _renderSearchError(); return; }
       // Merge client-side search of partial segments for the streaming participant
       if (state.streamingParticipant) {
@@ -102,7 +110,10 @@
       }
       state.searchResults = data;
       renderSearchResults(data);
-    }).catch(function () { _renderSearchError(); });
+    }).catch(function () {
+      if (reqVer !== _searchVer) return;
+      _renderSearchError();
+    });
   }
 
   function _searchPartialSegments(query, pid) {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -714,6 +714,12 @@
         _clearBootPlaceholders();
         return;
       }
+      // The page's boot fetch carries the live server config: in a
+      // transcripts-only session the cross-ref sheet fetch (the historical
+      // sole clipgenApplyConfig caller) never runs, leaving CLIPGEN_CONFIG on
+      // the hardcoded fallbacks — customized severity labels, friction
+      // categories, and hotkey rebinds would silently not apply here.
+      if (data.config) clipgenApplyConfig(data.config);
       state.participants = data.participants;
       state.hasSheet = !!data.has_sheet;
       state.transcribePrewarm = data.transcribe_prewarm || "queue_open";
@@ -1984,15 +1990,37 @@
   }
 
   function updateMarkLabel(markId, label) {
-    apiPut("api/marks/" + markId, { label: label || null });
     if (state.streamingParticipant) {
+      apiPut("api/marks/" + markId, { label: label || null }).catch(function () {
+        showToast("Failed to update mark");
+      });
       for (var key in _streamingMarks) {
         if (_streamingMarks[key].id === markId) {
           _streamingMarks[key].label = label || "";
           break;
         }
       }
+      return;
     }
+    // Mirror updateMarkCategory/Severity: write the state and repaint
+    // optimistically, restore on failure. Without the state write the badge
+    // never appears, reopening the popover shows the old label, and a later
+    // category/severity repaint resurrects it.
+    var found = _findSegmentByMarkId(markId);
+    if (!found) {
+      apiPut("api/marks/" + markId, { label: label || null }).catch(function () {
+        showToast("Failed to update mark");
+      });
+      return;
+    }
+    var prevLabel = found.mark.label;
+    found.mark.label = label || "";
+    _paintSegmentMark(found.idx, found.mark);
+    apiPut("api/marks/" + markId, { label: label || null }).catch(function () {
+      found.mark.label = prevLabel;
+      _paintSegmentMark(found.idx, found.mark);
+      showToast("Failed to update mark");
+    });
   }
 
   function updateMarkSeverity(markId, severity) {
@@ -2628,30 +2656,34 @@
     return apiPost("api/models/ollama/pull", { model: model }).then(function (data) {
       if (!data || !data.ok) return false;
       return new Promise(function (resolve) {
+        // createPoller, not a raw setInterval: the install dialog can sit
+        // open in a backgrounded tab for minutes, and this must pause with
+        // it instead of streaming 1 Hz requests at the server.
         var misses = 0;
-        var poll = setInterval(function () {
+        var poller = createPoller(function () {
           if (isCancelled && isCancelled()) {
-            clearInterval(poll);
+            poller.stop();
             resolve(false);
             return;
           }
           apiGet("api/models/ollama/pull-status?model=" + encodeURIComponent(model))
             .then(function (st) {
               if (!st || !st.ok || !st.found) {
-                if (++misses >= 20) { clearInterval(poll); resolve(false); }
+                if (++misses >= 20) { poller.stop(); resolve(false); }
                 return;
               }
               misses = 0;
               if (onProgress) onProgress(st);
               if (st.done) {
-                clearInterval(poll);
+                poller.stop();
                 resolve(!!st.succeeded);
               }
             })
             .catch(function () {
-              if (++misses >= 20) { clearInterval(poll); resolve(false); }
+              if (++misses >= 20) { poller.stop(); resolve(false); }
             });
-        }, 1000);
+        }, 1000, { runImmediately: true, label: "transcripts.ollamaPull" });
+        poller.start();
       });
     }).catch(function () { return false; });
   }
@@ -2666,30 +2698,32 @@
       if (!data || !data.ok) return false;
       if (data.already_installed) return true;
       return new Promise(function (resolve) {
+        // Same createPoller rationale as installOllamaModel above.
         var misses = 0;
-        var poll = setInterval(function () {
+        var poller = createPoller(function () {
           if (isCancelled && isCancelled()) {
-            clearInterval(poll);
+            poller.stop();
             resolve(false);
             return;
           }
           apiGet("api/models/ollama/install-status")
             .then(function (st) {
               if (!st || !st.ok || !st.found) {
-                if (++misses >= 20) { clearInterval(poll); resolve(false); }
+                if (++misses >= 20) { poller.stop(); resolve(false); }
                 return;
               }
               misses = 0;
               if (onProgress) onProgress(st);
               if (st.done) {
-                clearInterval(poll);
+                poller.stop();
                 resolve(!!st.succeeded);
               }
             })
             .catch(function () {
-              if (++misses >= 20) { clearInterval(poll); resolve(false); }
+              if (++misses >= 20) { poller.stop(); resolve(false); }
             });
-        }, 1000);
+        }, 1000, { runImmediately: true, label: "transcripts.ollamaInstall" });
+        poller.start();
       });
     }).catch(function () { return false; });
   }

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1563,7 +1563,10 @@
   // any write to invalidate renderPartialSegments' append-only fast path.
   var _streamingMarks = {};
   var _streamingMarksVersion = 0;
-  var _streamingMarksLoaded = false;
+  // Keyed by participant: a single boolean would make the first streaming
+  // participant's load swallow every later one's, leaving a second live
+  // stream's persisted marks unrendered until some task completed.
+  var _streamingMarksLoadedByPid = {};
 
   function _bumpStreamingMarksVersion() {
     _streamingMarksVersion++;
@@ -1571,8 +1574,8 @@
   }
 
   function _loadStreamingMarks(pid) {
-    if (_streamingMarksLoaded) return;
-    _streamingMarksLoaded = true;
+    if (_streamingMarksLoadedByPid[pid]) return;
+    _streamingMarksLoadedByPid[pid] = true;
     apiGet("api/marks").then(function (data) {
       if (!data.ok) return;
       if (data.categories) setMarkCategories(data.categories);
@@ -2064,6 +2067,10 @@
   }
 
   function showMarkPopover(anchorEl, segmentId, markObj) {
+    // A provisional mark (optimistic paint, POST still in flight) has no id
+    // yet — every popover action would hit api/marks/null. The POST resolves
+    // in well under a click-reopen, so just don't open for it.
+    if (markObj && markObj.id == null) return;
     var popover = qs("#markPopover");
     hideMarkPopover();
 
@@ -2472,7 +2479,7 @@
         // extending the grace window.
         _postCompletionGrace = POST_COMPLETION_GRACE_CYCLES;
         _streamingMarks = {};
-        _streamingMarksLoaded = false;
+        _streamingMarksLoadedByPid = {};
         _bumpStreamingMarksVersion();
       }
       if (needsRefresh) {
@@ -3564,6 +3571,7 @@
       // {"cancelled": true} / {"done": true} carry nothing — none has an
       // index, which is also what keeps them out of the completion tally.
       if (data.output_dir) outputDir = data.output_dir;
+      if (data.token) run.token = data.token; // echoed by Stop to scope the cancel
       if (data.done) sawDone = true;
       if (typeof data.index !== "number") return;
       run.done++;
@@ -3617,7 +3625,7 @@
     }
     // The server stops between files (a mux cannot be interrupted mid-copy), so
     // the abort just drops our end of a stream that is already winding down.
-    apiPost("api/embed-subtitles/cancel", {}).catch(function () {});
+    apiPost("api/embed-subtitles/cancel", { token: _embedSubsRun.token || null }).catch(function () {});
     _embedSubsRun.abort.abort();
   }
 
@@ -3932,6 +3940,7 @@
       if (!data) return;
       // The header and the trailing {"cancelled": true} / {"done": true} lines
       // carry no index, which is also what keeps them out of the tally.
+      if (data.token) run.token = data.token; // echoed by Stop to scope the cancel
       if (data.done) sawDone = true;
       if (typeof data.index !== "number") return;
       run.done++;
@@ -3998,7 +4007,7 @@
     // Unlike the embed run, the cancel event is threaded into ffmpeg itself, so
     // Stop interrupts the current file mid-encode; the abort just drops our end
     // of a stream that is already winding down.
-    apiPost("api/normalize-audio/cancel", {}).catch(function () {});
+    apiPost("api/normalize-audio/cancel", { token: _normAudioRun.token || null }).catch(function () {});
     _normAudioRun.abort.abort();
   }
 

--- a/source/friction.py
+++ b/source/friction.py
@@ -109,7 +109,10 @@ def _segment_score(
     is the deduped list of matched substrings, and counts maps each present
     category to its raw match count.
     """
-    word_count = max(len(text.split()), 1)
+    # Floor the denominator so one- and two-word interjections ("Oh.", "Um.")
+    # can't saturate at 1.0 and monopolise the candidate list ahead of longer
+    # segments with several genuine frustration markers.
+    word_count = max(len(text.split()), 8)
     counts: dict[str, int] = {}
     markers: list[str] = []
     seen_markers: set[str] = set()

--- a/source/ollama_client.py
+++ b/source/ollama_client.py
@@ -12,6 +12,7 @@ Deliberately small — higher-level reasoning lives in
 """
 
 import hashlib
+import http.client
 import json
 import os
 import shutil
@@ -105,7 +106,7 @@ def is_available() -> bool:
         req = urllib.request.Request(f"{config.OLLAMA_BASE_URL}/api/tags")
         with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT):
             return True
-    except (urllib.error.URLError, OSError, ValueError):
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
         return False
 
 
@@ -133,7 +134,13 @@ def list_models() -> list[dict[str, Any]] | None:
                     }
                 )
             return models
-    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+    except (
+        urllib.error.URLError,
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+        http.client.HTTPException,
+    ):
         return None
 
 
@@ -189,7 +196,7 @@ def unload_model(model: str) -> bool:
         with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT) as resp:
             resp.read()  # drain
             return True
-    except (urllib.error.URLError, OSError, ValueError):
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
         return False
 
 
@@ -317,7 +324,7 @@ def start_server() -> bool:
 
         utils.info_print("Starting Ollama server...")
         try:
-            subprocess.Popen(
+            proc = subprocess.Popen(
                 [resolve_ollama_bin() or "ollama", "serve"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -332,6 +339,16 @@ def start_server() -> bool:
             if is_available():
                 utils.info_print("Ollama server started.")
                 return True
+            # `serve` dying instantly (port already held, broken install)
+            # would otherwise burn the whole timeout with the lock held and
+            # report only a generic "did not start".
+            code = proc.poll()
+            if code is not None:
+                utils.warning_print(
+                    f"Ollama server exited immediately (code {code}) — "
+                    "is the port already in use?"
+                )
+                return False
             time.sleep(_START_POLL_INTERVAL)
 
     utils.warning_print("Ollama server did not start within timeout.")
@@ -689,6 +706,7 @@ def _do_generate(
     watcher: threading.Thread | None = None
     deadline = time.monotonic() + _GENERATE_DEADLINE
     deadline_exceeded = False
+    saw_done = False
     resp: Any = None
     try:
         resp = urllib.request.urlopen(req, timeout=_GENERATE_TIMEOUT)
@@ -714,7 +732,7 @@ def _do_generate(
                 return None
             try:
                 line = resp.readline()
-            except (OSError, ValueError, AttributeError):
+            except (OSError, ValueError, AttributeError, http.client.HTTPException):
                 # Raised when the watcher shuts down the socket mid-read, or
                 # when we shut it down above on deadline. http.client may
                 # surface this as AttributeError on Python 3.13+ when the
@@ -733,6 +751,8 @@ def _do_generate(
                 chunk = json.loads(line.decode("utf-8"))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 continue  # skip malformed lines, keep reading
+            if not isinstance(chunk, dict):
+                continue
             piece = chunk.get("response", "")
             if piece:
                 parts.append(piece)
@@ -742,6 +762,7 @@ def _do_generate(
                     except Exception as exc:
                         utils.verbose_print(f"Ollama on_token callback failed: {exc}")
             if chunk.get("done"):
+                saw_done = True
                 break
     finally:
         done_event.set()
@@ -759,6 +780,15 @@ def _do_generate(
             )
 
     if cancel_event is not None and cancel_event.is_set():
+        return None
+    if not saw_done:
+        # The stream ended (EOF) without a `done` chunk — Ollama restarted,
+        # was OOM-killed, or the connection dropped mid-generation. The
+        # accumulated text is a truncated prefix; returning it would commit a
+        # half-written result as a finished one.
+        utils.warning_print(
+            f"Ollama stream ended before completion (model: {body.get('model')})"
+        )
         return None
     text = "".join(parts).strip()
     if not text:
@@ -813,7 +843,7 @@ def generate(
     except urllib.error.HTTPError as exc:
         utils.warning_print(f"Ollama generate failed (HTTP {exc.code}): {exc.reason}")
         return None
-    except (urllib.error.URLError, OSError) as exc:
+    except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:
         if cancel_event is not None and cancel_event.is_set():
             return None
         if not _is_connection_refused(exc):
@@ -828,6 +858,7 @@ def generate(
             urllib.error.URLError,
             urllib.error.HTTPError,
             OSError,
+            http.client.HTTPException,
         ) as retry_exc:
             if cancel_event is not None and cancel_event.is_set():
                 return None
@@ -907,7 +938,7 @@ def pull_model(
     except urllib.error.HTTPError as exc:
         utils.warning_print(f"Ollama pull failed (HTTP {exc.code}): {exc.reason}")
         return False
-    except (urllib.error.URLError, OSError) as exc:
+    except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:
         if not _is_connection_refused(exc):
             utils.warning_print(f"Ollama pull failed (connection): {exc}")
             return False
@@ -916,6 +947,11 @@ def pull_model(
             return False
         try:
             return _do_pull(model, on_progress)
-        except (urllib.error.URLError, urllib.error.HTTPError, OSError) as retry_exc:
+        except (
+            urllib.error.URLError,
+            urllib.error.HTTPError,
+            OSError,
+            http.client.HTTPException,
+        ) as retry_exc:
             utils.warning_print(f"Ollama pull failed after retry: {retry_exc}")
             return False

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -2843,6 +2843,18 @@ def _init_screenspace_state(sheet_context: Any = None) -> None:
 
     global _manifest, _worker, _participant_source
 
+    # Retire the previous session's worker before touching any state: its
+    # callbacks resolve the module globals at call time, so left alive it
+    # would persist the old study's task results into the *new* study's
+    # manifest. Detach the callbacks and cancel first so the thread can only
+    # finish inertly; the short join keeps a swap request from blocking on an
+    # in-flight scan.
+    if _worker is not None:
+        _worker.on_task_complete = None
+        _worker.on_progress_update = None
+        _worker.cancel_all()
+        _worker.stop(join_timeout=2.0)
+
     _manifest = screenspace.load_screenspace_manifest()
     _backfill_missing_events(_manifest)
 

--- a/source/screenspace_worker.py
+++ b/source/screenspace_worker.py
@@ -313,12 +313,27 @@ class ScreenspaceWorker:
                     )
                 self._tasks[restored["id"]] = restored
 
-    def stop(self) -> None:
-        """Signal the worker thread to stop."""
+    def stop(self, join_timeout: float = 15) -> None:
+        """Signal the worker thread to stop.
+
+        *join_timeout* bounds the wait for the thread: shutdown can afford the
+        full default, while a sheet swap passes a short one — the thread is a
+        daemon and, once ``_running`` is False and the callbacks are detached,
+        it can only finish its current (cancelled) task and exit.
+        """
         self._running = False
         self._queue.put((0, "", _SENTINEL))
         if self._thread is not None:
-            self._thread.join(timeout=15)
+            self._thread.join(timeout=join_timeout)
+
+    def cancel_all(self) -> None:
+        """Cancel every queued, paused, or running task (used when the worker is retired)."""
+        with self._lock:
+            for task in self._tasks.values():
+                if task["status"] in (TASK_STATUS_QUEUED, TASK_STATUS_PAUSED):
+                    task["status"] = TASK_STATUS_CANCELLED
+                elif task["status"] == TASK_STATUS_RUNNING:
+                    task["_cancelled"] = True
 
     def enqueue(self, task: dict[str, Any]) -> str:
         """Add a task to the queue. Returns the task ID."""

--- a/source/server.py
+++ b/source/server.py
@@ -55,7 +55,6 @@ import os
 import queue
 import re
 import socket
-import string
 import sys
 import threading
 import time
@@ -1232,7 +1231,7 @@ def _coerce_studio_setting(name: str, value: Any) -> tuple[bool, Any, str | None
         return True, cleaned, None
     if stype == "prompt":
         text = str(value)
-        err = _validate_prompt(text, meta.get("placeholders") or [])
+        err = utils.validate_prompt(text, meta.get("placeholders") or [])
         if err is not None:
             return False, None, f"Invalid {name}: {err}"
         return True, text, None
@@ -2323,44 +2322,6 @@ def _settings_records() -> list[dict[str, Any]]:
             }
         )
     return records
-
-
-def _validate_prompt(text: str, placeholders: list[str]) -> str | None:
-    """Validate a user-edited thinking-agent prompt.
-
-    Returns an error string, or ``None`` if the prompt is safe to save. Prompts
-    that declare *placeholders* are ``.format()``-ed at runtime, so every
-    required placeholder must be present and the prompt must format cleanly with
-    exactly those keys. Prompts with no placeholders (the ``*_SYSTEM`` strings)
-    are sent to the model verbatim and accept any text.
-    """
-    if not placeholders:
-        return None
-    allowed = set(placeholders)
-    used: set[str] = set()
-    try:
-        for _literal, field_name, _spec, _conv in string.Formatter().parse(text):
-            if field_name:
-                # Strip any attribute/index access, e.g. "{a.b}" / "{a[0]}".
-                used.add(re.split(r"[.\[]", field_name, maxsplit=1)[0])
-    except (ValueError, IndexError):
-        return "unbalanced { } braces — escape literal braces as {{ and }}"
-    missing = allowed - used
-    if missing:
-        return "missing required placeholder(s): " + ", ".join(
-            "{" + p + "}" for p in sorted(missing)
-        )
-    # Ground truth: the prompt must .format() cleanly with exactly these keys.
-    # Catches unknown placeholders ({foo}), stray positional {}, and nested
-    # format-spec references the parse() scan above does not surface.
-    try:
-        text.format(**{p: "" for p in placeholders})
-    except (KeyError, IndexError, ValueError) as exc:
-        bad = exc.args[0] if exc.args else exc
-        return f"references an unknown placeholder ({bad}); allowed: " + ", ".join(
-            "{" + p + "}" for p in placeholders
-        )
-    return None
 
 
 def _apply_settings_payload(data: dict[str, Any]) -> tuple[dict[str, Any], str | None]:

--- a/source/thinking_agents.py
+++ b/source/thinking_agents.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import bisect
 import json
+import math
 import re
 import threading
 from collections.abc import Callable
@@ -238,14 +239,14 @@ def _find_closest_segment(
         return None
     pos = bisect.bisect_left(sorted_starts, target_seconds)
     best_pos: int | None = None
-    best_dist = tolerance + 1
+    best_dist = math.inf
     for candidate in (pos - 1, pos):
         if 0 <= candidate < len(sorted_starts):
             dist = abs(sorted_starts[candidate] - target_seconds)
             if dist < best_dist:
                 best_dist = dist
                 best_pos = candidate
-    if best_pos is None:
+    if best_pos is None or best_dist > tolerance:
         return None
     return sorted_indices[best_pos]
 
@@ -343,12 +344,30 @@ def find_citations(
         utils.warning_print("Citations: no response from the model")
         return None
 
-    parsed = _parse_citation_response(_strip_think(response), segments)
+    stripped = _strip_think(response)
+    if not _CITATION_LINE_RE.search(stripped):
+        # A non-empty response with zero lines in the expected "N: ts" shape
+        # (markdown bolding, "1." numbering, prose) is a parse failure, not
+        # "no sources exist" — committing a full list of empty refs would look
+        # identical to the latter in the UI. A response that *does* match the
+        # format but answers NONE everywhere still commits below.
+        utils.warning_print("Citations: response did not match the expected format")
+        return None
+    parsed = _parse_citation_response(stripped, segments)
 
     citations: list[dict[str, Any]] = []
     for i, sentence in enumerate(sentences):
         refs = sorted(parsed.get(i, []), key=lambda r: r["start"])
-        citations.append({"sentence": sentence, "refs": refs[:_MAX_REFS_PER_CLAIM]})
+        # The model may cite two timestamps that resolve to one segment;
+        # duplicates would eat the per-claim ref budget.
+        seen_segments: set[int] = set()
+        deduped: list[dict[str, Any]] = []
+        for ref in refs:
+            if ref["segment_index"] in seen_segments:
+                continue
+            seen_segments.add(ref["segment_index"])
+            deduped.append(ref)
+        citations.append({"sentence": sentence, "refs": deduped[:_MAX_REFS_PER_CLAIM]})
 
     total_refs = sum(len(c["refs"]) for c in citations)
     utils.verbose_print(
@@ -440,12 +459,20 @@ def _extract_json_array(text: str) -> list[Any]:
     def _is_object_array(data: Any) -> bool:
         return isinstance(data, list) and all(isinstance(x, dict) for x in data)
 
+    # Only a *non-empty* object array wins the scan — `[]` matches trivially,
+    # so an empty array anywhere before the payload ('{"moments": [], ...}')
+    # would otherwise end the search with zero results. A genuine empty array
+    # is remembered and returned only after nothing better turns up.
+    saw_empty_array = False
+
     fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", cleaned, re.DOTALL)
     if fence:
         try:
             data = json.loads(fence.group(1))
             if _is_object_array(data):
-                return data
+                if data:
+                    return data
+                saw_empty_array = True
         except json.JSONDecodeError:
             pass
 
@@ -455,11 +482,18 @@ def _extract_json_array(text: str) -> list[Any]:
         try:
             data, _ = decoder.raw_decode(cleaned[start:])
             if _is_object_array(data):
-                return data
+                if data:
+                    return data
+                saw_empty_array = True
         except json.JSONDecodeError:
             pass
         start = cleaned.find("[", start + 1)
 
+    if saw_empty_array:
+        # The model explicitly answered with an empty array — that IS the
+        # result; salvaging stray objects from surrounding prose would
+        # fabricate entries the model never returned.
+        return []
     return list(_extract_json_objects(cleaned))
 
 
@@ -471,7 +505,11 @@ def _format_friction_candidates(
     Context segments are merged into a single ordered, de-duplicated block so
     adjacent candidates don't repeat lines.
     """
-    id_to_idx = {seg.get("id"): i for i, seg in enumerate(segments)}
+    # Mirror friction.score_segments' id scheme exactly: it synthesizes
+    # str(index) for id-less segments (the Workflows path, where segments are
+    # never manifest-saved and so never get ids), and a lookup keyed on the
+    # raw id would drop every candidate there.
+    id_to_idx = {(seg.get("id") or str(i)): i for i, seg in enumerate(segments)}
     include: set[int] = set()
     for cand in candidates:
         idx = id_to_idx.get(cand.get("id"))
@@ -559,8 +597,9 @@ def find_friction_moments(
       - a list of moments (possibly empty) when the model responded — empty means
         it ran but found nothing,
       - ``[]`` when there are no candidates to send,
-      - ``None`` when the model call itself failed (unavailable / wrong model /
-        cancelled), so the caller can distinguish "no moments" from "didn't run".
+      - ``None`` when no model call was made or it failed (unavailable / wrong
+        model / cancelled / candidates that couldn't be rendered), so the
+        caller can distinguish "no moments" from "didn't run".
     """
     if not candidates:
         return []
@@ -569,7 +608,11 @@ def find_friction_moments(
 
     block = _format_friction_candidates(segments, candidates)
     if not block:
-        return []
+        # Candidates exist but none rendered (ids drifted after an edit, or
+        # every context segment is empty) — no model call was made, so this is
+        # "didn't run", not "ran and found nothing".
+        utils.warning_print("Friction: no candidate segments could be rendered")
+        return None
 
     prompt = config.OLLAMA_FRICTION_PROMPT.format(
         summary=_truncate_middle(summary, _MAX_FRICTION_SUMMARY_CHARS),
@@ -596,7 +639,7 @@ def find_friction_moments(
     # Keep only moments that cite at least one real segment, trimming any
     # hallucinated IDs. An unsourced moment can't be seeked to or quoted, so it
     # must never reach the manifest.
-    valid_ids = {seg.get("id") for seg in segments if seg.get("id")}
+    valid_ids = {(seg.get("id") or str(i)) for i, seg in enumerate(segments)}
     moments: list[dict[str, Any]] = []
     for moment in _parse_friction_response(response):
         kept = [sid for sid in moment["segment_ids"] if sid in valid_ids]

--- a/source/thinking_agents.py
+++ b/source/thinking_agents.py
@@ -758,12 +758,21 @@ def report_source_lines(participant: str) -> tuple[list[str], list[str]]:
     sheet-less launch) both lists come back empty and a report simply covers
     the summary alone. Shared by ``_run_report`` and the Workflows report node.
     """
-    obs_rows = _observation_rows_getter() if _observation_rows_getter else []
-    marks = (
-        _participant_marks_getter(participant)
-        if (_participant_marks_getter and participant)
-        else []
-    )
+    # Guard each getter so the documented "degrade to the sources that exist"
+    # holds for a *raising* source too — the sheet getter reaches Google's API
+    # and a network hiccup must cost that section, not the whole report.
+    obs_rows: list[dict[str, Any]] = []
+    if _observation_rows_getter:
+        try:
+            obs_rows = _observation_rows_getter()
+        except Exception as exc:
+            utils.warning_print(f"Report: sheet observations unavailable: {exc}")
+    marks: list[dict[str, Any]] = []
+    if _participant_marks_getter and participant:
+        try:
+            marks = _participant_marks_getter(participant)
+        except Exception as exc:
+            utils.warning_print(f"Report: transcript marks unavailable: {exc}")
     return (
         _format_report_observations(obs_rows, participant),
         _format_report_marks(marks),

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -1119,7 +1119,10 @@ def save_transcripts_manifest(
             config.TRANSCRIPTS_MANIFEST_FILENAME,
             default=_empty_transcripts_manifest(),
         )
-        marks = existing["marks"]
+        # .get like every other reader: load_json_manifest returns the raw
+        # parsed JSON (the default is whole-file, not per-key), and a KeyError
+        # here would silently kill the debounce timer thread.
+        marks = existing.get("marks", [])
 
     data = {
         "source_transcripts": source_transcripts,
@@ -1156,16 +1159,27 @@ def apply_corrections(
     """Apply corrections to transcript segments as post-processing.
 
     Returns a new list of segments with ``from -> to`` substitutions applied.
-    Never mutates the input. Case-insensitive, word-boundary matching.
+    Never mutates the input. Case-insensitive, word-boundary matching — a
+    ``"the" -> "they"`` correction must not rewrite "there" — with the
+    replacement inserted literally (a backslash in *to* is text, not a
+    ``re.sub`` template escape).
     """
     if not corrections:
         return list(segments)
 
-    pairs = [
-        (re.compile(re.escape(c["from"]), re.IGNORECASE), c["to"])
-        for c in corrections
-        if c.get("from") and c.get("to")
-    ]
+    pairs: list[tuple[re.Pattern[str], str]] = []
+    for c in corrections:
+        frm, to = c.get("from"), c.get("to")
+        if not frm or not to:
+            continue
+        # Anchor with \b only where the pattern edge is a word character —
+        # "\b" against punctuation would never match ("e.g." or "?!").
+        pattern = re.escape(frm)
+        if frm[0].isalnum() or frm[0] == "_":
+            pattern = r"\b" + pattern
+        if frm[-1].isalnum() or frm[-1] == "_":
+            pattern = pattern + r"\b"
+        pairs.append((re.compile(pattern, re.IGNORECASE), to))
     if not pairs:
         return list(segments)
 
@@ -1175,7 +1189,7 @@ def apply_corrections(
         text = seg["text"]
         seg_applied = 0
         for pattern, to_text in pairs:
-            new_text, count = pattern.subn(to_text, text)
+            new_text, count = pattern.subn(lambda _m, _to=to_text: _to, text)
             if count > 0:
                 text = new_text
                 seg_applied += count

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -373,16 +373,6 @@ def _load_model(model_name: str | None = None) -> Any:
             )
             return None
 
-        # Drop the previous model first, or ~1-2 GB of weights is double-held
-        # until the next GC cycle; gc.collect() also prods CUDA/MPS cleanup.
-        if _cached_model is not None:
-            import gc
-
-            _cached_model = None
-            _cached_model_name = None
-            _cached_model_key = None
-            gc.collect()
-
         def _do_load() -> Any:
             # Built from load_key, not re-read from config, so what is cached
             # is exactly what was constructed even if a setting changes while
@@ -414,6 +404,20 @@ def _load_model(model_name: str | None = None) -> Any:
         try:
             if not _confirm_model_download(model_name):
                 return None
+
+            # Drop the previous model only once the load is definitely
+            # happening (post-consent), or ~1-2 GB of weights is double-held
+            # until the next GC cycle; gc.collect() also prods CUDA/MPS
+            # cleanup. Evicting before the consent prompt left the cache empty
+            # when the user declined, costing a pointless reload of the model
+            # that was already warm.
+            if _cached_model is not None:
+                import gc
+
+                _cached_model = None
+                _cached_model_name = None
+                _cached_model_key = None
+                gc.collect()
 
             utils.info_print(f"Loading transcription model '{model_name}'...")
             _cached_model = utils.run_with_spinner(
@@ -1433,8 +1437,10 @@ def _vtt_time_to_seconds(ts: str) -> float:
     return 0.0
 
 
-def _md_time_to_seconds(ts: str) -> float:
-    return utils.timestamp_to_seconds(ts) or 0.0
+def _md_time_to_seconds(ts: str) -> float | None:
+    """Parse a Markdown transcript stamp; None on failure — never a fabricated
+    0.0, which reads as a valid segment start at the top of the recording."""
+    return utils.timestamp_to_seconds(ts)
 
 
 def _parse_srt(text: str, filepath: str) -> TranscriptResult:
@@ -1480,10 +1486,20 @@ def _parse_markdown(text: str, filepath: str) -> TranscriptResult:
         model = model_match.group(1)
 
     for match in _MD_SEGMENT.finditer(text):
+        start = _md_time_to_seconds(match.group(1))
+        end = _md_time_to_seconds(match.group(2))
+        if start is None or end is None:
+            # Hand-edited / third-party stamp the parser can't read (e.g.
+            # "0:00.5"): skip loudly rather than fabricate a 0:00 segment.
+            utils.warning_print(
+                f"Skipping transcript line with unparseable timestamp: "
+                f"{match.group(1)} - {match.group(2)}"
+            )
+            continue
         segments.append(
             TranscriptSegment(
-                start=_md_time_to_seconds(match.group(1)),
-                end=_md_time_to_seconds(match.group(2)),
+                start=start,
+                end=end,
                 text=match.group(3).strip(),
             )
         )

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -1561,19 +1561,27 @@ class TranscriptWorker:
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
-    def stop(self) -> None:
-        """Signal the worker thread to stop."""
+    def stop(self, join_timeout: float = 15) -> None:
+        """Signal the worker thread to stop.
+
+        *join_timeout* bounds the wait for the thread: shutdown can afford the
+        full default, while a sheet swap passes a short one — the thread is a
+        daemon and, once ``_running`` is False and the callbacks are detached,
+        it can only finish its current (cancelled) task and exit.
+        """
         self._running = False
         self._queue.put((0, _TRANSCRIPT_SENTINEL))
         if self._thread is not None:
-            self._thread.join(timeout=15)
+            self._thread.join(timeout=join_timeout)
 
-    def restore_tasks(self, tasks: list[dict[str, Any]]) -> None:
-        """Load historical tasks (completed/failed/cancelled) for display."""
+    def cancel_all(self) -> None:
+        """Cancel every queued or running task (used when the worker is retired)."""
         with self._lock:
-            for t in tasks:
-                if t.get("id"):
-                    self._tasks[t["id"]] = copy.deepcopy(t)
+            for task in self._tasks.values():
+                if task["status"] == TASK_STATUS_QUEUED:
+                    task["status"] = TASK_STATUS_CANCELLED
+                elif task["status"] == TASK_STATUS_RUNNING:
+                    task["_cancelled"] = True
 
     def enqueue(self, task: dict[str, Any]) -> str:
         """Add a task to the queue. Returns the task ID."""

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -2166,7 +2166,10 @@ def _merge_completed_results_locked() -> list[str]:
     if not _worker:
         return []
     merged_pids: list[str] = []
-    for task in _worker.get_all_tasks():
+    # include_partials=False: the merge only needs status/result, and the full
+    # copy would deep-copy the in-flight task's growing partial_segments tail
+    # on every debounced persist — all while holding _manifest_lock.
+    for task in _worker.get_all_tasks(include_partials=False):
         if (
             task["status"] == transcripts.TASK_STATUS_COMPLETED
             and task.get("result")
@@ -2179,7 +2182,6 @@ def _merge_completed_results_locked() -> list[str]:
             src[pid] = existing
             _merged_task_ids.add(task["id"])
             merged_pids.append(pid)
-    _manifest["tasks"] = _worker.get_all_tasks()
     # Queue the completion side effects for _on_task_complete no matter which
     # caller performed the merge (a debounced _do_persist can win the race).
     _pending_chain_pids.extend(merged_pids)
@@ -2360,6 +2362,28 @@ class AgentOrchestrator:
         if event is not None:
             event.set()
         return True
+
+    def stop_all(self) -> None:
+        """Abort every in-flight run across all agents (used on sheet swap).
+
+        The cancel events gate the commit step in ``run_agent``, so a run that
+        finishes after this returns discards its result instead of writing it
+        into the freshly-swapped manifest.
+        """
+        events: list[threading.Event] = []
+        with self._lock:
+            for agent_key, pids in self._in_flight.items():
+                for participant in pids:
+                    event = self._cancel_events.get(agent_key, {}).get(participant)
+                    if event is not None:
+                        events.append(event)
+                pids.clear()
+                self._started_at.get(agent_key, {}).clear()
+        with self._partial_lock:
+            for per_agent in self._partial.values():
+                per_agent.clear()
+        for event in events:
+            event.set()
 
     def next_eligible(
         self,
@@ -2577,6 +2601,18 @@ def _init_transcripts_state(sheet_context: Any = None) -> None:
     """
     global _manifest, _worker, _participant_source
 
+    # Retire the previous session's background work before touching any state:
+    # a lingering worker thread or agent run resolves the module globals at
+    # call time, so left alive it would merge the old study's segments and
+    # agent results into the *new* study's manifest. Detach the callback and
+    # cancel first so the thread can only finish inertly; the short join keeps
+    # a swap request from blocking on an in-flight Whisper segment.
+    if _worker is not None:
+        _worker.on_task_complete = None
+        _worker.cancel_all()
+        _worker.stop(join_timeout=2.0)
+    _orchestrator.stop_all()
+
     _manifest = transcripts.load_transcripts_manifest()
     _merged_task_ids.clear()
     _pending_chain_pids.clear()
@@ -2587,13 +2623,6 @@ def _init_transcripts_state(sheet_context: Any = None) -> None:
 
     _worker = transcripts.TranscriptWorker()
     _worker.on_task_complete = _on_task_complete
-    _worker.restore_tasks(_manifest.get("tasks", []))
-    # Restored completed tasks already have their segments saved in the manifest
-    # (possibly with later edits); seed the merged set so a startup persist does
-    # not re-apply their frozen results over those segments.
-    for task in _worker.get_all_tasks():
-        if task["status"] == transcripts.TASK_STATUS_COMPLETED and task.get("result"):
-            _merged_task_ids.add(task["id"])
     _worker.start()
 
     # Reclaim a stale empty manifest left by a prior abandoned session: the

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -209,7 +209,10 @@ def _invalidate_dependents(entry: dict[str, Any], agent: thinking_agents.Agent) 
     ``_manifest_lock``.
     """
     for dep in thinking_agents.AGENTS:
-        if agent["manifest_field"] not in dep["depends_on"]:
+        # depends_on holds agent *keys* (the convention every reader now
+        # shares); the four built-ins have key == manifest_field, which is
+        # what let a field-based check here pass by accident.
+        if agent["key"] not in dep["depends_on"]:
             continue
         if dep.get("on_upstream_change") == "stale":
             _mark_friction_stale(entry)  # only the friction shape has a stale flag
@@ -1137,7 +1140,7 @@ def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
     if result:
         resp: dict[str, Any] = {"ok": True, field: result}
         for dep in thinking_agents.AGENTS:
-            if field in dep["depends_on"]:
+            if agent_key in dep["depends_on"]:  # depends_on holds agent keys
                 dep_field = dep["manifest_field"]
                 generating = _orchestrator.is_generating(participant, dep["key"])
                 resp[f"{dep_field}_generating"] = generating
@@ -1186,6 +1189,14 @@ def api_agent_regenerate(agent_key: str, participant: str) -> FlaskResponse:
         return jsonify({"ok": False}), 404
     if _orchestrator.is_generating(participant, agent_key):
         return ok(generating=True)
+    # Abort in-flight dependents *before* clearing their fields: a citations
+    # run computed from the summary being discarded would otherwise commit
+    # after the clear, sit on the entry looking current, and block the fresh
+    # chain from ever re-running it. (stop acquires _manifest_lock, so it
+    # cannot live inside the block below.)
+    for dep in thinking_agents.AGENTS:
+        if agent_key in dep["depends_on"]:
+            _orchestrator.stop(dep["key"], participant)
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if (
@@ -2295,6 +2306,19 @@ def _on_task_complete() -> None:
         _merge_completed_results_locked()
         merged_pids = list(dict.fromkeys(_pending_chain_pids))
         _pending_chain_pids.clear()
+
+    # Abort any agent runs still in flight for the merged participants: they
+    # were computed from the *old* transcript, and left alive they'd commit
+    # after the clear below — an old-transcript summary would then read as
+    # current and the chain would advance from it. Stop first, clear second:
+    # a run that commits before its stop lands is wiped by the clear, and one
+    # stopped here can no longer commit (the cancel event gates the write).
+    # (stop acquires _manifest_lock, so it cannot live inside either block.)
+    for pid in merged_pids:
+        for agent in thinking_agents.AGENTS:
+            _orchestrator.stop(agent["key"], pid)
+
+    with _manifest_lock:
         src = _manifest.get("source_transcripts", {})
         for pid in merged_pids:
             entry = src.get(pid)

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -499,7 +499,8 @@ def api_edit_segment(participant: str) -> FlaskResponse:
         return err("Missing JSON body")
 
     segment_id = data.get("segment_id", "")
-    new_text = data.get("text", "").strip()
+    text_raw = data.get("text", "")
+    new_text = text_raw.strip() if isinstance(text_raw, str) else ""
     if not segment_id or not new_text:
         return err("segment_id and text required")
 
@@ -809,7 +810,15 @@ def api_embed_subtitles() -> FlaskResponse:
         cancel_flag = _embed_cancel_event.is_set
         try:
             yield (
-                json.dumps({"total": len(participants), "output_dir": str(output_dir)})
+                json.dumps(
+                    {
+                        "total": len(participants),
+                        "output_dir": str(output_dir),
+                        # The client echoes this in /cancel so a late cancel
+                        # POST for this run can never stop a successor run.
+                        "token": embed_token,
+                    }
+                )
                 + "\n"
             )
             # Sequential on purpose: every mux is a whole-file stream copy, so
@@ -852,8 +861,17 @@ def api_embed_subtitles() -> FlaskResponse:
 
 @transcripts_bp.route("/api/embed-subtitles/cancel", methods=["POST"])
 def api_embed_subtitles_cancel() -> FlaskResponse:
-    """Stop the in-flight embed run once the current file finishes."""
-    _embed_cancel_event.set()
+    """Stop the in-flight embed run once the current file finishes.
+
+    Scoped by the run token from the stream's header line: a cancel POST that
+    arrives after its own run released the slot (user stops run 1 and starts
+    run 2 immediately) must not cancel the successor.
+    """
+    data = request.get_json(silent=True) or {}
+    token = data.get("token")
+    with _embed_lock:
+        if _embed_busy and token == _embed_owner:
+            _embed_cancel_event.set()
     return ok()
 
 
@@ -1048,7 +1066,10 @@ def api_normalize_audio() -> FlaskResponse:
     def stream() -> Iterator[str]:
         cancel_flag = _normalize_cancel_event.is_set
         try:
-            yield json.dumps({"total": len(participants)}) + "\n"
+            yield (
+                json.dumps({"total": len(participants), "token": normalize_token})
+                + "\n"
+            )
             # Sequential on purpose: each rewrite reads and rewrites a whole
             # source file, so concurrency only contends for the same disk.
             for idx, pid in enumerate(participants):
@@ -1079,8 +1100,15 @@ def api_normalize_audio() -> FlaskResponse:
 
 @transcripts_bp.route("/api/normalize-audio/cancel", methods=["POST"])
 def api_normalize_audio_cancel() -> FlaskResponse:
-    """Stop the in-flight normalize run, interrupting the current file."""
-    _normalize_cancel_event.set()
+    """Stop the in-flight normalize run, interrupting the current file.
+
+    Token-scoped like the embed cancel above.
+    """
+    data = request.get_json(silent=True) or {}
+    token = data.get("token")
+    with _normalize_lock:
+        if _normalize_busy and token == _normalize_owner:
+            _normalize_cancel_event.set()
     return ok()
 
 
@@ -1293,7 +1321,8 @@ def api_summary_stream(participant: str) -> FlaskResponse:
 def api_summary_save(participant: str) -> FlaskResponse:
     """Save a user-edited summary for a participant."""
     data = request.get_json(silent=True)
-    if not data or not data.get("summary", "").strip():
+    summary_raw = (data or {}).get("summary", "")
+    if not isinstance(summary_raw, str) or not summary_raw.strip():
         return err("Summary text is required")
     summary_agent = thinking_agents.get_agent("summary")
     assert summary_agent is not None  # built-in agent, always registered
@@ -1301,7 +1330,7 @@ def api_summary_save(participant: str) -> FlaskResponse:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         if not entry:
             return err("Participant not found", 404)
-        entry["summary"] = data["summary"].strip()
+        entry["summary"] = summary_raw.strip()
         # An edited summary feeds every downstream agent: clear citations and
         # the report, flag friction stale — same invalidation as the summary
         # regenerate route.
@@ -1347,7 +1376,7 @@ def api_corrections_add() -> FlaskResponse:
                 break
 
         if chained:
-            if chained["from"].lower() == to_text.lower():
+            if chained.get("from", "").lower() == to_text.lower():
                 corrections.remove(chained)
                 removed_id = chained["id"]
                 correction = None
@@ -1573,7 +1602,7 @@ def api_marks_add() -> FlaskResponse:
     created = []
     with _manifest_lock:
         marks = _manifest.setdefault("marks", [])
-        existing_by_seg = {m["segment_id"]: m for m in marks}
+        existing_by_seg = {m.get("segment_id", ""): m for m in marks}
 
         for sid in segment_ids:
             if sid in existing_by_seg:

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -282,16 +282,6 @@ def api_participants() -> FlaskResponse:
             has_transcript = bool(entry.get("segments"))
             video_paths = p["video_paths"]
             first_path = video_paths[0]
-            # Combine every part's mtime so the frontend cache-bust (?v=) on any
-            # part URL invalidates when a non-first part is replaced too.
-            video_version: int | None = None
-            if p["has_video"]:
-                try:
-                    video_version = sum(
-                        Path(vp).stat().st_mtime_ns for vp in video_paths
-                    )
-                except OSError:
-                    video_version = None
             info: dict[str, Any] = {
                 "id": pid,
                 "video_path": first_path,
@@ -303,7 +293,8 @@ def api_participants() -> FlaskResponse:
                 "segment_count": len(entry.get("segments", [])),
                 "video_filename": Path(first_path).name,
                 "video_filenames": [Path(vp).name for vp in video_paths],
-                "video_version": video_version,
+                # Filled outside the lock below (stat/probe I/O).
+                "video_version": None,
                 "agents": {
                     "transcription": _step_state_transcription(entry),
                     "summary": _step_state_agent(pid, entry, "summary"),
@@ -312,20 +303,6 @@ def api_participants() -> FlaskResponse:
                     "report": _step_state_agent(pid, entry, "report"),
                 },
             }
-            # Multi-video: expose the timeline so the frontend can switch <video>
-            # source per part and seek the local offset. Omitted for a single video
-            # (no probe), leaving the frontend on its one-file path.
-            if p["has_video"] and len(video_paths) >= 2:
-                timeline = video.timeline_or_none(video_paths)
-                if timeline is not None:
-                    info["timeline"] = [
-                        {
-                            "filename": Path(path).name,
-                            "duration": dur,
-                            "cumulativeStart": cum,
-                        }
-                        for path, dur, cum in timeline
-                    ]
             if has_transcript:
                 info["language"] = entry.get("language", "")
                 info["model"] = entry.get("model", "")
@@ -336,6 +313,36 @@ def api_participants() -> FlaskResponse:
                 info["audio_track_label"] = entry.get("audio_track_label", "")
                 info["has_summary"] = bool(entry.get("summary"))
             result.append(info)
+
+    # Per-file stat()s and the (ffprobe-backed on a cache miss) multi-part
+    # timeline probe run after the lock is released — this I/O previously
+    # blocked every other route for the duration of the probes.
+    for info in result:
+        if not info["has_video"]:
+            continue
+        video_paths = info["video_paths"]
+        # Combine every part's mtime so the frontend cache-bust (?v=) on any
+        # part URL invalidates when a non-first part is replaced too.
+        try:
+            info["video_version"] = sum(
+                Path(vp).stat().st_mtime_ns for vp in video_paths
+            )
+        except OSError:
+            info["video_version"] = None
+        # Multi-video: expose the timeline so the frontend can switch <video>
+        # source per part and seek the local offset. Omitted for a single video
+        # (no probe), leaving the frontend on its one-file path.
+        if len(video_paths) >= 2:
+            timeline = video.timeline_or_none(video_paths)
+            if timeline is not None:
+                info["timeline"] = [
+                    {
+                        "filename": Path(path).name,
+                        "duration": dur,
+                        "cumulativeStart": cum,
+                    }
+                    for path, dur, cum in timeline
+                ]
 
     # Check for stale artifacts (transcript outdated relative to source)
     artifacts = viewer.load_manifest_artifacts()
@@ -398,10 +405,21 @@ def _corrected_segments(
     participant: str,
     raw_segments: list[Any],
     corrections: list[Any],
+    version: int | None = None,
 ) -> list[Any]:
-    """apply_corrections() for *participant*, memoized by corrections version."""
+    """apply_corrections() for *participant*, memoized by corrections version.
+
+    *version* is the ``_corrections_version`` the caller observed when it
+    snapshotted *raw_segments*/*corrections* under ``_manifest_lock``. Passing
+    it keys the memo to that snapshot generation: without it, a reader whose
+    snapshot predates a segment-list replacement could be served an entry a
+    *newer* snapshot cached under the current version and zip mismatched
+    lists. Callers that invoke this while still holding ``_manifest_lock`` may
+    omit it (their snapshot is by construction the current generation).
+    """
     with _corrected_cache_lock:
-        version = _corrections_version
+        if version is None:
+            version = _corrections_version
         cached = _corrected_cache.get(participant)
         if cached is not None and cached[0] == version:
             return cached[1]
@@ -428,9 +446,12 @@ def api_transcript(participant: str) -> FlaskResponse:
         language = entry.get("language", "")
         model = entry.get("model", "")
         transcribed_at = entry.get("transcribed_at", "")
+        version_snapshot = _corrections_version
 
     # Apply corrections to get corrected text (memoized per participant)
-    corrected_segments = _corrected_segments(participant, raw_segments, corrections)
+    corrected_segments = _corrected_segments(
+        participant, raw_segments, corrections, version=version_snapshot
+    )
 
     # Build marks-by-segment-id lookup
     marks_by_seg: dict[str, list[dict[str, Any]]] = {}
@@ -525,9 +546,13 @@ def api_vtt(participant: str) -> FlaskResponse:
         language = entry.get("language", "")
         source_file = entry.get("source_file", "")
         model = entry.get("model", "")
+        version_snapshot = _corrections_version
 
     corrected = _corrected_segments(
-        participant, segments_snapshot, corrections_snapshot
+        participant,
+        segments_snapshot,
+        corrections_snapshot,
+        version=version_snapshot,
     )
     result = transcripts.TranscriptResult(
         segments=corrected,
@@ -651,6 +676,7 @@ def _embed_subtitle_for_participant(
         language = entry.get("language", "")
         source_file = entry.get("source_file", "")
         model = entry.get("model", "")
+        version_snapshot = _corrections_version
 
     video_paths = _video_paths_for_participant(participant)
     if not video_paths or not Path(video_paths[0]).is_file():
@@ -670,7 +696,10 @@ def _embed_subtitle_for_participant(
     video_path = video_paths[0]
 
     corrected = _corrected_segments(
-        participant, segments_snapshot, corrections_snapshot
+        participant,
+        segments_snapshot,
+        corrections_snapshot,
+        version=version_snapshot,
     )
     result = transcripts.TranscriptResult(
         segments=corrected,
@@ -1056,9 +1085,13 @@ def api_normalize_audio_cancel() -> FlaskResponse:
 
 
 def _deterministic_friction(
-    agent_key: str, entry: dict[str, Any] | None
+    agent_key: str, segments: list[dict[str, Any]]
 ) -> dict[str, Any] | None:
     """The friction payload that needs no summary and no LLM, or None.
+
+    *segments* must be a snapshot taken under ``_manifest_lock`` — the scorer
+    iterates the whole list, and the live entry's list can be rebound by a
+    concurrent merge mid-scan.
 
     Friction's per-segment scores + session stats come from a pure, deterministic
     scorer (friction.py). They are served both *before* the summary-gated agent
@@ -1067,9 +1100,8 @@ def _deterministic_friction(
     ``deterministic`` flag lets the client show programmatic-only copy and keeps
     the friction poll from mistaking this for a completed run.
     """
-    if agent_key != "friction" or not entry or not entry.get("segments"):
+    if agent_key != "friction" or not segments:
         return None
-    segments = entry["segments"]
     scored = friction.score_segments(segments)
     stats = friction.compute_stats(scored, thinking_agents._segments_duration(segments))
     return {
@@ -1101,6 +1133,7 @@ def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
     with _manifest_lock:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         result = entry.get(field) if entry else None
+        segments_snapshot = list(entry.get("segments") or []) if entry else []
     if result:
         resp: dict[str, Any] = {"ok": True, field: result}
         for dep in thinking_agents.AGENTS:
@@ -1125,11 +1158,11 @@ def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
         # on the LLM. Any client refetch mid-run (tab refocus, participant
         # re-select, page reload) would otherwise blank the histogram, chips,
         # transcript tinting and timeline band until the agent finished.
-        deterministic = _deterministic_friction(agent_key, entry)
+        deterministic = _deterministic_friction(agent_key, segments_snapshot)
         if deterministic is not None:
             resp["friction"] = deterministic
         return jsonify(resp)
-    deterministic = _deterministic_friction(agent_key, entry)
+    deterministic = _deterministic_friction(agent_key, segments_snapshot)
     if deterministic is not None:
         return jsonify({"ok": True, "friction": deterministic})
     return jsonify({"ok": False}), 404
@@ -1627,33 +1660,42 @@ def api_search() -> FlaskResponse:
     results: list[dict[str, Any]] = []
     counts: dict[str, int] = {}
 
+    # Snapshot every participant's segment list (and the corrections) under
+    # the lock, then run the regex correction pass and build the payload
+    # against the snapshots — on a cache miss that pass covers every
+    # participant's entire transcript and must not stall every other route.
     with _manifest_lock:
         src = _manifest.get("source_transcripts", {})
-        corrections = _manifest.get("corrections", [])
+        corrections = list(_manifest.get("corrections", []))
+        version_snapshot = _corrections_version
+        segment_snapshots = {
+            pid: list(entry["segments"])
+            for pid, entry in src.items()
+            if entry.get("segments")
+        }
 
-        for pid, entry in src.items():
-            raw_segments = entry.get("segments", [])
-            if not raw_segments:
-                continue
-            corrected = _corrected_segments(pid, raw_segments, corrections)
-            participant_count = 0
-            for raw, seg in zip(raw_segments, corrected):
-                text_lower = seg["text"].lower()
-                n = text_lower.count(query_lower)
-                if n > 0:
-                    participant_count += n
-                    results.append(
-                        {
-                            "participant": pid,
-                            "segment_id": raw.get("id", ""),
-                            "start": seg["start"],
-                            "end": seg["end"],
-                            "text": seg["text"],
-                            "count": n,
-                        }
-                    )
-            if participant_count > 0:
-                counts[pid] = participant_count
+    for pid, raw_segments in segment_snapshots.items():
+        corrected = _corrected_segments(
+            pid, raw_segments, corrections, version=version_snapshot
+        )
+        participant_count = 0
+        for raw, seg in zip(raw_segments, corrected):
+            text_lower = seg["text"].lower()
+            n = text_lower.count(query_lower)
+            if n > 0:
+                participant_count += n
+                results.append(
+                    {
+                        "participant": pid,
+                        "segment_id": raw.get("id", ""),
+                        "start": seg["start"],
+                        "end": seg["end"],
+                        "text": seg["text"],
+                        "count": n,
+                    }
+                )
+        if participant_count > 0:
+            counts[pid] = participant_count
 
     total = sum(counts.values())
     return ok(

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -1369,23 +1369,17 @@ def _resolve_mark(
             "text": "",
         }
     pid, idx_str = parts
-    try:
-        idx = int(idx_str)
-    except ValueError:
-        return {
-            **mark,
-            "valid": False,
-            "participant": pid,
-            "start": 0,
-            "end": 0,
-            "text": "",
-        }
 
-    # Try persisted transcript first
+    # Try the persisted transcript first, resolving by the segment's stable id
+    # — never by the numeric suffix. Ids are assigned once at save and never
+    # rewritten, so a mark keeps pointing at the same segment even when later
+    # segments are added or edited; indexing by position would silently
+    # re-point every mark after any change to the list.
     src = _manifest.get("source_transcripts", {})
     entry = src.get(pid, {})
     segments = entry.get("segments", [])
-    if 0 <= idx < len(segments):
+    idx = next((i for i, s in enumerate(segments) if s.get("id") == seg_id), None)
+    if idx is not None:
         corrections = _manifest.get("corrections", [])
         # Correct the whole participant list once (memoized by corrections
         # version) instead of recompiling the regex set per mark.
@@ -1400,11 +1394,17 @@ def _resolve_mark(
             "text": seg["text"],
         }
 
-    # Fall back to partial segments from a running transcription task
+    # Fall back to partial segments from a running transcription task. Partials
+    # carry no id fields (ids are minted at manifest save), so the streaming
+    # frontend derives "{pid}:{index}" positionally and the suffix is an index.
     if partial_lookup:
         partial_segs = partial_lookup.get(pid, [])
-        if 0 <= idx < len(partial_segs):
-            seg = partial_segs[idx]
+        try:
+            partial_idx = int(idx_str)
+        except ValueError:
+            partial_idx = -1
+        if 0 <= partial_idx < len(partial_segs):
+            seg = partial_segs[partial_idx]
             return {
                 **mark,
                 "valid": True,
@@ -2178,6 +2178,20 @@ def _merge_completed_results_locked() -> list[str]:
             pid = task["participant"]
             src = _manifest.setdefault("source_transcripts", {})
             existing = src.get(pid, {})
+            if existing.get("segments"):
+                # A re-transcription replaces the segment list wholesale, and
+                # the fresh save will mint the same "{pid}:{index}" ids again —
+                # so marks made against the old transcript would re-point at
+                # whatever now sits under the same id. Drop them, keeping only
+                # marks created after this run started (streaming-era marks on
+                # the new transcript).
+                task_started = task.get("created_at") or ""
+                _manifest["marks"] = [
+                    m
+                    for m in _manifest.get("marks", [])
+                    if (m.get("segment_id") or "").split(":", 1)[0] != pid
+                    or (m.get("created") or "") >= task_started
+                ]
             existing.update(task["result"])
             src[pid] = existing
             _merged_task_ids.add(task["id"])

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -373,10 +373,15 @@ def api_participants() -> FlaskResponse:
 
     # ``has_sheet`` gates the off-sheet badge: with no sheet every entry is
     # ``in_sheet: False``, and marking them all would be noise.
+    # ``config`` rides along because this is the page's boot fetch: in a
+    # transcripts-only session nothing else delivers get_frontend_config(),
+    # leaving the page on utils.js' hardcoded fallbacks (customized severity
+    # labels, friction categories, and hotkey rebinds silently ignored).
     return ok(
         participants=result,
         has_sheet=bool(_participant_source and _participant_source["sheet_context"]),
         transcribe_prewarm=_transcribe_prewarm_setting(),
+        config=utils.get_frontend_config(),
     )
 
 

--- a/source/utils.py
+++ b/source/utils.py
@@ -6,7 +6,9 @@ import functools
 import json
 import math
 import os
+import re
 import shutil
+import string
 import subprocess
 import sys
 import threading
@@ -2146,9 +2148,57 @@ def set_program_settings() -> bool:
         error_print(f"Invalid value '{new_raw}' for type {current_type.__name__}")
         return False
 
+    # Prompt-typed settings are .format()-ed at agent runtime; an unvalidated
+    # edit here (unlike the Settings-modal PUT, which validates) would only
+    # surface as a KeyError inside the next agent run.
+    meta = config.STUDIO_SETTINGS.get(setting_name) or {}
+    if meta.get("type") == "prompt":
+        prompt_err = validate_prompt(str(converted), meta.get("placeholders") or [])
+        if prompt_err is not None:
+            error_print(f"Invalid prompt: {prompt_err}")
+            return False
+
     setattr(config, setting_name, converted)
     info_print(f"  '{setting_name}' set to {converted!r}")
     return True
+
+
+def validate_prompt(text: str, placeholders: list[str]) -> str | None:
+    """Validate a user-edited thinking-agent prompt.
+
+    Returns an error string, or ``None`` if the prompt is safe to save. Prompts
+    that declare *placeholders* are ``.format()``-ed at runtime, so every
+    required placeholder must be present and the prompt must format cleanly with
+    exactly those keys. Prompts with no placeholders (the ``*_SYSTEM`` strings)
+    are sent to the model verbatim and accept any text.
+    """
+    if not placeholders:
+        return None
+    allowed = set(placeholders)
+    used: set[str] = set()
+    try:
+        for _literal, field_name, _spec, _conv in string.Formatter().parse(text):
+            if field_name:
+                # Strip any attribute/index access, e.g. "{a.b}" / "{a[0]}".
+                used.add(re.split(r"[.\[]", field_name, maxsplit=1)[0])
+    except (ValueError, IndexError):
+        return "unbalanced { } braces — escape literal braces as {{ and }}"
+    missing = allowed - used
+    if missing:
+        return "missing required placeholder(s): " + ", ".join(
+            "{" + p + "}" for p in sorted(missing)
+        )
+    # Ground truth: the prompt must .format() cleanly with exactly these keys.
+    # Catches unknown placeholders ({foo}), stray positional {}, and nested
+    # format-spec references the parse() scan above does not surface.
+    try:
+        text.format(**{p: "" for p in placeholders})
+    except (KeyError, IndexError, ValueError) as exc:
+        bad = exc.args[0] if exc.args else exc
+        return f"references an unknown placeholder ({bad}); allowed: " + ", ".join(
+            "{" + p + "}" for p in placeholders
+        )
+    return None
 
 
 # ---- Miscellaneous utilities ----

--- a/source/workflows.py
+++ b/source/workflows.py
@@ -512,7 +512,7 @@ def _exec_friction(
     if not ollama_client.is_available():
         return {"friction": [], "__note__": "Ollama not available. Friction skipped"}
     scored = friction.score_segments(segments)
-    candidates = friction.select_candidates(scored)
+    candidates = friction.select_candidates(scored, config.FRICTION_CANDIDATE_LIMIT)
     moments = thinking_agents.find_friction_moments(
         summary,
         segments,
@@ -520,7 +520,11 @@ def _exec_friction(
         model=params.get("model") or None,
         cancel_event=ctx.cancel_event,
     )
-    return {"friction": moments or []}
+    if moments is None:
+        # "Didn't run" (model failure / unrenderable candidates) must not read
+        # as "ran and found nothing".
+        return {"friction": [], "__note__": "Friction analysis failed. See log"}
+    return {"friction": moments}
 
 
 def _exec_report(

--- a/tests/test_friction_agent.py
+++ b/tests/test_friction_agent.py
@@ -332,3 +332,61 @@ class TestRunFriction:
         result = agent["run"](self._entry(), None)
         assert result is not None
         assert result["moments"] == []
+
+
+class TestFrictionIdAlignment:
+    """The Workflows path feeds segments that were never manifest-saved, so
+    they carry no ids; the scorer synthesizes str(index) and the prompt
+    formatter and validity filter must use the same scheme."""
+
+    @patch("thinking_agents.ollama_client.generate")
+    def test_idless_segments_round_trip(self, mock_generate):
+        import friction
+
+        mock_generate.return_value = (
+            '[{"segment_ids": ["1"], "category": "frustration",'
+            ' "rationale": "stuck", "score": 0.8}]'
+        )
+        segments = [
+            {"start": 0.0, "end": 2.0, "text": "This is fine so far."},
+            {"start": 2.0, "end": 4.0, "text": "Ugh, this is so frustrating!"},
+            {"start": 4.0, "end": 6.0, "text": "Okay, moving on."},
+        ]
+        scored = friction.score_segments(segments)
+        candidates = friction.select_candidates(scored)
+        assert candidates, "scorer should flag the frustrated segment"
+        moments = thinking_agents.find_friction_moments(
+            "A summary.", segments, candidates
+        )
+        # Before the fix the candidate lookup keyed on raw ids (all None),
+        # rendered an empty block, and returned without calling the model.
+        assert mock_generate.called
+        assert moments == [
+            {
+                "segment_ids": ["1"],
+                "category": "frustration",
+                "rationale": "stuck",
+                "score": 0.8,
+            }
+        ]
+
+    def test_unrenderable_candidates_return_none(self):
+        """Candidates whose ids match no segment mean no model call was made —
+        that is "didn't run" (None), not "ran and found nothing" ([])."""
+        segments = [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "hello"}]
+        candidates = [{"id": "ghost", "score": 0.5}]
+        assert thinking_agents.find_friction_moments("s", segments, candidates) is None
+
+
+class TestExtractJsonArrayEmptyFirst:
+    def test_empty_array_before_payload_does_not_win(self):
+        out = thinking_agents._extract_json_array(
+            'Here are the moments: [] no wait, the real ones: [{"a": 1}]'
+        )
+        assert out == [{"a": 1}]
+
+    def test_explicit_empty_array_suppresses_object_salvage(self):
+        out = thinking_agents._extract_json_array(
+            '{"moments": [], "meta": {"model": "qwen"}}'
+        )
+        assert out == []

--- a/tests/test_friction_scorer.py
+++ b/tests/test_friction_scorer.py
@@ -63,18 +63,26 @@ class TestScoreSegments:
         assert scored[0]["score"] == 0.0
 
     def test_score_formula(self):
-        # "um, where is the menu?" → 5 words.
-        # hesitation "um" (w=1.0) + confusion "where is" (w=1.5) = 2.5 / 5 = 0.5
+        # "um, where is the menu?" → 5 words, denominator floored at 8.
+        # hesitation "um" (w=1.0) + confusion "where is" (w=1.5) = 2.5 / 8 = 0.3125
         scored = friction.score_segments(
             [{"id": "P01:0", "text": "um, where is the menu?"}]
         )
-        assert scored[0]["score"] == 0.5
+        assert scored[0]["score"] == 0.3125
         assert scored[0]["categories"] == ["hesitation", "confusion"]
 
     def test_score_clamped_to_one(self):
-        # A one-word frustration interjection would score 2.0 raw → clamped.
-        scored = friction.score_segments([{"id": "P01:0", "text": "ugh"}])
+        # Eight frustration interjections in eight words: 16.0 raw / 8 → clamped.
+        scored = friction.score_segments(
+            [{"id": "P01:0", "text": "ugh ugh ugh ugh ugh ugh ugh ugh"}]
+        )
         assert scored[0]["score"] == 1.0
+
+    def test_short_interjection_no_longer_saturates(self):
+        # The word-count floor keeps a one-word "ugh" well below the ceiling,
+        # so interjections can't monopolise the LLM candidate list.
+        scored = friction.score_segments([{"id": "P01:0", "text": "ugh"}])
+        assert 0 < scored[0]["score"] < 1.0
 
     def test_id_falls_back_to_index(self):
         scored = friction.score_segments([{"text": "um"}])

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -5,6 +5,7 @@ tests/test_thinking_agents.py.
 """
 
 import hashlib
+import http.client
 import http.server
 import io
 import json
@@ -506,6 +507,8 @@ class TestAutoStartServer:
         # What is under test is the poll *loop*, not the production 0.5 s spacing
         # between attempts — leaving it real just slept through two intervals.
         monkeypatch.setattr(ollama_client, "_START_POLL_INTERVAL", 0)
+        # A live server process: poll() None means "still running".
+        mock_popen.return_value.poll.return_value = None
         mock_avail.side_effect = [False, False, True]
         assert ollama_client.start_server() is True
         assert mock_avail.call_count == 3
@@ -895,3 +898,54 @@ class TestManagedInstall:
             assert ollama_client.install_managed() is False
         managed_dir = tmp_path / "cfg" / "tools" / "ollama"
         assert not list(managed_dir.glob("*.exe"))
+
+
+@patch("ollama_client.shutil.which", return_value="/usr/local/bin/ollama")
+@patch("ollama_client.subprocess.Popen")
+@patch("ollama_client.is_available", return_value=False)
+def test_start_server_reports_immediate_death(
+    mock_avail, mock_popen, mock_which, monkeypatch
+):
+    """A `serve` that dies instantly fails fast with its exit code instead of
+    burning the whole startup timeout holding the lock."""
+    monkeypatch.setattr(ollama_client, "_START_POLL_INTERVAL", 0)
+    mock_popen.return_value.poll.return_value = 1
+    start = time.monotonic()
+    assert ollama_client.start_server() is False
+    assert time.monotonic() - start < ollama_client._START_TIMEOUT
+
+
+class TestGenerateStreamTruncation:
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_eof_without_done_chunk_returns_none(self, mock_urlopen):
+        """A stream that ends before its `done` chunk is a truncated
+        generation (Ollama restart / OOM / dropped connection) — returning
+        the partial text would commit a half-written summary as finished."""
+        mock_urlopen.return_value = _make_streaming_resp(
+            _ndjson_lines({"response": "Half a "}, {"response": "summary"})
+        )
+        assert ollama_client.generate("prompt") is None
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_done_chunk_still_returns_text(self, mock_urlopen):
+        mock_urlopen.return_value = _make_streaming_resp(
+            _ndjson_lines({"response": "Full"}, {"response": " text", "done": True})
+        )
+        assert ollama_client.generate("prompt") == "Full text"
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_non_dict_ndjson_lines_are_skipped(self, mock_urlopen):
+        """A line decoding to null/number/list must be skipped, not raise."""
+        lines = _ndjson_lines({"response": "ok"}) + [b"null\n", b"[1,2]\n"]
+        lines += _ndjson_lines({"done": True})
+        mock_urlopen.return_value = _make_streaming_resp(lines)
+        assert ollama_client.generate("prompt") == "ok"
+
+    @patch("ollama_client.urllib.request.urlopen")
+    def test_incomplete_read_is_handled_not_raised(self, mock_urlopen):
+        """http.client exceptions are not OSError; they must not escape a
+        module documented to never raise on a network error."""
+        resp = MagicMock()
+        resp.readline.side_effect = http.client.IncompleteRead(b"partial")
+        mock_urlopen.return_value = resp
+        assert ollama_client.generate("prompt") is None

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -281,8 +281,14 @@ def test_participant_marks_resolved_and_filtered(client, monkeypatch):
                 },
             ],
             "source_transcripts": {
-                "P01": {"segments": [{"start": 5.0, "end": 7.0, "text": "hello"}]},
-                "P02": {"segments": [{"start": 1.0, "end": 2.0, "text": "x"}]},
+                "P01": {
+                    "segments": [
+                        {"id": "P01:0", "start": 5.0, "end": 7.0, "text": "hello"}
+                    ]
+                },
+                "P02": {
+                    "segments": [{"id": "P02:0", "start": 1.0, "end": 2.0, "text": "x"}]
+                },
             },
             "corrections": [],
         },

--- a/tests/test_thinking_agents.py
+++ b/tests/test_thinking_agents.py
@@ -671,3 +671,37 @@ class TestRunReport:
         kwargs = mock_generate.call_args[1]
         assert kwargs["cancel_event"] is evt
         assert kwargs["on_token"] is sink
+
+
+class TestCitationParseHardening:
+    @patch("thinking_agents.ollama_client.generate")
+    def test_unparseable_format_returns_none(self, mock_generate):
+        """A non-empty answer with zero "N: ts" lines (markdown bolding, "1."
+        numbering) is a parse failure — committing all-empty refs would read
+        as "no sources exist"."""
+        mock_generate.return_value = "**1:** 0:05\n2. 0:10\nClaim 3 - 0:15"
+        segments = [{"start": 0, "end": 5, "text": "Some text"}]
+        assert thinking_agents.find_citations("A claim.", segments) is None
+
+    @patch("thinking_agents.ollama_client.generate")
+    def test_duplicate_segment_refs_are_deduped(self, mock_generate):
+        """Two timestamps resolving to one segment must not eat the per-claim
+        ref budget as two entries."""
+        mock_generate.return_value = "1: 0:00, 0:02, 0:10"
+        segments = [
+            {"start": 0, "end": 5, "text": "Part A"},
+            {"start": 10, "end": 15, "text": "Part B"},
+        ]
+        result = thinking_agents.find_citations("A claim.", segments)
+        assert result is not None
+        assert [r["segment_index"] for r in result[0]["refs"]] == [0, 1]
+
+
+class TestFindClosestSegmentTolerance:
+    def test_distance_beyond_tolerance_is_rejected(self):
+        # 5.9 s away with the default 5.0 s tolerance: the old
+        # `best_dist = tolerance + 1` bound effectively accepted up to 6.0 s.
+        assert thinking_agents._find_closest_segment(5.9, [0.0], [0]) is None
+
+    def test_distance_at_tolerance_is_accepted(self):
+        assert thinking_agents._find_closest_segment(5.0, [0.0], [0]) == 0

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -2028,3 +2028,29 @@ class TestConfirmModelDownload:
             lambda *a, **k: pytest.fail("must not load after a decline"),
         )
         assert transcripts._load_model("large-v3") is None
+
+
+class TestApplyCorrectionsBoundaries:
+    def test_word_boundary_does_not_rewrite_substrings(self):
+        """ "the" -> "they" must not turn "there" into "theyre"."""
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="the cat sat there")]
+        result = transcripts.apply_corrections(segs, [{"from": "the", "to": "they"}])
+        assert result[0]["text"] == "they cat sat there"
+
+    def test_punctuation_edges_still_match(self):
+        """\\b against a punctuation edge never matches, so it is only applied
+        to word-character edges."""
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="use e.g. this")]
+        result = transcripts.apply_corrections(
+            segs, [{"from": "e.g.", "to": "for example"}]
+        )
+        assert result[0]["text"] == "use for example this"
+
+    def test_replacement_is_literal_not_template(self):
+        """A backslash in the replacement is text, not a re.sub escape —
+        previously this raised re.error and 500'd every corrected route."""
+        segs = [transcripts.TranscriptSegment(start=0, end=1, text="the path")]
+        result = transcripts.apply_corrections(
+            segs, [{"from": "path", "to": "C:\\Users\\path \\g<0>"}]
+        )
+        assert result[0]["text"] == "the C:\\Users\\path \\g<0>"

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1349,26 +1349,31 @@ class TestCreateTranscriptTask:
 
 
 class TestTranscriptWorker:
-    def test_restore_tasks(self):
-        worker = transcripts.TranscriptWorker()
-        tasks = [
-            {"id": "tr_abc12345", "status": "completed", "participant": "P01"},
-            {"id": "tr_def67890", "status": "failed", "participant": "P02"},
-        ]
-        worker.restore_tasks(tasks)
-        all_tasks = worker.get_all_tasks()
-        assert len(all_tasks) == 2
-        ids = {t["id"] for t in all_tasks}
-        assert "tr_abc12345" in ids
-        assert "tr_def67890" in ids
-
     def test_get_task(self):
         worker = transcripts.TranscriptWorker()
-        worker.restore_tasks([{"id": "tr_test1234", "status": "completed"}])
-        task = worker.get_task("tr_test1234")
+        task_id = worker.enqueue(transcripts.create_transcript_task("P01", ["/v.mp4"]))
+        task = worker.get_task(task_id)
         assert task is not None
-        assert task["id"] == "tr_test1234"
+        assert task["id"] == task_id
         assert worker.get_task("nonexistent") is None
+
+    def test_cancel_all_cancels_queued_and_flags_running(self):
+        """cancel_all marks queued tasks cancelled and flags running ones."""
+        worker = transcripts.TranscriptWorker()
+        queued_id = worker.enqueue(
+            transcripts.create_transcript_task("P01", ["/v.mp4"])
+        )
+        running_id = worker.enqueue(
+            transcripts.create_transcript_task("P02", ["/v.mp4"])
+        )
+        with worker._lock:
+            worker._tasks[running_id]["status"] = transcripts.TASK_STATUS_RUNNING
+        worker.cancel_all()
+        queued = worker.get_task(queued_id)
+        running = worker.get_task(running_id)
+        assert queued is not None and running is not None
+        assert queued["status"] == transcripts.TASK_STATUS_CANCELLED
+        assert running["_cancelled"] is True
 
     def test_get_all_tasks_slim_omits_partial_segments(self):
         """include_partials=False drops the growing segment tail, reports count."""

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -3363,18 +3363,24 @@ def test_invalidate_dependents_matches_on_agent_keys(monkeypatch):
     """depends_on holds agent *keys*; an agent whose key differs from its
     manifest_field must still have its dependents invalidated."""
     fake_agents = [
-        {
-            "key": "themes",
-            "manifest_field": "theme_analysis",
-            "depends_on": [],
-            "on_upstream_change": "clear",
-        },
-        {
-            "key": "digest",
-            "manifest_field": "digest_result",
-            "depends_on": ["themes"],
-            "on_upstream_change": "clear",
-        },
+        cast(
+            thinking_agents.Agent,
+            {
+                "key": "themes",
+                "manifest_field": "theme_analysis",
+                "depends_on": [],
+                "on_upstream_change": "clear",
+            },
+        ),
+        cast(
+            thinking_agents.Agent,
+            {
+                "key": "digest",
+                "manifest_field": "digest_result",
+                "depends_on": ["themes"],
+                "on_upstream_change": "clear",
+            },
+        ),
     ]
     monkeypatch.setattr(thinking_agents, "AGENTS", fake_agents)
     entry = {"theme_analysis": "old", "digest_result": "derived"}

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -3214,3 +3214,102 @@ def test_reinit_stops_previous_worker(tmp_path, monkeypatch):
     finally:
         if transcripts_server._worker is not None:
             transcripts_server._worker.stop(join_timeout=2.0)
+
+
+def test_marks_resolve_by_segment_id_not_index(tr_client):
+    """A mark follows its segment's stable id, never its list position.
+
+    The segment carrying id "P01:2" sits at index 0 here; positional
+    resolution would return the wrong row (or ship wrong times to Clip
+    Marked Lines), by-id resolution finds it regardless of position.
+    """
+    transcripts_server._manifest["source_transcripts"]["P01"] = {
+        "segments": [
+            {"id": "P01:2", "start": 20.0, "end": 21.0, "text": "late"},
+            {"id": "P01:0", "start": 0.0, "end": 1.0, "text": "early"},
+        ],
+    }
+    transcripts_server._manifest["marks"] = [
+        {
+            "id": "m_1",
+            "segment_id": "P01:2",
+            "category": "friction",
+            "label": None,
+            "severity": None,
+            "created": "2026-01-01T00:00:00+00:00",
+        },
+        # In numeric range as an index (2 segments would cover idx 1), but no
+        # segment carries this id — must resolve invalid, not to index 1.
+        {
+            "id": "m_2",
+            "segment_id": "P01:1",
+            "category": "friction",
+            "label": None,
+            "severity": None,
+            "created": "2026-01-01T00:00:00+00:00",
+        },
+    ]
+    marks = tr_client.get("/transcripts/api/marks").get_json()["marks"]
+    by_id = {m["id"]: m for m in marks}
+    assert by_id["m_1"]["valid"] is True
+    assert by_id["m_1"]["text"] == "late"
+    assert by_id["m_1"]["start"] == 20.0
+    assert by_id["m_2"]["valid"] is False
+
+
+def test_retranscription_merge_drops_pre_run_marks(monkeypatch, tmp_path):
+    """Replacing a transcript invalidates marks made against the old one.
+
+    The fresh save mints the same "{pid}:{index}" ids again, so old marks
+    would silently re-point at new content. Marks created after the task
+    started (streaming-era marks on the new transcript) survive; other
+    participants' marks are untouched.
+    """
+    monkeypatch.setattr(
+        transcripts_server,
+        "_manifest",
+        {
+            "source_transcripts": {
+                "P01": {
+                    "segments": [
+                        {"id": "P01:0", "start": 0.0, "end": 1.0, "text": "old"}
+                    ]
+                },
+            },
+            "corrections": [],
+            "marks": [
+                {
+                    "id": "m_old",
+                    "segment_id": "P01:0",
+                    "created": "2026-01-01T00:00:00+00:00",
+                },
+                {
+                    "id": "m_live",
+                    "segment_id": "P01:1",
+                    "created": "2026-03-01T12:00:00+00:00",
+                },
+                {
+                    "id": "m_other",
+                    "segment_id": "P02:0",
+                    "created": "2026-01-01T00:00:00+00:00",
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(transcripts_server, "_merged_task_ids", set())
+    monkeypatch.setattr(transcripts_server, "_pending_chain_pids", [])
+    task = {
+        "id": "tr_rerun001",
+        "participant": "P01",
+        "status": transcripts.TASK_STATUS_COMPLETED,
+        "created_at": "2026-03-01T00:00:00+00:00",
+        "result": {"segments": [{"start": 0.0, "end": 2.0, "text": "new"}]},
+    }
+    monkeypatch.setattr(transcripts_server, "_worker", _CompletedTasksWorker([task]))
+
+    with transcripts_server._manifest_lock:
+        merged = transcripts_server._merge_completed_results_locked()
+
+    assert merged == ["P01"]
+    remaining = {m["id"] for m in transcripts_server._manifest["marks"]}
+    assert remaining == {"m_live", "m_other"}

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -2562,7 +2562,7 @@ def test_persist_keeps_corrected_cache_for_unchanged_transcription(
     }
 
     class _FakeWorker:
-        def get_all_tasks(self):
+        def get_all_tasks(self, include_partials=True):
             return [_copy.deepcopy(completed)]  # mirror the real deepcopy contract
 
     monkeypatch.setattr(transcripts_server, "_worker", _FakeWorker())
@@ -2683,7 +2683,7 @@ def test_on_task_complete_registers_summary_before_disk_write(
     }
 
     class _FakeWorker:
-        def get_all_tasks(self):
+        def get_all_tasks(self, include_partials=True):
             return [dict(completed_task)]
 
     monkeypatch.setattr(transcripts_server, "_worker", _FakeWorker())
@@ -3007,7 +3007,7 @@ class _CompletedTasksWorker:
     def __init__(self, tasks):
         self._tasks = tasks
 
-    def get_all_tasks(self):
+    def get_all_tasks(self, include_partials=True):
         return self._tasks
 
 
@@ -3186,3 +3186,31 @@ class TestMediaRouteFollowsTheInputDir:
         (chosen / "study_P03.mp4").write_bytes(b"chosen")
         monkeypatch.setattr(config, "INPUT_DIR", str(chosen))
         assert tr_client.get("/transcripts/media/study_P03.mp4").status_code == 200
+
+
+def test_reinit_stops_previous_worker(tmp_path, monkeypatch):
+    """A sheet swap re-inits the blueprint; the old worker must be retired.
+
+    Left alive, its on_task_complete resolves the module globals at call time
+    and would merge the old study's segments into the new study's manifest —
+    and every swap would leak a live worker thread.
+    """
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(transcripts_server, "_worker", None)
+    monkeypatch.setattr(transcripts_server, "_manifest", {})
+    monkeypatch.setattr(transcripts_server, "_participant_source", None)
+    monkeypatch.setattr(transcripts_server, "_participants", [])
+
+    transcripts_server._init_transcripts_state()
+    first = transcripts_server._worker
+    assert first is not None
+    try:
+        transcripts_server._init_transcripts_state()
+        second = transcripts_server._worker
+        assert second is not first
+        assert first.on_task_complete is None
+        assert first._running is False
+    finally:
+        if transcripts_server._worker is not None:
+            transcripts_server._worker.stop(join_timeout=2.0)

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -3334,3 +3334,49 @@ def test_corrected_cache_generation_mismatch_recomputes(monkeypatch):
     # ...and does not poison the cache for current-generation readers.
     again = transcripts_server._corrected_segments("P01", new_segments, [], version=5)
     assert again[0]["text"] == "new"
+
+
+def test_regenerate_stops_in_flight_dependents(
+    tr_client, _agent_state_clean, monkeypatch
+):
+    """A citations run computed from the summary being regenerated must be
+    aborted, or its result commits after the clear, reads as current, and
+    blocks the fresh chain from re-running it."""
+    monkeypatch.setattr(transcripts_server, "_persist_manifest", lambda: None)
+    monkeypatch.setattr(
+        transcripts_server._orchestrator, "run_agent", lambda *a, **k: None
+    )
+    _seed_friction_entry(citations=None, friction=None)
+    # Mark citations as in flight for P01 (as if it were mid-run off the old
+    # summary) and hand it a cancel event to observe.
+    evt = threading.Event()
+    transcripts_server._orchestrator._in_flight["citations"].add("P01")
+    transcripts_server._orchestrator._cancel_events["citations"]["P01"] = evt
+
+    resp = tr_client.post("/transcripts/api/agent/summary/P01/regenerate")
+    assert resp.status_code == 200
+    assert evt.is_set(), "in-flight dependent must be cancelled"
+    assert "P01" not in transcripts_server._orchestrator._in_flight["citations"]
+
+
+def test_invalidate_dependents_matches_on_agent_keys(monkeypatch):
+    """depends_on holds agent *keys*; an agent whose key differs from its
+    manifest_field must still have its dependents invalidated."""
+    fake_agents = [
+        {
+            "key": "themes",
+            "manifest_field": "theme_analysis",
+            "depends_on": [],
+            "on_upstream_change": "clear",
+        },
+        {
+            "key": "digest",
+            "manifest_field": "digest_result",
+            "depends_on": ["themes"],
+            "on_upstream_change": "clear",
+        },
+    ]
+    monkeypatch.setattr(thinking_agents, "AGENTS", fake_agents)
+    entry = {"theme_analysis": "old", "digest_result": "derived"}
+    transcripts_server._invalidate_dependents(entry, fake_agents[0])
+    assert "digest_result" not in entry

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -3313,3 +3313,24 @@ def test_retranscription_merge_drops_pre_run_marks(monkeypatch, tmp_path):
     assert merged == ["P01"]
     remaining = {m["id"] for m in transcripts_server._manifest["marks"]}
     assert remaining == {"m_live", "m_other"}
+
+
+def test_corrected_cache_generation_mismatch_recomputes(monkeypatch):
+    """A reader whose snapshot predates a segment-list replacement must not be
+    served the entry a *newer* snapshot cached under the current version —
+    that zipped old raw segments against new corrected text."""
+    monkeypatch.setattr(transcripts_server, "_corrected_cache", {})
+    monkeypatch.setattr(transcripts_server, "_corrections_version", 5)
+    old_segments = [{"start": 0.0, "end": 1.0, "text": "old"}]
+    new_segments = [{"start": 0.0, "end": 1.0, "text": "new"}]
+
+    # A current-generation reader populates the cache.
+    out_new = transcripts_server._corrected_segments("P01", new_segments, [], version=5)
+    assert out_new[0]["text"] == "new"
+    # A reader holding a pre-replacement snapshot recomputes from its own
+    # segments instead of hitting the newer cache entry...
+    out_old = transcripts_server._corrected_segments("P01", old_segments, [], version=4)
+    assert out_old[0]["text"] == "old"
+    # ...and does not poison the cache for current-generation readers.
+    again = transcripts_server._corrected_segments("P01", new_segments, [], version=5)
+    assert again[0]["text"] == "new"

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1067,7 +1067,9 @@ def test_embed_subtitles_happy_path(tr_client, tmp_path, monkeypatch):
     assert resp.mimetype == "application/x-ndjson"
     header, result, done = _ndjson(resp)
     assert done == {"done": True}
-    assert header == {"total": 1, "output_dir": str(tmp_path)}
+    assert header["total"] == 1
+    assert header["output_dir"] == str(tmp_path)
+    assert header["token"]  # echoed by the Stop button to scope the cancel
     assert result["index"] == 0
     assert result["participant"] == "P01"
     assert result["ok"] is True
@@ -1294,12 +1296,27 @@ def test_embed_slot_release_is_scoped_to_its_own_run(monkeypatch):
     assert transcripts_server._embed_busy is False
 
 
-def test_embed_subtitles_cancel_route_sets_the_event(tr_client):
-    transcripts_server._embed_cancel_event.clear()
-    resp = tr_client.post("/transcripts/api/embed-subtitles/cancel")
-    assert resp.status_code == 200
-    assert transcripts_server._embed_cancel_event.is_set()
-    transcripts_server._embed_cancel_event.clear()
+def test_embed_subtitles_cancel_route_is_token_scoped(tr_client):
+    """Cancel only takes effect with the in-flight run's token: a late cancel
+    POST from a stopped run must not cancel its successor."""
+    token = transcripts_server._claim_embed_slot()
+    assert token is not None
+    try:
+        # Wrong (stale) token: ignored.
+        resp = tr_client.post(
+            "/transcripts/api/embed-subtitles/cancel", json={"token": "stale"}
+        )
+        assert resp.status_code == 200
+        assert not transcripts_server._embed_cancel_event.is_set()
+        # Matching token: cancels.
+        resp = tr_client.post(
+            "/transcripts/api/embed-subtitles/cancel", json={"token": token}
+        )
+        assert resp.status_code == 200
+        assert transcripts_server._embed_cancel_event.is_set()
+    finally:
+        transcripts_server._embed_cancel_event.clear()
+        transcripts_server._release_embed_slot()
 
 
 # ---- Normalize audio ----
@@ -1357,7 +1374,8 @@ def test_normalize_audio_happy_path_auto_track(tr_client, tmp_path, monkeypatch)
     assert resp.status_code == 200
     assert resp.mimetype == "application/x-ndjson"
     header, result, done = _ndjson(resp)
-    assert header == {"total": 1}
+    assert header["total"] == 1
+    assert header["token"]  # echoed by the Stop button to scope the cancel
     assert done == {"done": True}
     assert result["index"] == 0
     assert result["participant"] == "P01"
@@ -1744,12 +1762,24 @@ def test_normalize_slot_release_is_scoped_to_its_own_run(monkeypatch):
     assert transcripts_server._normalize_busy is False
 
 
-def test_normalize_audio_cancel_route_sets_the_event(tr_client):
-    transcripts_server._normalize_cancel_event.clear()
-    resp = tr_client.post("/transcripts/api/normalize-audio/cancel")
-    assert resp.status_code == 200
-    assert transcripts_server._normalize_cancel_event.is_set()
-    transcripts_server._normalize_cancel_event.clear()
+def test_normalize_audio_cancel_route_is_token_scoped(tr_client):
+    """Token-scoped like the embed cancel: see that test for the rationale."""
+    token = transcripts_server._claim_normalize_slot()
+    assert token is not None
+    try:
+        resp = tr_client.post(
+            "/transcripts/api/normalize-audio/cancel", json={"token": "stale"}
+        )
+        assert resp.status_code == 200
+        assert not transcripts_server._normalize_cancel_event.is_set()
+        resp = tr_client.post(
+            "/transcripts/api/normalize-audio/cancel", json={"token": token}
+        )
+        assert resp.status_code == 200
+        assert transcripts_server._normalize_cancel_event.is_set()
+    finally:
+        transcripts_server._normalize_cancel_event.clear()
+        transcripts_server._release_normalize_slot()
 
 
 # ---- Friction endpoints ----

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -607,9 +607,12 @@ def test_friction_refetch_keeps_the_programmatic_scores():
     assert "if (state.frictionPid !== pid) {" in body, (
         "the wipe must be gated on the participant actually changing"
     )
-    assert body.index("frictionPid !== pid") < body.index(
-        "state.frictionData = null"
-    ), "the gate has to precede the wipe it exists to prevent"
+    gate = body[body.index("frictionPid !== pid") :]
+    assert "clearFriction()" in gate.split("state.frictionPid = pid")[0], (
+        "the gated branch must wipe state AND DOM via clearFriction — a "
+        "state-only wipe left the previous participant's panes painted when "
+        "the switch's fetch failed transiently"
+    )
     # Mid-run the server ships the scores alongside the generating flag.
     gen = body[body.index("data.generating") :]
     assert "if (data.friction) _setFrictionData(data.friction);" in gen, (


### PR DESCRIPTION
## Summary

Fixes from a full review of the Transcripts feature set and frontend (~19k lines; every High/Medium finding re-verified against the source before fixing):

- **Silent wrong output**: sheet swaps retire the old `TranscriptWorker` and abort in-flight agents instead of merging the old study's results into the new manifest (same shape fixed in Screenspace); marks resolve by stable segment id and invalidate on re-transcribe; corrections do word-boundary matching with literal replacements; truncated Ollama streams and unparseable citation responses return `None` instead of committing as success; the Workflows Friction node's id mismatch (always zero moments) is fixed at the scorer/prompt seam.
- **Concurrency/locks**: `stat()`/ffprobe/regex work moved off `_manifest_lock` in `api_participants`/`api_search`/`api_agent_get`; the corrected-segments cache is keyed by snapshot generation; regenerate/re-transcribe stop in-flight dependents before clearing their fields; `depends_on` normalized to agent keys everywhere.
- **Frontend**: one failed poll GET no longer wipes a live agent panel (404 vs transient split, bounded retry, panes blanked on real participant switches); `/transcripts/api/participants` now carries `get_frontend_config()` so transcripts-only sessions get customized severity labels/friction categories/hotkey rebinds; `updateMarkLabel` writes state like its siblings; stale-badge patch gate, search generation counter, `createPoller`-based install polling.
- **Low sweep**: token-scoped embed/normalize cancels, JSON boundary guards, consent-gated Whisper model eviction, prompt validation in the CLI settings editor, guarded report getters, and assorted small satellite fixes.

## Test plan

- [x] `ruff format --check` + `ruff check` + `ty check` green
- [x] Full `pytest` suite green, including new regression tests per fix (worker-swap leak, mark-by-id resolution + re-transcribe invalidation, corrections boundary/backslash, truncated-stream `None`, empty-parse citations `None`, friction id round-trip on id-less segments, corrected-cache generation mismatch, token-scoped cancels)
- [x] /ui-check: six pages + five journeys clean, transcripts screenshot reviewed
- [ ] Manual: swap spreadsheets mid-transcription and confirm the job stops; blip the server during a summary run and confirm the panel survives; re-transcribe a marked participant and confirm marks invalidate