### PR TITLE
fix(transcripts): five bugs in the AI agent and corrections paths

### DIFF
--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -460,49 +460,60 @@
     state.summaryEditing = false;
     var content = qs("#summaryContent");
     var lines = text.split("\n");
-    var paragraphSentences = [];
-    var bullets = [];
-    var inBullets = false;
 
+    // Claims in document order, one block per run of same-kind lines. This walk
+    // must match thinking_agents._split_summary_sentences exactly: it is the
+    // backend's claim numbering, and data-cite-index is how renderCitations
+    // finds the claim a ref belongs to. A sticky "we're in bullets now" flag
+    // used to send prose written *after* the list into the <ul>, which both
+    // rendered it as a list item and slid every later citation onto the wrong
+    // sentence.
+    var blocks = [];
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i].trim();
       if (!line) continue;
-      if (line.indexOf("- ") === 0 || line.indexOf("* ") === 0) {
-        inBullets = true;
-        bullets.push(clipgenRenderInlineMarkdown(line.substring(2)));
-      } else if (!inBullets) {
-        // Split paragraph into individual sentences for citation targeting
+      var isBullet = line.indexOf("- ") === 0 || line.indexOf("* ") === 0;
+      var kind = isBullet ? "ul" : "p";
+      if (!blocks.length || blocks[blocks.length - 1].kind !== kind) {
+        blocks.push({ kind: kind, items: [] });
+      }
+      var items = blocks[blocks.length - 1].items;
+      // Models emit **bold** / `code` emphasis; render it instead of showing
+      // literal asterisks (same helper as the Overview report).
+      if (isBullet) {
+        items.push(clipgenRenderInlineMarkdown(line.substring(2).trim()));
+      } else {
+        // Split prose into individual sentences for citation targeting.
         var parts = line.split(/(?<=[.!?])\s+/);
         for (var k = 0; k < parts.length; k++) {
           var part = parts[k].trim();
-          // Models emit **bold** / `code` emphasis; render it instead of
-          // showing literal asterisks (same helper as the Overview report).
-          if (part) paragraphSentences.push(clipgenRenderInlineMarkdown(part));
+          if (part) items.push(clipgenRenderInlineMarkdown(part));
         }
-      } else {
-        bullets.push(clipgenRenderInlineMarkdown(line));
       }
     }
 
     // Build HTML with data-cite-index on each sentence/bullet
     var citeIdx = 0;
     var html = "";
-    if (paragraphSentences.length > 0) {
-      html += "<p>";
-      for (var si = 0; si < paragraphSentences.length; si++) {
-        if (si > 0) html += " ";
-        html += '<span data-cite-index="' + citeIdx + '">' + paragraphSentences[si] + "</span>";
-        citeIdx++;
+    for (var b = 0; b < blocks.length; b++) {
+      var block = blocks[b];
+      if (!block.items.length) continue;
+      if (block.kind === "p") {
+        html += "<p>";
+        for (var si = 0; si < block.items.length; si++) {
+          if (si > 0) html += " ";
+          html += '<span data-cite-index="' + citeIdx + '">' + block.items[si] + "</span>";
+          citeIdx++;
+        }
+        html += "</p>";
+      } else {
+        html += "<ul>";
+        for (var j = 0; j < block.items.length; j++) {
+          html += '<li data-cite-index="' + citeIdx + '">' + block.items[j] + "</li>";
+          citeIdx++;
+        }
+        html += "</ul>";
       }
-      html += "</p>";
-    }
-    if (bullets.length > 0) {
-      html += "<ul>";
-      for (var j = 0; j < bullets.length; j++) {
-        html += '<li data-cite-index="' + citeIdx + '">' + bullets[j] + "</li>";
-        citeIdx++;
-      }
-      html += "</ul>";
     }
 
     content.innerHTML = html;

--- a/assets/web/transcripts-corrections.js
+++ b/assets/web/transcripts-corrections.js
@@ -1,6 +1,6 @@
 /* clipgen Transcripts dictionary satellite — transcripts-corrections.js
  *
- * The dictionary modal's two halves. Corrections are find→replace rules that
+ * The Corrections modal's two halves. Corrections are find→replace rules that
  * rewrite transcript text you already have; known terms are the study glossary,
  * forwarded to Whisper as hotwords so the next run spells them right instead of
  * needing a correction. Loaded after transcripts.js; reads the hub's shared

--- a/assets/web/transcripts.html
+++ b/assets/web/transcripts.html
@@ -227,12 +227,12 @@
     </section>
   </main>
 
-  <!-- Transcript dictionary modal: corrections (fix past text) + known terms
+  <!-- Corrections modal: corrections (fix past text) + known terms
        (bias future transcription) -->
   <div id="correctionsModal" class="modal cg-modal-overlay hidden">
     <div class="modal-content">
       <div class="modal-header">
-        <h3>Transcript Dictionary</h3>
+        <h3>Corrections</h3>
         <div class="dict-actions">
           <button id="importDictBtn" type="button" class="btn btn-small">Import CSV</button>
           <button id="exportDictBtn" type="button" class="btn btn-small">Export CSV</button>

--- a/source/llm_client.py
+++ b/source/llm_client.py
@@ -914,12 +914,19 @@ def generate(
         "chat_template_kwargs": {"enable_thinking": False},
     }
 
+    # Whatever an earlier call on this thread left is not this call's reason.
+    take_last_error()
+
     try:
         text = _generate_with_load_retry(body, cancel_event, on_token)
-        _record_failure(resolved_model, "")  # it works now; forget any old mark
-        # A load retry can fail once and then succeed; that first reason must
-        # not outlive the call and get pinned on an unrelated empty result.
-        take_last_error()
+        # Only a *successful* call clears. A None means _do_generate already
+        # recorded why (empty answer, truncated stream, deadline), and the
+        # orchestrator turns that reason into the toast the user sees.
+        if text is not None:
+            _record_failure(resolved_model, "")  # it works now; forget any mark
+            # A load retry can fail once and then succeed; that first reason
+            # must not outlive the call and get pinned on an unrelated result.
+            take_last_error()
         return text
     except urllib.error.HTTPError as exc:
         detail = _http_error_detail(exc)
@@ -945,8 +952,9 @@ def generate(
             return None
         try:
             text = _generate_with_load_retry(body, cancel_event, on_token)
-            _record_failure(resolved_model, "")
-            take_last_error()
+            if text is not None:
+                _record_failure(resolved_model, "")
+                take_last_error()
             return text
         except urllib.error.HTTPError as retry_exc:
             detail = _http_error_detail(retry_exc)

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -1159,13 +1159,17 @@ def api_normalize_audio_cancel() -> FlaskResponse:
 
 
 def _deterministic_friction(
-    agent_key: str, segments: list[dict[str, Any]]
+    agent_key: str,
+    participant: str,
+    raw_segments: list[dict[str, Any]],
+    corrections: list[Any],
+    version: int | None = None,
 ) -> dict[str, Any] | None:
     """The friction payload that needs no summary and no LLM, or None.
 
-    *segments* must be a snapshot taken under ``_manifest_lock`` — the scorer
-    iterates the whole list, and the live entry's list can be rebound by a
-    concurrent merge mid-scan.
+    *raw_segments*, *corrections* and *version* must be a snapshot taken under
+    ``_manifest_lock`` — the scorer iterates the whole list, and the live
+    entry's list can be rebound by a concurrent merge mid-scan.
 
     Friction's per-segment scores + session stats come from a pure, deterministic
     scorer (friction.py). They are served both *before* the summary-gated agent
@@ -1173,9 +1177,16 @@ def _deterministic_friction(
     the whole time; only the LLM-refined "moments" wait on the agent. The
     ``deterministic`` flag lets the client show programmatic-only copy and keeps
     the friction poll from mistaking this for a completed run.
+
+    Scores the *corrected* text, exactly as the agent run does: the scorer
+    matches phrases, so scoring raw text here would make the histogram, tinting
+    and timeline band shift the moment a run lands, for no reason the user can see.
     """
-    if agent_key != "friction" or not segments:
+    if agent_key != "friction" or not raw_segments:
         return None
+    segments = _corrected_segments_with_ids(
+        participant, raw_segments, corrections, version=version
+    )
     scored = friction.score_segments(segments)
     stats = friction.compute_stats(scored, thinking_agents._segments_duration(segments))
     return {
@@ -1208,6 +1219,8 @@ def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
         entry = _manifest.get("source_transcripts", {}).get(participant)
         result = entry.get(field) if entry else None
         segments_snapshot = list(entry.get("segments") or []) if entry else []
+        corrections_snapshot = list(_manifest.get("corrections", []))
+        version_snapshot = _corrections_version
     if result:
         resp: dict[str, Any] = {"ok": True, field: result}
         for dep in thinking_agents.AGENTS:
@@ -1232,7 +1245,13 @@ def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
         # on the LLM. Any client refetch mid-run (tab refocus, participant
         # re-select, page reload) would otherwise blank the histogram, chips,
         # transcript tinting and timeline band until the agent finished.
-        deterministic = _deterministic_friction(agent_key, segments_snapshot)
+        deterministic = _deterministic_friction(
+            agent_key,
+            participant,
+            segments_snapshot,
+            corrections_snapshot,
+            version=version_snapshot,
+        )
         if deterministic is not None:
             resp["friction"] = deterministic
         return jsonify(resp)
@@ -1240,7 +1259,13 @@ def api_agent_get(agent_key: str, participant: str) -> FlaskResponse:
     # reason was previously a terminal warning only, so the page just showed an
     # empty panel and the user had no idea an unloadable model was the cause.
     error = _orchestrator.error_for(participant, agent_key)
-    deterministic = _deterministic_friction(agent_key, segments_snapshot)
+    deterministic = _deterministic_friction(
+        agent_key,
+        participant,
+        segments_snapshot,
+        corrections_snapshot,
+        version=version_snapshot,
+    )
     if deterministic is not None:
         resp = {"ok": True, "friction": deterministic}
         if error:
@@ -2981,6 +3006,11 @@ def _init_transcripts_state(sheet_context: Any = None) -> None:
     _manifest = transcripts.load_transcripts_manifest()
     _merged_task_ids.clear()
     _pending_chain_pids.clear()
+    # The corrected-segments memo is keyed on (participant, version), not on the
+    # segments it was computed from. Participant ids repeat across studies, so a
+    # swap that left the version alone served the *old* study's corrected text
+    # for the new study's P01 — zipped against the new raw segments.
+    _bump_corrections_version()
 
     # mtime None forces the first _refresh_participants() call to build.
     _participant_source = {"sheet_context": sheet_context, "dir": "", "mtime": None}

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -811,6 +811,30 @@ class TestAutoStartServer:
         assert llm_client.generate("hi", model="tiny") == "hello"
         assert llm_client.take_last_error() == ""
 
+    @patch("llm_client._generate_with_load_retry")
+    def test_a_failed_generate_keeps_its_reason(self, mock_run):
+        """The specific reason is the whole point of the failure toast.
+
+        _do_generate records why it gave up (empty answer, truncated stream,
+        deadline) and returns None without raising; clearing that on the way out
+        left the orchestrator with only "produced no result".
+        """
+
+        def fail(*args, **kwargs):
+            llm_client._fail("AI returned empty response (model: tiny)")
+
+        mock_run.side_effect = fail
+        assert llm_client.generate("hi", model="tiny") is None
+        assert "empty response" in llm_client.take_last_error()
+
+    @patch("llm_client._generate_with_load_retry")
+    def test_generate_drops_a_reason_left_by_an_earlier_call(self, mock_run):
+        """Agent threads are reused across runs; a stale reason must not carry."""
+        llm_client._fail("a reason from some earlier call")
+        mock_run.return_value = None
+        assert llm_client.generate("hi", model="tiny") is None
+        assert llm_client.take_last_error() == ""
+
     def test_take_last_error_pops_the_recorded_reason(self):
         """The orchestrator reads it once and turns it into a toast."""
         llm_client.take_last_error()  # drain anything a prior test left

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -775,6 +775,9 @@ def test_agents_read_corrected_segments(_agent_state_clean, monkeypatch):
         "marks": [],
         "known_terms": [],
     }
+    # Swapping _manifest wholesale is what _init_transcripts_state does, and the
+    # corrected-segments memo is keyed on (participant, version), not segments.
+    transcripts_server._bump_corrections_version()
 
     seen: dict = {}
     done = threading.Event()
@@ -1969,6 +1972,32 @@ def test_friction_get_keeps_deterministic_scores_while_the_agent_runs(
     )
     assert len(fr["segments"]) == 1 and "score" in fr["segments"][0]
     assert fr["moments"] == [], "only the LLM half waits on the agent"
+
+
+def test_friction_deterministic_scores_the_corrected_text(
+    tr_client, _agent_state_clean
+):
+    """The pre-run scores must match what a run would produce.
+
+    Stored segments stay raw so corrections can re-apply after a re-transcribe;
+    the agent snapshot applies them, so scoring raw text here made the
+    histogram, tinting and timeline band jump the moment a run landed.
+    """
+    transcripts_server._manifest["source_transcripts"]["P01"] = {
+        "segments": [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "this is fine"}],
+        "summary": "A session summary.",
+    }
+    transcripts_server._manifest["corrections"] = [
+        {"id": "c_1", "from": "this is fine", "to": "this is annoying"}
+    ]
+    transcripts_server._bump_corrections_version()
+    try:
+        fr = tr_client.get("/transcripts/api/agent/friction/P01").get_json()["friction"]
+    finally:
+        transcripts_server._manifest["corrections"] = []
+        transcripts_server._bump_corrections_version()
+    assert fr["segments"][0]["categories"] == ["frustration"]
+    assert fr["stats"]["total_markers"] == 1
 
 
 def test_friction_generating_without_segments_carries_no_scores(
@@ -3505,6 +3534,35 @@ def test_reinit_stops_previous_worker(tmp_path, monkeypatch):
         assert second is not first
         assert first.on_task_complete is None
         assert first._running is False
+    finally:
+        if transcripts_server._worker is not None:
+            transcripts_server._worker.stop(join_timeout=2.0)
+
+
+def test_reinit_invalidates_the_corrected_segments_cache(tmp_path, monkeypatch):
+    """Participant ids repeat across studies; the memo is keyed on the id.
+
+    Without the version bump a swap served the previous study's corrected text
+    for the new study's P01, zipped against the new raw segments.
+    """
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(transcripts_server, "_worker", None)
+    monkeypatch.setattr(transcripts_server, "_manifest", {})
+    monkeypatch.setattr(transcripts_server, "_participant_source", None)
+    monkeypatch.setattr(transcripts_server, "_participants", [])
+
+    old = [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "old study"}]
+    transcripts_server._corrected_segments("P01", old, [])
+    assert "P01" in transcripts_server._corrected_cache
+
+    try:
+        transcripts_server._init_transcripts_state()
+        assert transcripts_server._corrected_cache == {}
+        new = [{"id": "P01:0", "start": 0.0, "end": 1.0, "text": "new study"}]
+        assert transcripts_server._corrected_segments("P01", new, [])[0]["text"] == (
+            "new study"
+        )
     finally:
         if transcripts_server._worker is not None:
             transcripts_server._worker.stop(join_timeout=2.0)

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -12,9 +12,17 @@ has no JS DOM harness), but it catches HTML/JS drift for the elements that the
 render flow assumes exist.
 """
 
+import json
 import re
+import shutil
+import subprocess
 
+import pytest
+
+import thinking_agents
 from _frontend_source import WEB, concat_js, read
+
+NODE = shutil.which("node")
 
 _ICONS = WEB.parent / "icons"
 _CSS = read("transcripts.css")
@@ -1191,3 +1199,51 @@ def test_agent_failures_are_reported_to_the_user():
     assert "state.agentErrorsSeen[key] === message" in _JS
     # The generic "Server error 404" filler must not reach the user.
     assert "e.serverMessage = message" in read("utils.js")
+
+
+# ---- Citation claim numbering (frontend <-> backend contract) ----
+
+
+def _js_summary_claims(summary: str) -> list[str]:
+    """Claims renderSummary would number, run through node.
+
+    The claim-splitting block is sliced out of the real source, so the test
+    cannot drift from the shipped code the way a reimplementation would.
+    """
+    start = _JS.index('var lines = text.split("\\n");')
+    block = _JS[start : _JS.index("content.innerHTML = html;", start)]
+    script = (
+        "const text = JSON.parse(process.argv[1]);\n"
+        "const clipgenRenderInlineMarkdown = (s) => s;\n" + block + "const out = [];\n"
+        'const re = /data-cite-index="(\\d+)">([\\s\\S]*?)<\\/(?:span|li)>/g;\n'
+        "let m; while ((m = re.exec(html))) out[Number(m[1])] = m[2];\n"
+        "process.stdout.write(JSON.stringify(out));\n"
+    )
+    result = subprocess.run(
+        [str(NODE), "-e", script, json.dumps(summary)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_summary_claim_numbering_matches_the_backend():
+    """data-cite-index IS the backend's claim index, so the two splits must agree.
+
+    A sticky "we're in bullets now" flag used to send prose written after the
+    list into the <ul>, which slid every later citation onto the wrong sentence
+    while the backend kept counting in document order.
+    """
+    summary = (
+        "The participant explored the dashboard. They struggled with filters.\n"
+        "\n"
+        "- Filters were hard to find\n"
+        "* Export flow was smooth\n"
+        "\n"
+        "Overall the session went well. Follow-up needed."
+    )
+    assert _js_summary_claims(summary) == thinking_agents._split_summary_sentences(
+        summary
+    )


### PR DESCRIPTION
## Summary

Five bugs found while reviewing the recent local-AI work on the Transcripts page:

- `llm_client.generate()` cleared the thread-local failure reason unconditionally, so every non-raising failure (empty answer, truncated stream, deadline) surfaced as the generic "produced no result" instead of the real cause.
- `renderSummary`'s sticky `inBullets` flag numbered claims differently from `thinking_agents._split_summary_sentences`, so prose written after a bullet list rendered as a list item and slid every later citation onto the wrong sentence.
- `_deterministic_friction` scored raw segment text while the agent run scores corrected text, making the histogram, tinting and timeline band jump the moment a run committed.
- `_init_transcripts_state` never bumped `_corrections_version`, so the `(participant, version)`-keyed corrected-segments memo could serve the previous study's text for the new study's `P01` after a swap.
- The Corrections modal was titled "Transcript Dictionary" while the button opening it read "Corrections"; the title now matches.

## Test plan

- [x] `/check` green: ruff format + lint, `ty`, full suite (run 3× for the order-dependent flake this surfaced)
- [x] `/ui-check`: all six pages loaded clean, transcripts screenshot reviewed
- [x] Each fix has a regression test verified to fail without it; the claim-numbering one executes the real JS under node against the Python split
- [ ] Not exercised against a live `llama-server` — the agent paths are covered by mocks only