### PR TITLE
test(perf): rebuild bench fixtures when duration does not match

### DIFF
--- a/agents/skills/profile/SKILL.md
+++ b/agents/skills/profile/SKILL.md
@@ -224,8 +224,13 @@ manifest hides the callback), and diffs runs as JSON:
 ```bash
 uv run python tests/perf/scan_bench.py --save /tmp/base.json     # baseline
 # ...make the change...
-uv run python tests/perf/scan_bench.py --compare /tmp/base.json  # Δcallback %
+uv run python tests/perf/scan_bench.py --compare /tmp/base.json --fail-on 10
 ```
+
+`--duration` rebuilds when the existing fixture's probed length does not match.
+A leftover 120 s `/tmp/ssbench/bench_P01.mp4` would otherwise ignore
+`--duration 15` and poison `--compare`. The harness prints `fixture … Ns` at
+the start of a run so a wrong-length file is visible before the table.
 
 Template and Shape use a seeded top-left 20%-frame region. This keeps their
 reference non-degenerate while measuring bounded correlation instead of a
@@ -254,8 +259,12 @@ parallelism ratio, and the titlecard copy/reencode split, with the same
 
 ```bash
 uv run python tests/perf/clip_bench.py --save /tmp/clipbase.json
-uv run python tests/perf/clip_bench.py --compare /tmp/clipbase.json  # Δclip %
+uv run python tests/perf/clip_bench.py --compare /tmp/clipbase.json --fail-on 10
 ```
+
+`--duration` rebuilds the video *and* the sheet when the existing file's length
+does not match, and timestamps stay inside that length (an MM:SS with SS > 59
+is dropped at parse). Same `fixture … Ns` line as scan_bench.
 
 Live server: launch with `--profile`, then `curl http://127.0.0.1:8089/api/profile`
 (404 without the flag; `?reset=1` snapshots then clears, bracketing a window).

--- a/tests/perf/clip_bench.py
+++ b/tests/perf/clip_bench.py
@@ -10,12 +10,13 @@ Usage (from the repo root):
 
     uv run python tests/perf/clip_bench.py                     # sweep + table
     uv run python tests/perf/clip_bench.py --save base.json    # snapshot
-    uv run python tests/perf/clip_bench.py --compare base.json # A/B deltas
+    uv run python tests/perf/clip_bench.py --compare base.json --fail-on 10
     uv run python tests/perf/clip_bench.py --scenarios clips --runs 2
 
 Fixtures are built on demand in --input: a 120 s testsrc+sine video named
 `clipbench_P01.mp4` and `clipbench.xlsx` with 30 one-participant rows
-(varied 3-9 s ranges so encodes are not all identical). Each scenario
+(varied 3-9 s ranges so encodes are not all identical). `--duration` rebuilds
+both when the existing video's probed length does not match. Each scenario
 writes to its own wiped output dir so reservations and manifests never
 leak between runs. `--runs N` keeps the fastest run per scenario.
 
@@ -32,14 +33,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scan_bench import parse_profile
+from scan_bench import delta_pct, parse_profile, probe_duration, regressions
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 DATA_ROWS = 30  # sheet rows with timestamps; row 6 is the first
 
-# Scenario -> extra CLI args. All select the same 20 rows (sheet rows 6-25)
-# so clip counts match across scenarios and runs.
+# Same 20 rows (6-25) so clip counts match across scenarios.
 SCENARIOS: dict[str, list[str]] = {
     "clips": ["-r", "6-25", "--no-titlecards"],
     "clips-cards": ["-r", "6-25", "--titlecards"],
@@ -84,11 +84,55 @@ def keep_best(
     return best
 
 
+def clip_cell_range(row: int, duration: int) -> str:
+    """MM:SS window for data row *row* that stays inside *duration* seconds."""
+    start = 2 + (row * 3) % 49
+    end = start + 3 + row % 5
+    last = max(2, min(duration - 1, 57))
+    if end > last:
+        end = last
+        start = max(1, end - (3 + row % 5))
+    if start >= end:
+        start = max(0, end - 1)
+    return f"0:{start:02d}-0:{end:02d}"
+
+
+def _write_clip_sheet(sheet: Path, duration: int) -> None:
+    """Write clipbench.xlsx with timestamps that fit *duration*."""
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Observations"
+    ws["A1"] = "clipbench"
+    ws["F2"] = "ID"
+    ws["G2"] = "P01"
+    for col, header in enumerate(
+        ("Count", "Reported", "Severity", "Category", "Observation", "Summary"), 1
+    ):
+        ws.cell(5, col, header)
+    for r in range(DATA_ROWS):
+        ws.cell(6 + r, 3, ("Critical", "Serious", "Moderate", "Minor")[r % 4])
+        ws.cell(6 + r, 4, "Onboarding")
+        ws.cell(6 + r, 5, f"Observation {r}")
+        ws.cell(6 + r, 7, clip_cell_range(r, duration))
+    wb.save(sheet)
+
+
 def ensure_fixtures(input_dir: Path, duration: int) -> Path:
-    """Build the bench video and sheet if they are not already there."""
+    """Build the bench video and sheet, rebuilding if duration does not match."""
     input_dir.mkdir(parents=True, exist_ok=True)
     video = input_dir / "clipbench_P01.mp4"
-    if not video.is_file():
+    sheet = input_dir / "clipbench.xlsx"
+    existing = probe_duration(video) if video.is_file() else None
+    rebuild = existing is None or abs(existing - duration) >= 0.5
+    if rebuild:
+        if video.is_file():
+            was = f"{existing:.0f}s" if existing is not None else "unreadable"
+            print(f"rebuilding {video.name} ({was} → {duration}s)")
+            video.unlink()
+        if sheet.is_file():
+            sheet.unlink()
         subprocess.run(
             [
                 "ffmpeg",
@@ -116,29 +160,8 @@ def ensure_fixtures(input_dir: Path, duration: int) -> Path:
             ],
             check=True,
         )
-    sheet = input_dir / "clipbench.xlsx"
     if not sheet.is_file():
-        import openpyxl
-
-        wb = openpyxl.Workbook()
-        ws = wb.active
-        ws.title = "Observations"
-        ws["A1"] = "clipbench"
-        ws["F2"] = "ID"
-        ws["G2"] = "P01"
-        for col, header in enumerate(
-            ("Count", "Reported", "Severity", "Category", "Observation", "Summary"), 1
-        ):
-            ws.cell(5, col, header)
-        for r in range(DATA_ROWS):
-            # Varied 3-9 s windows so encodes differ; seconds stay <= 57
-            # (an MM:SS with SS > 59 is silently dropped at parse).
-            start = 2 + (r * 3) % 49
-            ws.cell(6 + r, 3, ("Critical", "Serious", "Moderate", "Minor")[r % 4])
-            ws.cell(6 + r, 4, "Onboarding")
-            ws.cell(6 + r, 5, f"Observation {r}")
-            ws.cell(6 + r, 7, f"0:{start:02d}-0:{start + 3 + r % 5:02d}")
-        wb.save(sheet)
+        _write_clip_sheet(sheet, duration)
     return sheet
 
 
@@ -167,6 +190,8 @@ def run_scenario(
         cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=1800, check=False
     )
     parsed = parse_profile(proc.stdout + proc.stderr)
+    if proc.returncode:
+        print(f"  ! {scenario}: clipgen exit {proc.returncode}")
     if "pipeline.clip" not in parsed:
         print(f"  ! {scenario}: no pipeline.clip in report (run refused?)")
         tail = "\n".join((proc.stdout + proc.stderr).strip().splitlines()[-5:])
@@ -193,8 +218,14 @@ def print_table(
         if baseline:
             base = baseline.get(scenario)
             if base and base.get("clip_s"):
-                pct = (row["clip_s"] / base["clip_s"] - 1.0) * 100
-                line += f"  {pct:>+7.1f}%"
+                pct = delta_pct(row["clip_s"], base["clip_s"])
+                line += f"  {pct:>+7.1f}%" if pct is not None else "  (no base)"
+                if (
+                    row.get("clips")
+                    and base.get("clips")
+                    and row["clips"] != base["clips"]
+                ):
+                    line += " n≠"
             else:
                 line += "  (no base)"
         print(line)
@@ -211,7 +242,7 @@ def main() -> int:
         "--input",
         default="/tmp/clipbench",
         type=Path,
-        help="fixture dir; video and sheet are built here if missing",
+        help="fixture dir; video and sheet are built or rebuilt here",
     )
     ap.add_argument(
         "--output",
@@ -223,7 +254,7 @@ def main() -> int:
         "--duration",
         default=120,
         type=int,
-        help="fixture length in seconds (only used when building)",
+        help="fixture length in seconds; rebuilds when the existing file differs",
     )
     ap.add_argument(
         "--runs",
@@ -233,7 +264,15 @@ def main() -> int:
     )
     ap.add_argument("--save", type=Path, help="write results JSON here")
     ap.add_argument("--compare", type=Path, help="baseline JSON to diff against")
+    ap.add_argument(
+        "--fail-on",
+        type=float,
+        default=None,
+        help="with --compare, exit 1 if any Δclip %% exceeds this",
+    )
     args = ap.parse_args()
+    if args.fail_on is not None and not args.compare:
+        ap.error("--fail-on requires --compare")
 
     scenarios = [s.strip() for s in args.scenarios.split(",") if s.strip()]
     unknown = [s for s in scenarios if s not in SCENARIOS]
@@ -242,6 +281,13 @@ def main() -> int:
         return 2
     out_root = args.output or (args.input / "bench-out")
     ensure_fixtures(args.input, args.duration)
+    video = args.input / "clipbench_P01.mp4"
+    probed = probe_duration(video)
+    print(
+        f"fixture {video.name}  {probed:.0f}s"
+        if probed is not None
+        else f"fixture {video.name}"
+    )
 
     baseline = None
     if args.compare:
@@ -266,6 +312,7 @@ def main() -> int:
                 {
                     "meta": {
                         "video": str(args.input / "clipbench_P01.mp4"),
+                        "duration": args.duration,
                         "runs": args.runs,
                     },
                     "scenarios": rows,
@@ -274,6 +321,12 @@ def main() -> int:
             )
         )
         print(f"\nsaved -> {args.save}")
+    if args.fail_on is not None and baseline is not None:
+        hit = regressions(rows, baseline, "clip_s", args.fail_on)
+        if hit:
+            for name, pct in hit:
+                print(f"fail-on: {name} {pct:+.1f}% (limit {args.fail_on:g}%)")
+            return 1
     return 0
 
 

--- a/tests/perf/scan_bench.py
+++ b/tests/perf/scan_bench.py
@@ -12,18 +12,20 @@ Usage (from the repo root):
 
     uv run python tests/perf/scan_bench.py                     # sweep + table
     uv run python tests/perf/scan_bench.py --save base.json    # snapshot
-    uv run python tests/perf/scan_bench.py --compare base.json # A/B deltas
+    uv run python tests/perf/scan_bench.py --compare base.json --fail-on 10
     uv run python tests/perf/scan_bench.py --tools color,text --runs 2
 
 The fixture video is built on demand (ffmpeg testsrc: constant motion, so
-phash-skip never hides the callback). Each tool writes to its own wiped
-output dir so a cached manifest can never absorb the scan. `--runs N` keeps
-the fastest run per tool (minimum callback seconds), the standard treatment
-for scheduler noise. Template and Shape use a fixed top-left 20% region for
-a non-degenerate reference and bounded search workload. `text` is excluded
-from the default sweep: OCR is an
-order of magnitude slower than every other tool and pins ~0.8 GB of RSS per
-pooled OCR engine (measured 3.3 GB at the default auto pool of 4).
+phash-skip never hides the callback) and rebuilt when `--duration` does not
+match the file already on disk — a leftover 120 s clip would otherwise
+ignore `--duration 15` and poison `--compare`. Each tool writes to its own
+wiped output dir so a cached manifest can never absorb the scan. `--runs N`
+keeps the fastest run per tool (minimum callback seconds), the standard
+treatment for scheduler noise. Template and Shape use a fixed top-left 20%
+region for a non-degenerate reference and bounded search workload. `text` is
+excluded from the default sweep: OCR is an order of magnitude slower than
+every other tool and pins ~0.8 GB of RSS per pooled OCR engine (measured
+3.3 GB at the default auto pool of 4).
 
 The parser (`parse_profile`) is unit-tested in test_scan_bench_parse.py;
 everything else is a thin subprocess driver kept dependency-free on purpose.
@@ -41,9 +43,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# The canonical flag set per tool — the load-bearing arguments SKILL.md warns
-# about (a tool missing its required flag refuses to build a task and reports
-# only ffprobe.run, which reads as a fast-filter skip).
+# Missing required flags refuse the task and report only ffprobe.run.
 TOOL_FLAGS: dict[str, list[str]] = {
     "color": ["--ss-target-color", "#FF0000", "--ss-tolerance", "20,30,30"],
     "change": ["--ss-threshold", "0.05"],
@@ -68,25 +68,91 @@ BENCH_REGION = {
 }
 REGION_TOOLS = {"template", "shape"}
 
-_PROFILE_RE = re.compile(r"^profile \| (\S+)\s+([\d.]+)s\s+n=(\d+)", re.MULTILINE)
+# Label is padded to 32 chars and may contain spaces (`route /api/foo`).
+_PROFILE_RE = re.compile(r"^profile \| (.+?)\s+([\d.]+)s\s+n=(\d+)(.*)$", re.MULTILINE)
 _RSS_RE = re.compile(r"^profile \| peak_rss\s+([\d.]+)MB", re.MULTILINE)
+_MS_RE = re.compile(r"\b(avg|max|first)=([\d.]+)ms")
+_BYTES_RE = re.compile(r"\bbytes=(\S+)")
+
+
+def _parse_bytes(token: str) -> float:
+    """Invert profiling.format_bytes; one-decimal sizes are approximate."""
+    if token.endswith("MB"):
+        return float(token[:-2]) * 1024 * 1024
+    if token.endswith("KB"):
+        return float(token[:-2]) * 1024
+    if token.endswith("B"):
+        return float(token[:-1])
+    return 0.0
 
 
 def parse_profile(text: str) -> dict[str, dict[str, float]]:
-    """Parse `profile |` report lines into {label: {seconds, n}} (+peak_rss)."""
+    """Parse `profile |` report lines into {label: {seconds, n, ...}} (+peak_rss)."""
     out: dict[str, dict[str, float]] = {}
-    for label, seconds, n in _PROFILE_RE.findall(text):
-        out[label] = {"seconds": float(seconds), "n": int(n)}
+    for label, seconds, n, rest in _PROFILE_RE.findall(text):
+        row: dict[str, float] = {"seconds": float(seconds), "n": int(n)}
+        for key, ms in _MS_RE.findall(rest):
+            row[key] = float(ms) / 1000.0
+        nbytes = _BYTES_RE.search(rest)
+        if nbytes:
+            row["bytes"] = _parse_bytes(nbytes.group(1))
+        out[label] = row
     rss = _RSS_RE.search(text)
     if rss:
         out["peak_rss"] = {"seconds": 0.0, "n": 0, "mb": float(rss.group(1))}
     return out
 
 
+def probe_duration(path: Path) -> float | None:
+    """Seconds of *path*, or None if ffprobe cannot say."""
+    proc = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        return float(proc.stdout.strip())
+    except ValueError:
+        return None
+
+
+def delta_pct(current: float, base: float) -> float | None:
+    """Percent change, or None when *base* is 0."""
+    if not base:
+        return None
+    return (current / base - 1.0) * 100.0
+
+
+def regressions(
+    rows: dict[str, dict[str, float]],
+    baseline: dict[str, dict[str, float]],
+    key: str,
+    limit: float,
+) -> list[tuple[str, float]]:
+    """Names whose *key* rose by more than *limit* percent."""
+    hit: list[tuple[str, float]] = []
+    for name, row in rows.items():
+        pct = delta_pct(row.get(key, 0.0), (baseline.get(name) or {}).get(key, 0.0))
+        if pct is not None and pct > limit:
+            hit.append((name, pct))
+    return hit
+
+
 def summarize(tool: str, profile: dict[str, dict[str, float]]) -> dict[str, float]:
     """Reduce one run's parsed report to the per-tool comparison row."""
     callback = profile.get(f"scan.callback.{tool}", {"seconds": 0.0, "n": 0})
     decode = profile.get("scan.decode_wait", {"seconds": 0.0, "n": 0})
+    filt = profile.get("scan.fast_filter", {"seconds": 0.0, "n": 0})
     heatmap = sum(
         profile.get(label, {}).get("seconds", 0.0)
         for label in ("heatmap.gifs", "heatmap.grid_layers")
@@ -97,6 +163,7 @@ def summarize(tool: str, profile: dict[str, dict[str, float]]) -> dict[str, floa
         "callback_avg_ms": callback["seconds"] / frames * 1000 if frames else 0.0,
         "frames": frames,
         "decode_s": decode["seconds"],
+        "filter_s": filt["seconds"],
         "heatmap_s": heatmap,
         "peak_rss_mb": profile.get("peak_rss", {}).get("mb", 0.0),
     }
@@ -122,10 +189,15 @@ def keep_best(
 
 
 def ensure_fixture(input_dir: Path, duration: int) -> Path:
-    """Build the deterministic benchmark video if it is not already there."""
+    """Build the benchmark video, rebuilding if its length does not match."""
     video = input_dir / "bench_P01.mp4"
-    if video.is_file():
+    existing = probe_duration(video) if video.is_file() else None
+    if existing is not None and abs(existing - duration) < 0.5:
         return video
+    if video.is_file():
+        was = f"{existing:.0f}s" if existing is not None else "unreadable"
+        print(f"rebuilding {video.name} ({was} → {duration}s)")
+        video.unlink()
     input_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         [
@@ -203,6 +275,8 @@ def run_tool(
     )
     output = proc.stdout + proc.stderr
     parsed = parse_profile(output)
+    if proc.returncode:
+        print(f"  ! {tool}: clipgen exit {proc.returncode}")
     if f"scan.callback.{tool}" not in parsed:
         print(f"  ! {tool}: no scan.callback.{tool} in report (task refused?)")
         tail = "\n".join(output.strip().splitlines()[-5:])
@@ -223,19 +297,25 @@ def print_table(
     delta_hdr = "  Δcallback" if baseline else ""
     print(
         f"{'tool':<12}{'callback':>10}{'avg':>9}{'frames':>8}"
-        f"{'decode':>9}{'heatmap':>9}{'rss':>9}{delta_hdr}"
+        f"{'decode':>9}{'filter':>9}{'heatmap':>9}{'rss':>9}{delta_hdr}"
     )
     for tool, row in rows.items():
         line = (
             f"{tool:<12}{row['callback_s']:>9.3f}s{row['callback_avg_ms']:>7.1f}ms"
-            f"{row['frames']:>8d}{row['decode_s']:>8.3f}s{row['heatmap_s']:>8.3f}s"
-            f"{row['peak_rss_mb']:>7.0f}MB"
+            f"{row['frames']:>8d}{row['decode_s']:>8.3f}s{row['filter_s']:>8.3f}s"
+            f"{row['heatmap_s']:>8.3f}s{row['peak_rss_mb']:>7.0f}MB"
         )
         if baseline:
             base = baseline.get(tool)
             if base and base.get("callback_s"):
-                pct = (row["callback_s"] / base["callback_s"] - 1.0) * 100
-                line += f"  {pct:>+8.1f}%"
+                pct = delta_pct(row["callback_s"], base["callback_s"])
+                line += f"  {pct:>+8.1f}%" if pct is not None else "  (no base)"
+                if (
+                    row.get("frames")
+                    and base.get("frames")
+                    and row["frames"] != base["frames"]
+                ):
+                    line += " frames≠"
             else:
                 line += "  (no base)"
         print(line)
@@ -252,7 +332,7 @@ def main() -> int:
         "--input",
         default="/tmp/ssbench",
         type=Path,
-        help="fixture dir; bench_P01.mp4 is built here if missing",
+        help="fixture dir; bench_P01.mp4 is built or rebuilt here",
     )
     ap.add_argument(
         "--output",
@@ -265,7 +345,7 @@ def main() -> int:
         "--duration",
         default=120,
         type=int,
-        help="fixture length in seconds (only used when building)",
+        help="fixture length in seconds; rebuilds when the existing file differs",
     )
     ap.add_argument(
         "--runs",
@@ -276,11 +356,19 @@ def main() -> int:
     ap.add_argument("--save", type=Path, help="write results JSON here")
     ap.add_argument("--compare", type=Path, help="baseline JSON to diff against")
     ap.add_argument(
+        "--fail-on",
+        type=float,
+        default=None,
+        help="with --compare, exit 1 if any Δcallback %% exceeds this",
+    )
+    ap.add_argument(
         "--deep",
         action="store_true",
         help="attach --profile-deep scan.callback.<tool> and print each pstats block",
     )
     args = ap.parse_args()
+    if args.fail_on is not None and not args.compare:
+        ap.error("--fail-on requires --compare")
 
     tools = [t.strip() for t in args.tools.split(",") if t.strip()]
     unknown = [t for t in tools if t not in TOOL_FLAGS]
@@ -288,7 +376,13 @@ def main() -> int:
         print(f"unknown tools: {', '.join(unknown)} (know: {', '.join(TOOL_FLAGS)})")
         return 2
     out_root = args.output or (args.input / "bench-out")
-    ensure_fixture(args.input, args.duration)
+    video = ensure_fixture(args.input, args.duration)
+    probed = probe_duration(video)
+    print(
+        f"fixture {video.name}  {probed:.0f}s  interval={args.interval}"
+        if probed is not None
+        else f"fixture {video.name}  interval={args.interval}"
+    )
 
     baseline = None
     if args.compare:
@@ -318,6 +412,7 @@ def main() -> int:
                     "meta": {
                         "interval": args.interval,
                         "video": str(args.input / "bench_P01.mp4"),
+                        "duration": args.duration,
                         "runs": args.runs,
                     },
                     "tools": rows,
@@ -326,6 +421,12 @@ def main() -> int:
             )
         )
         print(f"\nsaved -> {args.save}")
+    if args.fail_on is not None and baseline is not None:
+        hit = regressions(rows, baseline, "callback_s", args.fail_on)
+        if hit:
+            for name, pct in hit:
+                print(f"fail-on: {name} {pct:+.1f}% (limit {args.fail_on:g}%)")
+            return 1
     return 0
 
 

--- a/tests/perf/test_clip_bench_parse.py
+++ b/tests/perf/test_clip_bench_parse.py
@@ -38,6 +38,15 @@ def test_summarize_handles_missing_labels():
     assert row["parallelism"] == 0.0
 
 
+def test_clip_cell_range_matches_legacy_windows_on_long_fixture():
+    assert clip_bench.clip_cell_range(0, 120) == "0:02-0:05"
+    assert clip_bench.clip_cell_range(4, 120) == "0:14-0:21"
+
+
+def test_clip_cell_range_clamps_to_short_fixture():
+    assert clip_bench.clip_cell_range(4, 15) == "0:07-0:14"
+
+
 def test_keep_best_prefers_fastest_successful_run():
     ok = clip_bench.summarize(parse_profile(REPORT))
     failed = clip_bench.summarize(parse_profile(""))

--- a/tests/perf/test_scan_bench_parse.py
+++ b/tests/perf/test_scan_bench_parse.py
@@ -8,26 +8,70 @@ changes, so it is pinned here against a verbatim report snippet.
 import json
 from types import SimpleNamespace
 
+import pytest
+
 import scan_bench
 
 REPORT = """\
 profile | scan color bench_P01.mp4: decode_wait=0.798s/n=962  fast_filter=0.000s/n=962  callback=3.688s/n=962
 profile | scan.callback.color                 3.688s  n=962  avg=3.8ms  max=7.0ms
 profile | scan.decode_wait                    0.798s  n=962  avg=0.8ms
+profile | scan.fast_filter                    0.012s  n=962  avg=0.0ms
 profile | heatmap.gifs                        1.008s  n=1  avg=1007.7ms  max=1007.7ms
 profile | heatmap.grid_layers                 0.001s  n=1  avg=0.5ms  max=0.5ms
 profile | ffprobe.run                         0.039s  n=1  avg=39.0ms  max=39.0ms
 profile | peak_rss                            104.7MB
 """
 
+SPACED = """\
+profile | route /api/models                   0.120s  n=3  avg=40.0ms  max=80.0ms  bytes=1.2MB  first=80.0ms
+profile | manifest.load clips                 0.010s  n=2  avg=5.0ms  bytes=256B
+profile | stream /studio/api/generate         8.400s  n=1  avg=8400.0ms  bytes=4.0KB
+"""
+
 
 def test_parse_profile_extracts_labels_and_rss():
     parsed = scan_bench.parse_profile(REPORT)
-    assert parsed["scan.callback.color"] == {"seconds": 3.688, "n": 962}
+    color = parsed["scan.callback.color"]
+    assert color["seconds"] == 3.688
+    assert color["n"] == 962
+    assert color["avg"] == pytest.approx(0.0038)
+    assert color["max"] == pytest.approx(0.007)
     assert parsed["scan.decode_wait"]["seconds"] == 0.798
     assert parsed["peak_rss"]["mb"] == 104.7
-    # The per-scan summary line is not a totals label and must not parse.
+    # Per-scan summary lines are not totals and must not parse.
     assert "scan" not in parsed
+
+
+def test_parse_profile_keeps_spaced_labels_and_extra_fields():
+    parsed = scan_bench.parse_profile(SPACED)
+    route = parsed["route /api/models"]
+    assert route["seconds"] == 0.120
+    assert route["n"] == 3
+    assert route["max"] == pytest.approx(0.080)
+    assert route["first"] == pytest.approx(0.080)
+    assert route["bytes"] == pytest.approx(1.2 * 1024 * 1024)
+    assert parsed["manifest.load clips"]["n"] == 2
+    assert parsed["manifest.load clips"]["bytes"] == 256
+    assert parsed["stream /studio/api/generate"]["bytes"] == pytest.approx(4.0 * 1024)
+
+
+def test_parse_profile_round_trips_report(monkeypatch, capsys):
+    import config
+    import profiling
+
+    monkeypatch.setattr(config, "PROFILING", True)
+    profiling.reset()
+    profiling.add("route /api/models", 0.08, nbytes=1024)
+    profiling.add("route /api/models", 0.02, nbytes=512)
+    profiling.add("scan.callback.color", 1.5, 100, peak=0.02)
+    profiling.report()
+    parsed = scan_bench.parse_profile(capsys.readouterr().out)
+    assert parsed["route /api/models"]["n"] == 2
+    assert parsed["route /api/models"]["bytes"] > 0
+    assert parsed["scan.callback.color"]["seconds"] == pytest.approx(1.5)
+    assert parsed["scan.callback.color"]["max"] == pytest.approx(0.02)
+    profiling.reset()
 
 
 def test_summarize_reduces_to_comparison_row():
@@ -36,6 +80,7 @@ def test_summarize_reduces_to_comparison_row():
     assert row["frames"] == 962
     assert abs(row["callback_avg_ms"] - 3.834) < 0.01
     assert row["decode_s"] == 0.798
+    assert row["filter_s"] == 0.012
     assert abs(row["heatmap_s"] - 1.009) < 1e-9
     assert row["peak_rss_mb"] == 104.7
 
@@ -58,6 +103,48 @@ def test_summarize_handles_missing_labels():
     assert row["callback_s"] == 0.0
     assert row["frames"] == 0
     assert row["callback_avg_ms"] == 0.0
+    assert row["filter_s"] == 0.0
+
+
+def test_regressions_flags_callback_increase():
+    rows = {"color": {"callback_s": 1.2}}
+    base = {"color": {"callback_s": 1.0}}
+    hit = scan_bench.regressions(rows, base, "callback_s", 10)
+    assert hit == [("color", pytest.approx(20.0))]
+    assert scan_bench.regressions(rows, base, "callback_s", 25) == []
+
+
+def test_ensure_fixture_rebuilds_on_duration_mismatch(tmp_path, monkeypatch):
+    video = tmp_path / "bench_P01.mp4"
+    video.write_bytes(b"old")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd[0])
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(stdout="120.0\n", stderr="", returncode=0)
+        video.write_bytes(b"new")
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(scan_bench.subprocess, "run", fake_run)
+    out = scan_bench.ensure_fixture(tmp_path, 15)
+    assert out == video
+    assert video.read_bytes() == b"new"
+    assert calls[0] == "ffprobe"
+    assert "ffmpeg" in calls
+
+
+def test_ensure_fixture_keeps_matching_duration(tmp_path, monkeypatch):
+    video = tmp_path / "bench_P01.mp4"
+    video.write_bytes(b"keep")
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[0] == "ffprobe"
+        return SimpleNamespace(stdout="15.0\n", stderr="", returncode=0)
+
+    monkeypatch.setattr(scan_bench.subprocess, "run", fake_run)
+    scan_bench.ensure_fixture(tmp_path, 15)
+    assert video.read_bytes() == b"keep"
 
 
 def test_shape_is_in_default_sweep():
@@ -76,7 +163,7 @@ def test_shape_run_seeds_region(tmp_path, monkeypatch):
 
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
-        return SimpleNamespace(stdout=report, stderr="")
+        return SimpleNamespace(stdout=report, stderr="", returncode=0)
 
     monkeypatch.setattr(scan_bench.subprocess, "run", fake_run)
     parsed = scan_bench.run_tool("shape", tmp_path / "in", tmp_path / "out", 0.1)

--- a/tests/test_comment_conventions.py
+++ b/tests/test_comment_conventions.py
@@ -213,8 +213,6 @@ _TEST_HITS = {p.relative_to(ROOT).as_posix(): _scan(p) for p in _TEST_FILES}
 # Over-limit blocks per tests/ file as of the 2026-09 pass. Ratchets down only.
 _TEST_BASELINE: dict[str, int] = {
     "tests/conftest.py": 1,
-    "tests/perf/clip_bench.py": 2,
-    "tests/perf/scan_bench.py": 1,
     "tests/screenspace/test_attention.py": 11,
     "tests/screenspace/test_change_similarity.py": 4,
     "tests/screenspace/test_inactivity.py": 1,


### PR DESCRIPTION
## Summary

`--duration` used to reuse a leftover fixture of the wrong length, so `--compare` mixed workloads. `scan_bench` and `clip_bench` now rebuild when the probed length differs, parse spaced `profile |` labels (`route /api/…`), surface `scan.fast_filter`, and support `--fail-on` so a callback/clip regression can fail the run.

## Test plan

- [x] `/check` (ruff format + lint, ty, 3964 tests)
- [x] `scan_bench --duration 10` rebuilt a leftover 120 s `/tmp/ssbench/bench_P01.mp4`; a second run kept 10 s
- [x] `--compare --fail-on 25` on that color pair exited 0 (−4.3%)
- [ ] full `scan_bench` / `clip_bench` default 120 s sweep (not re-run after the commit)