### PR TITLE
fix(screenspace): treat unevaluable templates the same with and without a run region

### DIFF
--- a/source/screenspace_primitives.py
+++ b/source/screenspace_primitives.py
@@ -921,6 +921,13 @@ def _template_frame_gray(frame: np.ndarray) -> np.ndarray:
     return cv2.cvtColor(cv2.GaussianBlur(frame, (k, k), 0), cv2.COLOR_BGR2GRAY)
 
 
+def _template_is_evaluable(frame: np.ndarray, prepared: _PreparedTemplate) -> bool:
+    """Whether correlation is defined: a non-degenerate template that fits the frame."""
+    tmpl_gray, _gray_mask, degenerate = prepared
+    th, tw = tmpl_gray.shape[:2]
+    return not degenerate and th <= frame.shape[0] and tw <= frame.shape[1]
+
+
 def _template_correlation_map(
     frame: np.ndarray, prepared: _PreparedTemplate
 ) -> np.ndarray | None:
@@ -931,14 +938,11 @@ def _template_correlation_map(
     patches) are neutralized to ``-1.0`` so callers can safely threshold the map
     or read its peak (the threshold-independent scalar used by calibration).
     """
-    tmpl_gray, gray_mask, degenerate = prepared
-    if degenerate:
-        # Zero-variance template: see _prepare_template's degeneracy note.
+    tmpl_gray, gray_mask, _degenerate = prepared
+    # Degenerate or oversized: see _prepare_template's degeneracy note.
+    if not _template_is_evaluable(frame, prepared):
         return None
     frame_gray = _template_frame_gray(frame)
-    th, tw = tmpl_gray.shape[:2]
-    if th > frame_gray.shape[0] or tw > frame_gray.shape[1]:
-        return None
     result = cv2.matchTemplate(
         frame_gray, tmpl_gray, cv2.TM_CCOEFF_NORMED, mask=gray_mask
     )

--- a/source/screenspace_tools.py
+++ b/source/screenspace_tools.py
@@ -30,6 +30,7 @@ from screenspace_primitives import (
     _scale_template,
     _template_corr_window,
     _template_correlation_map,
+    _template_is_evaluable,
     blur_gray,
     color_matches,
     color_present,
@@ -709,8 +710,12 @@ class TemplateTool(AnalysisTool):
         # Peak correlation scores even a miss; the run region (zero-size = anywhere) scopes it.
         window = region_search_window(region)
         origin = (0, 0)
+        # A template that cannot be correlated at all is unevaluable, whichever path runs.
+        if not _template_is_evaluable(frame, prepared):
+            return False, None
         if window is not None and prepared[1] is None:
             packed = _template_corr_window(frame, prepared, window)
+            # None here means the window admits no match position: a scored miss.
             if packed is None:
                 return False, {"best_score": -1.0, "match_count": 0}
             corr, x_offset, y_offset = packed


### PR DESCRIPTION
## Summary

`TemplateTool.check_frame`'s ROI path returned a scored `best_score` of `-1.0` for a degenerate (zero-variance) or oversized template, while the full-frame path returned `None` and calibration flagged it `not_evaluable`. A flat template pinned with a run region therefore showed a real score instead of being marked unevaluable.

- `screenspace_primitives.py`: extracted `_template_is_evaluable(frame, prepared)` — non-degenerate template that fits the frame — and `_template_correlation_map` now calls it instead of inlining the same two checks.
- `screenspace_tools.py`: `check_frame` gates on that predicate before picking a path. A `None` from `_template_corr_window` past the gate now means only what the mask path's `None` means, a window that admits no match position, and both keep the scored `-1.0` miss.

## Test plan

- [x] Full suite: `uv run --extra dev pytest -c tests/pytest.ini`
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [ ] Not exercised in the browser: no frontend change, and the affected branch needs a real degenerate template pinned to a run region in Screenspace calibration.