### PR TITLE
perf: interpreter-bound hot loops in scans, friction polling, and canvas draws

### DIFF
--- a/assets/web/intake-cluster.js
+++ b/assets/web/intake-cluster.js
@@ -29,6 +29,8 @@
     });
     var clusters = [];
     var cur = null;
+    // Running sum; re-summing events on every append is quadratic per cluster.
+    var curSum = 0;
     for (var i = 0; i < sorted.length; i++) {
       var ev = sorted[i];
       if (
@@ -53,12 +55,12 @@
           events: [ev],
           confidence_avg: ev.confidence,
         };
+        curSum = ev.confidence;
       } else {
         cur.end = Math.max(cur.end, ev.time_out);
         cur.events.push(ev);
-        var sum = 0;
-        for (var j = 0; j < cur.events.length; j++) sum += cur.events[j].confidence;
-        cur.confidence_avg = sum / cur.events.length;
+        curSum += ev.confidence;
+        cur.confidence_avg = curSum / cur.events.length;
       }
     }
     if (cur) clusters.push(cur);

--- a/assets/web/transcripts-agents.js
+++ b/assets/web/transcripts-agents.js
@@ -1736,11 +1736,25 @@
     return !(f && f[_frictionMomentCategory(m)] === false);
   }
 
+  // id->index map, rebuilt when the segments array is replaced. The linear
+  // scan ran per cited id per moment inside the per-frame threshold-drag
+  // recompute; the map makes that a dict hit.
+  var _segIndexMap = null;
+  var _segIndexMapFor = null;
+
   function _segmentIndexById(id) {
-    for (var i = 0; i < state.segments.length; i++) {
-      if (state.segments[i].id === id) return i;
+    if (_segIndexMapFor !== state.segments) {
+      _segIndexMap = {};
+      for (var i = 0; i < state.segments.length; i++) {
+        // First occurrence wins, matching the scan this replaced.
+        if (!(state.segments[i].id in _segIndexMap)) {
+          _segIndexMap[state.segments[i].id] = i;
+        }
+      }
+      _segIndexMapFor = state.segments;
     }
-    return -1;
+    var idx = _segIndexMap[id];
+    return idx === undefined ? -1 : idx;
   }
 
   function _seekToSegmentIndex(idx) {

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -183,13 +183,13 @@
     var fcolor = getCSSVar("--color-friction", "#ea580c");
     if (fcolor.charAt(0) !== "#") fcolor = "#ea580c";
     var numBins = Math.max(1, Math.floor(cssW));
-    var sums = new Array(numBins);
-    var counts = new Array(numBins);
-    for (var b = 0; b < numBins; b++) { sums[b] = 0; counts[b] = 0; }
+    var sums = new Float64Array(numBins);
+    var counts = new Float64Array(numBins);
+    var bandMap = state.frictionBandBySegId || {};
     var any = false;
     for (var i = 0; i < state.segments.length; i++) {
       var seg = state.segments[i];
-      var sc = (state.frictionBandBySegId || {})[seg.id] || 0;
+      var sc = bandMap[seg.id] || 0;
       if (sc <= 0) continue;
       any = true;
       var x0 = Math.max(0, Math.floor(timeToX(seg.start)));
@@ -198,13 +198,17 @@
       for (var x = x0; x <= x1; x++) { sums[x] += sc; counts[x] += 1; }
     }
     if (!any) return;
+    // Solid fill + per-pixel globalAlpha composites identically to a per-pixel
+    // rgba() string but skips building one color string per column.
+    ctx.fillStyle = fcolor;
     for (var px = 0; px < numBins; px++) {
       if (!counts[px]) continue;
       var v = sums[px] / counts[px];
       if (v <= 0) continue;
-      ctx.fillStyle = hexToRgba(fcolor, Math.min(0.85, 0.15 + v * 0.7));
+      ctx.globalAlpha = Math.min(0.85, 0.15 + v * 0.7);
       ctx.fillRect(px, bandY, 1, bandH);
     }
+    ctx.globalAlpha = 1;
   }
 
   // The selected participant's running transcription task (the last match, so
@@ -301,6 +305,9 @@
   // along the bottom edge. Tune these two to taste.
   var _TX_DOT_STEP = 6;
   var _TX_DOT_PEAK_ALPHA = 0.4;
+  // Offscreen dot-texture cache; rebuilt when size/color/dpr change.
+  var _txDotTexture = null;
+  var _txDotTextureKey = null;
 
   // Paint the faint "unfilled" dot texture across the *untranscribed* remainder
   // of the timeline (full height, right of the fill front). The transcribed
@@ -323,18 +330,32 @@
     ctx.beginPath();
     ctx.rect(fillW, 0, endX - fillW, cssH); // untranscribed remainder only
     ctx.clip();
-    ctx.fillStyle = theme.textDim;
-    var step = _TX_DOT_STEP;
-    for (var y = step / 2; y < cssH; y += step) {
-      // Vertical gradient: ~invisible at the top, strongest at the bottom.
-      var f = y / cssH;
-      ctx.globalAlpha = _TX_DOT_PEAK_ALPHA * f * f;
-      for (var x = step / 2; x < cssW; x += step) {
-        ctx.beginPath();
-        ctx.arc(x, y, 1, 0, Math.PI * 2);
-        ctx.fill();
+    // The texture is static per size/color, but this draw runs at 60fps for
+    // the whole run (RAF easing), so render it once offscreen and blit.
+    var dpr = window.devicePixelRatio || 1;
+    var key = cssW + "|" + cssH + "|" + theme.textDim + "|" + dpr;
+    if (_txDotTextureKey !== key) {
+      var off = document.createElement("canvas");
+      off.width = Math.max(1, Math.round(cssW * dpr));
+      off.height = Math.max(1, Math.round(cssH * dpr));
+      var octx = off.getContext("2d");
+      octx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      octx.fillStyle = theme.textDim;
+      var step = _TX_DOT_STEP;
+      for (var y = step / 2; y < cssH; y += step) {
+        // Vertical gradient: ~invisible at the top, strongest at the bottom.
+        var f = y / cssH;
+        octx.globalAlpha = _TX_DOT_PEAK_ALPHA * f * f;
+        for (var x = step / 2; x < cssW; x += step) {
+          octx.beginPath();
+          octx.arc(x, y, 1, 0, Math.PI * 2);
+          octx.fill();
+        }
       }
+      _txDotTexture = off;
+      _txDotTextureKey = key;
     }
+    ctx.drawImage(_txDotTexture, 0, 0, cssW, cssH);
     ctx.restore();
   }
 

--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -211,14 +211,30 @@ def region_mask_for(region: dict[str, Any], h: int, w: int) -> np.ndarray | None
     return mask
 
 
+_mask_points_keys: dict[int, tuple[Any, tuple[Any, ...]]] = {}
+
+
 def mask_points_key(contours: Any) -> tuple[Any, ...]:
     """Hashable key for a region's ``mask_points`` contour list (or None/[]).
 
     Cache keys (per-frame memos, pin-OCR readings) must distinguish same-bbox/
     different-shape regions; nested lists aren't hashable, so every keyed cache
     routes through this helper instead of hand-rolled ``tuple(map(tuple, …))``.
+
+    Interned per contour-list object: multitool memos rebuild region keys every
+    frame, and the O(vertices) tuple build dominated the lookup. The strong ref
+    pins the id; contour lists are never mutated in place, only replaced.
     """
-    return tuple(tuple(tuple(p) for p in contour) for contour in contours or ())
+    if not contours:
+        return ()
+    entry = _mask_points_keys.get(id(contours))
+    if entry is not None and entry[0] is contours:
+        return entry[1]
+    key = tuple(tuple(tuple(p) for p in contour) for contour in contours)
+    if len(_mask_points_keys) > 512:
+        _mask_points_keys.clear()
+    _mask_points_keys[id(contours)] = (contours, key)
+    return key
 
 
 def filter_matches_by_region_mask(
@@ -943,35 +959,30 @@ def _match_template_prepared(
     else:
         ys, xs = locs[0], locs[1]
 
-    detections: list[dict[str, Any]] = []
-    for pt_y, pt_x, raw in zip(ys, xs, scores):
-        score = float(raw)
-        if not math.isfinite(score):
-            continue
-        detections.append(
-            {"x": int(pt_x), "y": int(pt_y), "w": tw, "h": th, "score": score}
-        )
-    detections.sort(key=lambda d: d["score"], reverse=True)
-
-    # Non-maximum suppression
+    # Vectorized greedy NMS. All boxes share the template's size, so IoU
+    # reduces to inter = max(0, tw-|dx|) * max(0, th-|dy|) over int arrays.
+    finite = np.isfinite(scores)
+    if not finite.all():
+        ys, xs, scores = ys[finite], xs[finite], scores[finite]
+    if scores.size == 0:
+        return []
+    # Stable sort keeps candidate order on ties, like the dict sort it replaced.
+    order = np.argsort(-scores, kind="stable")
+    ys = ys[order].astype(np.int64)
+    xs = xs[order].astype(np.int64)
+    scores = scores[order]
+    area = tw * th
     kept: list[dict[str, Any]] = []
-    for det in detections:
-        overlaps = False
-        for k_det in kept:
-            # Compute IoU
-            xa = max(det["x"], k_det["x"])
-            ya = max(det["y"], k_det["y"])
-            xb = min(det["x"] + det["w"], k_det["x"] + k_det["w"])
-            yb = min(det["y"] + det["h"], k_det["y"] + k_det["h"])
-            inter = max(0, xb - xa) * max(0, yb - ya)
-            area_a = det["w"] * det["h"]
-            area_b = k_det["w"] * k_det["h"]
-            union = area_a + area_b - inter
-            if union > 0 and inter / union > nms_overlap:
-                overlaps = True
-                break
-        if not overlaps:
-            kept.append(det)
+    while xs.size:
+        x0, y0 = int(xs[0]), int(ys[0])
+        kept.append({"x": x0, "y": y0, "w": tw, "h": th, "score": float(scores[0])})
+        if xs.size == 1:
+            break
+        inter = np.maximum(0, tw - np.abs(xs[1:] - x0)) * np.maximum(
+            0, th - np.abs(ys[1:] - y0)
+        )
+        keep = inter / (2 * area - inter) <= nms_overlap
+        xs, ys, scores = xs[1:][keep], ys[1:][keep], scores[1:][keep]
     return kept
 
 
@@ -1038,6 +1049,7 @@ def compute_optical_flow(
     pyr_scale: float = 0.0,
     return_grid: bool = False,
     mask: np.ndarray | None = None,
+    grid_min_magnitude: float | None = None,
 ) -> dict[str, Any]:
     """Compute dense optical flow between two grayscale frames.
 
@@ -1045,6 +1057,10 @@ def compute_optical_flow(
     *mask* (uint8, crop-sized) restricts the statistics instead. Vectors within
     ~one window of the polygon edge still see outside pixels — acceptable
     contamination for motion detection.
+
+    *grid_min_magnitude* skips the grid (angles and the per-cell loop) when the
+    mean magnitude lands below it — scan_flow discards those rows anyway, and
+    they are the common case on quiet footage. The key is absent, not empty.
 
     Returns:
         ``magnitude`` (mean vector length), ``angle`` (dominant direction, 0-360),
@@ -1068,10 +1084,10 @@ def compute_optical_flow(
     dx, dy = flow[..., 0], flow[..., 1]
     inside = mask > 0 if mask is not None else None
 
-    if return_grid:
-        mag, ang = cv2.cartToPolar(dx, dy, angleInDegrees=True)
-    else:
-        mag = cv2.magnitude(dx, dy)
+    # Angles (cv2.phase) are deferred to the grid branch below. Both halves
+    # track cartToPolar within last-ulp float32 drift (bound pinned in
+    # test_flow.py), far under the rounding of every emitted value.
+    mag = cv2.magnitude(dx, dy)
 
     mean_mag = (
         float(np.mean(mag[inside])) if inside is not None else float(np.mean(mag))
@@ -1096,7 +1112,11 @@ def compute_optical_flow(
         "angle": round(dominant_angle, 1),
     }
 
-    if return_grid:
+    # Gate on the rounded magnitude — the value callers threshold against.
+    if return_grid and (
+        grid_min_magnitude is None or result["magnitude"] >= grid_min_magnitude
+    ):
+        ang = cv2.phase(dx, dy, angleInDegrees=True)
         grid_size = config.SCREENSPACE_FLOW_GRID_SIZE
         min_mag_thresh = config.SCREENSPACE_FLOW_GRID_MIN_MAG
         gh, gw = mag.shape[:2]

--- a/source/screenspace_scans.py
+++ b/source/screenspace_scans.py
@@ -904,8 +904,14 @@ def scan_flow(
             if small_prev is None:
                 small_prev, _ = flow_downscale(prev_gray[0])
             small_curr, small_mask = flow_downscale(curr_gray, mask_for(pixels))
+            # grid_min_magnitude: sub-threshold rows are discarded below, so
+            # the grid (angles + cell loop) only materializes on emitted frames.
             flow_result = compute_optical_flow(
-                small_prev, small_curr, return_grid=True, mask=small_mask
+                small_prev,
+                small_curr,
+                return_grid=True,
+                mask=small_mask,
+                grid_min_magnitude=magnitude_threshold,
             )
             if flow_result["magnitude"] >= magnitude_threshold:
                 rd: dict[str, Any] = {

--- a/source/screenspace_tools.py
+++ b/source/screenspace_tools.py
@@ -10,6 +10,7 @@ The one tools->multitool edge (``MultitoolTool.scan`` -> ``scan_multitool``) is 
 function-local import, keeping the module graph acyclic.
 """
 
+import functools
 import math
 from collections.abc import Callable
 from pathlib import Path
@@ -147,35 +148,53 @@ def _cached_crop(
     cache: dict[Any, Any] | None, frame: np.ndarray, region: dict[str, int]
 ) -> np.ndarray:
     """Region crop of *frame*, memoized on *cache* (shared across chain steps)."""
-    return _memo(
-        cache, _region_key("crop", region), lambda: extract_region(frame, region)
-    )
+    if cache is None:
+        return extract_region(frame, region)
+    key = _region_key("crop", region)
+    value = cache.get(key, _MISSING)
+    if value is _MISSING:
+        value = cache[key] = extract_region(frame, region)
+    return value
+
+
+@functools.lru_cache(maxsize=64)
+def _mask_raster_cached(
+    points_key: tuple[Any, ...], h: int, w: int
+) -> np.ndarray | None:
+    """Rasterized shaped-region mask, cached across frames (shape + size constant)."""
+    return region_mask_for({"mask_points": points_key}, h, w)
 
 
 def _cached_mask(
     cache: dict[Any, Any] | None, frame: np.ndarray, region: dict[str, Any]
 ) -> np.ndarray | None:
-    """Shaped-region mask at the cached crop's size, memoized on *cache*.
+    """Shaped-region mask at the cached crop's size, cached across frames.
 
     ``None`` for rect regions, so masked tools can pass the value straight to
-    the primitives' optional ``mask`` params.
+    the primitives' optional ``mask`` params. The per-frame memo dict is fresh
+    each frame, so the raster lives in :func:`_mask_raster_cached` instead —
+    the polygon and crop size never change mid-scan. Callers must not mutate.
     """
-    return _memo(
-        cache,
-        _region_key("mask", region),
-        lambda: region_mask_for(region, *_cached_crop(cache, frame, region).shape[:2]),
-    )
+    points = region.get("mask_points")
+    if not points:
+        return None
+    crop = _cached_crop(cache, frame, region)
+    return _mask_raster_cached(mask_points_key(points), *crop.shape[:2])
 
 
 def _cached_gray(
     cache: dict[Any, Any] | None, frame: np.ndarray, region: dict[str, int]
 ) -> np.ndarray:
     """Grayscale of the region crop, memoized on *cache* (reuses the cached crop)."""
-    return _memo(
-        cache,
-        _region_key("gray", region),
-        lambda: cv2.cvtColor(_cached_crop(cache, frame, region), cv2.COLOR_BGR2GRAY),
-    )
+    if cache is None:
+        return cv2.cvtColor(_cached_crop(cache, frame, region), cv2.COLOR_BGR2GRAY)
+    key = _region_key("gray", region)
+    value = cache.get(key, _MISSING)
+    if value is _MISSING:
+        value = cache[key] = cv2.cvtColor(
+            _cached_crop(cache, frame, region), cv2.COLOR_BGR2GRAY
+        )
+    return value
 
 
 def _cached_blur_gray(
@@ -187,22 +206,26 @@ def _cached_blur_gray(
     frame's ``prev_cache``, so ChangeTool's previous-side blur+grayscale is a
     dict hit rather than a recompute.
     """
-    return _memo(
-        cache,
-        _region_key("blurgray", region),
-        lambda: blur_gray(_cached_crop(cache, frame, region)),
-    )
+    if cache is None:
+        return blur_gray(_cached_crop(cache, frame, region))
+    key = _region_key("blurgray", region)
+    value = cache.get(key, _MISSING)
+    if value is _MISSING:
+        value = cache[key] = blur_gray(_cached_crop(cache, frame, region))
+    return value
 
 
 def _cached_phash(
     cache: dict[Any, Any] | None, frame: np.ndarray, region: dict[str, int]
 ) -> "Any":
     """Perceptual hash of the region crop, memoized on *cache* (reuses the crop)."""
-    return _memo(
-        cache,
-        _region_key("phash", region),
-        lambda: compute_phash(_cached_crop(cache, frame, region)),
-    )
+    if cache is None:
+        return compute_phash(_cached_crop(cache, frame, region))
+    key = _region_key("phash", region)
+    value = cache.get(key, _MISSING)
+    if value is _MISSING:
+        value = cache[key] = compute_phash(_cached_crop(cache, frame, region))
+    return value
 
 
 def _cached_ocr(
@@ -221,17 +244,23 @@ def _cached_ocr(
     (fuzzy match, numeric operators, integers_only) is applied at scoring time.
     """
     langs = tuple(languages)
-    key = _region_key("ocr", region) + (langs, preprocess)
-    return _memo(
-        cache,
-        key,
-        lambda: _ocr_region_readings(
+    if cache is None:
+        return _ocr_region_readings(
             _cached_crop(cache, frame, region),
             languages=list(langs),
             preprocess=preprocess,
             mask_points=region.get("mask_points"),
-        ),
-    )
+        )
+    key = _region_key("ocr", region) + (langs, preprocess)
+    value = cache.get(key, _MISSING)
+    if value is _MISSING:
+        value = cache[key] = _ocr_region_readings(
+            _cached_crop(cache, frame, region),
+            languages=list(langs),
+            preprocess=preprocess,
+            mask_points=region.get("mask_points"),
+        )
+    return value
 
 
 def check_frame_for_tool(

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -408,6 +408,7 @@ def api_participants() -> FlaskResponse:
 # change. Its own lock covers both the lock-holding caller (api_search) and the
 # lock-free one; lock order is always _manifest_lock -> _corrected_cache_lock.
 _corrected_cache: dict[str, tuple[int, list[Any]]] = {}
+_friction_cache: dict[str, tuple[int, dict[str, Any]]] = {}
 _corrected_cache_lock = threading.Lock()
 _corrections_version = 0
 
@@ -418,6 +419,7 @@ def _bump_corrections_version() -> None:
     with _corrected_cache_lock:
         _corrections_version += 1
         _corrected_cache.clear()
+        _friction_cache.clear()
 
 
 def _corrected_segments(
@@ -1184,12 +1186,20 @@ def _deterministic_friction(
     """
     if agent_key != "friction" or not raw_segments:
         return None
+    # Memoized like _corrected_segments: the agent poll refetches this every
+    # 3s for the whole LLM run, re-scoring thousands of segments for nothing.
+    with _corrected_cache_lock:
+        if version is None:
+            version = _corrections_version
+        cached = _friction_cache.get(participant)
+        if cached is not None and cached[0] == version:
+            return cached[1]
     segments = _corrected_segments_with_ids(
         participant, raw_segments, corrections, version=version
     )
     scored = friction.score_segments(segments)
     stats = friction.compute_stats(scored, thinking_agents._segments_duration(segments))
-    return {
+    payload = {
         "segments": scored,
         "moments": [],
         "stats": stats,
@@ -1198,6 +1208,10 @@ def _deterministic_friction(
         "stale": False,
         "deterministic": True,
     }
+    with _corrected_cache_lock:
+        if _corrections_version == version:
+            _friction_cache[participant] = (version, payload)
+    return payload
 
 
 @transcripts_bp.route("/api/agent/<agent_key>/<participant>")

--- a/tests/screenspace/test_flow.py
+++ b/tests/screenspace/test_flow.py
@@ -1,5 +1,6 @@
 """Tests for optical flow primitives, grid, and heatmap."""
 
+import cv2
 import numpy as np
 
 import config
@@ -47,6 +48,42 @@ class TestComputeOpticalFlow:
         out, mask = screenspace.flow_downscale(gray)
         assert out is gray
         assert mask is None
+
+    def test_magnitude_and_phase_match_carttopolar(self):
+        """Guards the cartToPolar -> magnitude/phase split in compute_optical_flow.
+
+        The grid path defers angles to cv2.phase and always takes magnitude
+        from cv2.magnitude. Neither is bit-identical to cartToPolar (different
+        SIMD paths, last-ulp float32 drift), so this pins the bound instead:
+        far below the 4-decimal mag / 1-decimal angle rounding of emitted rows.
+        """
+        rng = np.random.default_rng(7)
+        dx = rng.standard_normal((256, 256)).astype(np.float32)
+        dy = rng.standard_normal((256, 256)).astype(np.float32)
+        mag_ref, ang_ref = cv2.cartToPolar(dx, dy, angleInDegrees=True)
+        assert float(np.abs(cv2.magnitude(dx, dy) - mag_ref).max()) < 1e-5
+        ang = cv2.phase(dx, dy, angleInDegrees=True)
+        assert float(np.abs(ang - ang_ref).max()) < 1e-3
+
+    def test_grid_min_magnitude_gates_grid(self):
+        prev = np.zeros((80, 80), dtype=np.uint8)
+        curr = np.zeros((80, 80), dtype=np.uint8)
+        prev[20:40, 20:40] = 255
+        curr[30:50, 30:50] = 255
+        full = screenspace.compute_optical_flow(prev, curr, return_grid=True)
+        assert full["magnitude"] > 0
+        # At or above the gate: identical result, grid included.
+        gated_on = screenspace.compute_optical_flow(
+            prev, curr, return_grid=True, grid_min_magnitude=full["magnitude"]
+        )
+        assert gated_on == full
+        # Below the gate: same scalars, no flow_grid key at all.
+        gated_off = screenspace.compute_optical_flow(
+            prev, curr, return_grid=True, grid_min_magnitude=full["magnitude"] + 1
+        )
+        assert "flow_grid" not in gated_off
+        assert gated_off["magnitude"] == full["magnitude"]
+        assert gated_off["angle"] == full["angle"]
 
 
 class TestOpticalFlowGrid:

--- a/tests/screenspace/test_static_gating.py
+++ b/tests/screenspace/test_static_gating.py
@@ -77,7 +77,9 @@ class TestFlowStaticGate:
 
         calls = [0]
 
-        def counting_flow(prev, curr, return_grid=False, mask=None):
+        def counting_flow(
+            prev, curr, return_grid=False, mask=None, grid_min_magnitude=None
+        ):
             calls[0] += 1
             return {
                 "magnitude": float(np.mean(cv2.absdiff(prev, curr))),

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -90,6 +90,60 @@ class TestCorrelationMapReuse:
         assert len(calls) == 1
 
 
+class TestNmsEquivalence:
+    """Vectorized NMS must reproduce the dict-loop NMS it replaced exactly."""
+
+    @staticmethod
+    def _reference_nms(result, tw, th, threshold, nms_overlap):
+        # The pre-vectorization implementation, kept as the behavioral spec.
+        import math
+
+        locs = np.where(result >= threshold)
+        scores = result[locs]
+        ys, xs = locs[0], locs[1]
+        detections = []
+        for pt_y, pt_x, raw in zip(ys, xs, scores):
+            score = float(raw)
+            if not math.isfinite(score):
+                continue
+            detections.append(
+                {"x": int(pt_x), "y": int(pt_y), "w": tw, "h": th, "score": score}
+            )
+        detections.sort(key=lambda d: d["score"], reverse=True)
+        kept = []
+        for det in detections:
+            overlaps = False
+            for k_det in kept:
+                xa = max(det["x"], k_det["x"])
+                ya = max(det["y"], k_det["y"])
+                xb = min(det["x"] + det["w"], k_det["x"] + k_det["w"])
+                yb = min(det["y"] + det["h"], k_det["y"] + k_det["h"])
+                inter = max(0, xb - xa) * max(0, yb - ya)
+                union = det["w"] * det["h"] + k_det["w"] * k_det["h"] - inter
+                if union > 0 and inter / union > nms_overlap:
+                    overlaps = True
+                    break
+            if not overlaps:
+                kept.append(det)
+        return kept
+
+    def test_matches_reference_on_dense_ties(self):
+        rng = np.random.RandomState(9)
+        template = rng.randint(0, 255, (8, 10, 3), dtype=np.uint8)
+        prepared = screenspace_primitives._prepare_template(template, None)
+        th, tw = prepared[0].shape[:2]
+        # Quantized map: thousands of candidates, heavy score ties, one inf.
+        corr = (rng.randint(0, 8, (60, 90)) / 8.0).astype(np.float32)
+        corr[0, 0] = np.inf
+        frame = np.zeros((10, 10, 3), dtype=np.uint8)  # unused when corr is given
+        for nms_overlap in (0.0, 0.3, 0.9):
+            got = screenspace_primitives._match_template_prepared(
+                frame, prepared, 0.25, nms_overlap, corr=corr
+            )
+            want = self._reference_nms(corr, tw, th, 0.25, nms_overlap)
+            assert got == want
+
+
 class TestPrepareTemplateMask:
     def test_binarizes_alpha_mask(self):
         """Mask should come out as strictly 0 or 255 (no soft-blurred edges)."""

--- a/tests/test_resource_lifecycle.py
+++ b/tests/test_resource_lifecycle.py
@@ -66,6 +66,7 @@ _NATURALLY_BOUNDED = {
     "_participant_timeline_cache": "one entry per participant in the cohort",
     "_video_metadata_cache": "one entry per participant video",
     "_corrected_cache": "one entry per participant transcript",
+    "_friction_cache": "one entry per participant transcript",
     "_ss_events_cache": "single entry, mtime-keyed",
     "_manifest_cache": "single entry (the one output dir), stamp-keyed",
     "_discover_videos_cache": "one entry per input dir seen this session",

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -293,14 +293,20 @@ def test_participant_marks_resolved_and_filtered(client, monkeypatch):
             "corrections": [],
         },
     )
-    resp = client.get("/screenspace/api/participants/P01/marks")
-    assert resp.status_code == 200
-    data = resp.get_json()
-    assert data["ok"] is True
-    # P02 filtered out (wrong participant); m3 dropped (out-of-range, unresolved).
-    assert [m["id"] for m in data["marks"]] == ["m1"]
-    assert data["marks"][0]["start"] == 5.0
-    assert data["marks"][0]["text"] == "hello"
+    # Swapping segments must bump, or another test's cached corrected P01
+    # (same version, different segments) resolves the mark to its start.
+    transcripts_server._bump_corrections_version()
+    try:
+        resp = client.get("/screenspace/api/participants/P01/marks")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        # P02 filtered out (wrong participant); m3 dropped (out-of-range, unresolved).
+        assert [m["id"] for m in data["marks"]] == ["m1"]
+        assert data["marks"][0]["start"] == 5.0
+        assert data["marks"][0]["text"] == "hello"
+    finally:
+        transcripts_server._bump_corrections_version()
 
 
 def test_participant_marks_unknown_participant(client):

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1951,6 +1951,33 @@ def test_friction_get_deterministic_when_absent_and_idle(tr_client, _agent_state
     assert "by_category" in fr["stats"]
 
 
+def test_friction_deterministic_payload_cached_per_version(
+    tr_client, _agent_state_clean
+):
+    """The agent poll refetches this every 3s for a whole LLM run; the scorer
+    must not re-run per poll. Same version serves the cached payload object;
+    a corrections/segments bump invalidates it."""
+    _seed_friction_entry()
+    transcripts_server._bump_corrections_version()
+    segs = transcripts_server._manifest["source_transcripts"]["P01"]["segments"]
+    try:
+        first = transcripts_server._deterministic_friction(
+            "friction", "P01", list(segs), []
+        )
+        second = transcripts_server._deterministic_friction(
+            "friction", "P01", list(segs), []
+        )
+        assert first is second
+        transcripts_server._bump_corrections_version()
+        third = transcripts_server._deterministic_friction(
+            "friction", "P01", list(segs), []
+        )
+        assert third is not second
+        assert third == second
+    finally:
+        transcripts_server._bump_corrections_version()
+
+
 def test_friction_get_keeps_deterministic_scores_while_the_agent_runs(
     tr_client, _agent_state_clean
 ):

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -1914,13 +1914,19 @@ def test_normalize_audio_cancel_route_is_token_scoped(tr_client):
 
 
 def _seed_friction_entry(pid="P01", **extra):
-    """Insert a transcript entry with a summary for *pid* into the manifest."""
+    """Insert a transcript entry with a summary for *pid* into the manifest.
+
+    Bumps the corrections version: seeding replaces segments, and a stale
+    corrected-segments cache entry would otherwise leak into any later test
+    (even cross-module) that resolves this participant at the same version.
+    """
     entry = {
         "segments": [{"id": f"{pid}:0", "start": 0.0, "end": 1.0, "text": "um where"}],
         "summary": "A session summary.",
     }
     entry.update(extra)
     transcripts_server._manifest["source_transcripts"][pid] = entry
+    transcripts_server._bump_corrections_version()
     return entry
 
 


### PR DESCRIPTION
## Summary

Cuts per-frame/per-poll Python and JS work in paths where the interpreter, not the underlying native ops, was the cost. All CV changes are output-identical (guarded by equivalence tests) except the flow magnitude/angle split, which is bounded at last-ulp float32 drift — far under the rounding of every emitted value — and pinned by a test.

- `screenspace`: template NMS vectorized (dict loop + O(n²) IoU → array ops; 81 ms → 2.3 ms on a dense ~3.6k-candidate frame, the documented worker-freeze case); flow grid built only for frames that will emit; multitool memo layer stops rebuilding nested-tuple cache keys and closures per frame and rasterizes polygon masks once per scan.
- `transcripts`: the deterministic friction payload is cached per corrections version — the 3s agent poll was re-scoring the whole transcript on every GET for the length of an LLM run (~100× per run).
- `web`: transcribe-band dot texture drawn once offscreen instead of ~2500 canvas calls per RAF frame; friction band drops the per-column color-string build; segment id→index map replaces a per-frame linear scan; intake clustering drops a quadratic re-sum.

`tests/perf/scan_bench.py` A/B vs baseline: modest fixture deltas (change −8%, inactivity −11%, others −2…−5%) — the big wins are situational (dense template frames, quiet flow footage, multitool chains, friction polling) and covered by the micro-benchmarks/tests above.

## Test plan

- [x] Full suite via `/check` (ruff format + lint, ty, pytest) green
- [x] New guards: NMS equivalence vs the pre-vectorization algorithm, flow grid gating + cartToPolar drift bound, friction cache identity/invalidation
- [x] `/ui-check` six-page smoke + journeys green; transcripts screenshot reviewed
- [x] `scan_bench.py --compare` baseline A/B (no regressions)
- [ ] Friction band / transcribe-band visuals during a real run (WebKit) — smoke drives Chromium only