### PR TITLE
fix: repair defects found auditing the last two weeks of PRs

### DIFF
--- a/assets/web/screenspace-model-view.js
+++ b/assets/web/screenspace-model-view.js
@@ -44,6 +44,7 @@
     numbers: "Grayscale region fed to OCR.",
     timelapse: "Region crop. FFmpeg encodes this unmodified.",
     template: "Gray-blurred frame, template, and normalized match heatmap.",
+    shape: "Edge ridges and scale-swept match heatmap.",
     flow: "Prev + current gray frames with dense optical-flow vectors.",
     scene: "Region (≤128 px), Canny edges, and 8-bin hue histogram.",
     inactivity: "Region and pHash bit grid (white = 1, black = 0).",
@@ -290,6 +291,17 @@
     return !!(ref && ref.source !== "full_frame");
   }
 
+  function _encodeMaskContours(contours) {
+    if (!contours || !contours.length) return null;
+    return contours
+      .map(function (contour) {
+        return contour
+          .map(function (pt) { return pt[0].toFixed(4) + "," + pt[1].toFixed(4); })
+          .join(";");
+      })
+      .join("|");
+  }
+
   // Bbox-relative contours of the previewed region as "u1,v1;u2,v2;…" (one
   // segment per contour, joined with "|") for the preview endpoint's optional
   // mask= param, or null for rect regions. A pending shaped draw carries
@@ -310,14 +322,7 @@
       var data = _regionObjectForRef(_previewRegionRef());
       if (data && data.points && data.points.length > 0) contours = data.points;
     }
-    if (!contours) return null;
-    return contours
-      .map(function (contour) {
-        return contour
-          .map(function (pt) { return pt[0].toFixed(4) + "," + pt[1].toFixed(4); })
-          .join(";");
-      })
-      .join("|");
+    return _encodeMaskContours(contours);
   }
 
   // True when the previewed region is shaped but the active tool can only
@@ -511,6 +516,8 @@
         if (capRect) {
           qsParts.push("ref_region=" + [capRect.x, capRect.y, capRect.w, capRect.h]
             .map(function (v) { return Number(v).toFixed(6); }).join(","));
+          var capMask = _encodeMaskContours(capRect.points);
+          if (capMask) qsParts.push("ref_mask=" + encodeURIComponent(capMask));
         }
       }
     }

--- a/assets/web/transcripts-video.js
+++ b/assets/web/transcripts-video.js
@@ -532,12 +532,35 @@
   // getStoredMarkersFor) into the request's start_seconds/end_seconds.
   var MARKERS_STORAGE_KEY = "ts_markers";
 
-  function _readStoredMarkers() {
+  function _markersScope() {
+    var ps = state.participants || [];
+    return ps.map(function (p) {
+      var file = p.video_path || (p.video_paths && p.video_paths[0]) || p.video_filename || "";
+      return p.id + "=" + file;
+    }).join("|");
+  }
+
+  function _readMarkerStore() {
     try {
       var raw = sessionStorage.getItem(MARKERS_STORAGE_KEY);
       var all = raw ? JSON.parse(raw) : null;
       return (all && typeof all === "object") ? all : {};
     } catch (_) { return {}; }
+  }
+
+  function _readStoredMarkers() {
+    var scoped = _readMarkerStore()[_markersScope()];
+    return (scoped && typeof scoped === "object") ? scoped : {};
+  }
+
+  function _writeStoredMarkers(pidMap) {
+    var store = _readMarkerStore();
+    var scope = _markersScope();
+    if (Object.keys(pidMap).length) store[scope] = pidMap;
+    else delete store[scope];
+    try {
+      sessionStorage.setItem(MARKERS_STORAGE_KEY, JSON.stringify(store));
+    } catch (_) { /* sessionStorage may be unavailable */ }
   }
 
   // {in, out} (numbers or null) for any participant — the batch transcribe
@@ -556,9 +579,7 @@
     var all = _readStoredMarkers();
     if (state.inMarker === null && state.outMarker === null) delete all[pid];
     else all[pid] = { in: state.inMarker, out: state.outMarker };
-    try {
-      sessionStorage.setItem(MARKERS_STORAGE_KEY, JSON.stringify(all));
-    } catch (_) { /* sessionStorage may be unavailable */ }
+    _writeStoredMarkers(all);
   }
 
   // Clear a (possibly non-selected) participant's stored markers — the pill
@@ -567,9 +588,7 @@
     if (!pid) return;
     var all = _readStoredMarkers();
     delete all[pid];
-    try {
-      sessionStorage.setItem(MARKERS_STORAGE_KEY, JSON.stringify(all));
-    } catch (_) { /* sessionStorage may be unavailable */ }
+    _writeStoredMarkers(all);
     if (pid === state.selectedParticipant) {
       state.inMarker = null;
       state.outMarker = null;

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -2968,7 +2968,7 @@
         return null;
       })
       .catch(function (e) {
-        showToast((e && e.message) || "The AI server did not start");
+        showToast((e && (e.serverMessage || e.message)) || "The AI server did not start");
         return null;
       });
   }

--- a/source/cli.py
+++ b/source/cli.py
@@ -1576,12 +1576,11 @@ _SS_VALID_TASK_TYPES = (
 def _ss_resolve_videos_for_participant(participant_id: str) -> list[str]:
     """Resolve a participant's ordered source video path(s) via filename discovery.
 
-    Mirrors how screenspace_server falls back when no spreadsheet is loaded. A
-    multi-video participant (numbered parts) returns all parts in timeline order;
+    Honours ``config.FILENAME_OVERRIDES`` the same way the web tools do.
+    A multi-video participant (numbered parts) returns all parts in timeline order;
     a normal participant returns a single-element list. Returns [] when unknown.
     """
-    discovered = utils.discover_participant_videos("")
-    for entry in discovered:
+    for entry in files.resolve_participant_videos():
         if entry["id"] == participant_id and entry.get("has_video"):
             return list(entry["video_paths"])
     return []
@@ -2259,10 +2258,10 @@ def _ss_extract_scene_frames(
 
 def _ss_reference_coords(
     parameters: dict[str, Any],
-    region_coords: dict[str, int],
+    region_coords: dict[str, Any],
     manifest: dict[str, Any],
     dims: tuple[int, int] | None,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     """Pixel rect a template/shape re-run cuts its sample from.
 
     The persisted capture region (``reference_region``) wins over the run
@@ -2283,7 +2282,7 @@ def _ss_rehydrate_task_media(
     task_type: str,
     parameters: dict[str, Any],
     frame_at: Callable[[float], "Any | None"],
-    region_coords: dict[str, int],
+    region_coords: dict[str, Any],
     manifest: dict[str, Any],
     dims: tuple[int, int] | None,
 ) -> None:
@@ -2298,7 +2297,7 @@ def _ss_rehydrate_task_media(
     """
     import screenspace
 
-    def _extract_frame(ref_ts: float, coords: dict[str, int], label: str) -> Any:
+    def _extract_frame(ref_ts: float, coords: dict[str, Any], label: str) -> Any:
         frame = frame_at(float(ref_ts))
         if frame is None:
             raise ValueError(f"{label}: could not read reference frame")
@@ -2317,10 +2316,14 @@ def _ss_rehydrate_task_media(
                 "template task built from an uploaded image cannot be re-run from the "
                 "manifest (no reference timestamp was saved)"
             )
+        coords = _ss_reference_coords(parameters, region_coords, manifest, dims)
         parameters["template_image"] = _extract_frame(
             parameters["reference_timestamp"],
-            _ss_reference_coords(parameters, region_coords, manifest, dims),
+            coords,
             "template",
+        )
+        screenspace.attach_capture_mask(
+            parameters, "template_image", "template_mask", coords
         )
 
     elif task_type == "shape":
@@ -2329,11 +2332,13 @@ def _ss_rehydrate_task_media(
                 "shape task built from an uploaded image cannot be re-run from the "
                 "manifest (no reference timestamp was saved)"
             )
+        coords = _ss_reference_coords(parameters, region_coords, manifest, dims)
         parameters["shape_image"] = _extract_frame(
             parameters["reference_timestamp"],
-            _ss_reference_coords(parameters, region_coords, manifest, dims),
+            coords,
             "shape",
         )
+        screenspace.attach_capture_mask(parameters, "shape_image", "shape_mask", coords)
 
     elif task_type == "scene":
         scene_refs = parameters.get("scene_references")
@@ -2378,6 +2383,9 @@ def _ss_rehydrate_task_media(
                     )
                 step["template_image"] = _extract_frame(
                     step["reference_timestamp"], step_coords, f"Step {i}"
+                )
+                screenspace.attach_capture_mask(
+                    step, "template_image", "template_mask", step_coords
                 )
             elif stype == "scene":
                 step_refs = step.get("scene_references")

--- a/source/llm_client.py
+++ b/source/llm_client.py
@@ -212,6 +212,17 @@ def _normalize_token(text: str) -> str:
     return re.sub(r"[/_\-.]", "", text.lower())
 
 
+def _quant_in_name(name: str, quant: str) -> bool:
+    """True when *quant* is a filename token, not a substring of another."""
+    return bool(
+        re.search(
+            r"(?:^|[-_.])" + re.escape(quant) + r"(?:$|[-_.])",
+            name,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
 def _ollama_models_dir() -> Path:
     """Ollama's model store: OLLAMA_MODELS, else ~/.ollama/models."""
     env = os.environ.get("OLLAMA_MODELS")
@@ -288,19 +299,18 @@ def _find_external_gguf(value: str) -> Path | None:
 
     repo, quant = _split_hf_ref(value)
     repo_token = _normalize_token(repo)
-    quant_token = _normalize_token(quant)
 
     hub_repo = _hf_hub_dir() / f"models--{repo.replace('/', '--')}" / "snapshots"
     if hub_repo.is_dir():
         for path in sorted(hub_repo.rglob("*.gguf")):
-            if quant_token in _normalize_token(path.stem) and path.is_file():
+            if _quant_in_name(path.stem, quant) and path.is_file():
                 return path
 
     cache = _llama_cache_dir()
     if cache.is_dir():
         for path in sorted(cache.glob("*.gguf")):
             name_token = _normalize_token(path.stem)
-            if repo_token in name_token and quant_token in name_token:
+            if repo_token in name_token and _quant_in_name(path.stem, quant):
                 return path
     return None
 
@@ -618,6 +628,7 @@ def start_server() -> bool:
 
     Returns True if the server is responding after startup, False otherwise.
     """
+    global _server_proc
     binary = resolve_server_bin()
     if binary is None:
         _fail("llama-server is not installed.", install_guidance_lines())
@@ -627,6 +638,9 @@ def start_server() -> bool:
         # Another thread may have already started the server while we waited.
         if is_available():
             return True
+        # A prior start that timed out can leave a live child on the port.
+        if _server_proc is not None:
+            _terminate_server()
 
         directory = models_dir()
         try:
@@ -659,7 +673,6 @@ def start_server() -> bool:
             _fail(f"Failed to start AI server: {exc}")
             return False
 
-        global _server_proc
         _server_proc = proc
 
         deadline = time.monotonic() + _START_TIMEOUT
@@ -680,8 +693,9 @@ def start_server() -> bool:
                 return False
             time.sleep(_START_POLL_INTERVAL)
 
-    _fail("AI server did not start within timeout.")
-    return False
+        _terminate_server()
+        _fail("AI server did not start within timeout.")
+        return False
 
 
 def _shutdown_response_socket(resp: Any) -> None:
@@ -753,6 +767,7 @@ def _do_generate(
     deadline = time.monotonic() + _GENERATE_DEADLINE
     deadline_exceeded = False
     saw_finish = False
+    recorded_failure = False
     resp: Any = None
     try:
         resp = urllib.request.urlopen(req, timeout=_GENERATE_TIMEOUT)
@@ -775,7 +790,7 @@ def _do_generate(
             if time.monotonic() >= deadline:
                 deadline_exceeded = True
                 _shutdown_response_socket(resp)
-                return None
+                break
             try:
                 line = resp.readline()
             except (OSError, ValueError, AttributeError, http.client.HTTPException):
@@ -784,15 +799,15 @@ def _do_generate(
                 # surface this as AttributeError on Python 3.13+ when the
                 # chunked-encoding state machine tries to advance past a
                 # closed fp.
-                return None
+                break
             if not line:
                 break
             if cancel_event is not None and cancel_event.is_set():
-                return None
+                break
             if time.monotonic() >= deadline:
                 deadline_exceeded = True
                 _shutdown_response_socket(resp)
-                return None
+                break
             payload = line.strip()
             if not payload.startswith(b"data:"):
                 continue  # skip SSE comments / blank keep-alives
@@ -808,7 +823,8 @@ def _do_generate(
             error = chunk.get("error")
             if error:
                 _fail(f"AI generate failed: {error}")
-                return None
+                recorded_failure = True
+                break
             piece, finished = _delta_piece(chunk)
             if piece:
                 parts.append(piece)
@@ -833,8 +849,11 @@ def _do_generate(
                 f"AI generate exceeded {_GENERATE_DEADLINE}s deadline "
                 f"(model: {body.get('model')}); aborting."
             )
+            recorded_failure = True
 
     if cancel_event is not None and cancel_event.is_set():
+        return None
+    if recorded_failure:
         return None
     if not saw_finish:
         # The stream ended (EOF) without a finish_reason — the server
@@ -1026,13 +1045,12 @@ def _resolve_hf_file(ref: str) -> dict[str, Any] | None:
     if not isinstance(tree, list):
         utils.warning_print(f"Unexpected model listing for {repo}.")
         return None
-    needle = quant.lower()
     matches = [
         entry
         for entry in tree
         if isinstance(entry, dict)
         and entry.get("path", "").lower().endswith(".gguf")
-        and needle in Path(entry.get("path", "")).stem.lower()
+        and _quant_in_name(Path(entry.get("path", "")).stem, quant)
     ]
     if not matches:
         utils.warning_print(f"No {quant} GGUF found in {repo}.")

--- a/source/screenspace.py
+++ b/source/screenspace.py
@@ -47,6 +47,7 @@ from screenspace_primitives import (
     _prepare_template,
     _template_correlation_map,
     average_color_hsv,
+    attach_capture_mask,
     canny_edges,
     blur_gray,
     color_matches,

--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -212,6 +212,21 @@ def region_mask_for(region: dict[str, Any], h: int, w: int) -> np.ndarray | None
     return mask
 
 
+def attach_capture_mask(
+    params: dict[str, Any],
+    image_key: str,
+    mask_key: str,
+    region: dict[str, Any],
+) -> None:
+    """Set the reference alpha mask from a shaped capture region."""
+    image = params.get(image_key)
+    if not isinstance(image, np.ndarray) or image.size == 0:
+        return
+    mask = region_mask_for(region, int(image.shape[0]), int(image.shape[1]))
+    if mask is not None:
+        params[mask_key] = mask
+
+
 _mask_points_keys: dict[int, tuple[Any, tuple[Any, ...]]] = {}
 
 

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -134,13 +134,35 @@ def _preview_ref_rect(
             except ValueError:
                 pass
             else:
-                return {
+                region_coords = {
                     "x": round(rrx * frame_w),
                     "y": round(rry * frame_h),
                     "w": round(rrw * frame_w),
                     "h": round(rrh * frame_h),
                 }
+    ref_mask = _parse_mask_points(request.args.get("ref_mask", "").strip())
+    if region_coords is not None and ref_mask:
+        region_coords = dict(region_coords)
+        region_coords["mask_points"] = ref_mask
     return region_coords
+
+
+def _parse_mask_points(raw: str) -> list[list[list[float]]]:
+    """Parse bbox-relative contours from a preview mask query."""
+    if not raw:
+        return []
+    try:
+        mask_points = [
+            [
+                [float(u), float(v)]
+                for u, v in (pair.split(",") for pair in part.split(";"))
+            ]
+            for part in raw.split("|")
+            if part
+        ]
+    except ValueError:
+        return []
+    return [c for c in mask_points if len(c) >= 3]
 
 
 FlaskResponse = Response | tuple[Response, int]
@@ -1244,22 +1266,9 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
             # fractions, multiple contours joined with "|". Malformed values
             # are ignored (preview falls back to the plain rect) rather than
             # failing the whole preview.
-            mask_str = request.args.get("mask", "").strip()
-            if mask_str:
-                try:
-                    mask_points = [
-                        [
-                            [float(u), float(v)]
-                            for u, v in (pair.split(",") for pair in part.split(";"))
-                        ]
-                        for part in mask_str.split("|")
-                        if part
-                    ]
-                except ValueError:
-                    mask_points = []
-                mask_points = [c for c in mask_points if len(c) >= 3]
-                if mask_points:
-                    region_coords["mask_points"] = mask_points
+            mask_points = _parse_mask_points(request.args.get("mask", "").strip())
+            if mask_points:
+                region_coords["mask_points"] = mask_points
 
     # Prev frame for tools that consume a temporal pair. Attention's motion
     # channel compares at its own (shorter) sampling interval by default.
@@ -1327,6 +1336,9 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
                     params["template_image"] = _ss_tpl.extract_region(
                         ref_frame_tpl, tpl_rect
                     )
+                    screenspace.attach_capture_mask(
+                        params, "template_image", "template_mask", tpl_rect
+                    )
 
     elif tool == "shape":
         import screenspace as _ss_shp
@@ -1354,6 +1366,9 @@ def api_preview(participant: str, timestamp: str) -> FlaskResponse:
                 if ref_frame_shp is not None:
                     params["shape_image"] = _ss_shp.extract_region(
                         ref_frame_shp, ref_rect
+                    )
+                    screenspace.attach_capture_mask(
+                        params, "shape_image", "shape_mask", ref_rect
                     )
 
     layer = (request.args.get("layer") or "").strip()
@@ -2145,12 +2160,9 @@ def _extract_tool_media(
             if frame is None:
                 return err(f"{context}could not read template frame")
             spec["template_image"] = screenspace.extract_region(frame, region_coords)
-            # A shaped capture region doubles as the template's alpha mask.
-            tpl_mask = screenspace.region_mask_for(
-                region_coords, *spec["template_image"].shape[:2]
+            screenspace.attach_capture_mask(
+                spec, "template_image", "template_mask", region_coords
             )
-            if tpl_mask is not None:
-                spec["template_mask"] = tpl_mask
 
     elif tool_type == "shape":
         upload_b64 = spec.pop("shape_image_data", None)
@@ -2168,13 +2180,9 @@ def _extract_tool_media(
             if frame is None:
                 return err(f"{context}could not read shape reference frame")
             spec["shape_image"] = screenspace.extract_region(frame, region_coords)
-            # A shaped capture region doubles as the reference mask: inner
-            # content (e.g. a button's label) can be lassoed out of the match.
-            crop_mask = screenspace.region_mask_for(
-                region_coords, *spec["shape_image"].shape[:2]
+            screenspace.attach_capture_mask(
+                spec, "shape_image", "shape_mask", region_coords
             )
-            if crop_mask is not None:
-                spec["shape_mask"] = crop_mask
 
     elif tool_type == "scene":
         scene_refs = cast(list[dict[str, Any]], spec["scene_references"])

--- a/source/transcripts.py
+++ b/source/transcripts.py
@@ -1216,6 +1216,19 @@ def get_known_terms(manifest: dict[str, Any]) -> list[str]:
 # One flat table carries both halves so a study's vocabulary travels as a single
 # file: "correction" rows use both text columns, "term" rows only ``to``.
 DICTIONARY_CSV_COLUMNS = ("type", "from", "to")
+_CSV_FORMULA_SIGILS = frozenset("=+-@\t\r")
+
+
+def _defang_csv_text(value: str) -> str:
+    """Prefix a spreadsheet formula trigger so Excel stores it as text."""
+    return ("'" + value) if value[:1] in _CSV_FORMULA_SIGILS else value
+
+
+def _undefang_csv_text(value: str) -> str:
+    """Undo :func:`_defang_csv_text` on a re-imported cell."""
+    return (
+        value[1:] if value[:1] == "'" and value[1:2] in _CSV_FORMULA_SIGILS else value
+    )
 
 
 def dictionary_to_csv(corrections: list[dict[str, Any]], known_terms: list[str]) -> str:
@@ -1223,11 +1236,18 @@ def dictionary_to_csv(corrections: list[dict[str, Any]], known_terms: list[str])
     import data_export
 
     rows: list[dict[str, Any]] = [
-        {"type": "correction", "from": c.get("from", ""), "to": c.get("to", "")}
+        {
+            "type": "correction",
+            "from": _defang_csv_text(str(c.get("from", ""))),
+            "to": _defang_csv_text(str(c.get("to", ""))),
+        }
         for c in corrections
         if c.get("from") and c.get("to")
     ]
-    rows += [{"type": "term", "from": "", "to": term} for term in known_terms]
+    rows += [
+        {"type": "term", "from": "", "to": _defang_csv_text(term)}
+        for term in known_terms
+    ]
     if not rows:
         # to_csv derives its columns from the data, so an empty dictionary would
         # export a zero-byte file that cannot be re-imported.
@@ -1245,10 +1265,10 @@ def parse_dictionary_csv(text: str) -> tuple[list[dict[str, str]], list[str]]:
     """
     corrections: list[dict[str, str]] = []
     terms: list[str] = []
-    for row in csv.DictReader(io.StringIO(text)):
+    for row in csv.DictReader(io.StringIO(text.lstrip("\ufeff"))):
         kind = (row.get("type") or "").strip().lower()
-        frm = (row.get("from") or "").strip()
-        to = (row.get("to") or "").strip()
+        frm = _undefang_csv_text((row.get("from") or "").strip())
+        to = _undefang_csv_text((row.get("to") or "").strip())
         if kind == "correction":
             if frm and to:
                 corrections.append({"from": frm, "to": to})

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -2232,7 +2232,7 @@ def api_llm_start() -> FlaskResponse:
         return err("AI runtime is not installed")
     started = llm_client.start_server()
     if not started:
-        return err("AI server did not start")
+        return err(llm_client.take_last_error() or "AI server did not start")
     return ok(started=True)
 
 

--- a/source/workflows.py
+++ b/source/workflows.py
@@ -232,6 +232,10 @@ def _exec_region(
         entry = regions.get(name)
         if isinstance(entry, dict):
             coords = {k: entry[k] for k in ("x", "y", "w", "h") if k in entry}
+            if entry.get("points"):
+                coords["points"] = entry["points"]
+            if entry.get("shape"):
+                coords["shape"] = entry["shape"]
     result: dict[str, Any] = {"region": {"name": name, "coords": coords}}
     if name and coords is None:
         # A named-but-missing region degrades to the full frame downstream
@@ -686,7 +690,7 @@ def _attach_ss_reference(
     base_params: dict[str, Any],
     params: dict[str, Any],
     video_path: str,
-    region_coords: dict[str, int],
+    region_coords: dict[str, Any],
 ) -> bool:
     """Self-extract a reference frame from ``video_path`` at ``reference_seconds``.
 
@@ -707,8 +711,14 @@ def _attach_ss_reference(
         base_params["reference_frame"] = crop
     elif tool_name == "template":
         base_params["template_image"] = crop
+        screenspace.attach_capture_mask(
+            base_params, "template_image", "template_mask", region_coords
+        )
     elif tool_name == "shape":
         base_params["shape_image"] = crop
+        screenspace.attach_capture_mask(
+            base_params, "shape_image", "shape_mask", region_coords
+        )
     elif tool_name == "scene":
         base_params["reference_scenes"] = [{"name": "ref", "frame": crop}]
     return True
@@ -834,7 +844,7 @@ def _exec_detect(
 
 def _resolve_region_coords(
     region_in: dict[str, Any], video_path: str
-) -> tuple[str, dict[str, int]]:
+) -> tuple[str, dict[str, Any]]:
     """Resolve a region input to pixel coords, defaulting to the **full frame**.
 
     A region port is optional on every Screenspace node; when it is unwired (or a
@@ -851,7 +861,7 @@ def _resolve_region_coords(
     props = video.probe_video_properties(video_path) or {}
     width = int(props.get("width", 0) or 0)
     height = int(props.get("height", 0) or 0)
-    coords: dict[str, int] = {"x": 0, "y": 0, "w": 0, "h": 0}
+    coords: dict[str, Any] = {"x": 0, "y": 0, "w": 0, "h": 0}
     norm = region_in.get("coords")
     if isinstance(norm, dict) and norm and width > 0 and height > 0:
         coords = screenspace.denormalize_region(norm, width, height)

--- a/source/workflows_catalog.py
+++ b/source/workflows_catalog.py
@@ -53,10 +53,12 @@ class NodeContext:
     def resolve_videos(self, participant: str) -> list[str]:
         """Return a participant's ordered source video path(s), or ``[]`` if none.
 
-        Multi-part participants (a session split across numbered files) return all
-        parts in timeline order — mirrors ``utils.discover_participant_videos``.
+        Honours ``config.FILENAME_OVERRIDES``. Multi-part participants return all
+        parts in timeline order.
         """
-        for entry in utils.discover_participant_videos():
+        import files
+
+        for entry in files.resolve_participant_videos():
             if entry.get("id") == participant and entry.get("has_video"):
                 return list(entry["video_paths"])
         return []

--- a/tests/screenspace/test_region_mask.py
+++ b/tests/screenspace/test_region_mask.py
@@ -6,6 +6,7 @@ import screenspace_ocr
 from screenspace_ocr import _ocr_region_readings
 from screenspace_primitives import (
     average_color_hsv,
+    attach_capture_mask,
     color_present,
     compare_scene_fingerprints,
     compute_frame_diff,
@@ -361,3 +362,19 @@ class TestRegionMasker:
         assert c is not None and c.shape == (20, 20)
         rect_masker = region_masker({"x": 0, "y": 0, "w": 10, "h": 10})
         assert rect_masker(np.zeros((40, 40, 3), dtype=np.uint8)) is None
+
+
+class TestAttachCaptureMask:
+    def test_sets_mask_for_a_shaped_region(self):
+        params = {"shape_image": np.zeros((40, 40, 3), dtype=np.uint8)}
+        region = {"mask_points": [TRIANGLE]}
+        attach_capture_mask(params, "shape_image", "shape_mask", region)
+        assert params["shape_mask"].shape == (40, 40)
+        assert set(np.unique(params["shape_mask"])) <= {0, 255}
+
+    def test_skips_rectangular_regions(self):
+        params = {"shape_image": np.zeros((40, 40, 3), dtype=np.uint8)}
+        attach_capture_mask(
+            params, "shape_image", "shape_mask", {"x": 0, "y": 0, "w": 40, "h": 40}
+        )
+        assert "shape_mask" not in params

--- a/tests/test_cli_screenspace_args.py
+++ b/tests/test_cli_screenspace_args.py
@@ -1,6 +1,7 @@
 """Tests for Screenspace CLI flags and dispatch helpers."""
 
 from argparse import Namespace
+from typing import Any
 
 import pytest
 
@@ -1168,3 +1169,21 @@ def test_ss_run_task_parent_stash_disambiguates(monkeypatch):
     assert saved_tasks
     # stash_a's hud -> {10,10,10,10}, not stash_b's {20,...} nor the stale saved coords.
     assert saved_tasks[0]["region_coords"] == {"x": 10, "y": 10, "w": 10, "h": 10}
+
+
+def test_ss_rehydrate_applies_shaped_capture_mask():
+    import numpy as np
+
+    frame = np.zeros((80, 80, 3), dtype=np.uint8)
+    parameters: dict[str, Any] = {"reference_timestamp": 0.0}
+    region = {
+        "x": 10,
+        "y": 10,
+        "w": 40,
+        "h": 40,
+        "mask_points": [[[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]],
+    }
+    cli._ss_rehydrate_task_media(
+        "shape", parameters, lambda ts: frame, region, {"regions": {}}, (80, 80)
+    )
+    assert parameters["shape_mask"].shape == (40, 40)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -230,6 +230,16 @@ class TestExternalCaches:
         (cache / "acme_tiny_tiny-Q2_K.gguf").write_bytes(b"GGUF")
         assert llm_client._find_external_gguf("acme/tiny:Q8_0") is None
 
+    def test_q4km_does_not_match_iq4km(self, tmp_path, monkeypatch):
+        self._llama_cache(tmp_path, monkeypatch)
+        hub = self._hub(tmp_path, monkeypatch)
+        snap = hub / "models--acme--tiny" / "snapshots" / "abc123"
+        snap.mkdir(parents=True)
+        (snap / "tiny-IQ4_K_M.gguf").write_bytes(b"IQ")
+        (snap / "tiny-Q4_K_M.gguf").write_bytes(b"Q4")
+        found = llm_client._find_external_gguf("acme/tiny:Q4_K_M")
+        assert found == snap / "tiny-Q4_K_M.gguf"
+
     def test_installed_check_materializes_symlink(self, tmp_path, monkeypatch):
         cache = self._llama_cache(tmp_path, monkeypatch)
         self._hub(tmp_path, monkeypatch)
@@ -535,6 +545,17 @@ class TestGenerateStreamTruncation:
         resp.readline.side_effect = http.client.IncompleteRead(b"partial")
         mock_urlopen.return_value = resp
         assert llm_client.generate("hi") is None
+
+    @patch("llm_client.urllib.request.urlopen")
+    def test_in_stream_error_is_not_reported_as_truncation(self, mock_urlopen):
+        mock_urlopen.return_value = _make_streaming_resp(
+            [b'data: {"error": "model overloaded"}\n']
+        )
+        llm_client.take_last_error()
+        assert llm_client.generate("hi") is None
+        reason = llm_client.take_last_error()
+        assert "overloaded" in reason
+        assert "stream ended" not in reason
 
 
 class _SSEChatHandler(http.server.BaseHTTPRequestHandler):
@@ -886,6 +907,26 @@ class TestAutoStartServer:
         monkeypatch.setattr(llm_client, "_START_TIMEOUT", 0.2)
         assert llm_client.start_server() is False
 
+    @patch("llm_client.subprocess.Popen")
+    @patch("llm_client.is_available")
+    @patch("llm_client.shutil.which")
+    def test_start_server_kills_the_child_on_timeout(
+        self, mock_which, mock_available, mock_popen, monkeypatch
+    ):
+        mock_which.return_value = "/usr/local/bin/llama-server"
+        mock_available.return_value = False
+        proc = mock_popen.return_value
+        proc.poll.return_value = None
+        monkeypatch.setattr(llm_client, "_START_POLL_INTERVAL", 0.01)
+        monkeypatch.setattr(llm_client, "_START_TIMEOUT", 0.05)
+        monkeypatch.setattr(llm_client, "_server_proc", None)
+        llm_client.take_last_error()
+
+        assert llm_client.start_server() is False
+        proc.terminate.assert_called()
+        assert llm_client._server_proc is None
+        assert "timeout" in llm_client.take_last_error()
+
 
 def _tree_entry(path: str, size: int, sha: str | None = "a" * 64) -> dict:
     entry: dict = {"path": path, "size": size}
@@ -959,6 +1000,17 @@ class TestDownloadModel:
         with patch("llm_client.urllib.request.urlopen") as mock_urlopen:
             mock_urlopen.side_effect = self._mock_hf(tree)
             assert llm_client.download_model("acme/big:Q8_0") is False
+
+    def test_iq4_does_not_make_q4_look_sharded(self):
+        tree = [
+            _tree_entry("tiny-IQ4_K_M.gguf", 12),
+            _tree_entry("tiny-Q4_K_M.gguf", 12),
+        ]
+        with patch("llm_client.urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = self._mock_hf(tree)
+            resolved = llm_client._resolve_hf_file("acme/tiny:Q4_K_M")
+        assert resolved is not None
+        assert resolved["path"] == "tiny-Q4_K_M.gguf"
 
     def test_gated_repo_reports_failure(self):
         with patch("llm_client.urllib.request.urlopen") as mock_urlopen:

--- a/tests/test_multi_video.py
+++ b/tests/test_multi_video.py
@@ -1466,3 +1466,16 @@ def test_ss_cli_resolves_all_parts(monkeypatch, tmp_path):
     paths = cli._ss_resolve_videos_for_participant("P01")
     assert [_basename(p) for p in paths] == ["study_P01-1.mp4", "study_P01-2.mp4"]
     assert cli._ss_resolve_videos_for_participant("PX") == []
+
+
+def test_ss_cli_honours_filename_overrides(monkeypatch, tmp_path):
+    import cli
+
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path), raising=False)
+    (tmp_path / "study_P01.mp4").write_text("pattern")
+    (tmp_path / "other.mp4").write_text("override")
+    monkeypatch.setattr(
+        config, "FILENAME_OVERRIDES", {"P01": "other.mp4"}, raising=False
+    )
+    paths = cli._ss_resolve_videos_for_participant("P01")
+    assert [_basename(p) for p in paths] == ["other.mp4"]

--- a/tests/test_screenspace_frontend_source.py
+++ b/tests/test_screenspace_frontend_source.py
@@ -16,6 +16,7 @@ CALIBRATION_JS = read("screenspace-calibration.js")
 SCREENSPACE_CSS = read("screenspace.css")
 SCREENSPACE_JS = read("screenspace.js")
 TASKS_JS = read("screenspace-tasks.js")
+MODEL_VIEW_JS = read("screenspace-model-view.js")
 
 
 def _shared_slider_rule() -> str:
@@ -162,3 +163,9 @@ def test_frame_preload_drops_results_for_a_replaced_source_file():
     assert "_preloadStopped" in body, (
         "a preload that resolves after pagehide must revoke its own blob URL"
     )
+
+
+def test_shape_model_view_has_meta_and_sends_capture_mask():
+    assert "shape:" in MODEL_VIEW_JS[MODEL_VIEW_JS.index("var MODEL_VIEW_META") :]
+    assert "ref_mask=" in MODEL_VIEW_JS
+    assert "function _encodeMaskContours(" in MODEL_VIEW_JS

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1165,6 +1165,22 @@ class TestDictionaryCsv:
     def test_garbage_input_yields_nothing(self):
         assert transcripts.parse_dictionary_csv("not a csv at all") == ([], [])
 
+    def test_utf8_bom_does_not_drop_the_header(self):
+        text = "\ufefftype,from,to\ncorrection,teh,the\nterm,,Widget\n"
+        assert transcripts.parse_dictionary_csv(text) == (
+            [{"from": "teh", "to": "the"}],
+            ["Widget"],
+        )
+
+    def test_formula_cells_round_trip_as_text(self):
+        corrections = [{"from": "=SUM(1)", "to": "+cmd"}]
+        terms = ["@ref"]
+        text = transcripts.dictionary_to_csv(corrections, terms)
+        assert "'=SUM(1)" in text
+        assert "'+cmd" in text
+        assert "'@ref" in text
+        assert transcripts.parse_dictionary_csv(text) == (corrections, terms)
+
 
 # ---------------------------------------------------------------------------
 # get_corrections_keywords

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -3281,6 +3281,19 @@ def test_llm_delete_refused_while_generating(tr_client, tmp_path, monkeypatch):
     assert (directory / "busy.gguf").exists()
 
 
+def test_llm_start_returns_the_recorded_reason(tr_client, monkeypatch):
+    import llm_client
+
+    monkeypatch.setattr(llm_client, "is_installed", lambda: True)
+    monkeypatch.setattr(llm_client, "start_server", lambda: False)
+    monkeypatch.setattr(
+        llm_client, "take_last_error", lambda: "AI server did not start within timeout."
+    )
+    resp = tr_client.post("/transcripts/api/models/llm/start", json={})
+    assert resp.status_code == 400
+    assert "timeout" in resp.get_json()["error"]
+
+
 def test_api_models_includes_cached_and_agents(monkeypatch):
     import llm_client
     import server as server_mod

--- a/tests/test_transcripts_dom_wiring.py
+++ b/tests/test_transcripts_dom_wiring.py
@@ -834,6 +834,7 @@ def test_the_density_band_covers_both_evidence_sources():
     )
     video = read("transcripts-video.js")
     assert "state.frictionBandBySegId" in video
+
     draw = video.index("function _drawFrictionBand(")
     draw_body = video[draw : video.index("\n  // The selected participant", draw)]
     assert "frictionMatchBySegId" not in draw_body, (
@@ -907,6 +908,21 @@ def test_llm_start_posts_to_the_transcripts_blueprint():
     """
     assert _JS.count('apiPost("api/models/llm/start"') == 1
     assert 'apiPost("/api/models/llm/start"' not in _JS
+
+
+def test_llm_start_toasts_the_server_reason():
+    start = _JS.index("function _startAiServer(")
+    body = _JS[start : _JS.index("\n  function ", start + 1)]
+    assert "e.serverMessage" in body
+
+
+def test_transcript_markers_are_scoped_to_the_study():
+    video = read("transcripts-video.js")
+    assert "function _markersScope(" in video
+    assert "_writeStoredMarkers(all)" in video
+    assert (
+        "sessionStorage.setItem(MARKERS_STORAGE_KEY, JSON.stringify(all))" not in video
+    )
 
 
 def test_a_stopped_ai_server_is_started_not_asked_about():

--- a/tests/test_workflows_executors.py
+++ b/tests/test_workflows_executors.py
@@ -113,6 +113,60 @@ def test_region_notes_missing_name(tmp_path, monkeypatch):
     assert "__note__" not in out
 
 
+def test_region_forwards_polygon_points(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        screenspace,
+        "load_screenspace_manifest",
+        lambda: {
+            "regions": {
+                "btn": {
+                    "x": 0.1,
+                    "y": 0.1,
+                    "w": 0.2,
+                    "h": 0.2,
+                    "points": [[[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]],
+                    "shape": "polygon",
+                }
+            }
+        },
+    )
+    out = _run("region", _ctx(tmp_path), {}, {"name": "btn"})
+    coords = out["region"]["coords"]
+    assert coords["points"][0][0] == [0.0, 0.0]
+    assert coords["shape"] == "polygon"
+
+
+def test_attach_ss_reference_keeps_shaped_capture_mask(monkeypatch):
+    import numpy as np
+
+    frame = np.zeros((80, 80, 3), dtype=np.uint8)
+    monkeypatch.setattr(video, "extract_frame_at_timestamp", lambda *a, **k: frame)
+    coords = {
+        "x": 10,
+        "y": 10,
+        "w": 40,
+        "h": 40,
+        "mask_points": [[[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]],
+    }
+    params: dict[str, Any] = {}
+    assert workflows._attach_ss_reference(
+        "shape", params, {"reference_seconds": 0}, "v.mp4", coords
+    )
+    assert params["shape_mask"].shape == (40, 40)
+
+
+def test_workflow_resolve_videos_honours_filename_overrides(tmp_path, monkeypatch):
+    (tmp_path / "study_P01.mp4").write_text("pattern")
+    (tmp_path / "other.mp4").write_text("override")
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(
+        config, "FILENAME_OVERRIDES", {"P01": "other.mp4"}, raising=False
+    )
+    ctx = _ctx(tmp_path)
+    paths = ctx.resolve_videos("P01")
+    assert [Path(p).name for p in paths] == ["other.mp4"]
+
+
 def test_transcript_marks_resolves_categories_and_pads(tmp_path, monkeypatch):
     import transcripts
 


### PR DESCRIPTION
## Summary

Audit of post–Aug 20 merges (Shape, llama.cpp, transcripts, workflows) found eight defects; each has a regression test.

- **llama-server** — a start timeout left the child running so a retry could spawn a second process; generate failures were overwritten as truncation; `Q4_K_M` matched `IQ4_K_M`; `/api/llm/start` dropped `take_last_error()`.
- **Shape/Template** — lasso masks were dropped on preview, CLI rehydrate, and workflow Region/reference; the model view now sends `ref_mask=` with `ref_region`.
- **Transcripts/files** — dictionary CSV now prefixes formula sigils and strips a BOM on parse; in/out markers are scoped per study; CLI and workflows honor `FILENAME_OVERRIDES`.

## Test plan

- [x] `/check` green — ruff format + lint, `ty`, full suite