### PR TITLE
fix: clean failed reels and align preview overlays

### DIFF
--- a/assets/web/screenspace-model-view.js
+++ b/assets/web/screenspace-model-view.js
@@ -88,6 +88,8 @@
           state.overlayImageObjectUrl = null;
         }
         state.overlayImage = null;
+        state.overlayImageScope = null;
+        state.overlayImageRegion = null;
         state.overlayImageTimestamp = null;
         state.overlayImageTool = null;
         refreshModelView();
@@ -155,6 +157,7 @@
     _updateOverlayUi();
     _updateFocusLabel();
     refreshModelView();
+    SS.renderOverlay();
     if (SS.calRender) SS.calRender();
   }
 
@@ -509,6 +512,15 @@
     }
     var regionStr = _normalizedRegionString();
     var hasRegion = _hasActiveOrPendingRegion();
+    var overlayRegion = null;
+    if (hasRegion) {
+      var regionParts = regionStr.split(",").map(Number);
+      overlayRegion = {
+        x: regionParts[0], y: regionParts[1],
+        w: regionParts[2], h: regionParts[3],
+        source_width: 1,
+      };
+    }
 
     if (tool === "template" || tool === "shape") {
       var snapRegion = !sfx && state.capturedRefPreview
@@ -617,6 +629,8 @@
           state.overlayImageObjectUrl = null;
         }
         state.overlayImage = null;
+        state.overlayImageScope = null;
+        state.overlayImageRegion = null;
         state.overlayImageTimestamp = null;
         state.overlayImageTool = null;
         return;
@@ -637,6 +651,7 @@
           if (gen !== _modelViewGen) return;
           state.overlayImage = oi;
           state.overlayImageScope = resolved.scope;
+          state.overlayImageRegion = overlayRegion;
           state.overlayImageTimestamp = ts;
           state.overlayImageTool = toolKey;
           SS.renderOverlay();

--- a/assets/web/screenspace-overlay.js
+++ b/assets/web/screenspace-overlay.js
@@ -347,6 +347,7 @@
     // Model-view overlay (toggle or held-key blink comparator)
     var overlayActive = (state.overlayEnabled || state.overlayBlinkActive)
       && state.overlayImage
+      && state.overlayImageTool === SS._previewToolKey()
       && _overlayEligibleForActiveTool();
     if (overlayActive) {
       ctx.globalAlpha = state.overlayBlinkActive ? 1.0 : 0.7;
@@ -354,16 +355,14 @@
       if (scope === "frame") {
         ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
       } else {
-        var oRegion = state.pendingRegion
-          ? state.pendingRegion
-          : (state.activeRegion ? state.regions[state.activeRegion] : null);
+        var oRegion = state.overlayImageRegion;
         if (oRegion) {
           var oPx = regionToPixels(oRegion);
           if (oPx && oPx.w && oPx.h) {
             ctx.drawImage(state.overlayImage, oPx.x, oPx.y, oPx.w, oPx.h);
           }
         } else {
-          // No region active — overlay covers the whole frame.
+          // Full-frame previews cover the canvas.
           ctx.drawImage(state.overlayImage, 0, 0, canvas.width, canvas.height);
         }
       }

--- a/assets/web/screenspace.js
+++ b/assets/web/screenspace.js
@@ -234,6 +234,8 @@
     overlayBlinkActive: false,
     overlayImage: null,
     overlayImageObjectUrl: null,
+    overlayImageScope: null,
+    overlayImageRegion: null,
     overlayImageTimestamp: null,
     overlayImageTool: null,
     overlayLayerSpec: {},

--- a/source/app.py
+++ b/source/app.py
@@ -846,14 +846,19 @@ def _run_reellate_mode_interactive() -> tuple[bool, str | None]:
             resolved_clips, output_file, reencode_on_fail=True
         )
 
-    ok = (
-        utils.run_with_spinner(
-            f"Concatenating {len(selected_clips)} clips into {output_file}...",
-            _concat_reellate,
+    ok = False
+    try:
+        ok = (
+            utils.run_with_spinner(
+                f"Concatenating {len(selected_clips)} clips into {output_file}...",
+                _concat_reellate,
+            )
+            if utils.use_progress()
+            else _concat_reellate()
         )
-        if utils.use_progress()
-        else _concat_reellate()
-    )
+    finally:
+        if not ok:
+            files.release_reservation(output_file)
 
     if ok:
         return (True, output_file)

--- a/tests/test_interactive_prompts.py
+++ b/tests/test_interactive_prompts.py
@@ -427,3 +427,28 @@ def test_reellate_user_filename_lands_in_output_dir(monkeypatch, tmp_path):
     assert output_file == seen["output"]
     assert Path(output_file).parent == tmp_path
     assert Path(output_file).name == "myreel.mp4"
+
+
+def test_reellate_failure_releases_output(monkeypatch, tmp_path):
+    """A failed concat must not leave its reserved output behind."""
+    import app
+    import config
+    import files
+    import video
+
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(files, "discover_clips", lambda: ["a.mp4", "b.mp4"])
+    monkeypatch.setattr(utils, "use_progress", lambda: False)
+    _scripted(monkeypatch, ["A + B", "y", "failed-reel"])
+
+    def fail_concat(_clips, output_file, **_kwargs):
+        assert Path(output_file).is_file()
+        return False
+
+    monkeypatch.setattr(video, "concatenate_clips", fail_concat)
+
+    ok, output_file = app._run_reellate_mode_interactive()
+
+    assert ok is False
+    assert output_file is None
+    assert not (tmp_path / "failed-reel.mp4").exists()

--- a/tests/test_screenspace_frontend_source.py
+++ b/tests/test_screenspace_frontend_source.py
@@ -17,6 +17,7 @@ SCREENSPACE_CSS = read("screenspace.css")
 SCREENSPACE_JS = read("screenspace.js")
 TASKS_JS = read("screenspace-tasks.js")
 MODEL_VIEW_JS = read("screenspace-model-view.js")
+OVERLAY_JS = read("screenspace-overlay.js")
 INTERACTION_JS = read("screenspace-overlay-interaction.js")
 SAMPLE_EDITOR_JS = read("screenspace-sample-editor.js")
 
@@ -218,6 +219,15 @@ def test_model_view_previews_focused_multitool_step():
     assert 'sfx = "_mt" + stepIdx' in body
     assert "_collectPreviewParams(tool, sfx)" in body
     assert "(state.multitoolSteps || [])[0]" not in MODEL_VIEW_JS
+
+
+def test_model_view_overlay_uses_preview_region():
+    """The overlay must use the region that produced its preview image."""
+    assert "state.overlayImageRegion = overlayRegion;" in MODEL_VIEW_JS
+    start = OVERLAY_JS.index("// Model-view overlay")
+    body = OVERLAY_JS[start : OVERLAY_JS.index("ctx.globalAlpha = 1.0;", start)]
+    assert "state.overlayImageTool === SS._previewToolKey()" in body
+    assert "var oRegion = state.overlayImageRegion;" in body
 
 
 def test_multitool_branch_refreshes_model_view():


### PR DESCRIPTION
## Summary

- Remove reserved Reellate outputs when concatenation fails or raises.
- Bind Screenspace preview overlays to their generated region and hide stale focused-step images.

## Test plan

- [x] Ruff format, Ruff lint, and `ty` checks
- [x] Full pytest suite (3,959 passed)
- [x] Six-page UI smoke and journeys (17 passed); Screenspace screenshots reviewed
