### PR TITLE
perf(screenspace): bound Template and Shape correlation to the search window

### DIFF
--- a/agents/skills/profile/SKILL.md
+++ b/agents/skills/profile/SKILL.md
@@ -220,6 +220,15 @@ uv run python tests/perf/scan_bench.py --save /tmp/base.json     # baseline
 uv run python tests/perf/scan_bench.py --compare /tmp/base.json  # Δcallback %
 ```
 
+Template and Shape use a seeded top-left 20%-frame region. This keeps their
+reference non-degenerate while measuring bounded correlation instead of a
+full-frame reference. Shape is part of the default non-OCR sweep. Drill into
+its scale correlations with the same workload:
+
+```bash
+uv run python tests/perf/scan_bench.py --tools shape --deep --runs 2
+```
+
 `--tools color,text` narrows the sweep (`text` is off by default: OCR is 10×
 slower and pins ~0.8 GB RSS per pooled engine — 3.3 GB at the default auto
 pool of 4); `--runs 2` keeps the fastest run per tool. For a

--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -913,6 +913,40 @@ def _prepare_template(
     return (tmpl_gray, gray_mask, degenerate)
 
 
+def _match_corr_window(
+    source: np.ndarray,
+    template: np.ndarray,
+    window: tuple[float, float, float, float] | None,
+) -> tuple[np.ndarray, int, int] | None:
+    """Correlate only source pixels producing centers inside *window*.
+
+    OpenCV may shift raw scores below 5e-5 when crop dimensions change.
+    """
+    sh, sw = source.shape[:2]
+    th, tw = template.shape[:2]
+    if th > sh or tw > sw:
+        return None
+    rw, rh = sw - tw + 1, sh - th + 1
+    if window is None:
+        xa, ya, xb, yb = 0, 0, rw, rh
+    else:
+        xa = max(0, math.floor(window[0] - tw / 2.0))
+        ya = max(0, math.floor(window[1] - th / 2.0))
+        xb = min(rw, math.ceil(window[2] - tw / 2.0) + 1)
+        yb = min(rh, math.ceil(window[3] - th / 2.0) + 1)
+    if xa >= xb or ya >= yb:
+        return None
+    cropped = source[ya : yb + th - 1, xa : xb + tw - 1]
+    result = cv2.matchTemplate(cropped, template, cv2.TM_CCOEFF_NORMED)
+    return result, xa, ya
+
+
+def _template_frame_gray(frame: np.ndarray) -> np.ndarray:
+    """Blur and grayscale a frame for template correlation."""
+    k = config.SCREENSPACE_BLUR_KERNEL
+    return cv2.cvtColor(cv2.GaussianBlur(frame, (k, k), 0), cv2.COLOR_BGR2GRAY)
+
+
 def _template_correlation_map(
     frame: np.ndarray, prepared: _PreparedTemplate
 ) -> np.ndarray | None:
@@ -927,8 +961,7 @@ def _template_correlation_map(
     if degenerate:
         # Zero-variance template: see _prepare_template's degeneracy note.
         return None
-    k = config.SCREENSPACE_BLUR_KERNEL
-    frame_gray = cv2.cvtColor(cv2.GaussianBlur(frame, (k, k), 0), cv2.COLOR_BGR2GRAY)
+    frame_gray = _template_frame_gray(frame)
     th, tw = tmpl_gray.shape[:2]
     if th > frame_gray.shape[0] or tw > frame_gray.shape[1]:
         return None
@@ -940,6 +973,24 @@ def _template_correlation_map(
     return result
 
 
+def _template_corr_window(
+    frame: np.ndarray,
+    prepared: _PreparedTemplate,
+    window: tuple[float, float, float, float],
+) -> tuple[np.ndarray, int, int] | None:
+    """Compute an unmasked template correlation ROI."""
+    tmpl_gray, gray_mask, degenerate = prepared
+    if degenerate or gray_mask is not None:
+        return None
+    packed = _match_corr_window(_template_frame_gray(frame), tmpl_gray, window)
+    if packed is None:
+        return None
+    result, x_offset, y_offset = packed
+    if not np.all(np.isfinite(result)):
+        result = np.where(np.isfinite(result), result, -1.0)
+    return result, x_offset, y_offset
+
+
 def _match_template_prepared(
     frame: np.ndarray,
     prepared: _PreparedTemplate,
@@ -947,6 +998,7 @@ def _match_template_prepared(
     nms_overlap: float,
     corr: np.ndarray | None = None,
     window: tuple[float, float, float, float] | None = None,
+    origin: tuple[int, int] = (0, 0),
 ) -> list[dict[str, Any]]:
     """Match a frame against an already-prepared template payload.
 
@@ -956,10 +1008,18 @@ def _match_template_prepared(
     passing frame. *window* (see :func:`region_search_window`) restricts
     matching to positions whose match center falls inside the rect.
     """
-    result = _template_correlation_map(frame, prepared) if corr is None else corr
+    tmpl_gray, gray_mask, _degenerate = prepared
+    if corr is None and window is not None and gray_mask is None:
+        packed = _template_corr_window(frame, prepared, window)
+        if packed is None:
+            return []
+        result, x_offset, y_offset = packed
+        origin = (x_offset, y_offset)
+        window = None
+    else:
+        result = _template_correlation_map(frame, prepared) if corr is None else corr
     if result is None:
         return []
-    tmpl_gray, _gray_mask, _degenerate = prepared
     th, tw = tmpl_gray.shape[:2]
     if window is not None:
         masked = _mask_corr_outside_window(result, tw, th, window)
@@ -998,7 +1058,15 @@ def _match_template_prepared(
     kept: list[dict[str, Any]] = []
     while xs.size:
         x0, y0 = int(xs[0]), int(ys[0])
-        kept.append({"x": x0, "y": y0, "w": tw, "h": th, "score": float(scores[0])})
+        kept.append(
+            {
+                "x": x0 + origin[0],
+                "y": y0 + origin[1],
+                "w": tw,
+                "h": th,
+                "score": float(scores[0]),
+            }
+        )
         if xs.size == 1:
             break
         inter = np.maximum(0, tw - np.abs(xs[1:] - x0)) * np.maximum(
@@ -1279,27 +1347,41 @@ def match_shape(
         threshold-independent scalar calibration reads even on a miss
         (``-1.0`` when no scale was matchable).
     """
+    return _match_shape_scales(
+        frame_edges, prepared, threshold, nms_overlap, window=window
+    )
+
+
+def _match_shape_scales(
+    frame_edges: np.ndarray,
+    prepared: _PreparedShape,
+    threshold: float = 0.0,
+    nms_overlap: float = 0.0,
+    window: tuple[float, float, float, float] | None = None,
+    executor: Any = None,
+) -> tuple[list[dict[str, Any]], float]:
+    """Match prepared Shape rungs, optionally through an ordered executor."""
     if threshold <= 0.0:
         threshold = config.SCREENSPACE_SHAPE_MATCH_THRESHOLD
     if nms_overlap <= 0.0:
         nms_overlap = config.SCREENSPACE_TEMPLATE_NMS_OVERLAP
     _MAX_CANDIDATES = 5000
-    fh, fw = frame_edges.shape[:2]
     best_peak = -1.0
     candidates: list[dict[str, Any]] = []
-    for entry in prepared:
-        tw, th = entry["w"], entry["h"]
-        if th > fh or tw > fw:
+
+    def _one(entry: dict[str, Any]) -> tuple[dict[str, Any], Any]:
+        return entry, _match_corr_window(frame_edges, entry["edges"], window)
+
+    rows = executor.map(_one, prepared) if executor is not None else map(_one, prepared)
+    for entry, packed in rows:
+        if packed is None:
             continue
-        result = cv2.matchTemplate(frame_edges, entry["edges"], cv2.TM_CCOEFF_NORMED)
+        result, x_offset, y_offset = packed
+        tw, th = entry["w"], entry["h"]
         # Flat windows normalize by ~0 std; neutralize like template matching.
         if not np.all(np.isfinite(result)):
             result = np.where(np.isfinite(result), result, -1.0)
         np.clip(result, -1.0, 1.0, out=result)
-        if window is not None:
-            result = _mask_corr_outside_window(result, tw, th, window)
-            if result is None:
-                continue
         if result.size:
             best_peak = max(best_peak, float(result.max()))
         locs = np.where(result >= threshold)
@@ -1312,8 +1394,8 @@ def match_shape(
             ys, xs, scores = ys[top_idx], xs[top_idx], scores[top_idx]
         candidates.extend(
             {
-                "x": int(x),
-                "y": int(y),
+                "x": int(x) + x_offset,
+                "y": int(y) + y_offset,
                 "w": tw,
                 "h": th,
                 "score": float(sc),

--- a/source/screenspace_scans.py
+++ b/source/screenspace_scans.py
@@ -6,8 +6,10 @@ template, shape, flow, scene, inactivity, boundary, attention). Scans never
 call each other.
 """
 
+import os
 import subprocess
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import cv2
@@ -22,6 +24,7 @@ from screenspace_primitives import (
     _frame_diff_mask_gray,
     _frame_is_static,
     _is_static_skip,
+    _match_shape_scales,
     blur_gray,
     _frame_edge_map,
     _match_template_prepared,
@@ -29,7 +32,6 @@ from screenspace_primitives import (
     _prepare_shape_reference,
     _prepare_template,
     _scale_template,
-    match_shape,
     region_search_window,
     color_matches,
     color_present,
@@ -746,7 +748,6 @@ def scan_template(
         if config.SCREENSPACE_CV_RESOLUTION_SCALE > 0
         else 1.0
     )
-
     # Static-frame carry: template rows are per-frame with no consecutive buffer,
     # so a naive skip would drop a persistent match's rows and flicker the
     # detection. Cache the last result and re-emit it (re-stamped) on a static
@@ -919,6 +920,12 @@ def scan_shape(
         return results
 
     _nms_overlap = config.SCREENSPACE_TEMPLATE_NMS_OVERLAP
+    outer_workers = max(1, config.SCREENSPACE_PARALLEL_WORKERS)
+    cpu_capacity = max(1, (os.cpu_count() or 1) // outer_workers)
+    rung_workers = min(4, cpu_capacity, len(_prepared))
+    executor = (
+        ThreadPoolExecutor(max_workers=rung_workers) if rung_workers > 1 else None
+    )
     # ffmpeg already scaled the frame by cv_scale, so match boxes need both that
     # and the fast-scan internal 2x downscale undone to land in original pixels.
     _cv_scale = (
@@ -966,8 +973,13 @@ def scan_shape(
         # Unlike template, the run region scopes the search: only matches
         # centered inside it count (Full frame = zero-size rect = anywhere).
         window = region_search_window(region, _cv_scale / scale_back)
-        matches, _peak = match_shape(
-            _frame_edge_map(work_frame), _prepared, threshold, _nms_overlap, window
+        matches, _peak = _match_shape_scales(
+            _frame_edge_map(work_frame),
+            _prepared,
+            threshold,
+            _nms_overlap,
+            window,
+            executor,
         )
         if matches:
             # Undo fast-scan downscale, then undo cv_scale, so reported
@@ -1008,17 +1020,21 @@ def scan_shape(
             on_progress((ts - start_seconds) / total_range)
         return None
 
-    scan_video_full_frames(
-        video_path,
-        interval_seconds,
-        _cb,
-        start_seconds=start_seconds,
-        end_seconds=end_seconds,
-        fps=vid_fps,
-        duration=vid_duration,
-        fast_opts=fast_opts,
-        profile_kind="shape",
-    )
+    try:
+        scan_video_full_frames(
+            video_path,
+            interval_seconds,
+            _cb,
+            start_seconds=start_seconds,
+            end_seconds=end_seconds,
+            fps=vid_fps,
+            duration=vid_duration,
+            fast_opts=fast_opts,
+            profile_kind="shape",
+        )
+    finally:
+        if executor is not None:
+            executor.shutdown()
 
     if on_progress:
         on_progress(1.0)

--- a/source/screenspace_tools.py
+++ b/source/screenspace_tools.py
@@ -24,9 +24,11 @@ import utils
 from screenspace_primitives import (
     _frame_edge_map,
     _mask_corr_outside_window,
+    _match_template_prepared,
     _prepare_shape_reference,
     _prepare_template,
     _scale_template,
+    _template_corr_window,
     _template_correlation_map,
     blur_gray,
     color_matches,
@@ -40,7 +42,6 @@ from screenspace_primitives import (
     filter_matches_by_region_mask,
     mask_points_key,
     match_shape,
-    match_template,
     region_mask_for,
     region_search_window,
     regions_are_similar,
@@ -732,16 +733,24 @@ class TemplateTool(AnalysisTool):
                 _prepare_template(scaled_img, scaled_mask),
             )
             params["_prepared_template"] = cached
-        scaled_img, scaled_mask, prepared = cached
+        _scaled_img, _scaled_mask, prepared = cached
         # Peak correlation is the threshold-independent scalar; available even on
         # a miss (unlike match_template, which only returns above-threshold hits).
-        corr = _template_correlation_map(frame, prepared)
-        if corr is None:
-            return False, None
         # The run region scopes both the search and the peak (Full frame /
         # zero-size = anywhere), so calibration scores the targeted spot.
         window = region_search_window(region)
-        if window is not None:
+        origin = (0, 0)
+        if window is not None and prepared[1] is None:
+            packed = _template_corr_window(frame, prepared, window)
+            if packed is None:
+                return False, {"best_score": -1.0, "match_count": 0}
+            corr, x_offset, y_offset = packed
+            origin = (x_offset, y_offset)
+        else:
+            corr = _template_correlation_map(frame, prepared)
+            if corr is None:
+                return False, None
+        if window is not None and prepared[1] is not None:
             tpl_h, tpl_w = prepared[0].shape[:2]
             corr = _mask_corr_outside_window(corr, tpl_w, tpl_h, window)
             if corr is None:
@@ -749,13 +758,13 @@ class TemplateTool(AnalysisTool):
         peak = float(corr.max())
         if peak < threshold:
             return False, {"best_score": round(peak, 4), "match_count": 0}
-        matches = match_template(
+        matches = _match_template_prepared(
             frame,
-            scaled_img,
-            threshold=threshold,
-            mask=scaled_mask,
-            prepared=prepared,
-            corr=corr,
+            prepared,
+            threshold,
+            config.SCREENSPACE_TEMPLATE_NMS_OVERLAP,
+            corr,
+            origin=origin,
         )
         # Shaped region: the polygon refines the rect window as a detection
         # filter — passing requires at least one surviving match. best_score

--- a/source/server.py
+++ b/source/server.py
@@ -104,6 +104,7 @@ from server_utils import (
 from datetime import UTC
 
 FlaskResponse = Response | tuple[Response, int]
+_SERVER_POLL_INTERVAL = 0.5
 
 # ---- Module-level state (set once by _init_studio_state) ----
 
@@ -4899,7 +4900,10 @@ def serve_combined_app(
     srv.block_on_close = False
 
     thread = threading.Thread(
-        target=srv.serve_forever, daemon=True, name="clipgen-server"
+        target=srv.serve_forever,
+        kwargs={"poll_interval": _SERVER_POLL_INTERVAL},
+        daemon=True,
+        name="clipgen-server",
     )
     thread.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,8 +95,8 @@ def _sandbox_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
 
-@pytest.fixture(autouse=True)
-def _sandbox_user_config(tmp_path, monkeypatch):
+@pytest.fixture(scope="session", autouse=True)
+def _sandbox_user_config(tmp_path_factory):
     """Keep per-user clipgen state out of the developer's real home.
 
     ``start_settings.config_dir()`` resolves from ``Path.home()`` (or
@@ -109,9 +109,25 @@ def _sandbox_user_config(tmp_path, monkeypatch):
     ``Path.home``/``LOCALAPPDATA`` in the test body, which runs after this
     fixture and therefore still wins. Stubbing ``config_dir`` would break it.
     """
-    home = tmp_path / "home"
-    monkeypatch.setattr(Path, "home", lambda: home)
-    monkeypatch.setenv("LOCALAPPDATA", str(home / "Local"))
+    home = tmp_path_factory.mktemp("user-home")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(Path, "home", lambda: home)
+        monkeypatch.setenv("LOCALAPPDATA", str(home / "Local"))
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_user_config():
+    """Keep persisted test preferences from reaching later module fixtures."""
+    import start_settings
+
+    root = start_settings.config_dir()
+    paths = (root / "start.json", root / "studio_settings.json")
+    for path in paths:
+        path.unlink(missing_ok=True)
+    yield
+    for path in paths:
+        path.unlink(missing_ok=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/perf/scan_bench.py
+++ b/tests/perf/scan_bench.py
@@ -19,7 +19,9 @@ The fixture video is built on demand (ffmpeg testsrc: constant motion, so
 phash-skip never hides the callback). Each tool writes to its own wiped
 output dir so a cached manifest can never absorb the scan. `--runs N` keeps
 the fastest run per tool (minimum callback seconds), the standard treatment
-for scheduler noise. `text` is excluded from the default sweep: OCR is an
+for scheduler noise. Template and Shape use a fixed top-left 20% region for
+a non-degenerate reference and bounded search workload. `text` is excluded
+from the default sweep: OCR is an
 order of magnitude slower than every other tool and pins ~0.8 GB of RSS per
 pooled OCR engine (measured 3.3 GB at the default auto pool of 4).
 
@@ -50,10 +52,21 @@ TOOL_FLAGS: dict[str, list[str]] = {
     "scene": ["--ss-scene-ref", "menu:1"],
     "flow": ["--ss-threshold", "2"],
     "template": ["--ss-reference-timestamp", "1", "--ss-threshold", "0.7"],
+    "shape": ["--ss-reference-timestamp", "1", "--ss-threshold", "0.55"],
     "attention": [],
     "text": ["--ss-text", "00:00:01"],
 }
 DEFAULT_TOOLS = [t for t in TOOL_FLAGS if t != "text"]
+
+BENCH_REGION = {
+    "x": 0.0,
+    "y": 0.0,
+    "w": 0.2,
+    "h": 0.2,
+    "source_width": 1280,
+    "source_height": 720,
+}
+REGION_TOOLS = {"template", "shape"}
 
 _PROFILE_RE = re.compile(r"^profile \| (\S+)\s+([\d.]+)s\s+n=(\d+)", re.MULTILINE)
 _RSS_RE = re.compile(r"^profile \| peak_rss\s+([\d.]+)MB", re.MULTILINE)
@@ -153,6 +166,19 @@ def run_tool(
     out_dir = out_root / f"bench-{tool}"
     if out_dir.exists():
         shutil.rmtree(out_dir)
+    region_args: list[str] = []
+    if tool in REGION_TOOLS:
+        out_dir.mkdir(parents=True)
+        manifest = {
+            "screenspace": {
+                "regions": {"bench": BENCH_REGION},
+                "tasks": [],
+                "events": [],
+                "stashes": [],
+            }
+        }
+        (out_dir / "clipgen.json").write_text(json.dumps(manifest))
+        region_args = ["bench"]
     cmd = [
         "uv",
         "run",
@@ -160,6 +186,7 @@ def run_tool(
         "--ss-task",
         tool,
         "P01",
+        *region_args,
         *TOOL_FLAGS[tool],
         "--ss-interval",
         str(interval),

--- a/tests/perf/test_scan_bench_parse.py
+++ b/tests/perf/test_scan_bench_parse.py
@@ -5,6 +5,9 @@ the parser is the part that silently rots if the `profile |` line shape
 changes, so it is pinned here against a verbatim report snippet.
 """
 
+import json
+from types import SimpleNamespace
+
 import scan_bench
 
 REPORT = """\
@@ -55,3 +58,31 @@ def test_summarize_handles_missing_labels():
     assert row["callback_s"] == 0.0
     assert row["frames"] == 0
     assert row["callback_avg_ms"] == 0.0
+
+
+def test_shape_is_in_default_sweep():
+    assert "shape" in scan_bench.DEFAULT_TOOLS
+    assert scan_bench.TOOL_FLAGS["shape"] == [
+        "--ss-reference-timestamp",
+        "1",
+        "--ss-threshold",
+        "0.55",
+    ]
+
+
+def test_shape_run_seeds_region(tmp_path, monkeypatch):
+    captured = {}
+    report = REPORT.replace("color", "shape")
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(stdout=report, stderr="")
+
+    monkeypatch.setattr(scan_bench.subprocess, "run", fake_run)
+    parsed = scan_bench.run_tool("shape", tmp_path / "in", tmp_path / "out", 0.1)
+    manifest_path = tmp_path / "out" / "bench-shape" / "clipgen.json"
+    manifest = json.loads(manifest_path.read_text())
+
+    assert parsed["scan.callback.shape"]["seconds"] == 3.688
+    assert captured["cmd"][3:7] == ["--ss-task", "shape", "P01", "bench"]
+    assert manifest["screenspace"]["regions"]["bench"] == scan_bench.BENCH_REGION

--- a/tests/screenspace/test_shape.py
+++ b/tests/screenspace/test_shape.py
@@ -1,11 +1,16 @@
 """Tests for the Shape tool: scale-swept edge matching primitives, scan, tool."""
 
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
 import cv2
 import numpy as np
+import pytest
 
 import config
 import screenspace
 import screenspace_frames
+import screenspace_primitives
 import screenspace_scans
 
 _BG = 40  # flat dark background with strong luma contrast to white outlines
@@ -27,6 +32,51 @@ def _make_outline_frame(
     frame = np.full((frame_h, frame_w, 3), _BG, dtype=np.uint8)
     frame[y : y + size, x : x + size] = _make_outline(size, color=color)
     return frame
+
+
+def _full_shape(frame_edges, prepared, threshold, overlap, window):
+    """Previous full-map Shape matcher used as an exact reference."""
+    candidates = []
+    best_peak = -1.0
+    fh, fw = frame_edges.shape[:2]
+    for entry in prepared:
+        tw, th = entry["w"], entry["h"]
+        if th > fh or tw > fw:
+            continue
+        result = cv2.matchTemplate(frame_edges, entry["edges"], cv2.TM_CCOEFF_NORMED)
+        if not np.all(np.isfinite(result)):
+            result = np.where(np.isfinite(result), result, -1.0)
+        np.clip(result, -1.0, 1.0, out=result)
+        if window is not None:
+            result = screenspace_primitives._mask_corr_outside_window(
+                result, tw, th, window
+            )
+            if result is None:
+                continue
+        if result.size:
+            best_peak = max(best_peak, float(result.max()))
+        locs = np.where(result >= threshold)
+        ys, xs = locs[0], locs[1]
+        scores = result[locs]
+        if scores.size > 5000:
+            top_idx = np.argpartition(scores, -5000)[-5000:]
+            ys, xs, scores = ys[top_idx], xs[top_idx], scores[top_idx]
+        candidates.extend(
+            {
+                "x": int(x),
+                "y": int(y),
+                "w": tw,
+                "h": th,
+                "score": float(score),
+                "scale": entry["scale"],
+                "scale_y": entry["scale_y"],
+            }
+            for y, x, score in zip(ys, xs, scores, strict=True)
+        )
+    if len(candidates) > 5000:
+        candidates.sort(key=lambda candidate: -candidate["score"])
+        del candidates[5000:]
+    return screenspace.nms_boxes_iou(candidates, overlap), best_peak
 
 
 class TestPrepareShapeReference:
@@ -198,6 +248,73 @@ class TestMatchShape:
 
 
 class TestSearchWindow:
+    def test_roi_matches_full_map(self):
+        rng = np.random.RandomState(84)
+        frame = rng.randint(0, 255, (96, 144, 3), dtype=np.uint8)
+        reference = frame[20:52, 37:81].copy()
+        prepared = screenspace._prepare_shape_reference(
+            reference, scale_min=0.75, scale_max=1.4, scale_steps=4
+        )
+        edges = screenspace._frame_edge_map(frame)
+        for window in ((0.0, 0.0, 33.0, 26.0), (31.0, 17.0, 93.0, 72.0)):
+            want = _full_shape(edges, prepared, 0.05, 0.3, window)
+            got = screenspace.match_shape(edges, prepared, 0.05, 0.3, window)
+            got_matches, got_peak = got
+            want_matches, want_peak = want
+            assert [
+                {key: value for key, value in row.items() if key != "score"}
+                for row in got_matches
+            ] == [
+                {key: value for key, value in row.items() if key != "score"}
+                for row in want_matches
+            ]
+            assert all(
+                abs(got_row["score"] - want_row["score"]) < 5e-5
+                for got_row, want_row in zip(got_matches, want_matches, strict=True)
+            )
+            assert abs(got_peak - want_peak) < 5e-5
+
+    def test_unmatchable_scale_is_identical(self):
+        edges = screenspace._frame_edge_map(_make_outline_frame(80, 60, 10, 8, 30))
+        prepared = screenspace._prepare_shape_reference(
+            _make_outline(120), scale_min=1.0, scale_max=1.0, scale_steps=1
+        )
+        window = (0.0, 0.0, 20.0, 20.0)
+        assert screenspace.match_shape(edges, prepared, 0.1, 0.3, window) == (
+            [],
+            -1.0,
+        )
+
+    def test_executor_is_exact_and_ordered(self):
+        frame = _make_outline_frame(180, 120, 72, 36, 42)
+        edges = screenspace._frame_edge_map(frame)
+        prepared = screenspace._prepare_shape_reference(
+            _make_outline(42), scale_min=0.7, scale_max=1.4, scale_steps=5
+        )
+        sequential = screenspace_primitives._match_shape_scales(
+            edges, prepared, 0.1, 0.3
+        )
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            parallel = screenspace_primitives._match_shape_scales(
+                edges, prepared, 0.1, 0.3, executor=executor
+            )
+        assert parallel == sequential
+
+        pool = Mock()
+        seen = []
+
+        def ordered(fn, entries):
+            entries = list(entries)
+            seen.extend(entry["scale"] for entry in entries)
+            return map(fn, entries)
+
+        pool.map.side_effect = ordered
+        got = screenspace_primitives._match_shape_scales(
+            edges, prepared, 0.1, 0.3, executor=pool
+        )
+        assert got == sequential
+        assert seen == [entry["scale"] for entry in prepared]
+
     def test_window_scopes_matches_and_peak(self):
         # Same frame, two run regions: over the shape → hit; elsewhere → the
         # peak drops too (region-local calibration honesty).
@@ -339,6 +456,67 @@ class TestScanShape:
         )
         assert [r["timestamp"] for r in results] == [0.0, 1.0]
         assert results[0]["best_score"] == results[1]["best_score"]
+
+    def test_executor_shutdown(self, monkeypatch):
+        frame = _make_outline_frame(160, 120, 50, 30, 40)
+        pool = Mock()
+        created = {}
+        pool.map.side_effect = lambda fn, entries: map(fn, entries)
+
+        def make_pool(**kwargs):
+            created.update(kwargs)
+            return pool
+
+        monkeypatch.setattr(screenspace_scans, "ThreadPoolExecutor", make_pool)
+        monkeypatch.setattr(screenspace_scans.os, "cpu_count", lambda: 8)
+        monkeypatch.setattr(config, "SCREENSPACE_PARALLEL_WORKERS", 1)
+        self._patch_single_frame(monkeypatch, frame)
+        screenspace.scan_shape(
+            "/fake.mp4",
+            {"x": 0, "y": 0, "w": 160, "h": 120},
+            _make_outline(40),
+            threshold=0.5,
+        )
+        assert created["max_workers"] == 4
+        pool.shutdown.assert_called_once_with()
+
+    def test_executor_shutdown_on_cancel(self, monkeypatch):
+        pool = Mock()
+        monkeypatch.setattr(screenspace_scans, "ThreadPoolExecutor", lambda **_k: pool)
+        monkeypatch.setattr(screenspace_scans.os, "cpu_count", lambda: 8)
+        monkeypatch.setattr(config, "SCREENSPACE_PARALLEL_WORKERS", 1)
+        self._patch_single_frame(monkeypatch, _make_outline_frame(160, 120, 50, 30, 40))
+        assert (
+            screenspace.scan_shape(
+                "/fake.mp4",
+                {"x": 0, "y": 0, "w": 160, "h": 120},
+                _make_outline(40),
+                cancel_flag=lambda: True,
+            )
+            == []
+        )
+        pool.shutdown.assert_called_once_with()
+
+    def test_executor_shutdown_on_error(self, monkeypatch):
+        pool = Mock()
+        monkeypatch.setattr(screenspace_scans, "ThreadPoolExecutor", lambda **_k: pool)
+        monkeypatch.setattr(screenspace_scans.os, "cpu_count", lambda: 8)
+        monkeypatch.setattr(config, "SCREENSPACE_PARALLEL_WORKERS", 1)
+        monkeypatch.setattr(
+            screenspace_frames, "_probe_video_meta", lambda _path: (30.0, 1.0)
+        )
+
+        def fail(*_args, **_kwargs):
+            raise RuntimeError("scan failed")
+
+        monkeypatch.setattr(screenspace_scans, "scan_video_full_frames", fail)
+        with pytest.raises(RuntimeError, match="scan failed"):
+            screenspace.scan_shape(
+                "/fake.mp4",
+                {"x": 0, "y": 0, "w": 160, "h": 120},
+                _make_outline(40),
+            )
+        pool.shutdown.assert_called_once_with()
 
 
 class TestShapeTool:

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -1,5 +1,6 @@
 """Tests for template matching primitives and heatmap."""
 
+import cv2
 import numpy as np
 
 import config
@@ -71,16 +72,13 @@ class TestCorrelationMapReuse:
     def test_tool_check_frame_computes_the_map_once(self, monkeypatch):
         frame, template = self._frame_and_template()
         calls = []
-        real = screenspace_primitives._template_correlation_map
+        real = screenspace_primitives._match_corr_window
 
-        def counting(frame_arg, prepared):
+        def counting(source, template_arg, window):
             calls.append(1)
-            return real(frame_arg, prepared)
+            return real(source, template_arg, window)
 
-        monkeypatch.setattr(
-            screenspace_primitives, "_template_correlation_map", counting
-        )
-        monkeypatch.setattr(screenspace_tools, "_template_correlation_map", counting)
+        monkeypatch.setattr(screenspace_primitives, "_match_corr_window", counting)
         params = {"template_image": template, "threshold": 0.9}
         matched, details = screenspace_tools.TemplateTool().check_frame(
             frame, None, {"x": 0, "y": 0, "w": 200, "h": 100}, params
@@ -132,8 +130,8 @@ class TestNmsEquivalence:
         template = rng.randint(0, 255, (8, 10, 3), dtype=np.uint8)
         prepared = screenspace_primitives._prepare_template(template, None)
         th, tw = prepared[0].shape[:2]
-        # Quantized map: thousands of candidates, heavy score ties, one inf.
-        corr = (rng.randint(0, 8, (60, 90)) / 8.0).astype(np.float32)
+        # Quantized map: hundreds of candidates, heavy score ties, one inf.
+        corr = (rng.randint(0, 8, (16, 24)) / 8.0).astype(np.float32)
         corr[0, 0] = np.inf
         frame = np.zeros((10, 10, 3), dtype=np.uint8)  # unused when corr is given
         for nms_overlap in (0.0, 0.3, 0.9):
@@ -142,6 +140,105 @@ class TestNmsEquivalence:
             )
             want = self._reference_nms(corr, tw, th, 0.25, nms_overlap)
             assert got == want
+
+
+class TestCorrelationRoi:
+    def test_unmasked_matches_full_map(self, monkeypatch):
+        monkeypatch.setattr(config, "SCREENSPACE_BLUR_KERNEL", 1)
+        rng = np.random.RandomState(81)
+        gray = rng.randint(0, 5, (180, 320), dtype=np.uint8).astype(np.float32)
+        frame = np.repeat(gray[:, :, None], 3, axis=2)
+        template = frame[20:52, 10:54].copy()
+        frame[130:162, 260:304] = template
+        prepared = screenspace_primitives._prepare_template(template, None)
+        full = screenspace_primitives._template_correlation_map(frame, prepared)
+        assert full is not None
+
+        windows = (
+            (0.0, 0.0, 64.0, 60.0),
+            (80.0, 45.0, 180.0, 120.0),
+            (250.0, 125.0, 320.0, 180.0),
+        )
+        for window in windows:
+            masked = screenspace_primitives._mask_corr_outside_window(
+                full, 44, 32, window
+            )
+            assert masked is not None
+            want = screenspace_primitives._match_template_prepared(
+                frame, prepared, 0.9, 0.3, corr=masked
+            )
+            got = screenspace_primitives._match_template_prepared(
+                frame, prepared, 0.9, 0.3, window=window
+            )
+            assert got == want
+
+    def test_uint8_drift_is_bounded(self):
+        rng = np.random.RandomState(85)
+        frame = rng.randint(0, 255, (180, 320, 3), dtype=np.uint8)
+        template = frame[20:52, 10:54].copy()
+        prepared = screenspace_primitives._prepare_template(template, None)
+        full = screenspace_primitives._template_correlation_map(frame, prepared)
+        assert full is not None
+        window = (0.0, 0.0, 64.0, 60.0)
+        masked = screenspace_primitives._mask_corr_outside_window(full, 44, 32, window)
+        assert masked is not None
+        want = screenspace_primitives._match_template_prepared(
+            frame, prepared, 0.1, 0.3, corr=masked
+        )
+        got = screenspace_primitives._match_template_prepared(
+            frame, prepared, 0.1, 0.3, window=window
+        )
+        assert [(row["x"], row["y"], row["w"], row["h"]) for row in got] == [
+            (row["x"], row["y"], row["w"], row["h"]) for row in want
+        ]
+        assert (
+            max(
+                abs(got_row["score"] - want_row["score"])
+                for got_row, want_row in zip(got, want, strict=True)
+            )
+            < 5e-5
+        )
+
+    def test_roi_values_match_exactly(self):
+        rng = np.random.RandomState(82)
+        source = rng.randint(0, 5, (39, 61), dtype=np.uint8).astype(np.float32)
+        template = source[7:16, 13:27].copy()
+        full = cv2.matchTemplate(source, template, cv2.TM_CCOEFF_NORMED)
+        window = (0.0, 8.0, 31.0, 28.0)
+        packed = screenspace_primitives._match_corr_window(source, template, window)
+        assert packed is not None
+        corr, x_offset, y_offset = packed
+        assert np.array_equal(
+            corr,
+            full[
+                y_offset : y_offset + corr.shape[0],
+                x_offset : x_offset + corr.shape[1],
+            ],
+        )
+
+    def test_masked_keeps_full_map(self, monkeypatch):
+        rng = np.random.RandomState(83)
+        frame = rng.randint(0, 255, (64, 96, 3), dtype=np.uint8)
+        template = frame[20:36, 33:55].copy()
+        mask = np.full((16, 22), 255, dtype=np.uint8)
+        prepared = screenspace_primitives._prepare_template(template, mask)
+        window = (25.0, 15.0, 68.0, 48.0)
+        full = screenspace_primitives._template_correlation_map(frame, prepared)
+        assert full is not None
+        masked = screenspace_primitives._mask_corr_outside_window(full, 22, 16, window)
+        assert masked is not None
+        want = screenspace_primitives._match_template_prepared(
+            frame, prepared, 0.1, 0.3, corr=masked
+        )
+
+        def fail(*_args):
+            raise AssertionError("masked correlation used ROI")
+
+        monkeypatch.setattr(screenspace_primitives, "_match_corr_window", fail)
+        got = screenspace_primitives._match_template_prepared(
+            frame, prepared, 0.1, 0.3, window=window
+        )
+        assert got == want
 
 
 class TestPrepareTemplateMask:

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -199,7 +199,9 @@ class TestCorrelationRoi:
             < 5e-5
         )
 
-    def test_roi_values_match_exactly(self):
+    def test_roi_values_track_full_map(self):
+        # Crop width picks the SIMD path, so ROI scores land ulp-close to the
+        # full map rather than bit-identical. The peak still agrees.
         rng = np.random.RandomState(82)
         source = rng.randint(0, 5, (39, 61), dtype=np.uint8).astype(np.float32)
         template = source[7:16, 13:27].copy()
@@ -208,13 +210,13 @@ class TestCorrelationRoi:
         packed = screenspace_primitives._match_corr_window(source, template, window)
         assert packed is not None
         corr, x_offset, y_offset = packed
-        assert np.array_equal(
-            corr,
-            full[
-                y_offset : y_offset + corr.shape[0],
-                x_offset : x_offset + corr.shape[1],
-            ],
-        )
+        want = full[
+            y_offset : y_offset + corr.shape[0],
+            x_offset : x_offset + corr.shape[1],
+        ]
+        assert corr.shape == want.shape
+        assert float(np.abs(corr - want).max()) < 1e-5
+        assert int(corr.argmax()) == int(want.argmax())
 
     def test_masked_keeps_full_map(self, monkeypatch):
         rng = np.random.RandomState(83)

--- a/tests/test_boot_dispatcher.py
+++ b/tests/test_boot_dispatcher.py
@@ -15,6 +15,11 @@ import server
 import utils
 
 
+@pytest.fixture(autouse=True)
+def _fast_server_poll(monkeypatch):
+    monkeypatch.setattr(server, "_SERVER_POLL_INTERVAL", 0.01)
+
+
 def _boot_state(**overrides: Any) -> dict[str, Any]:
     state: dict[str, Any] = {
         "ready": False,

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -628,7 +628,9 @@ def _stub_chat_server():
     srv = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _SSEChatHandler)
     srv.daemon_threads = True
     port = srv.server_address[1]
-    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread = threading.Thread(
+        target=lambda: srv.serve_forever(poll_interval=0.01), daemon=True
+    )
     thread.start()
     try:
         yield f"http://127.0.0.1:{port}"

--- a/tests/test_start_endpoints.py
+++ b/tests/test_start_endpoints.py
@@ -1182,6 +1182,7 @@ def test_combined_server_forces_non_interactive(monkeypatch):
     monkeypatch.setattr(utils, "preload_vision_libs_quietly", lambda **kwargs: None)
     monkeypatch.setattr(utils, "sweep_stale_temp_artifacts", lambda: None)
     monkeypatch.setattr(server, "build_combined_app", lambda **kwargs: _fake_app)
+    monkeypatch.setattr(server, "_SERVER_POLL_INTERVAL", 0.01)
 
     live = server.serve_combined_app(port=0, block_until_ready=True)
     try:


### PR DESCRIPTION
## Summary

Template and Shape correlated the whole frame and then masked everything outside the run region; they now crop the source to just the pixels that can produce a match center inside the window, so cost scales with the region instead of the frame.

- `_match_corr_window()` returns the cropped correlation ROI plus its origin; `_match_template_prepared()` and `_match_shape_scales()` shift boxes back into frame coordinates. Masked templates keep the full-map path, since `matchTemplate` with a mask does not tile the same way.
- Shape's scale rungs run through an optional `ThreadPoolExecutor` sized against `SCREENSPACE_PARALLEL_WORKERS`, shut down on cancel and on error.
- `tests/perf/scan_bench.py` seeds a top-left 20% region for Template and Shape so their reference is non-degenerate, and Shape joins the default sweep; `_SERVER_POLL_INTERVAL` and a session-scoped `conftest` user-config sandbox cut test shutdown latency.

## Test plan

- [x] `/check` green: `ruff format --check`, `ruff check --fix`, `ty check`, full pytest suite
- [x] New tests pin the ROI path against the previous full-map matcher for both tools (exact box equality; scores within 5e-5 on uint8 frames), plus executor shutdown on cancel/error