### PR TITLE
refactor(web): move the cross-ref toggle into Settings

### DIFF
--- a/assets/web/command-palette.js
+++ b/assets/web/command-palette.js
@@ -226,13 +226,13 @@
         run: function () { window.ClipgenStartOverlay.open(); },
       },
       {
-        id: "global:tooltips",
-        title: "Toggle cross-reference tooltips",
+        id: "global:crossrefs",
+        title: "Toggle cross-references",
         icon: "chat-bubble-left-ellipsis",
-        keywords: "xref hover badges",
+        keywords: "xref hover badges overlap tooltips",
         section: "Global",
-        visible: function () { return !!document.getElementById("tooltipToggle"); },
-        run: function () { document.getElementById("tooltipToggle").click(); },
+        visible: function () { return typeof setCrossReferences === "function"; },
+        run: function () { setCrossReferences(!CLIPGEN_CONFIG.crossReferences); },
       },
     ];
   }

--- a/assets/web/overview-convergence.js
+++ b/assets/web/overview-convergence.js
@@ -57,6 +57,10 @@
     participants: [],
     sortByDensity: false,
     swimLaneEl: null,
+    // Cross-references were flipped while this tab was hidden; re-render on
+    // the next activate. A hidden panel measures zero width, so rendering
+    // straight away would bake a broken swim lane in.
+    crossRefsStale: false,
     _snapshot: null,
   };
 
@@ -755,6 +759,7 @@
   }
 
   function renderImpl() {
+    cvState.crossRefsStale = false;
     renderTimeline();
     if (cvState.selection && cvState.selection.zone) {
       // Re-render the inline detail panel after the swim-lane rebuild.
@@ -1124,6 +1129,7 @@
       // recalculate() re-reads the reassigned baselines and clears the paint.
       recalculate();
     } else {
+      if (cvState.crossRefsStale) render();
       checkStaleness();
     }
   }
@@ -1685,8 +1691,17 @@
     });
   }
 
+  // The detail rows bake their cross-reference badges into the DOM, so a
+  // settings flip needs a re-render — render() rebuilds the swim lane and
+  // reopens the selected zone's detail from cvState.selection.
+  function renderCrossRefs() {
+    if (cvState.active) render();
+    else cvState.crossRefsStale = true;
+  }
+
   // --- Hub exports (OV namespace) ---
   window.ClipgenOverview.convergenceActivate = activate;
+  window.ClipgenOverview.convergenceRenderCrossRefs = renderCrossRefs;
   window.ClipgenOverview.convergenceDeactivate = deactivate;
   window.ClipgenOverview.convergenceResize = debounce(function () {
     if (!cvState.active) return;

--- a/assets/web/overview.js
+++ b/assets/web/overview.js
@@ -261,6 +261,14 @@
     if (fn) fn();
   }
 
+  // Shared by the settings modal and the command palette's cross-ref command.
+  // Convergence detail rows hold the page's only cross-reference badges;
+  // syncTab would close the open zone detail without rebuilding those rows.
+  function rerenderCrossRefs() {
+    if (OV.convergenceRenderCrossRefs) OV.convergenceRenderCrossRefs();
+  }
+  window.clipgenRerenderCrossRefs = rerenderCrossRefs;
+
   function syncTab(animate) {
     var panels = {
       convergence: qs("#convergencePanel"),
@@ -357,7 +365,13 @@
     if (typeof initThemeToggle === "function") {
       initThemeToggle();
     }
-    if (window.wireSettingsButton) window.wireSettingsButton({});
+    if (window.wireSettingsButton) {
+      window.wireSettingsButton({
+        onApply: function (applied, settings) {
+          if (applyCrossRefSetting(applied, settings)) rerenderCrossRefs();
+        },
+      });
+    }
 
     var refreshBtn = qs("#ovRefresh");
     if (refreshBtn) {

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -684,8 +684,8 @@
   // the Add-All/Reel-All buttons, threshold, search, and the per-type extra
   // control. Must be called exactly once per panel at startup — never from a
   // render path (CODE-REVIEW.md listener-cleanup rule). Per-type behavior is
-  // supplied via cfg; the shared `#trIntakeTooltip` host and the
-  // `trIntakeTooltipsEnabled` gate are owned here so both panels behave alike.
+  // supplied via cfg; the shared `#trIntakeTooltip` host and its cross-reference
+  // gate are owned here so both panels behave alike.
   function initIntakePanel(cfg) {
     var cards = qs(cfg.cardsSel);
     if (!cards) return;
@@ -731,7 +731,7 @@
         if (densityEl) densityEl.setHovered(idx);
       }
       var tooltip = qs("#trIntakeTooltip");
-      if (tooltip && state.trIntakeTooltipsEnabled) {
+      if (tooltip && CLIPGEN_CONFIG.crossReferences) {
         var tooltipText = cfg.onCardHover(card, idx) || "";
         if (tooltipText) {
           tooltip.textContent = tooltipText;
@@ -1617,22 +1617,6 @@
     renderIntakeCards(MN_INTAKE, filtered);
   }
 
-  function initTooltipToggle() {
-    state.trIntakeTooltipsEnabled = getStoredTooltipPref();
-    var btn = qs("#tooltipToggle");
-    if (!btn) return;
-    btn.setAttribute("aria-pressed", state.trIntakeTooltipsEnabled ? "true" : "false");
-    btn.addEventListener("click", function () {
-      state.trIntakeTooltipsEnabled = !state.trIntakeTooltipsEnabled;
-      btn.setAttribute("aria-pressed", state.trIntakeTooltipsEnabled ? "true" : "false");
-      setStoredTooltipPref(state.trIntakeTooltipsEnabled);
-      if (!state.trIntakeTooltipsEnabled) {
-        var tt = qs("#trIntakeTooltip");
-        if (tt) tt.classList.add("hidden");
-      }
-    });
-  }
-
   // Init the intake panels. Folded from the hub-boot initIntakePanel calls
   // so the SS_INTAKE/TR_INTAKE/CO_INTAKE configs never need to leave this file.
   function initIntake() {
@@ -1687,7 +1671,6 @@
   STUDIO.refreshComposerIntake = refreshComposerIntake;
   STUDIO.refreshMindnodeIntake = refreshMindnodeIntake;
   STUDIO.focusComposerIntakeItem = focusComposerIntakeItem;
-  STUDIO.initTooltipToggle = initTooltipToggle;
   STUDIO.refreshIntakeCardStates = refreshIntakeCardStates;
   STUDIO.renderIntake = renderIntake;
   STUDIO._syncMarkCategoriesFromSettings = _syncMarkCategoriesFromSettings;

--- a/assets/web/studio.css
+++ b/assets/web/studio.css
@@ -66,43 +66,6 @@ body {
   overflow: hidden;
 }
 
-/* Theme toggle (matches viewer.css) */
-
-#tooltipToggle {
-  position: relative;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, transform var(--duration-fast) ease, box-shadow var(--duration-normal) ease;
-  flex-shrink: 0;
-  color: var(--color-text);
-}
-
-#tooltipToggle:hover {
-  background: var(--color-surface);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
-}
-
-#tooltipToggle:active {
-  transform: scale(0.96);
-}
-
-#tooltipToggle:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-#tooltipToggle[aria-pressed="false"] {
-  opacity: 0.4;
-}
-
 /* Transcript intake tooltip */
 
 .tr-intake-tooltip {

--- a/assets/web/studio.js
+++ b/assets/web/studio.js
@@ -87,7 +87,6 @@
     trIntakeFilterText: "",
     trIntakeShowAll: false,
     trIntakeHoveredIdx: -1,
-    trIntakeTooltipsEnabled: true,
     coIntakeItems: [],
     coTrimCardKeys: {},
     coIntakeFilterParticipants: [],
@@ -4565,7 +4564,18 @@
         renderIntake(false);
       }
     }
+    if (applyCrossRefSetting(null, state.settingsData)) rerenderCrossRefs();
   }
+
+  // Shared by the settings modal and the command palette's cross-ref command.
+  // A flip while a card is hovered (palette, no mouse move) leaves the tooltip
+  // painted; rebuilding the cards alone does not take it down.
+  function rerenderCrossRefs() {
+    var tooltip = qs("#trIntakeTooltip");
+    if (tooltip) tooltip.classList.add("hidden");
+    renderIntake(false);
+  }
+  window.clipgenRerenderCrossRefs = rerenderCrossRefs;
 
   function persistTitlecardSettings() {
     var cb = qs("#titlecardEnabled");
@@ -4754,7 +4764,6 @@
   function refreshComposerIntake() { return STUDIO.refreshComposerIntake && STUDIO.refreshComposerIntake.apply(null, arguments); }
   function refreshMindnodeIntake() { return STUDIO.refreshMindnodeIntake && STUDIO.refreshMindnodeIntake.apply(null, arguments); }
   function focusComposerIntakeItem() { return STUDIO.focusComposerIntakeItem && STUDIO.focusComposerIntakeItem.apply(null, arguments); }
-  function initTooltipToggle() { return STUDIO.initTooltipToggle && STUDIO.initTooltipToggle.apply(null, arguments); }
   function refreshIntakeCardStates() { return STUDIO.refreshIntakeCardStates && STUDIO.refreshIntakeCardStates.apply(null, arguments); }
   function renderIntake() { return STUDIO.renderIntake && STUDIO.renderIntake.apply(null, arguments); }
   function _syncMarkCategoriesFromSettings() { return STUDIO._syncMarkCategoriesFromSettings && STUDIO._syncMarkCategoriesFromSettings.apply(null, arguments); }
@@ -4914,7 +4923,6 @@
     setActiveTabAttr(state.activePreviewTab);
     bindSidebarToggle();
     initThemeToggle();
-    initTooltipToggle();
     initPreviewTabs();
     initDropTargets();
     initWheelScroll();

--- a/assets/web/topnav.js
+++ b/assets/web/topnav.js
@@ -189,24 +189,6 @@
     settingsBtn.appendChild(settingsIcon);
     right.appendChild(settingsBtn);
 
-    // Tooltip toggle — opt-in per page (Studio + Transcripts). Keeps the
-    // existing #tooltipToggle id so studio.js / transcripts.js bindings continue.
-    var showTooltip = state.activeFrontend === "studio" || state.activeFrontend === "transcripts";
-    if (showTooltip) {
-      var tooltipBtn = document.createElement("button");
-      tooltipBtn.type = "button";
-      tooltipBtn.id = "tooltipToggle";
-      tooltipBtn.className = "topnav-icon-btn";
-      tooltipBtn.setAttribute("data-tooltip", "Toggle cross-reference tooltips");
-      tooltipBtn.setAttribute("aria-label", "Toggle cross-reference tooltips");
-      tooltipBtn.setAttribute("aria-pressed", "true");
-      var tooltipIcon = document.createElement("span");
-      tooltipIcon.className = "topnav-icon";
-      tooltipIcon.style.cssText = iconMaskStyle("chat-bubble-left-ellipsis");
-      tooltipBtn.appendChild(tooltipIcon);
-      right.appendChild(tooltipBtn);
-    }
-
     // Theme toggle.
     // Keeps the existing #themeToggle id + .theme-toggle-icon class names so
     // initThemeToggle() in utils.js continues to work without changes.

--- a/assets/web/transcripts.css
+++ b/assets/web/transcripts.css
@@ -96,31 +96,6 @@ body {
   .status-indicator--working { animation: none; }
 }
 
-/* Theme toggle (matches Screenspace/Studio) */
-
-#tooltipToggle {
-  position: relative;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border);
-  background: transparent;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text);
-  transition: opacity var(--duration-fast), background var(--duration-fast);
-}
-
-#tooltipToggle:hover {
-  background: var(--color-surface);
-}
-
-#tooltipToggle[aria-pressed="false"] {
-  opacity: 0.4;
-}
-
 /* Search bar */
 
 #headerSearch {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -55,7 +55,6 @@
     xrefPoller: null,
     xrefEligible: false,
     xrefIndex: { eventsByParticipant: {}, sheetByParticipant: {} },
-    tooltipsEnabled: true,
     summaryEditing: false,
     summaryText: "",
     summaryCitations: null,
@@ -1087,7 +1086,7 @@
       html += sevDotHtml;
       html += '<span class="segment-timestamp">' + formatTime(seg.start);
       // Cross-reference badges in gutter (inside timestamp, positioned at right edge)
-      if (state.tooltipsEnabled) {
+      if (CLIPGEN_CONFIG.crossReferences) {
         var xref = findOverlapsForSearch(state.selectedParticipant, seg.start, seg.end);
         if (xref.screenspaceEvents.length > 0 || xref.sheetObservations.length > 0) {
           html += '<span class="segment-xref-badges">';
@@ -2552,19 +2551,6 @@
     return TS.loadCorrections && TS.loadCorrections();
   }
 
-  function initTooltipToggle() {
-    state.tooltipsEnabled = getStoredTooltipPref();
-    var btn = qs("#tooltipToggle");
-    if (!btn) return;
-    btn.setAttribute("aria-pressed", state.tooltipsEnabled ? "true" : "false");
-    btn.addEventListener("click", function () {
-      state.tooltipsEnabled = !state.tooltipsEnabled;
-      btn.setAttribute("aria-pressed", state.tooltipsEnabled ? "true" : "false");
-      setStoredTooltipPref(state.tooltipsEnabled);
-      if (state.segments.length > 0) renderSegments();
-    });
-  }
-
   // ---- Settings (shared modal lives in settings-modal.js) ----
 
   // Models are also fetched for per-pill model overrides; keep a tiny
@@ -3080,7 +3066,14 @@
       hideMarkPopover();
       if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
     }
+    if (applyCrossRefSetting(applied, settings)) rerenderCrossRefs();
   }
+
+  // Shared by the settings modal and the command palette's cross-ref command.
+  function rerenderCrossRefs() {
+    if (state.segments.length > 0) renderSegments();
+  }
+  window.clipgenRerenderCrossRefs = rerenderCrossRefs;
 
   // A changed transcription model invalidates the prewarm guards: the new
   // model may be uncached and must get its own download confirmation, so we
@@ -4195,7 +4188,6 @@
 
   document.addEventListener("DOMContentLoaded", function () {
     initThemeToggle();
-    initTooltipToggle();
     initStatusIndicatorTooltip();
     checkNavLinks();
     initFrontendSwitcher();

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -68,6 +68,7 @@ var CLIPGEN_CONFIG = {
   composerAnnotationSpanSeconds: 10.0,
   composerScrubMaxAudioSeconds: 180.0,
   composerDoubleClickCuts: true,
+  crossReferences: true,
   mediaContainerWarning: true,
   // Mirrors video.SUBTITLE_CODEC_BY_CONTAINER / SUBTITLE_ALWAYS_DEFAULT_CONTAINERS.
   // `supported` is what mux_subtitles can write at all; `alwaysDefault` is the
@@ -159,6 +160,9 @@ var clipgenApplyConfig = function (payload) {
   }
   if (typeof payload.composerDoubleClickCuts === "boolean") {
     CLIPGEN_CONFIG.composerDoubleClickCuts = payload.composerDoubleClickCuts;
+  }
+  if (typeof payload.crossReferences === "boolean") {
+    CLIPGEN_CONFIG.crossReferences = payload.crossReferences;
   }
   if (typeof payload.mediaContainerWarning === "boolean") {
     CLIPGEN_CONFIG.mediaContainerWarning = payload.mediaContainerWarning;
@@ -1865,6 +1869,7 @@ var xrefBadgeIcon = function (iconName) {
 // intake cards and the Overview page (Convergence detail rows, Map drill-down).
 // selfBadge: optional { icon, color, title } to prepend as the "self" source badge.
 var buildXrefBadges = function (xref, selfSource, selfBadge) {
+  if (!CLIPGEN_CONFIG.crossReferences) return null;
   var badges = [];
   if (selfBadge) badges.push(selfBadge);
   if (selfSource !== "screenspace" && xref.screenspaceEvents.length > 0) {
@@ -2050,7 +2055,6 @@ function categoryColor(label, alpha) {
 // ---- Shared settings (localStorage) ----
 
 var THEME_STORAGE_KEY = "clipgen-theme";
-var TOOLTIP_STORAGE_KEY = "clipgen-tooltips";
 
 // In the native window the theme is not just the page's business: AppKit fills
 // the area a resize exposes with an appearance-derived colour for the frame
@@ -2197,18 +2201,37 @@ var initFrontendSwitcher = function () {
     .catch(function () {});
 };
 
-var getStoredTooltipPref = function () {
-  try {
-    var v = window.localStorage.getItem(TOOLTIP_STORAGE_KEY);
-    if (v === "false") return false;
-  } catch (_) {}
-  return true;
+// Cross-reference badges: three pages mirror the setting, the command palette
+// flips it. applyCrossRefSetting reads a /api/settings save or reset payload and
+// reports whether the value moved, so callers only re-render when it did.
+var applyCrossRefSetting = function (applied, settings) {
+  var value;
+  if (applied && applied.CROSS_REFERENCES_ENABLED !== undefined) {
+    value = applied.CROSS_REFERENCES_ENABLED;
+  } else if (settings) {
+    for (var i = 0; i < settings.length; i++) {
+      if (settings[i].name === "CROSS_REFERENCES_ENABLED") {
+        value = settings[i].value;
+        break;
+      }
+    }
+  }
+  if (value === undefined) return false;
+  var changed = CLIPGEN_CONFIG.crossReferences !== !!value;
+  CLIPGEN_CONFIG.crossReferences = !!value;
+  return changed;
 };
 
-var setStoredTooltipPref = function (enabled) {
-  try {
-    window.localStorage.setItem(TOOLTIP_STORAGE_KEY, enabled ? "true" : "false");
-  } catch (_) {}
+// Settings live at the combined-app root, not under the page prefix.
+var setCrossReferences = function (enabled) {
+  return apiPut("/api/settings", { settings: { CROSS_REFERENCES_ENABLED: enabled } })
+    .then(function () {
+      CLIPGEN_CONFIG.crossReferences = enabled;
+      if (typeof window.clipgenRerenderCrossRefs === "function") {
+        window.clipgenRerenderCrossRefs();
+      }
+    })
+    .catch(function () {});
 };
 
 // ---- Participant deep links (location.hash) ----

--- a/source/config.py
+++ b/source/config.py
@@ -235,6 +235,10 @@ STUDIO_CARD_SCRUBBER: bool = False
 STUDIO_SCRUBBER_SPRITE_COLS: int = 5
 STUDIO_SCRUBBER_SPRITE_ROWS: int = 5
 
+# Cross-reference badges on Studio, Transcripts, and Overview.
+# Mirrored to JS via get_frontend_config() (never hardcode).
+CROSS_REFERENCES_ENABLED: bool = True
+
 # Metadata tab: count Screenspace as time-adjacent clusters rather than raw
 # events, so a dense 10k-event scan reads as a handful of blocks instead of
 # overshadowing the sheet/transcript streams. Boot-embedded into /api/sheet, not
@@ -720,6 +724,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "MANIFEST_ENABLED": "Write a manifest JSON file alongside generated artifacts for session tracking.",
     "STUDIO_CELL_EXPAND_HOVER": "Expand overflowing timestamp cells on hover in the Sheet Preview.",
     "STUDIO_CARD_SCRUBBER": "Hover a queue card's thumbnail to scrub through frames, hear the clip's audio, and see a waveform overlay.",
+    "CROSS_REFERENCES_ENABLED": "Show cross-reference badges linking spreadsheet, Screenspace, transcript, and Composer data across pages.",
     "COMPOSER_DOUBLE_CLICK_CUTS": "Double-click the Composer timeline to set the in point, then double-click again to commit the out point.",
     "MEDIA_CONTAINER_WARNING": "Warn when a source recording is a fragmented MP4 that browsers cannot seek (OBS 'fragmented recording'), and offer a one-click remux to fix it.",
     "STUDIO_METADATA_CLUSTER_SCREENSPACE": "In the Metadata tab, count Screenspace data as time-adjacent clusters instead of raw events, so a dense scan doesn't overshadow the spreadsheet and transcript streams. On by default.",
@@ -778,6 +783,11 @@ STUDIO_SETTINGS: dict[str, dict[str, Any]] = {
     "STUDIO_CARD_SCRUBBER": {
         "tab": "General",
         "group": "Sheet Preview",
+        "type": "bool",
+    },
+    "CROSS_REFERENCES_ENABLED": {
+        "tab": "General",
+        "group": "Cross-References",
         "type": "bool",
     },
     "STUDIO_METADATA_CLUSTER_SCREENSPACE": {

--- a/source/utils.py
+++ b/source/utils.py
@@ -1112,6 +1112,7 @@ def get_frontend_config() -> dict[str, Any]:
         "convergenceSources": list(config.CONVERGENCE_SOURCES),
         "cardScrubberSpriteCols": config.STUDIO_SCRUBBER_SPRITE_COLS,
         "cardScrubberSpriteRows": config.STUDIO_SCRUBBER_SPRITE_ROWS,
+        "crossReferences": config.CROSS_REFERENCES_ENABLED,
         "clipFormat": config.FILEFORMAT,
         "screenshotFormat": config.SCREENSHOT_FORMAT,
         "gifFormat": config.GIF_FORMAT,

--- a/tests/test_css_token_discipline.py
+++ b/tests/test_css_token_discipline.py
@@ -26,7 +26,7 @@ _BASELINE = {
     "screenspace.css": (52, 0, 1, 14),
     "settings-modal.css": (11, 0, 1, 4),
     "start-overlay.css": (168, 9, 34, 11),
-    "studio.css": (54, 5, 9, 50),
+    "studio.css": (53, 5, 9, 50),
     "topnav.css": (25, 0, 0, 7),
     "transcripts.css": (35, 2, 6, 0),
     "viewer.css": (26, 0, 2, 16),

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -148,6 +148,7 @@ def test_clipgen_config_defaults_match_python():
         == py_config["composerScrubMaxAudioSeconds"]
     )
     assert js_config["composerDoubleClickCuts"] == py_config["composerDoubleClickCuts"]
+    assert js_config["crossReferences"] == py_config["crossReferences"]
     assert js_config["mediaContainerWarning"] == py_config["mediaContainerWarning"]
     # The Embed Subtitles dialog filters its target list against these, so JS
     # drifting from video.SUBTITLE_CODEC_BY_CONTAINER means promising output
@@ -212,6 +213,7 @@ def test_get_frontend_config_shape():
         "composerAnnotationSpanSeconds",
         "composerScrubMaxAudioSeconds",
         "composerDoubleClickCuts",
+        "crossReferences",
         "mediaContainerWarning",
         "subtitleContainers",
         "hotkeyOverrides",


### PR DESCRIPTION
## Summary

Replaces the localStorage-backed `#tooltipToggle` topnav button with `CROSS_REFERENCES_ENABLED` under **Settings → General → Cross-References**, mirrored to JS as `crossReferences` through `get_frontend_config()`.

- The old `clipgen-tooltips` key drove two unrelated features — Transcripts' gutter badges and Studio's intake hover tooltip — so one page's toggle silently changed the other's. One setting now gates both, plus the badges that were unconditional (Studio intake cards, Overview Convergence), via an early return in `buildXrefBadges()`.
- New `utils.js` helpers `applyCrossRefSetting()` / `setCrossReferences()`; each page registers `window.clipgenRerenderCrossRefs` so the settings modal and the repointed command-palette entry share one re-render path. Overview defers its re-render while Convergence is hidden, since a hidden panel measures zero width.
- `studio.css`'s raw-value baseline ratchets 54 → 53: the deleted button CSS took a raw `box-shadow` px value with it.

## Test plan

- [x] `/check` green — ruff format + lint, `ty`, full suite (3690 passed)
- [x] `/ui-check` — 16 headless page tests pass, screenshots reviewed (Settings modal renders the new group correctly)
- [x] In-browser via `shot.py --eval`: PUT→GET round-trip persists; `buildXrefBadges` returns `null` off and `.xref-badge-stack` on; palette entry resolves; no `#tooltipToggle` on Studio or Transcripts
- [x] Overview Convergence — with a zone detail open, flipping moves badges 12 → 0 → 12 and leaves the detail open; flipping while on Metadata then returning renders 0
- [x] Studio — a visible `#trIntakeTooltip` is hidden when the setting is flipped mid-hover
- [ ] Not browser-checked in WebKit/Safari (Chromium only)