### PR TITLE
build(deps): re-pin Windows ffmpeg to gyan.dev and add pin tooling

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -61,9 +61,8 @@ jobs:
         # which would silently replace the force-reinstalled no-FFmpeg cv2
         # wheel (below) with the official GPL-tainted one from PyPI — the
         # pre-PyInstaller assert caught exactly that on the first CI run.
-        run: |
-          uv sync --locked
-          uv pip install pyinstaller==6.19.0
+        # --extra build: PyInstaller, pinned once in pyproject.toml.
+        run: uv sync --locked --extra build
 
       # The official opencv-python-headless macOS arm64 wheels bundle a
       # GPL-3-configured Homebrew FFmpeg (upstream bug opencv/opencv-python#1260,

--- a/.github/workflows/pin-health.yml
+++ b/.github/workflows/pin-health.yml
@@ -1,0 +1,32 @@
+name: pin-health
+
+# Every pinned download in build/fetch_binaries.py lives on someone else's
+# server. The build only fetches on a cache miss, so a vanished asset stays
+# invisible until the next pin edit rotates the cache key — usually on a
+# release day. Probe weekly instead, and surface lockfile drift while here.
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Probe every pinned URL
+        # stdlib-only script; the runner's python3 is enough.
+        run: python3 build/fetch_binaries.py --check-urls
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Lockfile agrees with pyproject
+        run: uv lock --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,4 +128,5 @@ The version lives in [build/VERSION](build/VERSION). Agents bump the patch numbe
 - **Performance** — [agents/PERFORMANCE.md](agents/PERFORMANCE.md). Measure before optimizing: [agents/skills/profile/SKILL.md](agents/skills/profile/SKILL.md) (`--profile`, `/api/profile`, `shot.py --perf`).
 - **Code review** — [agents/CODE-REVIEW.md](agents/CODE-REVIEW.md).
 - **CLI command recipes** — [agents/skills/generate/SKILL.md](agents/skills/generate/SKILL.md).
+- **Pinned binaries** (ffmpeg, llama.cpp, OCR models, PyInstaller) — [agents/skills/bump-pins/SKILL.md](agents/skills/bump-pins/SKILL.md). Pins live in `build/fetch_binaries.py`; `--repin <url>` rewrites one, `--check-urls` probes them all (weekly `pin-health` workflow).
 - **Diagnostics** — [agents/skills/debug/SKILL.md](agents/skills/debug/SKILL.md).

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Selection modes: batch (`-b`), line (`-l`), range (`-r`), category (`-C`), cell 
 To build locally with PyInstaller:
 
 ```shell
-pip install pyinstaller
-uv run build/fetch_binaries.py      # pinned ffmpeg/ffprobe for the bundle (SHA256-verified)
-pyinstaller --clean --noconfirm build/clipgen.spec
+uv sync --extra build               # PyInstaller, pinned in pyproject.toml
+uv run build/fetch_binaries.py      # pinned ffmpeg/ffprobe/llama-server + OCR models (SHA256-verified)
+uv run --no-sync pyinstaller --clean --noconfirm build/clipgen.spec
 ```
 
 ## Third-party attribution

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -11,6 +11,7 @@ Skill procedures for development workflows and CLI usage. Each skill is also ava
 - [test-perf](test-perf/SKILL.md) — verify new tests are not slow, and fix the ones that are
 - [profile](profile/SKILL.md) — enable the instrumentation, capture numbers, prove a perf fix
 - [bump](bump/SKILL.md) — increment patch version
+- [bump-pins](bump-pins/SKILL.md) — update the pinned ffmpeg / llama.cpp / OCR / PyInstaller versions
 - [new-mode](new-mode/SKILL.md) — checklist for adding a CLI mode or flag
 - [new-screenspace-tool](new-screenspace-tool/SKILL.md) — checklist for adding a Screenspace tool
 - [new-thinking-agent](new-thinking-agent/SKILL.md) — checklist for adding a local-LLM thinking agent

--- a/agents/skills/build/SKILL.md
+++ b/agents/skills/build/SKILL.md
@@ -12,8 +12,8 @@ frozen build — most of the cost here has historically gone into rediscovering 
 ## Build it
 
 ```bash
-uv pip install pyinstaller==6.19.0          # match the CI pin
-uv run --no-sync build/fetch_binaries.py    # pinned ffmpeg/ffprobe → build/vendor/ (idempotent)
+uv sync --extra build                       # PyInstaller, pinned once in pyproject.toml
+uv run --no-sync build/fetch_binaries.py    # pinned ffmpeg/ffprobe/llama-server + OCR models → build/vendor/ (idempotent)
 uv run --no-sync pyinstaller --clean --noconfirm build/clipgen.spec
 ```
 
@@ -21,7 +21,8 @@ Takes ~90 s. Output: `dist/clipgen.app` (macOS) or `dist/clipgen/` (Windows: `cl
 `lib/`). The build is **one-dir** — see "Why one-dir" below before changing that.
 
 The fetch step downloads the pinned static GPL ffmpeg/ffprobe builds (SHA256-verified, see the
-`PINS` block in `build/fetch_binaries.py` for provenance) into the gitignored `build/vendor/`.
+`PINS` block in `build/fetch_binaries.py` for provenance; bumping a pin is
+[bump-pins](../bump-pins/SKILL.md)) into the gitignored `build/vendor/`.
 The spec hard-fails without them — a build that skipped the step must break on the build machine,
 not ship an app that dies on its startup ffmpeg check. They land in `<bundle>/bin/`, which
 `utils.prepend_bundled_bin_to_path()` puts at the head of PATH on frozen launches, so the app
@@ -249,6 +250,7 @@ the build instead of silently degrading webp/vp9/titlecards.
 ## Related
 
 - [agents/skills/check/SKILL.md](../check/SKILL.md) — the pre-commit gate
+- [agents/skills/bump-pins/SKILL.md](../bump-pins/SKILL.md) — updating the pinned ffmpeg / llama.cpp / OCR / PyInstaller versions
 - [plans/archive/DESKTOP-PACKAGING-PLAN.md](../../../plans/archive/DESKTOP-PACKAGING-PLAN.md) — how
   the current shape was arrived at. Its "deferred ffmpeg bundling" note is resolved: the bundle now
   ships pinned GPL ffmpeg/ffprobe (licensing recorded in `build/THIRD-PARTY-LICENSES` and

--- a/agents/skills/bump-pins/SKILL.md
+++ b/agents/skills/bump-pins/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: clipgen-bump-pins
+description: Update the pinned ffmpeg / llama.cpp / OCR-model / PyInstaller versions the desktop bundle ships
+---
+
+# Bumping pinned binaries
+
+Every third-party binary in the desktop bundle is pinned by URL + SHA256 in
+`build/fetch_binaries.py` (`PINS` per platform, `OCR_MODEL_PINS` for the RapidOCR
+recognition models). PyInstaller is pinned once, in the `build` extra of `pyproject.toml`.
+Nothing updates these automatically — Dependabot cannot see `fetch_binaries.py` — so a
+bump is a deliberate PR. The weekly `pin-health` workflow only tells you when a pinned
+URL has vanished.
+
+## When to bump
+
+| Pin | Bump when | Not when |
+|---|---|---|
+| llama.cpp (`b…` release, both platforms) | a feature or fix needs a newer build, or ~quarterly alongside a release; re-run the router-mode gate validation | upstream cut a new build (it does, several times a day) |
+| ffmpeg (macOS: Martin Riedl; Windows: gyan.dev) | an upstream point release (8.1.x → 8.2) or a feature gap | — never pin a moving alias (`release-essentials`, `latest`) |
+| RapidOCR models | only together with a `rapidocr` bump in `pyproject.toml`; re-derive URLs + hashes from the new wheel's `default_models.yaml` | on their own |
+| PyInstaller | with the regular dependency refresh, as its own PR | — |
+
+One pin per `build(deps):` PR. No `build/VERSION` bump.
+
+## Procedure (ffmpeg / llama.cpp)
+
+1. Pick the new asset URL on the provider. Permanent URLs only: gyan.dev
+   `/builds/packages/ffmpeg-<ver>-essentials_build.zip` (the `full_build` is `.7z`, which
+   the stdlib-only fetch script cannot extract), Martin Riedl's per-build paths, llama.cpp
+   GitHub release assets. llama.cpp needs both platforms' URLs.
+2. `uv run build/fetch_binaries.py --repin <url> [<url> ...]` — finds the entry each URL
+   replaces (same host; platform token in the filename), checks the archive against the
+   provider's `<url>.sha256` when one is published, re-hashes every member the old entry
+   pinned, and rewrites the entry in place. A member missing from the new archive aborts
+   with the list — the provider's closure changed, edit by hand.
+3. Update the provenance block at the top of `fetch_binaries.py` and the matching
+   paragraph in `build/THIRD-PARTY-LICENSES`.
+4. `rm -rf build/vendor && uv run build/fetch_binaries.py` — the real fetch, against the
+   rewritten hashes.
+5. `uv run --extra dev pytest -c tests/pytest.ini tests/test_packaging.py` — member paths
+   must belong to their archive, OCR pins must match `screenspace_ocr`, and the rendered
+   entries must round-trip.
+6. Open the PR, then `gh workflow run build-binaries.yml --ref <branch>`. CI greps the
+   in-bundle ffmpeg for libx264 / libwebp / libvpx-vp9 / drawtext and runs
+   `llama-server --version`; Windows can only be verified this way, say so in the PR.
+7. Download the artifact and launch it the way a user does (`open dist/clipgen.app`) —
+   [build](../build/SKILL.md) explains why `--help` proves nothing.
+
+## Procedure (OCR models)
+
+Bump `rapidocr` in `pyproject.toml`, `uv lock`, then open the installed wheel's
+`default_models.yaml` (onnxruntime section) and copy each rec model's URL + SHA256 into
+`OCR_MODEL_PINS`. `--repin` works here too once the URL is known. Keep the PP-OCR version
+rule in step with `screenspace_ocr._build_ocr_reader` (v4 for japan, v5 otherwise; the
+test enforces it).
+
+## Procedure (PyInstaller / opencv / ruff)
+
+- PyInstaller: edit the `build` extra in `pyproject.toml`, `uv lock`. Nothing else names
+  the version; the test fails if something starts to.
+- opencv: the `>=` floor in `pyproject.toml` must equal the sdist URL, cache key, and
+  extracted-dir name in `build-binaries.yml` — four places, one test.
+- ruff: `required-version` in `pyproject.toml` must equal the `uvx ruff@…` pin in
+  `tests.yml`.
+
+## Health check
+
+`uv run build/fetch_binaries.py --check-urls` probes every pinned URL. The `pin-health`
+workflow runs it Mondays and on dispatch, plus `uv lock --check`.

--- a/build/THIRD-PARTY-LICENSES
+++ b/build/THIRD-PARTY-LICENSES
@@ -1331,10 +1331,9 @@ this provenance):
   macOS arm64:  FFmpeg 8.1.2 release, build 1783011502_8.1.2 from Martin
                 Riedl's FFmpeg build server. Binaries, checksums, and the full
                 build configuration: https://ffmpeg.martin-riedl.de
-  Windows x64:  FFmpeg 8.1 release branch (n8.1.2-44-g7c533d0f86) from BtbN
-                FFmpeg-Builds, release tag autobuild-2026-08-16-13-00.
-                Binaries, checksums, and build scripts:
-                https://github.com/BtbN/FFmpeg-Builds
+  Windows x64:  FFmpeg 8.1.2 release, package ffmpeg-8.1.2-essentials_build
+                from Gyan Doshi's build site. Binaries, checksums, and the
+                full build configuration: https://www.gyan.dev/ffmpeg/builds/
 
 FFmpeg source code: https://ffmpeg.org/download.html (releases) and
 https://git.ffmpeg.org/ffmpeg.git. Sources and build configuration for the

--- a/build/clipgen.spec
+++ b/build/clipgen.spec
@@ -69,8 +69,11 @@ datas += _rapidocr_datas
 # Vendored non-default recognition models (fetch_binaries.py OCR_MODEL_PINS),
 # guarded like ffmpeg below: a build that skipped the fetch must fail here.
 # "ocr_models" matches screenspace_ocr._vendored_rec_model's frozen lookup.
+sys.path.insert(0, str(Path(SPECPATH)))  # noqa: F821
+from fetch_binaries import OCR_MODEL_PINS, PINS  # noqa: E402
+
 _ocr_vendor = Path(SPECPATH) / "vendor" / "ocr"  # noqa: F821
-_ocr_models = ["latin_rec.onnx", "japan_rec.onnx", "korean_rec.onnx"]
+_ocr_models = [pin["target"] for pin in OCR_MODEL_PINS]
 _missing_models = [n for n in _ocr_models if not (_ocr_vendor / n).is_file()]
 if _missing_models:
     raise SystemExit(
@@ -112,14 +115,12 @@ excludes = [
 # THIRD-PARTY-LICENSES carries the licenses). They land in <bundle>/bin/,
 # which cli.main prepends to PATH on frozen launches, so every "ffmpeg" /
 # "llama-server" argv in the codebase resolves to these copies. The tool list
-# is derived from PINS so this guard can never drift from the pin set.
+# is derived from PINS (imported with OCR_MODEL_PINS above) so this guard can
+# never drift from the pin set.
 # Guarded like source/ below: a build that skipped the fetch step must fail
 # here, not ship an app that dies on its startup ffmpeg check.
 _vendor_platform = "macos-arm64" if sys.platform == "darwin" else "windows-x64"
 _vendor_bin = Path(SPECPATH) / "vendor" / _vendor_platform / "bin"  # noqa: F821
-sys.path.insert(0, str(Path(SPECPATH)))  # noqa: F821
-from fetch_binaries import PINS  # noqa: E402
-
 _tool_names = [
     member["target"]
     for archive in PINS[_vendor_platform]

--- a/build/fetch_binaries.py
+++ b/build/fetch_binaries.py
@@ -18,18 +18,14 @@ Provenance (THIRD-PARTY-LICENSES cites this block):
     Build 1783011502_8.1.2 — FFmpeg 8.1.2 release, GPLv3 build
     (--enable-gpl --enable-version3, with libx264/libvpx/libwebp/libfreetype;
     VideoToolbox enabled by default on macOS). Permanent per-build URLs.
-  windows-x64: BtbN FFmpeg-Builds, https://github.com/BtbN/FFmpeg-Builds
-    Release tag autobuild-2026-08-16-13-00 (a dated tag — never pin "latest",
-    its assets are replaced daily), asset
-    ffmpeg-n8.1.2-44-g7c533d0f86-win64-gpl-8.1.zip — FFmpeg 8.1 release
-    branch, GPLv3 build. Archive hash cross-checked against the release's
-    published checksums.sha256.
-    CAUTION: BtbN prunes dated autobuild tags after roughly two weeks, so
-    this pin has a shelf life. CI usually survives on the build/vendor cache,
-    but any change to this file rotates the cache key and forces a real
-    download — so refresh this pin (tag, asset name, all three hashes)
-    whenever you touch this file, and expect a 404 here if the pin has
-    lapsed.
+  windows-x64: Gyan Doshi's builds, https://www.gyan.dev/ffmpeg/builds/
+    Package ffmpeg-8.1.2-essentials_build.zip — FFmpeg 8.1.2 release, GPLv3
+    build (--enable-gpl --enable-version3, with libx264/libvpx/libwebp/
+    libfreetype). Versioned packages under /builds/packages/ are permanent;
+    the archive hash matches the provider's published .sha256 file. Never pin
+    the "release-essentials" / "git-essentials" aliases: those move. (The
+    earlier BtbN autobuild pin was dropped because BtbN prunes dated tags
+    after ~2 weeks and any edit here rotates the CI cache key.)
 
   llama.cpp (both platforms): ggml-org/llama.cpp GitHub release b10588 (MIT),
     https://github.com/ggml-org/llama.cpp/releases/tag/b10588 — the exact
@@ -41,22 +37,27 @@ Provenance (THIRD-PARTY-LICENSES cites this block):
     runtime). Release assets are permanent; member hashes were computed from
     the archives at pin time.
 
-Updating the pins: pick a new build/tag on the provider, update the archive
-URL + sha256 (from the provider's published .sha256 / checksums.sha256 files),
-clear build/vendor/, run this script — it prints the extracted-file hashes on
-mismatch so the member sha256s can be copied in — then let CI's post-build
-feature check (libx264/libwebp/libvpx-vp9/drawtext) confirm the new build
-still carries everything clipgen's soft gates probe for.
+Updating the pins: `uv run build/fetch_binaries.py --repin <new-url>` finds
+the entry the URL replaces (same host, same platform), downloads it, checks
+the archive against the provider's published `<url>.sha256` when one exists,
+re-hashes the members the old entry pinned, and rewrites the entry in place.
+`--check-urls` probes every pinned URL (the weekly pin-health workflow runs
+it). The full procedure — provenance notes, THIRD-PARTY-LICENSES, CI
+dispatch, launching the frozen app — is agents/skills/bump-pins/SKILL.md.
 """
 
+import argparse
 import hashlib
 import platform
+import re
 import sys
 import tarfile
 import tempfile
+import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
+from urllib.parse import urlsplit
 
 PINS: dict[str, list[dict]] = {
     "macos-arm64": [
@@ -133,16 +134,16 @@ PINS: dict[str, list[dict]] = {
     ],
     "windows-x64": [
         {
-            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-16-13-00/ffmpeg-n8.1.2-44-g7c533d0f86-win64-gpl-8.1.zip",
-            "sha256": "d2425b12dc746a2b044148c6100440d4065876ac4ed6e3eb13a68437b7719796",
+            "url": "https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-8.1.2-essentials_build.zip",
+            "sha256": "db580001caa24ac104c8cb856cd113a87b0a443f7bdf47d8c12b1d740584a2ec",
             "members": {
-                "ffmpeg-n8.1.2-44-g7c533d0f86-win64-gpl-8.1/bin/ffmpeg.exe": {
+                "ffmpeg-8.1.2-essentials_build/bin/ffmpeg.exe": {
                     "target": "ffmpeg.exe",
-                    "sha256": "361c161fa536922d32badacad5f32fbd8561f945bd6e0bf4cb1f1017deb03541",
+                    "sha256": "1326dde4c84ff1f96fe6b8916c5bed29e163e9b5dccf995f6f3db069d143ec5e",
                 },
-                "ffmpeg-n8.1.2-44-g7c533d0f86-win64-gpl-8.1/bin/ffprobe.exe": {
+                "ffmpeg-8.1.2-essentials_build/bin/ffprobe.exe": {
                     "target": "ffprobe.exe",
-                    "sha256": "9fe11967029cff5562e7b0c2e74987690bea1b8b877fcadd6c9939a334fc9fb3",
+                    "sha256": "b49ccc7c6547b141ad5a2f6ec69cc04323d7133d7704d70b331b904c63eecb07",
                 },
             },
         },
@@ -279,6 +280,16 @@ OCR_MODEL_PINS: list[dict] = [
 ]
 
 _CHUNK = 1024 * 1024
+_USER_AGENT = "clipgen-fetch-binaries"
+
+
+def _request(
+    url: str, method: str = "GET", headers: dict[str, str] | None = None
+) -> urllib.request.Request:
+    # martin-riedl.de returns 403 to urllib's default Python-urllib/3.x agent.
+    return urllib.request.Request(
+        url, method=method, headers={"User-Agent": _USER_AGENT, **(headers or {})}
+    )
 
 
 def host_platform() -> str:
@@ -320,13 +331,9 @@ def download_archive(url: str, expected_sha256: str, dest: Path) -> None:
     print(f"fetch_binaries: downloading {url}")
     digest = hashlib.sha256()
     received = 0
-    # martin-riedl.de returns 403 to urllib's default Python-urllib/3.x agent.
-    request = urllib.request.Request(
-        url, headers={"User-Agent": "clipgen-fetch-binaries"}
-    )
     try:
         with (
-            urllib.request.urlopen(request, timeout=60) as response,
+            urllib.request.urlopen(_request(url), timeout=60) as response,
             dest.open("wb") as out,
         ):
             while chunk := response.read(_CHUNK):
@@ -360,15 +367,16 @@ def _open_member(bundle, member_name: str):
     return handle
 
 
+def _opener(archive_path: Path):
+    if archive_path.name.endswith((".tar.gz", ".tgz")):
+        return tarfile.open
+    return zipfile.ZipFile
+
+
 def extract_members(
     archive_path: Path, members: dict[str, dict], vendor_bin: Path
 ) -> None:
-    opener = (
-        tarfile.open
-        if archive_path.name.endswith((".tar.gz", ".tgz"))
-        else zipfile.ZipFile
-    )
-    with opener(archive_path) as bundle:
+    with _opener(archive_path)(archive_path) as bundle:
         for member_name, member in members.items():
             target = vendor_bin / member["target"]
             digest = hashlib.sha256()
@@ -408,7 +416,230 @@ def fetch_ocr_models() -> None:
     print(f"fetch_binaries: done — {vendor_ocr} is ready.")
 
 
+def all_pinned_urls() -> list[str]:
+    """Every pinned URL: both platforms' archives plus the OCR models."""
+    urls = [a["url"] for archives in PINS.values() for a in archives]
+    return urls + [pin["url"] for pin in OCR_MODEL_PINS]
+
+
+def _probe(url: str) -> int:
+    """HTTP status for *url*: HEAD, then a one-byte GET for hosts that reject HEAD."""
+    status = 0
+    for method, headers in (("HEAD", {}), ("GET", {"Range": "bytes=0-0"})):
+        try:
+            with urllib.request.urlopen(
+                _request(url, method, headers), timeout=30
+            ) as response:
+                return 200 if response.status in (200, 206) else response.status
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+        except OSError:
+            status = 0
+    return status
+
+
+def check_urls() -> None:
+    """Probe every pinned URL; exit non-zero when any has gone away."""
+    urls = all_pinned_urls()
+    gone = []
+    for url in urls:
+        status = _probe(url)
+        print(f"fetch_binaries: {status or 'ERR':>3}  {url}")
+        if status != 200:
+            gone.append(url)
+    if gone:
+        raise SystemExit(
+            f"fetch_binaries: {len(gone)} of {len(urls)} pinned URLs unreachable:\n  "
+            + "\n  ".join(gone)
+        )
+    print(f"fetch_binaries: all {len(urls)} pinned URLs reachable.")
+
+
+def published_sha256(url: str) -> str | None:
+    """The provider's `<url>.sha256` digest, or None when it publishes none."""
+    try:
+        with urllib.request.urlopen(_request(url + ".sha256"), timeout=30) as resp:
+            text = resp.read(4096).decode("utf-8", "replace")
+    except OSError:
+        return None
+    match = re.search(r"\b[0-9a-f]{64}\b", text)
+    return match.group(0) if match else None
+
+
+_PLATFORM_TOKEN = {"macos-arm64": "macos", "windows-x64": "win"}
+
+
+def _entry_for(url: str) -> dict:
+    """The PINS / OCR entry *url* replaces: same host, then platform or family."""
+    host = urlsplit(url).netloc
+    name = Path(urlsplit(url).path).name.lower()
+    archives = [
+        (plat, a)
+        for plat, entries in PINS.items()
+        for a in entries
+        if urlsplit(a["url"]).netloc == host
+    ]
+    if len(archives) > 1:
+        archives = [(p, a) for p, a in archives if _PLATFORM_TOKEN[p] in name]
+    models = [
+        ("ocr", pin)
+        for pin in OCR_MODEL_PINS
+        if urlsplit(pin["url"]).netloc == host
+        and pin["target"].removesuffix("_rec.onnx") in name
+    ]
+    candidates = archives + models
+    if len(candidates) != 1:
+        raise SystemExit(
+            f"fetch_binaries: {url} matches {len(candidates)} pinned entries; "
+            "expected exactly one (same host, platform token in the filename)."
+        )
+    return candidates[0][1]
+
+
+def _member_target(name: str) -> str:
+    """Pinned target for an archive member: basename, dylibs sans minor.patch."""
+    base = name.rsplit("/", 1)[-1]
+    return re.sub(r"^(.+?\.\d+)\.\d+\.\d+\.dylib$", r"\1.dylib", base)
+
+
+def _archive_files(archive_path: Path) -> list[str]:
+    with _opener(archive_path)(archive_path) as bundle:
+        if isinstance(bundle, zipfile.ZipFile):
+            return [i.filename for i in bundle.infolist() if not i.is_dir()]
+        return [m.name for m in bundle.getmembers() if m.isfile()]
+
+
+def _rehash_members(archive_path: Path, old_members: dict[str, dict]) -> dict:
+    """Re-pin each old member target against the new archive's files."""
+    by_target = {_member_target(n): n for n in _archive_files(archive_path)}
+    missing = [
+        m["target"] for m in old_members.values() if m["target"] not in by_target
+    ]
+    if missing:
+        raise SystemExit(
+            f"fetch_binaries: {archive_path.name} lacks pinned members {missing} "
+            "— the provider's closure changed; edit the entry by hand."
+        )
+    members: dict[str, dict] = {}
+    with _opener(archive_path)(archive_path) as bundle:
+        for old in old_members.values():
+            name = by_target[old["target"]]
+            digest = hashlib.sha256()
+            with _open_member(bundle, name) as src:
+                while chunk := src.read(_CHUNK):
+                    digest.update(chunk)
+            members[name] = {"target": old["target"], "sha256": digest.hexdigest()}
+    return members
+
+
+def _render_entry(entry: dict, indent: int) -> list[str]:
+    """The entry as source lines in ruff's layout, so the diff stays minimal."""
+    pad = " " * indent
+    lines = [
+        f"{pad}{{\n",
+        f'{pad}    "url": "{entry["url"]}",\n',
+        f'{pad}    "sha256": "{entry["sha256"]}",\n',
+    ]
+    if "members" in entry:
+        lines.append(f'{pad}    "members": {{\n')
+        for name, member in entry["members"].items():
+            lines += [
+                f'{pad}        "{name}": {{\n',
+                f'{pad}            "target": "{member["target"]}",\n',
+                f'{pad}            "sha256": "{member["sha256"]}",\n',
+                f"{pad}        }},\n",
+            ]
+        lines.append(f"{pad}    }},\n")
+    else:
+        lines.append(f'{pad}    "target": "{entry["target"]}",\n')
+    lines.append(f"{pad}}},\n")
+    return lines
+
+
+def _replace_entry(old_url: str, entry: dict) -> None:
+    """Rewrite the PINS / OCR entry holding *old_url* in this file."""
+    source = Path(__file__)
+    lines = source.read_text(encoding="utf-8").splitlines(keepends=True)
+    url_line = next(i for i, line in enumerate(lines) if f'"url": "{old_url}"' in line)
+    start = url_line - 1
+    assert lines[start].strip() == "{", lines[start]
+    depth = 0
+    for end in range(start, len(lines)):
+        depth += lines[end].count("{") - lines[end].count("}")
+        if depth == 0:
+            break
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    lines[start : end + 1] = _render_entry(entry, indent)
+    source.write_text("".join(lines), encoding="utf-8")
+
+
+def repin(url: str) -> None:
+    """Point the entry *url* replaces at *url*, with freshly computed hashes."""
+    old = _entry_for(url)
+    print(f"fetch_binaries: re-pinning {old['url']}\n  -> {url}")
+    with tempfile.TemporaryDirectory() as tmp:
+        archive_path = Path(tmp) / Path(urlsplit(url).path).name
+        print(f"fetch_binaries: downloading {url}")
+        try:
+            with (
+                urllib.request.urlopen(_request(url), timeout=60) as response,
+                archive_path.open("wb") as out,
+            ):
+                while chunk := response.read(_CHUNK):
+                    out.write(chunk)
+        except OSError as exc:
+            raise SystemExit(
+                f"fetch_binaries: download failed for {url}: {exc}"
+            ) from exc
+        sha256 = file_sha256(archive_path)
+        published = published_sha256(url)
+        if published is None:
+            print(
+                "fetch_binaries: provider publishes no .sha256 — trusting first download"
+            )
+        elif published != sha256:
+            raise SystemExit(
+                f"fetch_binaries: {url} does not match the provider's .sha256\n"
+                f"  published {published}\n  received  {sha256}"
+            )
+        else:
+            print("fetch_binaries: archive matches the provider's published .sha256")
+        entry = {"url": url, "sha256": sha256}
+        if "members" in old:
+            entry["members"] = _rehash_members(archive_path, old["members"])
+        else:
+            entry["target"] = old["target"]
+    _replace_entry(old["url"], entry)
+    print(
+        f"fetch_binaries: rewrote {Path(__file__).name}. Next: update the provenance "
+        "docstring and build/THIRD-PARTY-LICENSES, clear build/vendor/, rerun "
+        "this script, dispatch build-binaries."
+    )
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--repin",
+        metavar="URL",
+        nargs="+",
+        help="re-pin the entries these URLs replace",
+    )
+    parser.add_argument(
+        "--check-urls", action="store_true", help="probe every pinned URL and exit"
+    )
+    args = parser.parse_args()
+    if args.check_urls:
+        check_urls()
+        return
+    if args.repin:
+        for url in args.repin:
+            repin(url)
+        return
+    fetch_vendor()
+
+
+def fetch_vendor() -> None:
     plat = host_platform()
     archives = PINS[plat]
     vendor_bin = Path(__file__).resolve().parent / "vendor" / plat / "bin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dev = ["pytest", "pytest-randomly"]
 # barely matters: the harness always passes `executable_path` explicitly rather
 # than letting playwright resolve the browser build it expects.
 ui = ["playwright>=1.55"]
+# PyInstaller for the desktop bundle (agents/skills/build/SKILL.md). Pinned
+# exactly, and only here: CI and the build docs install it with
+# `uv sync --extra build`, so a bump is a one-line change plus `uv lock`.
+build = ["pyinstaller==6.19.0"]
 
 [tool.setuptools]
 packages = []

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -121,6 +121,125 @@ def _looks_like_sha256(value: str) -> bool:
     return len(value) == 64 and all(c in "0123456789abcdef" for c in value)
 
 
+def test_vendor_pin_member_paths_belong_to_their_archive() -> None:
+    """A half-bumped entry (new URL, stale ``llama-b…/`` member paths) only
+    fails at extraction on the slow per-platform release build."""
+    pins = _fetch_binaries_module().PINS
+    for archives in pins.values():
+        for archive in archives:
+            archive_name = archive["url"].rsplit("/", 1)[1]
+            for member in archive["members"]:
+                top, sep, _rest = member.partition("/")
+                if sep:
+                    assert top in archive_name, f"{member} is not from {archive_name}"
+
+
+def test_vendor_pin_entries_round_trip_through_repin() -> None:
+    """``--repin`` rewrites an entry by rendering it; the rendering must match
+    the file's (ruff-formatted) layout or every bump produces a noisy diff."""
+    module = _fetch_binaries_module()
+    text = (_ROOT / "build" / "fetch_binaries.py").read_text(encoding="utf-8")
+    entries = [a for archives in module.PINS.values() for a in archives]
+    entries += module.OCR_MODEL_PINS
+    for entry in entries:
+        indent = 8 if "members" in entry else 4
+        rendered = "".join(module._render_entry(entry, indent))
+        assert rendered in text, f"rendering drifted for {entry['url']}"
+
+
+def test_member_target_strips_dylib_minor_versions() -> None:
+    """``--repin`` matches new archive members to old targets by this rule."""
+    target = _fetch_binaries_module()._member_target
+    assert target("llama-b10588/libggml.0.21.0.dylib") == "libggml.0.dylib"
+    assert target("llama-b10588/llama-server") == "llama-server"
+    assert target("ffmpeg-8.1.2-essentials_build/bin/ffmpeg.exe") == "ffmpeg.exe"
+    assert target("ggml-cpu-x64.dll") == "ggml-cpu-x64.dll"
+
+
+def test_ocr_model_pins_match_the_ocr_module() -> None:
+    """The vendored rec models must cover every non-default family the OCR
+    module maps languages to, at the PP-OCR version its dev fallback asks for."""
+    import screenspace_ocr
+
+    pins = _fetch_binaries_module().OCR_MODEL_PINS
+    families = {
+        model
+        for model in screenspace_ocr._OCR_LANG_TO_MODEL.values()
+        if model != screenspace_ocr._OCR_MODEL_DEFAULT
+    }
+    assert {pin["target"] for pin in pins} == {f"{m}_rec.onnx" for m in families}
+    for pin in pins:
+        family = pin["target"].removesuffix("_rec.onnx")
+        # Mirrors _build_ocr_reader: japan has no PP-OCRv5 ONNX model upstream.
+        version = "PP-OCRv4" if family == "japan" else "PP-OCRv5"
+        assert f"/{version}/" in pin["url"], pin["url"]
+        assert f"{family}_{version}_rec_mobile.onnx" in pin["url"], pin["url"]
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_pyinstaller_is_pinned_once() -> None:
+    """The ``build`` extra is the only place PyInstaller's version lives."""
+    build = _pyproject()["project"]["optional-dependencies"]["build"]
+    assert len(build) == 1 and re.fullmatch(r"pyinstaller==[\d.]+", build[0]), build
+    for rel in (
+        ".github/workflows/build-binaries.yml",
+        "README.md",
+        "agents/skills/build/SKILL.md",
+    ):
+        text = (_ROOT / rel).read_text(encoding="utf-8")
+        assert "pyinstaller==" not in text, f"{rel} restates the PyInstaller pin"
+    workflow = (_ROOT / ".github" / "workflows" / "build-binaries.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "uv sync --locked --extra build" in workflow
+
+
+def test_opencv_pin_agrees_across_pyproject_and_ci() -> None:
+    """The macOS leg rebuilds opencv from its sdist: floor, sdist URL, cache
+    key, and extracted dir must all name the same version."""
+    dep = next(
+        d
+        for d in _pyproject()["project"]["dependencies"]
+        if d.startswith("opencv-python-headless")
+    )
+    match = re.search(r">=([\d.]+)", dep)
+    assert match, dep
+    version = match.group(1)
+    workflow = (_ROOT / ".github" / "workflows" / "build-binaries.yml").read_text(
+        encoding="utf-8"
+    )
+    assert f"opencv_python_headless-{version}.tar.gz" in workflow
+    assert f"opencv-noffmpeg-{version}-" in workflow
+    assert f"/tmp/opencv_python_headless-{version}" in workflow
+    other = set(re.findall(r"opencv[_-]python[_-]headless-(\d+(?:\.\d+)*)", workflow))
+    assert other == {version}, other
+
+
+def test_ruff_pin_agrees_across_pyproject_and_ci() -> None:
+    required = _pyproject()["tool"]["ruff"]["required-version"]
+    version = required.removeprefix(">=")
+    workflow = (_ROOT / ".github" / "workflows" / "tests.yml").read_text(
+        encoding="utf-8"
+    )
+    pinned = set(re.findall(r"uvx ruff@([\d.]+)", workflow))
+    assert pinned == {version}, (required, pinned)
+
+
+def test_pin_health_workflow_probes_every_url() -> None:
+    """Pinned downloads live on other people's servers; a vanished asset only
+    shows up on a release-day cache miss unless something probes weekly."""
+    workflow = (_ROOT / ".github" / "workflows" / "pin-health.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "build/fetch_binaries.py --check-urls" in workflow
+    assert "uv lock --check" in workflow
+
+
 def test_spec_guards_and_upx_excludes_the_vendored_tools() -> None:
     """The spec must refuse to build without the fetched binaries (a silent
     skip ships an app that dies on its startup ffmpeg check), and UPX must
@@ -148,8 +267,8 @@ def test_ci_verifies_all_vendored_ocr_models() -> None:
     yml = (_ROOT / ".github" / "workflows" / "build-binaries.yml").read_text(
         encoding="utf-8"
     )
-    for name in ("latin_rec.onnx", "japan_rec.onnx", "korean_rec.onnx"):
-        assert name in yml, name
+    for pin in _fetch_binaries_module().OCR_MODEL_PINS:
+        assert pin["target"] in yml, pin["target"]
 
 
 def test_spec_never_strips_or_packs_on_windows() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,15 @@ overrides = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -241,6 +250,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+build = [
+    { name = "pyinstaller" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-randomly" },
@@ -261,6 +273,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "playwright", marker = "extra == 'ui'", specifier = ">=1.55" },
+    { name = "pyinstaller", marker = "extra == 'build'", specifier = "==6.19.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-randomly", marker = "extra == 'dev'" },
     { name = "pywebview", specifier = ">=6.2.1" },
@@ -268,7 +281,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "werkzeug", specifier = ">=3.0.0" },
 ]
-provides-extras = ["dev", "ui"]
+provides-extras = ["dev", "ui", "build"]
 
 [[package]]
 name = "clr-loader"
@@ -712,6 +725,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -970,6 +995,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1171,6 +1205,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/63/fd62472b6371d89dc138d40c36d87a50dc2de18a035803bbdc376b4ffac4/pyinstaller-6.19.0.tar.gz", hash = "sha256:ec73aeb8bd9b7f2f1240d328a4542e90b3c6e6fbc106014778431c616592a865", size = 4036072, upload-time = "2026-02-14T18:06:28.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/eb/23374721fecfa72677e79800921cb6aceefa6ba48574dc404f3f6c6c3be7/pyinstaller-6.19.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4190e76b74f0c4b5c5f11ac360928cd2e36ec8e3194d437bf6b8648c7bc0c134", size = 1040563, upload-time = "2026-02-14T18:05:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11", size = 735477, upload-time = "2026-02-14T18:05:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c9/ee3a4101c31f26344e66896c73c1fd6ed8282bf871473365b7f8674af406/pyinstaller-6.19.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf", size = 747143, upload-time = "2026-02-14T18:05:31.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0a/fc77e9f861be8cf300ac37155f59cc92aff99b29f2ddd78546f563a5b5a6/pyinstaller-6.19.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4ab2bb52e58448e14ddf9450601bdedd66800465043501c1d8f1cab87b60b122", size = 744849, upload-time = "2026-02-14T18:05:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e3/6872e020ee758afe0b821663858492c10745608b07150e5e2c824a5b3e1c/pyinstaller-6.19.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:da6d5c6391ccefe73554b9fa29b86001c8e378e0f20c2a4004f836ba537eff63", size = 741590, upload-time = "2026-02-14T18:05:39.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe", size = 741448, upload-time = "2026-02-14T18:05:45.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/63b0600f2694e9141b83129fbc1c488ec84d5a0770b1448ec154dcd0fee9/pyinstaller-6.19.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:e649ba6bd1b0b89b210ad92adb5fbdc8a42dd2c5ca4f72ef3a0bfec83a424b83", size = 740613, upload-time = "2026-02-14T18:05:49.726Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d4/e812ad36178093a0e9fd4b8127577748dd85b0cb71de912229dca21fd741/pyinstaller-6.19.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:481a909c8e60c8692fc60fcb1344d984b44b943f8bc9682f2fcdae305ad297e6", size = 740350, upload-time = "2026-02-14T18:05:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/b2c2ee41fb8e10fd2a45d21f5ec2ef25852cfb978dbf762972eed59e3d63/pyinstaller-6.19.0-py3-none-win32.whl", hash = "sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2", size = 1324317, upload-time = "2026-02-14T18:06:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d3/6d5e62b8270e2b53a6065e281b3a7785079b00e9019c8019952828dd1669/pyinstaller-6.19.0-py3-none-win_amd64.whl", hash = "sha256:b5bb6536c6560330d364d91522250f254b107cf69129d9cbcd0e6727c570be33", size = 1384894, upload-time = "2026-02-14T18:06:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/458cd523308a101a22fd2742893405030cc24994cc74b1b767cecf137160/pyinstaller-6.19.0-py3-none-win_arm64.whl", hash = "sha256:c2d5a539b0bfe6159d5522c8c70e1c0e487f22c2badae0f97d45246223b798ea", size = 1325374, upload-time = "2026-02-14T18:06:12.804Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
 name = "pyobjc-core"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1334,6 +1408,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/4a/05307135dafba67778669d194bd1a3822a7685ec9ee8a6d7e70856c1a551/pywebview-6.2.1.tar.gz", hash = "sha256:71b7136752e40824655304d938efb62014218d1a90bd8e87e1cbdb1ce9c466af", size = 513126, upload-time = "2026-04-15T09:02:16.595Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/25/9491695c22c4842c5b3903b4dc172e0eecf67a27c0af34a71512c9b76a0a/pywebview-6.2.1-py3-none-any.whl", hash = "sha256:9d07275f53894ab4d5e2e0e996227193e7187dec276d9b624dccbce029216b46", size = 525463, upload-time = "2026-04-15T09:02:10.186Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The Windows ffmpeg pin was a BtbN dated autobuild tag, which the provider prunes after ~2 weeks — it had reached expiry, and any edit to `build/fetch_binaries.py` rotates the CI cache key and forces a 404. Re-pinned to gyan.dev's permanent `ffmpeg-8.1.2-essentials_build.zip` (GPLv3, libx264/libvpx/libwebp/libfreetype confirmed from the binary's configure line), and added the tooling so future bumps are routine:

- `build/fetch_binaries.py --repin <url>` rewrites the entry a URL replaces with freshly computed hashes (cross-checked against the provider's `<url>.sha256` when published); `--check-urls` probes every pinned URL.
- `.github/workflows/pin-health.yml` runs `--check-urls` and `uv lock --check` weekly and on dispatch.
- PyInstaller is pinned once, in the `build` extra of `pyproject.toml`; CI installs it with `uv sync --locked --extra build`. README and the build skill updated.
- `build/clipgen.spec` derives the OCR model filenames from `OCR_MODEL_PINS`.
- `tests/test_packaging.py` guards the restated pins: member paths belong to their archive, repin rendering round-trips, OCR pins match `screenspace_ocr`, PyInstaller named once, opencv/ruff versions agree across `pyproject.toml` and the workflows.
- `agents/skills/bump-pins/SKILL.md` (`/bump-pins`): bump policy per pin and the procedure.

## Test plan

- [x] `/check`: ruff format + lint, ty, full suite green
- [x] `--repin` run against the live gyan URL is byte-idempotent; `--check-urls` reports all 8 pinned URLs reachable
- [x] New Windows pin verified locally with the script's own `extract_members` (archive + both member hashes)
- [x] `uv lock --check`; `uv sync --locked --extra build` installs PyInstaller 6.19.0
- [x] `build-binaries` dispatched on this branch: both legs green, Windows ffmpeg feature gate passed on the gyan pin (https://github.com/henedl/clipgen/actions/runs/32637911355)
- [ ] `pin-health` — cannot be dispatched before merge (GitHub only lists workflows on the default branch); run it once after merge