### PR TITLE
fix: sweep 28 bugs across pipeline, servers, and web frontends

### DIFF
--- a/assets/web/card-scrubber.js
+++ b/assets/web/card-scrubber.js
@@ -8,7 +8,6 @@
 (function () {
   // ---- Module-scope state (shared across all attached cards) ----
 
-  var _spriteRaf = 0;
   var _audioCtx = null;
   // Decoded-audio cache, LRU by total seconds: one 180 s Composer bar is ~35 MB decoded.
   var _AUDIO_CACHE_MAX_SECONDS = 600;
@@ -313,11 +312,15 @@
     mediaEl.style.backgroundSize = (sd.cols * 100) + "% " + (sd.rows * 100) + "%";
     mediaEl.style.backgroundPosition = framePosition(restFrame);
 
+    var pendingX = 0;
+    var spriteRaf = 0;
     function onMove(e) {
-      var clientX = e.clientX;
-      if (_spriteRaf) return;
-      _spriteRaf = requestAnimationFrame(function () {
-        _spriteRaf = 0;
+      // Keep the newest sample; the frame callback reads it.
+      pendingX = e.clientX;
+      if (spriteRaf) return;
+      spriteRaf = requestAnimationFrame(function () {
+        spriteRaf = 0;
+        var clientX = pendingX;
         var rect = mediaEl.getBoundingClientRect();
         var frac = (clientX - rect.left) / rect.width;
         var frameIndex = Math.floor(frac * sd.frameCount);

--- a/assets/web/media-banner.js
+++ b/assets/web/media-banner.js
@@ -148,16 +148,21 @@
       .then(function (data) {
         if (!_host) return;
         var job = (data.jobs || {})[_host.participant];
-        if (!job || job.state === "running") {
+        if (job && job.state === "running") {
           render({
             mode: "running",
             text: "Remuxing " + _host.participant + "…",
-            progress: job ? job.progress : 0,
+            progress: job.progress,
           });
           _pollTimer = setTimeout(poll, POLL_MS);
           return;
         }
         stopPolling();
+        if (!job) {
+          // Another page finished or discarded it; show the on-disk state.
+          refresh();
+          return;
+        }
         if (job.state === "error") {
           renderError(job.error);
           return;

--- a/assets/web/overview-metadata.js
+++ b/assets/web/overview-metadata.js
@@ -1043,7 +1043,7 @@
     var m = Math.floor((sec - h * 3600) / 60);
     var s = sec - h * 3600 - m * 60;
     var pad = function (n) { return n < 10 ? "0" + n : "" + n; };
-    if (h > 0) return h + ":" + pad(m);
+    if (h > 0) return h + ":" + pad(m) + ":" + pad(s);
     return m + ":" + pad(s);
   }
 

--- a/assets/web/screenspace-model-view.js
+++ b/assets/web/screenspace-model-view.js
@@ -241,7 +241,13 @@
 
   // Preview target: last run-region toggled on, else the active chip. Multitool/boundary hide the picker.
   function _previewRegionRef() {
-    if (state.activeWorkflow !== "multitool" && state.activeWorkflow !== "boundary") {
+    if (state.activeWorkflow === "multitool") {
+      var first = (state.multitoolSteps || [])[0];
+      if (first && first.region_ref) return normalizeRegionRef(first.region_ref);
+      if (first && first.region && state.regions[first.region]) return activeRegionRef(first.region);
+      return null;
+    }
+    if (state.activeWorkflow !== "boundary") {
       for (var i = state.runRegions.length - 1; i >= 0; i--) {
         var ref = normalizeRegionRef(state.runRegions[i]);
         if (!ref) continue;
@@ -365,41 +371,44 @@
     );
   }
 
-  function _collectPreviewParams(tool) {
+  function _collectPreviewParams(tool, sfx) {
+    sfx = sfx || "";
     var out = {};
     if (tool === "color") {
-      var c = SS.getColorHiddenInputs();
-      if (c) {
+      var c = sfx
+        ? { h: qs("#paramColorH" + sfx), s: qs("#paramColorS" + sfx), v: qs("#paramColorV" + sfx) }
+        : SS.getColorHiddenInputs();
+      if (c && c.h && c.s && c.v) {
         out.h = c.h.value; out.s = c.s.value; out.v = c.v.value;
       }
     } else if (tool === "change") {
-      var n = qs("#paramChangeNoise");
+      var n = qs("#paramChangeNoise" + sfx);
       if (n) out.noise = n.value;
     } else if (tool === "flow") {
-      var m = qs("#paramFlowMag");
+      var m = qs("#paramFlowMag" + sfx);
       if (m) out.magnitude = m.value;
     } else if (tool === "text") {
-      var tp = qs("#paramTextOcrPreprocess");
+      var tp = qs("#paramTextOcrPreprocess" + sfx);
       if (tp && tp.checked) out.ocr_preprocess = "1";
     } else if (tool === "numbers") {
-      var np = qs("#paramNumOcrPreprocess");
+      var np = qs("#paramNumOcrPreprocess" + sfx);
       if (np && np.checked) out.ocr_preprocess = "1";
     } else if (tool === "shape") {
-      var st = qs("#paramShapeThresh");
+      var st = qs("#paramShapeThresh" + sfx);
       if (st) out.threshold = st.value;
-      var smin = qs("#paramShapeScaleMin");
+      var smin = qs("#paramShapeScaleMin" + sfx);
       if (smin) out.scale_min = (parseFloat(smin.value) || 0) / 100;
-      var smax = qs("#paramShapeScaleMax");
+      var smax = qs("#paramShapeScaleMax" + sfx);
       if (smax) out.scale_max = (parseFloat(smax.value) || 0) / 100;
-      var sst = qs("#paramShapeSteps");
+      var sst = qs("#paramShapeSteps" + sfx);
       if (sst) out.scale_steps = sst.value;
-      var slink = qs("#paramShapeLinkAxes");
+      var slink = qs("#paramShapeLinkAxes" + sfx);
       if (slink && !slink.checked) {
-        var symin = qs("#paramShapeScaleYMin");
+        var symin = qs("#paramShapeScaleYMin" + sfx);
         if (symin) out.scale_y_min = (parseFloat(symin.value) || 0) / 100;
-        var symax = qs("#paramShapeScaleYMax");
+        var symax = qs("#paramShapeScaleYMax" + sfx);
         if (symax) out.scale_y_max = (parseFloat(symax.value) || 0) / 100;
-        var systeps = qs("#paramShapeStepsY");
+        var systeps = qs("#paramShapeStepsY" + sfx);
         if (systeps) out.scale_y_steps = systeps.value;
       }
     } else if (tool === "attention") {
@@ -411,7 +420,7 @@
         center_bias: "paramAttnCenterBias",
       };
       Object.keys(attnIds).forEach(function (key) {
-        var input = qs("#" + attnIds[key]);
+        var input = qs("#" + attnIds[key] + sfx);
         if (input) out[key] = input.value;
       });
     }
@@ -433,6 +442,18 @@
     }
 
     var tool = state.activeWorkflow;
+    var sfx = "";
+    if (tool === "multitool") {
+      // The server previews a plain tool; send the first step as that tool.
+      var firstStep = (state.multitoolSteps || [])[0];
+      if (!firstStep || !firstStep.type) {
+        meta.textContent = "Add a step to see its preview.";
+        img.removeAttribute("src");
+        return;
+      }
+      tool = firstStep.type;
+      sfx = "_mt0";
+    }
     var regionStr = _normalizedRegionString();
     var hasRegion = _hasActiveOrPendingRegion();
 
@@ -456,7 +477,7 @@
       }
     }
 
-    var params = _collectPreviewParams(tool);
+    var params = _collectPreviewParams(tool, sfx);
     var qsParts = ["tool=" + encodeURIComponent(tool)];
     if (regionStr) qsParts.push("region=" + regionStr);
     var maskStr = _regionMaskString();
@@ -520,6 +541,7 @@
       img.src = u;
       meta.classList.remove("cg-shimmer");
       var metaText = MODEL_VIEW_META[tool] || "";
+      if (sfx) metaText = "First step (" + tool + "). " + metaText;
       if (!hasRegion) {
         metaText = (metaText ? metaText + " " : "") + "(Full frame — no region selected.)";
       } else if (_maskFallbackActive()) {

--- a/assets/web/screenspace-results.js
+++ b/assets/web/screenspace-results.js
@@ -248,7 +248,7 @@
           renderResults();
           renderTimeline();
           showToast("Excluded " + clipgenPluralUnit(idsToExclude.length, "event", "events"));
-        });
+        }).catch(toastError("Could not exclude events"));
       }
 
       // loadAndShowResults alone fills taskEvents; a streamed task may have none yet, so fetch here.
@@ -614,7 +614,7 @@
       state.resultsLazyObserver.disconnect();
       state.resultsLazyObserver = null;
     }
-    var countEl = qs("#resultCount") || { textContent: "" };
+    var countEl = qs("#resultCount");
     var actionsEl = qs("#resultsActions");
     var results = state.selectedTaskResults;
     var task = state.selectedTaskId ? findTask(state.selectedTaskId) : null;
@@ -706,7 +706,7 @@
             } else {
               showToast(data.error || "Failed to re-queue task");
             }
-          });
+          }).catch(toastError("Could not queue task"));
         });
       })(task);
       fastLabel.appendChild(rerunBtn);

--- a/assets/web/screenspace.html
+++ b/assets/web/screenspace.html
@@ -268,6 +268,7 @@
         <button class="rp-tab" data-tab="results" type="button">
           <span class="rp-tab-icon rp-tab-icon-results"></span>
           <span class="rp-tab-label">Results</span>
+          <span class="rp-tab-count" id="resultCount"></span>
           <span class="rp-tab-crumb" id="resultsTabCrumb"></span>
           <span class="rp-tab-chevron"></span>
         </button>

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -1850,7 +1850,7 @@
       // Pills stash out (jump + wiggle + dissolve), then the stash card lands.
       if (chips.length && window.ClipgenMotion) ClipgenMotion.animateOutAll(chips, "stash").then(commit);
       else commit();
-    });
+    }).catch(toastError("Could not create stash"));
   }
 
   function dismissStash(stashId) {
@@ -1861,7 +1861,7 @@
       renderRunRegionPicker();
       renderStashCards();
       showToast("Stash dismissed");
-    });
+    }).catch(toastError("Could not delete stash"));
   }
 
   function restoreStash(stashId) {
@@ -1876,7 +1876,7 @@
       updateRunButton();
       renderStashCards();
       showToast("Regions restored");
-    });
+    }).catch(toastError("Could not restore stash"));
   }
 
   function copyRegionToStash(name, stashId) {
@@ -1909,7 +1909,7 @@
         }
       }
       renderRunRegionPicker();
-    });
+    }).catch(toastError("Could not rename stash"));
   }
 
   function renderStashCards() {

--- a/assets/web/studio-generate.js
+++ b/assets/web/studio-generate.js
@@ -276,6 +276,8 @@
           event_ids: itm.event_ids || [],
           source: itm.source || "screenspace",
           mark_ids: itm.mark_ids || [],
+          text: itm.text || "",
+          label: itm.label || "",
         };
       });
 

--- a/assets/web/studio-intake.js
+++ b/assets/web/studio-intake.js
@@ -955,6 +955,8 @@
       desc: cluster.category || "transcript",
       source: "transcript",
       mark_ids: cluster.marks.map(function (m) { return m.id; }),
+      text: cluster.text || "",
+      label: cluster.label || "",
     };
   }
 

--- a/assets/web/studio-stash.js
+++ b/assets/web/studio-stash.js
@@ -227,7 +227,8 @@
 
   function recallStashItem(cfg, stash) {
     if (cfg.isLocked()) return;
-    state[cfg.queueKey] = stash.items.slice();
+    // Deep copy: the trim pop-over edits queue items in place.
+    state[cfg.queueKey] = JSON.parse(JSON.stringify(stash.items));
     cfg.renderQueue();
     var q = state[cfg.queueKey];
     for (var i = 0; i < q.length; i++) {

--- a/assets/web/transcripts-corrections.js
+++ b/assets/web/transcripts-corrections.js
@@ -84,7 +84,7 @@
       if (!data.ok) return;
       state.corrections = data.corrections;
       renderCorrections();
-    });
+    }).catch(toastError("Could not load corrections"));
   }
 
   function renderCorrections() {
@@ -155,7 +155,7 @@
       if (!data.ok) return;
       state.knownTerms = data.terms;
       renderKnownTerms();
-    });
+    }).catch(toastError("Could not load known terms"));
   }
 
   function renderKnownTerms() {
@@ -263,7 +263,7 @@
           clipgenPluralUnit(data.terms, "term", "terms") +
           "."
         : "Reuse one house glossary across studies.";
-    });
+    }).catch(toastError("Could not load dictionary"));
   }
 
   function saveGlobalDictionary() {

--- a/assets/web/transcripts-search.js
+++ b/assets/web/transcripts-search.js
@@ -41,7 +41,7 @@
         showToast("Marked " + clipgenPluralUnit(data.marks.length, "segment", "segments"));
         if (state.selectedParticipant) loadTranscript(state.selectedParticipant);
       }
-    });
+    }).catch(toastError("Could not mark results"));
   }
 
   function initSearch() {

--- a/assets/web/transcripts.js
+++ b/assets/web/transcripts.js
@@ -1677,7 +1677,7 @@
       // No loaded row; reload so the new mark still appears.
       apiPost("api/marks", { segment_ids: [segmentId], category: state.lastMarkCategory }).then(function (data) {
         if (data.ok && state.selectedParticipant) loadTranscript(state.selectedParticipant);
-      });
+      }).catch(toastError("Could not add mark"));
       return;
     }
     // Optimistic: fill the dot now, reconcile the real id on success, revert on failure.
@@ -1722,7 +1722,7 @@
         };
         _bumpStreamingMarksVersion();
       }
-    });
+    }).catch(toastError("Could not add mark"));
   }
 
   function removeMark(markId) {
@@ -1741,7 +1741,7 @@
           }
           pollTaskStatus();
         }
-      });
+      }).catch(toastError("Could not remove mark"));
       return;
     }
     // Optimistic: clear the dot now, restore on failure.
@@ -1749,7 +1749,7 @@
     if (!found) {
       apiDelete("api/marks/" + markId).then(function (data) {
         if (data.ok && state.selectedParticipant) loadTranscript(state.selectedParticipant);
-      });
+      }).catch(toastError("Could not remove mark"));
       return;
     }
     var prevMarks = found.seg.marks;
@@ -1790,7 +1790,7 @@
           }
           pollTaskStatus();
         }
-      });
+      }).catch(toastError("Could not change category"));
       return;
     }
     // Optimistic: recolor the dot now, restore on failure.
@@ -1798,7 +1798,7 @@
     if (!found) {
       apiPut("api/marks/" + markId, { category: category }).then(function (data) {
         if (data.ok && state.selectedParticipant) loadTranscript(state.selectedParticipant);
-      });
+      }).catch(toastError("Could not change category"));
       return;
     }
     var prevCategory = found.mark.category;
@@ -1857,7 +1857,7 @@
           }
           pollTaskStatus();
         }
-      });
+      }).catch(toastError("Could not change severity"));
       return;
     }
     // Loaded: optimistic repaint, restore on failure (mirrors updateMarkCategory).
@@ -1865,7 +1865,7 @@
     if (!found) {
       apiPut("api/marks/" + markId, { severity: sev }).then(function (data) {
         if (data.ok && state.selectedParticipant) loadTranscript(state.selectedParticipant);
-      });
+      }).catch(toastError("Could not change severity"));
       return;
     }
     var prevSeverity = found.mark.severity;

--- a/assets/web/utils.js
+++ b/assets/web/utils.js
@@ -614,6 +614,11 @@ var formatTime = function (sec, options) {
   if (sec == null || isNaN(sec) || !isFinite(sec)) return "--:--";
   if (sec < 0) sec = 0;
   var decimals = options.decimals || 0;
+  if (decimals > 0) {
+    // Round first so "59.97" becomes 1:00.0, not 0:60.0.
+    var p = Math.pow(10, decimals);
+    sec = Math.round(sec * p) / p;
+  }
   var totalInt = Math.floor(sec);
   var h = Math.floor(totalInt / 3600);
   var m = Math.floor((totalInt % 3600) / 60);

--- a/source/app.py
+++ b/source/app.py
@@ -726,15 +726,10 @@ def _run_reel_mode_interactive(
     output_file = utils.read_user_input(
         f"\nOutput filename (Enter for default {default_filename}):\n>> "
     )
-    reel_output_file = None
-    if output_file:
-        reel_output_file = (
-            output_file
-            if output_file.endswith(config.FILEFORMAT)
-            else output_file + config.FILEFORMAT
-        )
-    else:
-        reel_output_file = files.get_unique_filename(default_filename)
+    if output_file and not output_file.endswith(config.FILEFORMAT):
+        output_file += config.FILEFORMAT
+    # Reserve in the output dir either way; process_reel releases it on abort.
+    reel_output_file = files.get_unique_filename(output_file or default_filename)
     return (clips_list, True, reel_output_file)
 
 
@@ -822,10 +817,9 @@ def _run_reellate_mode_interactive() -> tuple[bool, str | None]:
     output_file = utils.read_user_input(
         '\nOutput filename (Enter for default "reel.mp4"):\n>> '
     )
-    if not output_file:
-        output_file = files.get_unique_filename(f"reel{config.FILEFORMAT}")
-    elif not output_file.endswith(config.FILEFORMAT):
-        output_file = output_file + config.FILEFORMAT
+    if output_file and not output_file.endswith(config.FILEFORMAT):
+        output_file += config.FILEFORMAT
+    output_file = files.get_unique_filename(output_file or f"reel{config.FILEFORMAT}")
 
     resolved_clips = [str(utils.resolve_output_path(name)) for name in selected_clips]
 

--- a/source/files.py
+++ b/source/files.py
@@ -18,7 +18,9 @@ _unique_high_water_lock = threading.Lock()
 
 
 def safe_truncate(text: str, max_chars: int) -> str:
-    """Truncate to ``max_chars`` code points, then drop trailing combining marks.
+    """Truncate to ``max_chars`` UTF-8 bytes, then drop trailing combining marks.
+
+    Filesystems cap names in bytes, so multi-byte scripts back off further.
 
     Plain ``text[:n]`` can split a grapheme cluster (e.g. emoji + skin-tone
     modifier, or letter + combining accent), leaving an orphan combining
@@ -28,6 +30,8 @@ def safe_truncate(text: str, max_chars: int) -> str:
     if max_chars <= 0:
         return ""
     truncated = text[:max_chars]
+    while truncated and len(truncated.encode("utf-8")) > max_chars:
+        truncated = truncated[:-1]
     # Trim trailing combining marks / joiners that would render orphaned.
     while truncated and (
         unicodedata.category(truncated[-1]) in ("Mn", "Mc", "Me")
@@ -454,17 +458,18 @@ def prepare_clip(clip: ClipRecord) -> ClipRecord:
         key: sorted(indexes) for key, indexes in segment_annotations.items()
     }
     clip["times"] = utils.parse_timestamps(cleaned_cell_value, cell_ref=cell_ref)
-    timestamp_baseline = clip.get("timestamp_baseline")
-    if timestamp_baseline:
-        clip["times"] = utils.convert_clock_pairs_to_relative(
-            clip["times"], timestamp_baseline, cell_ref=cell_ref
-        )
+    # Select before the baseline conversion: it drops pairs and shifts indexes.
     selected_segment_indexes = clip.get("selected_segment_indexes")
     if selected_segment_indexes is not None:
         selected_set = set(selected_segment_indexes)
         clip["times"] = [
             pair for index, pair in enumerate(clip["times"]) if index in selected_set
         ]
+    timestamp_baseline = clip.get("timestamp_baseline")
+    if timestamp_baseline:
+        clip["times"] = utils.convert_clock_pairs_to_relative(
+            clip["times"], timestamp_baseline, cell_ref=cell_ref
+        )
     if config.DEBUGGING:
         config.debug_ic(clip["times"])
 

--- a/source/interactive.py
+++ b/source/interactive.py
@@ -35,7 +35,7 @@ def prompt_batch_confirm(ctx: SheetContext) -> bool:
     )
     msg = f"\nThis will generate {len(clips)} clips (from {num_data_rows} data rows and {ctx.num_participants} participant column(s)). Proceed? [y/n]\n>> "
     yn = utils.read_user_input(msg)
-    return yn == "y"
+    return yn.strip().lower() == "y"
 
 
 def prompt_multi_selection(
@@ -88,7 +88,7 @@ def prompt_multi_selection(
                 for item in selected:
                     utils.info_print(f"  - {confirm_display(item)}")
                 yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
-                if yn == "y":
+                if yn.strip().lower() == "y":
                     return selected
             else:
                 utils.info_print("No valid selections. Please try again.")
@@ -120,7 +120,7 @@ def prompt_multi_selection(
                 for item in matched:
                     utils.info_print(f"  - {confirm_display(item)}")
                 yn = utils.read_user_input("\nIs this correct? [y/n]\n>> ")
-                if yn == "y":
+                if yn.strip().lower() == "y":
                     return matched
             else:
                 utils.info_print(no_match_msg)
@@ -208,7 +208,7 @@ def prompt_line_selection(ctx: SheetContext) -> list[int] | None:
             continue
         utils.info_print("")
         yn = utils.read_user_input("Are these the correct issues? [y/n]\n>> ")
-        if yn == "y":
+        if yn.strip().lower() == "y":
             return valid_lines
 
 
@@ -234,7 +234,7 @@ def prompt_range_selection(ctx: SheetContext) -> tuple[int, int] | None:
             f"Lines selected: {ctx.sheet_data[start_line - 1][ctx.observation_cell.col - 1]} to {ctx.sheet_data[end_line - 1][ctx.observation_cell.col - 1]}"
         )
         yn = utils.read_user_input("Is this correct? [y/n]\n>> ")
-        if yn == "y":
+        if yn.strip().lower() == "y":
             return (start_line, end_line)
 
 
@@ -296,7 +296,7 @@ def prompt_cell_selection(ctx: SheetContext) -> list[tuple[str, int]] | None:
                 continue
             utils.info_print("")
             yn = utils.read_user_input("Are these the correct cells? [y/n]\n>> ")
-            if yn == "y":
+            if yn.strip().lower() == "y":
                 return valid_specs
         except KeyboardInterrupt:
             utils.info_print("Cancelled by user.")
@@ -375,7 +375,7 @@ def prompt_participant_selection(ctx: SheetContext) -> list[str] | None:
         yn = utils.read_user_input(
             "Generate all clips for these participants? [y/n]\n>> "
         )
-        if yn == "y":
+        if yn.strip().lower() == "y":
             return unique_ids
 
 
@@ -392,7 +392,7 @@ def prompt_keyword_selection(ctx: SheetContext) -> list[str] | None:
         yn = utils.read_user_input(
             f"\nKeyword mode: found annotation '!{aid}' ({count_label}). Proceed? [y/n]\n>> "
         )
-        if yn == "y":
+        if yn.strip().lower() == "y":
             return [aid]
         return None
 

--- a/source/pipeline.py
+++ b/source/pipeline.py
@@ -1169,14 +1169,16 @@ def process_clips(
                 max_duration=max_duration,
             )
 
-        def _cut_error(idx: int, exc: Exception) -> tuple[int, list[tuple[str, int]]]:
+        def _cut_error(
+            idx: int, exc: Exception
+        ) -> tuple[int, list[tuple[str, int]], bool]:
             clip, _ = prepared[idx]
             desc = (clip.get("desc") or "")[: config.PROGRESS_DESCRIPTION_LENGTH]
             utils.error_print(
                 f"Clip failed: [{clip.get('participant', '')}] {desc}",
                 [str(exc)],
             )
-            return (0, [])
+            return _EMPTY_RESULT
 
         progress = utils.create_progress_bar()
         if progress:
@@ -1943,8 +1945,8 @@ def _regenerate_single_artifact(
             if video.run_ffmpeg(
                 input_file=part_path,
                 output_file=tmp,
-                start_pos=utils.seconds_to_timestamp(int(part.get("localStart", 0))),
-                end_pos=utils.seconds_to_timestamp(int(part.get("localEnd", 0))),
+                start_pos=utils.seconds_to_timestamp(round(part.get("localStart", 0))),
+                end_pos=utils.seconds_to_timestamp(round(part.get("localEnd", 0))),
                 reencode=config.REENCODING,
             ):
                 temp_paths.append(tmp)
@@ -1978,8 +1980,9 @@ def _regenerate_single_artifact(
 
     local_start = artifact.get("localStart", artifact.get("start", 0))
     local_end = artifact.get("localEnd", artifact.get("end", 0))
-    start_ts = utils.seconds_to_timestamp(int(local_start))
-    end_ts = utils.seconds_to_timestamp(int(local_end))
+    # Round like _local_timestamp so regeneration reproduces the original cut.
+    start_ts = utils.seconds_to_timestamp(round(local_start))
+    end_ts = utils.seconds_to_timestamp(round(local_end))
 
     if artifact_type == "clip":
         ok = video.run_ffmpeg(
@@ -2002,8 +2005,9 @@ def _regenerate_single_artifact(
             timestamp=start_ts,
         )
     elif artifact_type == "gif":
+        # The span is the clip's, not the GIF's; the GIF stays capped like generation.
         duration = max(
-            int(local_end - local_start), config.DEFAULT_GIF_DURATION_SECONDS
+            1, min(int(local_end - local_start), config.DEFAULT_GIF_DURATION_SECONDS)
         )
         return video.extract_gif(
             input_file=source_path,

--- a/source/screenspace_preview.py
+++ b/source/screenspace_preview.py
@@ -57,7 +57,8 @@ def build_preview(
         return _preview_flow(frame, prev_frame, region, params)
     if tool == "scene":
         return _preview_scene(frame, region, params)
-    if tool == "inactivity":
+    if tool in ("inactivity", "boundary"):
+        # Boundary compares consecutive pHashes; show the same bit grid.
         return _preview_inactivity(frame, region)
     if tool == "attention":
         return _preview_attention(frame, prev_frame, params)

--- a/source/screenspace_server.py
+++ b/source/screenspace_server.py
@@ -624,7 +624,7 @@ def api_pins_update(pin_id: str) -> FlaskResponse:
                 return err("label must be a string")
             pin["label"] = data["label"].strip()[:_PIN_LABEL_MAX_CHARS]
         _do_persist(drain_events=False)
-    return ok(pin=pin)
+        return ok(pin=copy.deepcopy(pin))
 
 
 @screenspace_bp.route("/api/pins/<pin_id>", methods=["DELETE"])
@@ -768,7 +768,7 @@ def api_calibrate() -> FlaskResponse:
     is per-frame only — temporal params (consecutive/interval) are not validated.
     """
     data = request.get_json(silent=True)
-    if not data:
+    if not data or not isinstance(data, dict):
         return err("JSON body required")
 
     tool = (data.get("tool") or "").strip()
@@ -1680,10 +1680,10 @@ def api_regions_list() -> FlaskResponse:
 def api_regions_create() -> FlaskResponse:
     """Create or update a named region."""
     data = request.get_json(silent=True)
-    if not data:
+    if not data or not isinstance(data, dict):
         return err("JSON body required")
 
-    name = data.get("name", "").strip()
+    name = str(data.get("name") or "").strip()
     if not name:
         return err("Region name is required")
 
@@ -1818,10 +1818,10 @@ def api_stashes_create() -> FlaskResponse:
 def api_stashes_update(stash_id: str) -> FlaskResponse:
     """Update a stash (rename)."""
     data = request.get_json(silent=True)
-    if not data:
+    if not data or not isinstance(data, dict):
         return err("JSON body required")
 
-    name = data.get("name", "").strip()
+    name = str(data.get("name") or "").strip()
     with _manifest_lock:
         stashes = _manifest.get("stashes", [])
         stash = find_by_id(stashes, stash_id)
@@ -1830,7 +1830,7 @@ def api_stashes_update(stash_id: str) -> FlaskResponse:
         if name:
             stash["name"] = name
         _do_persist(drain_events=False)
-    return ok(stash=stash)
+        return ok(stash=copy.deepcopy(stash))
 
 
 @screenspace_bp.route("/api/stashes/<stash_id>", methods=["DELETE"])
@@ -1863,9 +1863,9 @@ def api_stashes_add_region(stash_id: str) -> FlaskResponse:
     overwrites it (last-write-wins, matching api_regions_create's upsert).
     """
     data = request.get_json(silent=True)
-    if not data:
+    if not data or not isinstance(data, dict):
         return err("JSON body required")
-    name = data.get("name", "").strip()
+    name = str(data.get("name") or "").strip()
     if not name:
         return err("Region name is required")
 
@@ -1878,8 +1878,7 @@ def api_stashes_add_region(stash_id: str) -> FlaskResponse:
             return err("Stash not found", 404)
         stash.setdefault("regions", {})[name] = copy.deepcopy(regions[name])
         _do_persist(drain_events=False)
-
-    return ok(stash=stash)
+        return ok(stash=copy.deepcopy(stash))
 
 
 # ---- Tasks CRUD ----
@@ -1928,15 +1927,15 @@ def _validate_task_request(
     Returns (task_type, participant, region_name, parameters, all_known_regions,
     requested_region) on success, or a Flask error response on failure.
     """
-    task_type = data.get("type", "").strip()
+    task_type = str(data.get("type") or "").strip()
     if task_type not in _VALID_TASK_TYPES:
         return err(f"type must be one of: {', '.join(_VALID_TASK_TYPES)}")
 
-    participant = data.get("participant", "").strip()
+    participant = str(data.get("participant") or "").strip()
     if not participant:
         return err("participant is required")
 
-    region_name = data.get("region", "").strip()
+    region_name = str(data.get("region") or "").strip()
     region_ref = data.get("region_ref")
     raw_parameters = data.get("parameters")
     if raw_parameters is None:
@@ -2306,7 +2305,7 @@ def api_tasks_create() -> FlaskResponse:
         return err("Worker not initialized", 500)
 
     data = request.get_json(silent=True)
-    if not data:
+    if not data or not isinstance(data, dict):
         return err("JSON body required")
 
     # Boundary/Attention are full-frame by contract; force it before validation so stored
@@ -2629,7 +2628,7 @@ def _set_event_excluded(event_id: str, excluded: bool) -> FlaskResponse:
     """Set one event's excluded flag; 404 when the id is unknown."""
     with _manifest_lock:
         for e in _manifest.get("events", []):
-            if e["id"] == event_id:
+            if e.get("id") == event_id:
                 e["excluded"] = excluded
                 _bump_events_version()
                 _do_persist(drain_events=False)
@@ -2646,7 +2645,7 @@ def _bulk_set_excluded(excluded: bool) -> FlaskResponse:
     with _manifest_lock:
         count = 0
         for e in _manifest.get("events", []):
-            if e["id"] in ids:
+            if e.get("id") in ids:
                 e["excluded"] = excluded
                 count += 1
         if count:

--- a/source/server.py
+++ b/source/server.py
@@ -59,6 +59,7 @@ import sys
 import threading
 import time
 import traceback
+import uuid
 import webbrowser
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -149,6 +150,8 @@ _busy_slots: dict[str, bool] = {
     "timeline_viewer": False,
     "gallery": False,
 }
+# Claim token per slot; a stale release must not drop a successor's claim.
+_busy_owners: dict[str, str | None] = {slot: None for slot in _busy_slots}
 # Intake has no busy slot (it runs alongside generate); sheet swaps still check this.
 _intake_active = 0
 # Serializes stash load → mutate → save across concurrent CRUD requests.
@@ -267,18 +270,20 @@ _sprite_cache = _MediaCache(_SPRITE_CACHE_MAX)
 _audio_cache = _MediaCache(_AUDIO_CACHE_MAX)
 
 
-def _try_claim_busy(slot: str) -> bool:
+def _try_claim_busy(slot: str) -> str | None:
     """Atomically reserve the single-job slot for *slot*.
 
-    Valid slots: the ``_busy_slots`` keys. Returns True on success (caller must
-    call ``_release_busy`` when done) or False if another request is already
-    holding the slot (or the slot name is unknown).
+    Valid slots: the ``_busy_slots`` keys. Returns the claim token on success
+    (pass it to ``_release_busy`` when done) or None if another request is
+    already holding the slot (or the slot name is unknown).
     """
     with _busy_lock:
         if slot not in _busy_slots or _busy_slots[slot]:
-            return False
+            return None
         _busy_slots[slot] = True
-        return True
+        token = uuid.uuid4().hex
+        _busy_owners[slot] = token
+        return token
 
 
 def _parse_titlecard_request(
@@ -344,11 +349,15 @@ def _append_generated_reel(reel: dict[str, Any]) -> None:
         _generated_reels.append(reel)
 
 
-def _release_busy(slot: str) -> None:
-    """Release the single-job slot for *slot* (unknown slots are a no-op)."""
+def _release_busy(slot: str, token: str | None = None) -> None:
+    """Release *slot* if *token* still owns it; ``None`` releases unconditionally."""
     with _busy_lock:
-        if slot in _busy_slots:
-            _busy_slots[slot] = False
+        if slot not in _busy_slots:
+            return
+        if token is not None and _busy_owners[slot] != token:
+            return
+        _busy_slots[slot] = False
+        _busy_owners[slot] = None
 
 
 def _reset_reel_job_state(endpoint: str) -> None:
@@ -1061,8 +1070,13 @@ def _process_intake_item(
             )
             transcript_text = item_text
             if not transcript_text and mark_ids:
-                # Fallback: look up segment text by id from the manifest.
-                wanted = set(mark_ids)
+                # Fallback: marks name segments; join those segments' text.
+                mark_set = set(mark_ids)
+                wanted = {
+                    m.get("segment_id")
+                    for m in transcripts_server._manifest.get("marks", []) or []
+                    if isinstance(m, dict) and m.get("id") in mark_set
+                }
                 parts: list[str] = []
                 for seg in src_entry.get("segments", []) or []:
                     if seg.get("id") in wanted:
@@ -1347,6 +1361,7 @@ def _stream_reel_job(
     work: Callable[[Callable[[dict[str, Any]], None]], None],
     *,
     slot: str = "reel",
+    token: str | None = None,
     on_cleanup: Callable[[], None] | None = None,
 ) -> Iterator[str]:
     """Run a reel build on a worker thread and stream its events as NDJSON.
@@ -1380,13 +1395,13 @@ def _stream_reel_job(
             if on_cleanup is not None:
                 on_cleanup()
             event_queue.put(sentinel)
-            _release_busy(slot)
+            _release_busy(slot, token)
 
     try:
         threading.Thread(target=worker, daemon=True).start()
     except BaseException:
         # Worker never ran, so its finally won't release the slot.
-        _release_busy(slot)
+        _release_busy(slot, token)
         raise
 
     while True:
@@ -1402,6 +1417,7 @@ def _stream_process_reel(
     *,
     titlecards_enabled: bool | None = None,
     titlecard_duration_seconds: int | None = None,
+    token: str | None = None,
 ) -> Iterator[str]:
     """Run pipeline.process_reel on a worker thread and yield its progress events
     as NDJSON lines, finishing with a final result/error line."""
@@ -1427,7 +1443,7 @@ def _stream_process_reel(
         _save_manifest_quiet()
         emit_event({"ok": True, "generated": generated, "reels": reel_records})
 
-    yield from _stream_reel_job(work)
+    yield from _stream_reel_job(work, token=token)
 
 
 def _apply_time_overrides(clips: list[Any], overrides: dict[str, Any]) -> None:
@@ -1496,14 +1512,15 @@ def api_generate() -> FlaskResponse:
     if output_format not in ("clip", "screen", "gif"):
         return err(f"Invalid format: {output_format}")
 
-    if not _try_claim_busy("generate"):
+    token = _try_claim_busy("generate")
+    if token is None:
         return err("A clip generation is already in progress", 409)
 
     try:
         cell_input = ", ".join(cell_strings)
         cell_specs = spreadsheet.parse_cell_specifications(cell_input)
         if not cell_specs:
-            _release_busy("generate")
+            _release_busy("generate", token)
             return err("Could not parse cell specifications")
 
         clips = spreadsheet.generate_list(
@@ -1515,7 +1532,7 @@ def api_generate() -> FlaskResponse:
         )
         _apply_time_overrides(clips, overrides)
     except Exception as e:
-        _release_busy("generate")
+        _release_busy("generate", token)
         return err(str(e), 500)
 
     # Count progress per segment, not per cell; the pipeline's later prepare_clip
@@ -1722,13 +1739,16 @@ def api_generate() -> FlaskResponse:
             # process_clips skipped the purge.
             titlecards.clear_endcard_cache()
             _save_manifest_quiet()
-            _release_busy("generate")
+            _release_busy("generate", token)
 
-    return Response(
+    response = Response(
         profiled_stream(stream_with_busy_release()),
         mimetype="application/x-ndjson",
         headers={"X-Accel-Buffering": "no"},
     )
+    # Covers an unstarted generator; the token makes the double release safe.
+    response.call_on_close(lambda: _release_busy("generate", token))
+    return response
 
 
 @studio_bp.route("/api/highlights-preview", methods=["POST"])
@@ -1805,13 +1825,15 @@ def api_reel() -> FlaskResponse:
         except (ValueError, TypeError):
             pass
 
-    if not _try_claim_busy("reel"):
+    token = _try_claim_busy("reel")
+    if token is None:
         return err("A reel build is already in progress", 409)
 
+    # The worker owns the busy slot once started; until then every exit path
+    # releases it.
+    started = {"worker": False}
+
     def stream() -> Any:
-        # The worker owns the busy slot once started; until then every exit path
-        # releases it.
-        worker_started = False
         try:
             with _override_config(**highlights_overrides):
                 reel_input = ", ".join(cell_strings)
@@ -1897,24 +1919,30 @@ def api_reel() -> FlaskResponse:
                 _reel_cancel_event.clear()
                 _reset_reel_job_state("reel")
                 cancel_flag = _reel_cancel_event.is_set
-                worker_started = True
+                started["worker"] = True
                 yield from _stream_process_reel(
                     clips,
                     cancel_flag,
                     titlecards_enabled=titlecards_enabled,
                     titlecard_duration_seconds=titlecard_duration_seconds,
+                    token=token,
                 )
         except Exception as e:
             yield json.dumps({"ok": False, "error": str(e)}) + "\n"
         finally:
-            if not worker_started:
-                _release_busy("reel")
+            if not started["worker"]:
+                _release_busy("reel", token)
 
-    return Response(
+    response = Response(
         profiled_stream(stream()),
         mimetype="application/x-ndjson",
         headers={"X-Accel-Buffering": "no"},
     )
+    # An unstarted generator never runs its finally; a running worker keeps the slot.
+    response.call_on_close(
+        lambda: None if started["worker"] else _release_busy("reel", token)
+    )
+    return response
 
 
 @studio_bp.route("/api/viewer", methods=["POST"])
@@ -2776,7 +2804,8 @@ def api_reel_direct() -> FlaskResponse:
     if not segments:
         return err("No segments specified")
 
-    if not _try_claim_busy("reel"):
+    token = _try_claim_busy("reel")
+    if token is None:
         return err("A reel build is already in progress", 409)
 
     _reel_cancel_event.clear()
@@ -2787,7 +2816,11 @@ def api_reel_direct() -> FlaskResponse:
         titlecards_enabled, titlecard_duration_seconds
     )
 
+    # Once the generator runs, _stream_reel_job's worker owns the slot.
+    started = {"stream": False}
+
     def stream() -> Iterator[str]:
+        started["stream"] = True
         # Hoisted so cleanup() can purge it even after a mid-build failure.
         temp_clips: list[str] = []
 
@@ -2984,13 +3017,17 @@ def api_reel_direct() -> FlaskResponse:
                 except OSError:
                     pass
 
-        yield from _stream_reel_job(work, on_cleanup=cleanup)
+        yield from _stream_reel_job(work, token=token, on_cleanup=cleanup)
 
-    return Response(
+    response = Response(
         profiled_stream(stream()),
         mimetype="application/x-ndjson",
         headers={"X-Accel-Buffering": "no"},
     )
+    response.call_on_close(
+        lambda: None if started["stream"] else _release_busy("reel", token)
+    )
+    return response
 
 
 @studio_bp.route("/api/job-status", methods=["GET"])

--- a/source/server_utils.py
+++ b/source/server_utils.py
@@ -431,6 +431,10 @@ def profiled_stream(body: Any) -> Any:
     )
 
 
+# notify() default: wake every client regardless of key.
+_BROADCAST = object()
+
+
 def make_sse_channel(
     *, maxsize: int = 64, keepalive_seconds: float = 15.0
 ) -> tuple[
@@ -443,8 +447,8 @@ def make_sse_channel(
     Collapses the bounded-queue + coalesce-on-overflow + keepalive + cleanup
     boilerplate otherwise duplicated across the run / batch / task SSE endpoints.
 
-    - ``notify(key=None, marker="update")`` wakes every client registered with a
-      matching ``key`` (``key=None`` = broadcast). On a full queue it coalesces:
+    - ``notify(key=_BROADCAST, marker="update")`` wakes every client registered
+      with a matching ``key``; omitting ``key`` wakes every client. On a full queue it coalesces:
       drop one stale entry, re-push ``marker`` (dropped silently if still full).
       The queued token is never inspected by the streamer — it only triggers a
       full payload rebuild — so ``marker``'s value is cosmetic.
@@ -459,10 +463,10 @@ def make_sse_channel(
     clients: list[tuple[Any, queue.Queue[str]]] = []
     lock = threading.Lock()
 
-    def notify(key: Any = None, marker: str = "update") -> None:
+    def notify(key: Any = _BROADCAST, marker: str = "update") -> None:
         with lock:
             for ckey, cq in clients:
-                if ckey != key:
+                if key is not _BROADCAST and ckey != key:
                     continue
                 try:
                     cq.put_nowait(marker)

--- a/source/titlecards.py
+++ b/source/titlecards.py
@@ -163,20 +163,9 @@ def _build_card_frame(
     if not use_image_background and not allow_color_fallback:
         return None
 
-    try:
-        with tempfile.NamedTemporaryFile(suffix=config.FILEFORMAT, delete=False) as tmp:
-            card_path = tmp.name
-    except OSError as error:
-        utils.warning_print(
-            f"Could not create temporary file for {label}.",
-            [str(error)],
-        )
-        return None
-
     if config.DEBUGGING:
         utils.debug_print(
-            f"Debugging enabled, would generate {label} '{card_path}' "
-            f"at resolution {resolution}."
+            f"Debugging enabled, would generate {label} at resolution {resolution}."
         )
         return None
 
@@ -184,6 +173,16 @@ def _build_card_frame(
         utils.warning_print(
             f"Invalid resolution string '{resolution}' for {label}.",
             ["Expected format 'WIDTHxHEIGHT' (e.g. '1280x720')."],
+        )
+        return None
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=config.FILEFORMAT, delete=False) as tmp:
+            card_path = tmp.name
+    except OSError as error:
+        utils.warning_print(
+            f"Could not create temporary file for {label}.",
+            [str(error)],
         )
         return None
 
@@ -279,6 +278,7 @@ def _build_card_frame(
         return None
 
     if not video.verify_output_file(card_path, f"{label.capitalize()} generation"):
+        Path(card_path).unlink(missing_ok=True)
         return None
     return card_path
 

--- a/source/transcripts_server.py
+++ b/source/transcripts_server.py
@@ -1363,8 +1363,8 @@ def api_corrections_add() -> FlaskResponse:
     if not data:
         return err("Missing JSON body")
 
-    from_text = data.get("from", "").strip()
-    to_text = data.get("to", "").strip()
+    from_text = str(data.get("from") or "").strip()
+    to_text = str(data.get("to") or "").strip()
     if not from_text or not to_text:
         return err("'from' and 'to' required")
 

--- a/source/video.py
+++ b/source/video.py
@@ -1005,9 +1005,9 @@ def run_ffmpeg(
             [f"Video file: '{input_file}'"],
         )
         return False
-    if duration < 0:
+    if duration <= 0:
         utils.error_print(
-            "Negative duration calculated for video clip. Skipping.",
+            "Clip has no length. Skipping.",
             [
                 f"Start: {start_pos}, End: {end_pos}, Duration: {duration}s",
                 "The end timestamp must be after the start timestamp.",
@@ -1048,7 +1048,7 @@ def run_ffmpeg(
             yn = utils.read_user_input(
                 f"The generated video will be {duration}s ({duration // 60}m {duration % 60}s), over 10 minutes long. Generate anyway? [y/n]\n>> "
             )
-            if yn != "y":
+            if yn.strip().lower() != "y":
                 return False
 
     utils.verbose_print(f"Cutting {input_file} from {start_pos} to {end_pos}.")
@@ -3507,10 +3507,10 @@ def _parallel_extract_gifs(
         ts_str = utils.seconds_to_timestamp(ts)
         ts_safe = ts_str.replace(":", "_")
         filename = f"gallery_{ts_safe}{ext}"
-        output_path = files.get_unique_filename(filename, file_format=ext)
         gif_dur = min(gif_duration_seconds, duration - ts)
         if gif_dur <= 0:
             break
+        output_path = files.get_unique_filename(filename, file_format=ext)
         tasks.append((input_file, output_path, ts_str, gif_dur, float(ts)))
 
     if not tasks:
@@ -3649,9 +3649,9 @@ def generate_interval_captures(
         ts_str = utils.seconds_to_timestamp(ts)
         ts_safe = ts_str.replace(":", "_")
         filename = f"gallery_{ts_safe}{ext}"
-        output_path = files.get_unique_filename(filename, file_format=ext)
 
         if output_format == "screen":
+            output_path = files.get_unique_filename(filename, file_format=ext)
             ok = extract_screenshot(
                 input_file, output_path, ts_str, cancel_flag=cancel_flag
             )
@@ -3660,6 +3660,8 @@ def generate_interval_captures(
             gif_dur = min(gif_duration_seconds, duration - ts)
             if gif_dur <= 0:
                 break
+            # Reserve only once the GIF is known to have length.
+            output_path = files.get_unique_filename(filename, file_format=ext)
             ok = extract_gif(
                 input_file, output_path, ts_str, gif_dur, cancel_flag=cancel_flag
             )

--- a/source/workflows_server.py
+++ b/source/workflows_server.py
@@ -609,7 +609,9 @@ def _merged_runs() -> dict[str, dict[str, Any]]:
     merged: dict[str, dict[str, Any]] = {}
     with _manifest_lock:
         for record in _manifest.get("runs", []):
-            merged[record.get("id")] = copy.deepcopy(record)
+            rid = record.get("id")
+            if rid:
+                merged[rid] = copy.deepcopy(record)
     with _runs_lock:
         live = list(_runs.items())
     for run_id, runner in live:
@@ -1182,9 +1184,10 @@ def _poll_transcript_completions() -> None:
     Transcribe nodes never write the transcripts manifest, so a triggered graph
     can't re-fire itself.
     """
-    markers = _transcript_markers()
     fire: list[str] = []
     with _watch_lock:
+        # Under the lock: an arming _seed_watch_seen also rebinds the cache.
+        markers = _transcript_markers()
         for pid, stamp in markers.items():
             if _watch_transcript_baseline.get(pid) != stamp:
                 _watch_transcript_baseline[pid] = stamp
@@ -1195,9 +1198,9 @@ def _poll_transcript_completions() -> None:
 
 def _poll_scan_completions() -> None:
     """Fire once per newly-completed Screenspace task (keyed by task id)."""
-    markers = _scan_markers()
     fire: list[str] = []
     with _watch_lock:
+        markers = _scan_markers()
         for task_id, pid in markers.items():
             if task_id not in _watch_scan_seen:
                 _watch_scan_seen.add(task_id)

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -147,13 +147,14 @@ def _assert_same_boxes(got, want, score_tolerance):
     assert [(row["x"], row["y"], row["w"], row["h"]) for row in got] == [
         (row["x"], row["y"], row["w"], row["h"]) for row in want
     ]
-    assert (
-        max(
+    drift = max(
+        (
             abs(got_row["score"] - want_row["score"])
             for got_row, want_row in zip(got, want, strict=True)
-        )
-        < score_tolerance
+        ),
+        default=0.0,
     )
+    assert drift < score_tolerance
 
 
 class TestCorrelationRoi:

--- a/tests/screenspace/test_template.py
+++ b/tests/screenspace/test_template.py
@@ -142,6 +142,20 @@ class TestNmsEquivalence:
             assert got == want
 
 
+def _assert_same_boxes(got, want, score_tolerance):
+    """Boxes match exactly; scores only to the platform's matchTemplate ulp drift."""
+    assert [(row["x"], row["y"], row["w"], row["h"]) for row in got] == [
+        (row["x"], row["y"], row["w"], row["h"]) for row in want
+    ]
+    assert (
+        max(
+            abs(got_row["score"] - want_row["score"])
+            for got_row, want_row in zip(got, want, strict=True)
+        )
+        < score_tolerance
+    )
+
+
 class TestCorrelationRoi:
     def test_unmasked_matches_full_map(self, monkeypatch):
         monkeypatch.setattr(config, "SCREENSPACE_BLUR_KERNEL", 1)
@@ -170,7 +184,7 @@ class TestCorrelationRoi:
             got = screenspace_primitives._match_template_prepared(
                 frame, prepared, 0.9, 0.3, window=window
             )
-            assert got == want
+            _assert_same_boxes(got, want, 1e-5)
 
     def test_uint8_drift_is_bounded(self):
         rng = np.random.RandomState(85)
@@ -188,16 +202,7 @@ class TestCorrelationRoi:
         got = screenspace_primitives._match_template_prepared(
             frame, prepared, 0.1, 0.3, window=window
         )
-        assert [(row["x"], row["y"], row["w"], row["h"]) for row in got] == [
-            (row["x"], row["y"], row["w"], row["h"]) for row in want
-        ]
-        assert (
-            max(
-                abs(got_row["score"] - want_row["score"])
-                for got_row, want_row in zip(got, want, strict=True)
-            )
-            < 5e-5
-        )
+        _assert_same_boxes(got, want, 5e-5)
 
     def test_roi_values_track_full_map(self):
         # Crop width picks the SIMD path: ulp-close to the full map, same peak.

--- a/tests/test_clip_pipeline.py
+++ b/tests/test_clip_pipeline.py
@@ -1378,3 +1378,80 @@ def test_completion_message_reports_aborted_reel(monkeypatch, capsys):
 
     app._print_completion_message(1, "clip", is_reel=True)
     assert "created 1 reel" in capsys.readouterr().out
+
+
+def test_process_clips_parallel_survives_one_failing_clip(monkeypatch, make_clip):
+    """A clip that raises is reported and skipped; the batch still completes."""
+    clips = [make_clip(row=i, col=2) for i in range(3, 7)]
+    monkeypatch.setattr(
+        pipeline.files,
+        "prepare_clip",
+        lambda clip: _prepared_clip(clip, [("00:10", "00:20")]),
+    )
+    monkeypatch.setattr(pipeline.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(pipeline.utils, "create_progress_bar", lambda: None)
+    monkeypatch.setattr(config, "CLIP_PARALLEL_WORKERS", 4)
+    monkeypatch.setattr(
+        pipeline.files,
+        "get_unique_filename",
+        lambda template, file_format=None: f"{template}{file_format or ''}",
+    )
+
+    import threading
+
+    calls = {"n": 0}
+    lock = threading.Lock()
+
+    def run_ffmpeg(*_args, **_kwargs):
+        with lock:
+            calls["n"] += 1
+            first = calls["n"] == 1
+        if first:
+            raise RuntimeError("boom")
+        return True
+
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", run_ffmpeg)
+
+    count, _artifacts = pipeline.process_clips(clips, output_format="clip")
+    assert count == 3
+
+
+def test_regenerate_gif_artifact_keeps_default_gif_length(monkeypatch, tmp_path):
+    """The stored span is the clip's; the GIF stays capped like generation."""
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
+    (tmp_path / "study_P01.mp4").write_text("v")
+    extract_gif = Mock(return_value=True)
+    monkeypatch.setattr(pipeline.video, "extract_gif", extract_gif)
+
+    artifact = {
+        "type": "gif",
+        "file": "clip.gif",
+        "sourceVideo": "study_P01.mp4",
+        "localStart": 0.0,
+        "localEnd": 60.0,
+    }
+    assert pipeline._regenerate_single_artifact(artifact, set()) is True
+    _, kwargs = extract_gif.call_args
+    assert kwargs["duration_seconds"] == config.DEFAULT_GIF_DURATION_SECONDS
+
+
+def test_regenerate_artifact_rounds_fractional_local_times(monkeypatch, tmp_path):
+    """Rounding matches the original cut; truncation drifted by up to a second."""
+    monkeypatch.setattr(config, "INPUT_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
+    (tmp_path / "study_P01.mp4").write_text("v")
+    run_ffmpeg = Mock(return_value=True)
+    monkeypatch.setattr(pipeline.video, "run_ffmpeg", run_ffmpeg)
+
+    artifact = {
+        "type": "clip",
+        "file": "clip.mp4",
+        "sourceVideo": "study_P01.mp4",
+        "localStart": 10.6,
+        "localEnd": 20.4,
+    }
+    assert pipeline._regenerate_single_artifact(artifact, set()) is True
+    _, kwargs = run_ffmpeg.call_args
+    assert kwargs["start_pos"] == "0:11"
+    assert kwargs["end_pos"] == "0:20"

--- a/tests/test_files_and_artifacts.py
+++ b/tests/test_files_and_artifacts.py
@@ -474,3 +474,22 @@ def test_no_baseline_row_means_relative_timestamps_only():
     # Without a baseline row, times remain absolute clock values
     assert prepared_p01["times"] == [("09:13:00", "09:14:00")]
     assert prepared_p02["times"] == [("09:20:00", "09:21:00")]
+
+
+def test_prepare_clip_selects_segments_before_baseline_conversion(make_clip):
+    """Keyword indexes count the cell's tokens; conversion may drop earlier pairs."""
+    clip = make_clip(value="09:00:00-09:05:00 09:10:00-09:15:00 !key")
+    clip["timestamp_baseline"] = "09:08:00"
+    clip["selected_segment_indexes"] = [1]
+
+    prepared = files.prepare_clip(clip)
+
+    assert prepared["times"] == [("0:02:00", "0:07:00")]
+
+
+def test_safe_truncate_counts_utf8_bytes():
+    """Filesystems cap names in bytes; CJK text must back off further."""
+    cjk = files.safe_truncate("\u4f60" * 200, 255)
+    assert cjk
+    assert len(cjk.encode("utf-8")) <= 255
+    assert len(files.safe_truncate("a" * 300, 255)) == 255

--- a/tests/test_frontend_syntax.py
+++ b/tests/test_frontend_syntax.py
@@ -50,3 +50,20 @@ def test_js_parses(name: str) -> None:
 def test_js_is_es5(name: str) -> None:
     """House style: every page script is ES5 (no arrows, no async/await)."""
     assert_es5(strip_comments((WEB / name).read_text(encoding="utf-8")), name)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed; JS syntax gate skipped")
+def test_format_time_rounds_fractional_seconds() -> None:
+    """Rounding after splitting produced "1:010.0" and "0:60.0"."""
+    assert NODE is not None
+    src = (WEB / "utils.js").read_text(encoding="utf-8")
+    snippet = src[src.index("var pad2 = ") : src.index("// Rounds rather than floors")]
+    probe = (
+        "console.log([formatTime(69.96, {decimals: 1}), formatTime(59.97, {decimals: 1}),"
+        " formatTime(9.99, {decimals: 1}), formatTime(3599.9), formatTime(65.4)]"
+        '.join(" "));'
+    )
+    result = subprocess.run(
+        [NODE, "-e", snippet + probe], check=True, capture_output=True, text=True
+    )
+    assert result.stdout.split() == ["1:10.0", "1:00.0", "0:10.0", "59:59", "1:05"]

--- a/tests/test_interactive_prompts.py
+++ b/tests/test_interactive_prompts.py
@@ -6,6 +6,7 @@ routes user input through utils.read_user_input(). These tests drive each
 prompt with scripted input sequences and assert on the resolved selection.
 """
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import google_api
@@ -393,3 +394,36 @@ def test_browse_spreadsheet_selector_no_clips(monkeypatch):
         _browse_sheet(), process_fn=lambda clips, fmt: calls.append(1) or (0, [])
     )
     assert calls == []
+
+
+def test_prompt_batch_confirm_accepts_uppercase(monkeypatch):
+    _scripted(monkeypatch, ["Y"])
+    assert interactive.prompt_batch_confirm(_ctx()) is True
+
+
+def test_reellate_user_filename_lands_in_output_dir(monkeypatch, tmp_path):
+    """A typed reel name is reserved in the output dir, not the process CWD."""
+    import app
+    import config
+    import files
+    import video
+
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(files, "discover_clips", lambda: ["a.mp4", "b.mp4"])
+    monkeypatch.setattr(utils, "use_progress", lambda: False)
+    _scripted(monkeypatch, ["A + B", "y", "myreel"])
+    seen = {}
+
+    def concat(_clips, output_file, **_kwargs):
+        seen["output"] = output_file
+        return True
+
+    monkeypatch.setattr(video, "concatenate_clips", concat)
+
+    ok, output_file = app._run_reellate_mode_interactive()
+
+    assert ok is True
+    assert output_file is not None
+    assert output_file == seen["output"]
+    assert Path(output_file).parent == tmp_path
+    assert Path(output_file).name == "myreel.mp4"

--- a/tests/test_screenspace_api.py
+++ b/tests/test_screenspace_api.py
@@ -3712,3 +3712,23 @@ def test_media_route_follows_a_mid_session_output_dir_change(
         assert c.get("/screenspace/media/heatmap_ss_abc.png").status_code == 404
         monkeypatch.setattr(config, "OUTPUT_DIR", str(second))
         assert c.get("/screenspace/media/heatmap_ss_abc.png").status_code == 200
+
+
+def test_regions_create_rejects_non_string_name(client):
+    resp = client.post("/screenspace/api/regions", json={"name": 5})
+    assert resp.status_code == 400
+
+
+def test_regions_create_rejects_non_object_body(client):
+    resp = client.post("/screenspace/api/regions", json=[1])
+    assert resp.status_code == 400
+
+
+def test_event_exclude_tolerates_an_id_less_event(client):
+    screenspace_server._manifest["events"] = [
+        {"task_id": "t1"},
+        {"id": "e1", "task_id": "t1", "excluded": False},
+    ]
+    resp = client.put("/screenspace/api/events/e1/exclude")
+    assert resp.status_code == 200
+    assert screenspace_server._manifest["events"][1]["excluded"] is True

--- a/tests/test_screenspace_frontend_source.py
+++ b/tests/test_screenspace_frontend_source.py
@@ -203,3 +203,17 @@ def test_sample_editor_uses_blocking_modal_and_is_es5():
     assert "openBlockingModal(" in SAMPLE_EDITOR_JS
     assert "closeBlockingModal(" in SAMPLE_EDITOR_JS
     assert_es5(SAMPLE_EDITOR_JS, "screenspace-sample-editor.js")
+
+
+def test_results_tab_count_element_exists():
+    """Five writes target #resultCount; without the span they went nowhere."""
+    assert 'qs("#resultCount")' in read("screenspace-results.js")
+    assert 'id="resultCount"' in read("screenspace.html")
+
+
+def test_model_view_previews_first_multitool_step():
+    """The server previews plain tools; multitool must send its first step."""
+    body = MODEL_VIEW_JS[MODEL_VIEW_JS.index("function _doRefreshModelView") :]
+    assert "(state.multitoolSteps || [])[0]" in body
+    assert 'sfx = "_mt0"' in body
+    assert "_collectPreviewParams(tool, sfx)" in body

--- a/tests/test_screenspace_preview.py
+++ b/tests/test_screenspace_preview.py
@@ -510,3 +510,16 @@ def test_overlay_scene_edges_thicken_with_region() -> None:
         f"larger region edges should be substantially denser due to dilation "
         f"(small={small_density:.3f}, large={large_density:.3f})"
     )
+
+
+def test_boundary_previews_the_phash_grid(
+    synthetic_frame: np.ndarray, region: dict[str, int]
+) -> None:
+    """Boundary is a valid task type; it shows the same bits pHash compares."""
+    boundary = screenspace_preview.build_preview(
+        synthetic_frame, None, region, "boundary", {}
+    )
+    inactivity = screenspace_preview.build_preview(
+        synthetic_frame, None, region, "inactivity", {}
+    )
+    assert np.array_equal(boundary, inactivity)

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -167,3 +167,19 @@ def test_opt_number_missing_returns_default():
 def test_opt_number_parses_and_falls_back():
     assert server_utils.opt_number({"x": "1.5"}, "x") == 1.5
     assert server_utils.opt_number({"x": "nope"}, "x", 7.0) == 7.0
+
+
+def test_sse_notify_without_key_wakes_every_client():
+    import queue
+
+    notify, _stream, clients = server_utils.make_sse_channel()
+    qa: queue.Queue = queue.Queue(maxsize=4)
+    qb: queue.Queue = queue.Queue(maxsize=4)
+    clients.append(("a", qa))
+    clients.append(("b", qb))
+
+    notify("a")
+    assert qa.qsize() == 1 and qb.qsize() == 0
+
+    notify()
+    assert qa.qsize() == 2 and qb.qsize() == 1

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -2674,6 +2674,7 @@ def test_api_reel_passes_titlecard_options_to_pipeline(client, monkeypatch):
         *,
         titlecards_enabled=None,
         titlecard_duration_seconds=None,
+        token=None,
     ):
         captured["enabled"] = titlecards_enabled
         captured["duration"] = titlecard_duration_seconds
@@ -4751,3 +4752,88 @@ def test_media_route_serves_generated_artifacts(client, tmp_path, monkeypatch):
     monkeypatch.setattr(server.config, "OUTPUT_DIR", str(other))
     assert client.get("/studio/media/moved.mp4").status_code == 200
     assert client.get("/studio/media/Study%20P01%20clip.mp4").status_code == 404
+
+
+def test_api_generate_intake_resolves_mark_ids_to_segment_text(client, monkeypatch):
+    """Marks name segments; the fallback joins those segments' text."""
+    import transcripts_server
+
+    monkeypatch.setattr(
+        server, "_resolve_intake_video_paths", lambda p, s="": ["/fake/video.mp4"]
+    )
+    monkeypatch.setattr("video.run_ffmpeg", lambda *a, **kw: True)
+    monkeypatch.setattr(server, "_save_manifest_quiet", lambda: None)
+    monkeypatch.setattr(
+        transcripts_server,
+        "_manifest",
+        {
+            "source_transcripts": {
+                "P01": {
+                    "transcribed_at": "2026-01-01T00:00:00+00:00",
+                    "segments": [
+                        {"id": "P01:0", "text": "hello there"},
+                        {"id": "P01:1", "text": "not marked"},
+                    ],
+                }
+            },
+            "marks": [{"id": "m_1", "segment_id": "P01:0"}],
+        },
+    )
+
+    items = [
+        {
+            "participant": "P01",
+            "start": 0.0,
+            "end": 5.0,
+            "event_type": "transcript",
+            "event_ids": [],
+            "source": "transcript",
+            "mark_ids": ["m_1"],
+        }
+    ]
+    resp = client.post(
+        "/studio/api/generate-intake", json={"items": items, "format": "clip"}
+    )
+    assert resp.status_code == 200
+    line = json.loads(resp.data.decode().strip().split("\n")[0])
+    assert line["ok"] is True
+    assert line["artifact"]["transcriptText"] == "hello there"
+
+
+def test_api_reel_releases_busy_slot_when_stream_never_starts(
+    studio_app, client, monkeypatch, tmp_path
+):
+    """A response torn down before iteration must not hold the slot forever."""
+    _setup_api_reel(monkeypatch, tmp_path)
+    endpoint = next(
+        rule.endpoint
+        for rule in studio_app.url_map.iter_rules()
+        if rule.rule == "/studio/api/reel" and "POST" in (rule.methods or set())
+    )
+    view = studio_app.view_functions[endpoint]
+
+    with studio_app.test_request_context(
+        "/studio/api/reel", method="POST", json={"cells": ["P01.5"]}
+    ):
+        resp = view()
+        assert server._busy_slots["reel"] is True
+        resp.close()
+
+    assert server._busy_slots["reel"] is False
+
+
+def test_release_busy_ignores_a_stale_token():
+    """A late second release must not drop the next request's claim."""
+    server._release_busy("generate")
+    first = server._try_claim_busy("generate")
+    assert first
+    server._release_busy("generate", first)
+    second = server._try_claim_busy("generate")
+    assert second and second != first
+
+    server._release_busy("generate", first)  # stale: the generator's finally
+    assert server._busy_slots["generate"] is True
+    assert server._try_claim_busy("generate") is None
+
+    server._release_busy("generate", second)
+    assert server._busy_slots["generate"] is False

--- a/tests/test_titlecards.py
+++ b/tests/test_titlecards.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 
@@ -877,3 +878,36 @@ def test_pipeline_wraps_clip_without_forcing_source_resolution(monkeypatch, make
         ("out1.mp4", None),
         ("out2.mp4", None),
     ]
+
+
+def test_build_titlecard_frame_validates_before_creating_a_temp_file(
+    monkeypatch, make_clip
+):
+    def boom(*_args, **_kwargs):
+        raise AssertionError("temp file created before validation")
+
+    monkeypatch.setattr(titlecards.tempfile, "NamedTemporaryFile", boom)
+    monkeypatch.setattr(titlecards.Path, "is_file", lambda self: True)
+
+    assert titlecards.build_titlecard_frame(make_clip(), "1280") is None
+
+
+def test_build_titlecard_frame_removes_card_when_verify_fails(monkeypatch, make_clip):
+    seen = {}
+
+    def fake_verify(path, *_args, **_kwargs):
+        seen["path"] = path
+        return False
+
+    monkeypatch.setattr(
+        video,
+        "run_ffmpeg_process",
+        lambda cmd, **_k: subprocess.CompletedProcess(
+            args=cmd, returncode=0, stderr=""
+        ),
+    )
+    monkeypatch.setattr(video, "verify_output_file", fake_verify)
+    monkeypatch.setattr(titlecards.Path, "is_file", lambda self: True)
+
+    assert titlecards.build_titlecard_frame(make_clip(), "1280x720") is None
+    assert not os.path.exists(seen["path"])

--- a/tests/test_transcripts_api.py
+++ b/tests/test_transcripts_api.py
@@ -3784,3 +3784,10 @@ def test_invalidate_dependents_matches_on_agent_keys(monkeypatch):
     entry = {"theme_analysis": "old", "digest_result": "derived"}
     transcripts_server._invalidate_dependents(entry, fake_agents[0])
     assert "digest_result" not in entry
+
+
+def test_corrections_add_rejects_non_string_fields(tr_client):
+    resp = tr_client.post(
+        "/transcripts/api/corrections", json={"from": None, "to": "x"}
+    )
+    assert resp.status_code == 400

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -2133,3 +2133,25 @@ def test_probe_video_properties_single_flight(monkeypatch, tmp_path):
     assert len(calls) == 1
     assert all(r == results[0] for r in results) and results[0]["width"] == 1280
     assert not video_mod._probe_inflight  # flight entry released
+
+
+def test_parallel_gifs_reserve_nothing_for_a_tail_past_the_end(monkeypatch, tmp_path):
+    """A timestamp with no room for a GIF must not leave a 0-byte placeholder."""
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(video, "extract_gif", lambda *_a, **_k: True)
+
+    artifacts = video._parallel_extract_gifs("in.mp4", [0, 10], 10, 3, 10)
+
+    assert artifacts is not None and len(artifacts) == 1
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["gallery_0_00.gif"]
+
+
+def test_run_ffmpeg_rejects_a_zero_length_range(monkeypatch):
+    """ffmpeg -t 0 writes a stub file; a same-start-and-end range is skipped."""
+    captured: list = []
+    _run_ffmpeg_harness(monkeypatch, captured, file_duration=100)
+
+    assert (
+        video.run_ffmpeg("in.mp4", "out.mp4", "01:23", "01:23", reencode=False) is False
+    )
+    assert captured == []

--- a/tests/ui/_ui_browser.py
+++ b/tests/ui/_ui_browser.py
@@ -69,12 +69,14 @@ def browsers_root() -> Path:
     override = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
     if override:
         return Path(override).expanduser()
+    # The developer's real home: tests/conftest.py sandboxes Path.home().
+    home = Path(os.path.expanduser("~"))
     if sys.platform == "darwin":
-        return Path.home() / "Library" / "Caches" / "ms-playwright"
+        return home / "Library" / "Caches" / "ms-playwright"
     if sys.platform == "win32":
-        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        base = os.environ.get("LOCALAPPDATA") or str(home / "AppData" / "Local")
         return Path(base) / "ms-playwright"
-    return Path.home() / ".cache" / "ms-playwright"
+    return home / ".cache" / "ms-playwright"
 
 
 def _build_number(name: str) -> int:


### PR DESCRIPTION
## Summary

A whole-codebase bug hunt, each finding verified against the tree and covered by a regression test.

- **pipeline/files/app:** a raising clip no longer kills the parallel batch; GIF regeneration keeps the default length and fractional times round; keyword segment selection runs before baseline conversion; typed reel names reserve in the output dir (a same-named CWD file could be deleted on abort); filename truncation counts UTF-8 bytes.
- **video/titlecards/interactive:** zero-length ranges skip instead of reaching `ffmpeg -t 0`; gallery placeholders and card temp files stop leaking; `[y/n]` prompts accept `Y`.
- **server:** intake transcript text resolves mark ids to segments (it compared mark ids to segment ids, so Studio intake clips lost their excerpt); busy slots release on `call_on_close` with a claim token so a stale release cannot drop a successor; non-string/non-object JSON bodies return 400; manifest dicts are deep-copied inside the lock; `make_sse_channel().notify()` broadcasts as documented; workflows watcher caches rebind under `_watch_lock`.
- **screenspace/web:** Multitool preview and overlay work (the client now previews the first step) and Boundary renders the pHash grid; the Results tab count element exists; `formatTime` rounds before splitting (`1:010.0` → `1:10.0`); stash recall deep-copies; the remux banner stops when the job vanishes; sprite scrub keeps the newest pointer sample; fifteen fire-and-forget mutations toast on failure.
- **tests/ui:** the Playwright cache resolves from the real home, so `/ui-check` runs again instead of silently skipping every journey.

Flagged, not fixed: `get_num_participants` assumes participant columns are contiguous after ID.

## Test plan

- [x] `uv run --extra dev pytest -c tests/pytest.ini` (20 new regression tests)
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check`
- [x] `/ui-check`: 17 journeys green, no console errors; Screenspace Results tab shows `(2)`
- [x] `ffmpeg -t 0` probed by hand: writes a 0.3 s stub, so the zero-length guard stays
- [ ] Multitool / Boundary preview on real media (fixture project has no multitool task)